### PR TITLE
WeBWorK: md alignment and intertext

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -614,6 +614,101 @@
         </section>
 
         <section>
+            <title>Math Content</title>
+
+            <p>
+                This section helps with testing thins and that regarding math content.
+            </p>
+
+            <exercise>
+                <title>Math Elements and Alignment</title>
+                <introduction>
+                    <p>
+                        In this exercise we demonstrate the allowed math elements: <tag>m</tag>, <tag>me</tag>, and <tag>md</tag>.
+                        The last of these may have attribute <attr>alignment</attr> with options <c>gather</c>, <c>align</c>, or <c>alignat</c>.
+                        The first two are used by default, depending on if you have <c>&amp;</c> or <c>\amp</c> in your math.
+                    </p>
+                </introduction>
+                <webwork>
+                    <statement>
+                        <p>
+                            If <m>a=5</m> and <m>b=12</m>, then <me>a^2+b^2=13^2</me>.
+                        </p>
+                        <p>
+                            Here, we solve an equation.
+                            <md>
+                                <mrow>2x+1 \amp= 3</mrow>
+                                <mrow>2x   \amp= 2</mrow>
+                                <mrow>x    \amp= 1</mrow>
+                            </md>
+                            Here we have a three-way inequality to solve.
+                            <md>
+                                <mrow>1 \lt 2x+1 \lt 3</mrow>
+                                <mrow>0 \lt 2x   \lt 2</mrow>
+                                <mrow>0 \lt x    \lt 1</mrow>
+                            </md>
+                            And here, we see a system of equations.
+                            <md alignment="alignat">
+                                <mrow>2x + 2y \amp {}+{} \amp z \amp {}={} \amp 10</mrow>
+                                <mrow>y \amp {}-{} \amp  4z \amp {}={} \amp 9</mrow>
+                                <mrow>\amp\amp   3z \amp {}={} \amp -6</mrow>
+                            </md>
+                        </p>
+                    </statement>
+                </webwork>
+            </exercise>
+
+            <exercise>
+                <title>Intertext</title>
+                <introduction>
+                    <p>
+                        With an <tag>md</tag> you might have <tag>intertext</tag> among the rows.
+                    </p>
+                </introduction>
+                <webwork>
+                    <statement>
+                        <p>
+                            Here, we solve an equation.
+                            <md>
+                                <mrow>2x+1 \amp= 3</mrow>
+                                <intertext> Now subtract <m>1</m> from each side.</intertext>
+                                <mrow>2x   \amp= 2</mrow>
+                                <intertext> Now divide by <m>2</m> on each side.</intertext>
+                                <mrow>x    \amp= 1</mrow>
+                            </md>
+                        </p>
+                        <p>
+                            We should also test when the <tag>md</tag> is within a list.
+                            <ol>
+                                <li>
+                                    <p>
+                                        Start a list.
+                                    </p>
+                                </li>
+                                <li>
+                                    <p>
+                                        <md>
+                                            <mrow>2x+1 \amp= 3</mrow>
+                                            <intertext> Now subtract <m>1</m> from each side.</intertext>
+                                            <mrow>2x   \amp= 2</mrow>
+                                            <intertext> Now divide by <m>2</m> on each side.</intertext>
+                                            <mrow>x    \amp= 1</mrow>
+                                        </md>
+                                    </p>
+                                </li>
+                                <li>
+                                    <p>
+                                        Still in the list?
+                                    </p>
+                                </li>
+                            </ol>
+                        </p>
+                    </statement>
+                </webwork>
+            </exercise>
+        </section>
+
+        <section>
             <title>PGML Formatting and Verbatim Calisthenics</title>
 
             <p>This section is designed to test various PGML formatting rules and verbatim content returned in answer hashes. Consult the source to see how the special characters and formatting are realized.</p>


### PR DESCRIPTION
This addresses a report from the forums that within a `webwork`, `alignment="aligned"` had no effect. Brought the `md` template into line with how `md` is built in other stylesheets. 

While I was in the same place, I implemented `intertext` for an `md` in a `webwork`.

Tested that HTML and PDF look good, and there is nothing bad in the diff between the webwork-extraction file in the before and after.