### PR TITLE
Code cleanup: use select when possible for variables

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1418,12 +1418,8 @@
             <xsl:value-of select="substring-before($trimmed-start, '}')"/>
         </xsl:if>
     </xsl:variable>
-    <xsl:variable name="macro-command">
-        <xsl:value-of select="substring-before($macros, '&#xa;')"/>
-    </xsl:variable>
-    <xsl:variable name="next-lines">
-        <xsl:value-of select="substring-after($macros, '&#xa;')"/>
-    </xsl:variable>
+    <xsl:variable name="macro-command" select="substring-before($macros, '&#xa;')"/>
+    <xsl:variable name="next-lines" select="substring-after($macros, '&#xa;')"/>
     <xsl:if test="contains(., $macro-name)">
         <xsl:value-of select="normalize-space($macro-command)"/>
     </xsl:if>
@@ -1808,9 +1804,7 @@
     </xsl:if>
     <!-- prefix is optional -->
     <xsl:if test="@prefix">
-        <xsl:variable name="prefix">
-            <xsl:value-of select="@prefix" />
-        </xsl:variable>
+        <xsl:variable name="prefix" select="string(@prefix)"/>
         <xsl:variable name="short">
             <xsl:for-each select="document('pretext-units.xsl')">
                 <xsl:value-of select="key('prefix-key',concat('prefixes',$prefix))/@short"/>
@@ -1821,9 +1815,7 @@
     <!-- base unit is *mandatory* so check to see if it has been provided -->
     <xsl:choose>
         <xsl:when test="@base">
-            <xsl:variable name="base">
-                <xsl:value-of select="@base" />
-            </xsl:variable>
+            <xsl:variable name="base" select="string(@base)"/>
             <xsl:variable name="short">
                 <xsl:for-each select="document('pretext-units.xsl')">
                     <xsl:value-of select="key('base-key',concat('bases',$base))/@short"/>

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -634,12 +634,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   <xsl:value-of select="count(*)"/>
   <xsl:text>, raster equal height=rows, raster force size=false, raster column skip=0ex] &#xa;</xsl:text>
 
-  <xsl:variable name="columnCount">
-    <xsl:value-of select="count(*)"/>
-  </xsl:variable>
-  <xsl:variable name="widthFraction">
-    <xsl:value-of select="1 div $columnCount" />
-  </xsl:variable>
+  <xsl:variable name="columnCount" select="count(*)"/>
+  <xsl:variable name="widthFraction" select="1 div $columnCount"/>
 
   <xsl:for-each select="*">
     <xsl:if test="parent::*/@pause = 'yes'">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -350,17 +350,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This is set (temporarily) in docinfo, which will change           -->
 <!-- We do no special error-checking here since this will change       -->
 <!-- The variable will be empty if not set                             -->
-<xsl:variable name="numbering-exercises">
-    <xsl:value-of select="$docinfo/numbering/exercises/@level"/>
-</xsl:variable>
+<xsl:variable name="numbering-exercises" select="number($docinfo/numbering/exercises/@level)"/>
 
 <!-- Figure-Like can optionally run on their own numbering scheme      -->
 <!-- This is set (temporarily) in docinfo, which will change           -->
 <!-- We do no special error-checking here since this will change       -->
 <!-- The variable will be empty if not set                             -->
-<xsl:variable name="numbering-figures">
-    <xsl:value-of select="$docinfo/numbering/figures/@level"/>
-</xsl:variable>
+<xsl:variable name="numbering-figures" select="number($docinfo/numbering/figures/@level)"/>
 
 <!-- User-supplied Numbering for Equations    -->
 <!-- Respect switch, or provide sensible defaults -->
@@ -482,9 +478,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- use this to distinguish one document from another.  -->
 <!-- The global variable here is empty to signal         -->
 <!-- "no choice" by the author.                          -->
-<xsl:variable name="document-id">
-    <xsl:value-of select="$docinfo/document-id"/>
-</xsl:variable>
+<xsl:variable name="document-id" select="string($docinfo/document-id)"/>
 
 <!-- The new version can return to the generic version  -->
 <!-- once we kill the dashed version for author use.    -->
@@ -3934,9 +3928,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:variable name="raw-title">
         <xsl:apply-templates select="." mode="title-simple"/>
     </xsl:variable>
-    <xsl:variable name="letter-only-title">
-        <xsl:value-of select="translate($raw-title, translate($raw-title, concat(&SIMPLECHAR;,' '), ''), '')" />
-    </xsl:variable>
+    <xsl:variable name="letter-only-title" select="translate($raw-title, translate($raw-title, concat(&SIMPLECHAR;,' '), ''), '')"/>
     <xsl:value-of select="translate($letter-only-title, ' ', '_')" />
 </xsl:template>
 
@@ -4250,9 +4242,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:variable name="width-percent">
         <xsl:apply-templates select="." mode="get-width-percentage" />
     </xsl:variable>
-    <xsl:variable name="width-fraction">
-        <xsl:value-of select="substring-before($width-percent,'%') div 100" />
-    </xsl:variable>
+    <xsl:variable name="width-fraction" select="substring-before($width-percent,'%') div 100"/>
     <xsl:value-of select="round($design-width-pixels * $width-fraction)" />
 </xsl:template>
 
@@ -4263,9 +4253,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
     <xsl:variable name="width-percent">
         <xsl:apply-templates select="." mode="get-width-percentage" />
     </xsl:variable>
-    <xsl:variable name="width-fraction">
-        <xsl:value-of select="substring-before($width-percent,'%') div 100" />
-    </xsl:variable>
+    <xsl:variable name="width-fraction" select="substring-before($width-percent,'%') div 100"/>
     <xsl:variable name="aspect-ratio">
         <xsl:apply-templates select="." mode="get-aspect-ratio">
             <xsl:with-param name="default-aspect" select="$default-aspect" />
@@ -4500,9 +4488,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 
 <xsl:template match="icon">
     <!-- the name attribute of the "icon" in text as a string -->
-    <xsl:variable name="icon-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="icon-name" select="string(@name)"/>
 
     <!-- for-each is just one node, but sets context for key() -->
     <xsl:for-each select="$icon-table">
@@ -8786,9 +8772,7 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- these, and so this template may never be hit         -->
 <!-- (or only rarely?)                                    -->
 <xsl:template match="xref[@provisional]">
-    <xsl:variable name="inline-warning">
-        <xsl:value-of select="@provisional" />
-    </xsl:variable>
+    <xsl:variable name="inline-warning" select="string(@provisional)"/>
     <xsl:variable name="margin-warning">
         <xsl:text>Provisional xref</xsl:text>
     </xsl:variable>
@@ -11222,15 +11206,11 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <!-- [0-9]*\.?[0-9]*%          -->
 <xsl:template name="normalize-percentage">
     <xsl:param name="percentage" />
-    <xsl:variable name="stripped-percentage">
-        <xsl:value-of select="normalize-space($percentage)" />
-    </xsl:variable>
+    <xsl:variable name="stripped-percentage" select="normalize-space($percentage)"/>
     <xsl:if test="substring($stripped-percentage,string-length($stripped-percentage)) != '%'">
         <xsl:message terminate="yes">MBX:FATAL:   expecting a percentage ending in '%'; got <xsl:value-of select="$stripped-percentage"/></xsl:message>
     </xsl:if>
-    <xsl:variable name="percent">
-        <xsl:value-of select="normalize-space(substring($stripped-percentage,1,string-length($stripped-percentage) - 1))" />
-    </xsl:variable>
+    <xsl:variable name="percent" select="normalize-space(substring($stripped-percentage,1,string-length($stripped-percentage) - 1))"/>
     <xsl:if test="number($percent) != $percent">
         <xsl:message terminate="yes">MBX:FATAL:   expecting a numerical value preceding '%'; got <xsl:value-of select="$percent"/></xsl:message>
     </xsl:if>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -937,9 +937,7 @@ width: 100%
 <!-- Font Awesome CSS loading, $icon-table is in -common -->
 <xsl:template match="icon">
     <!-- the name attribute of the "icon" in text as a string -->
-    <xsl:variable name="icon-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="icon-name" select="string(@name)"/>
 
     <!-- for-each is just one node, but sets context for key() -->
     <xsl:for-each select="$icon-table">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7407,9 +7407,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="mag">
-    <xsl:variable name="mag">
-        <xsl:value-of select="."/>
-    </xsl:variable>
+    <xsl:variable name="mag" select="string(.)"/>
     <xsl:variable name="math-pi">
         <xsl:call-template name="begin-inline-math" />
         <xsl:text>\pi</xsl:text>
@@ -7436,9 +7434,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <!-- prefix is optional -->
     <xsl:if test="@prefix">
-        <xsl:variable name="prefix">
-            <xsl:value-of select="@prefix" />
-        </xsl:variable>
+        <xsl:variable name="prefix" select="string(@prefix)"/>
         <xsl:variable name="short">
             <xsl:for-each select="document('pretext-units.xsl')">
                 <xsl:value-of select="key('prefix-key',concat('prefixes',$prefix))/@short"/>
@@ -7447,9 +7443,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="$short" />
     </xsl:if>
     <!-- base unit is required -->
-    <xsl:variable name="base">
-        <xsl:value-of select="@base" />
-    </xsl:variable>
+    <xsl:variable name="base" select="string(@base)"/>
     <xsl:variable name="short">
         <xsl:for-each select="document('pretext-units.xsl')">
             <xsl:value-of select="key('base-key',concat('bases',$base))/@short"/>
@@ -8034,9 +8028,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Presumes CSS headers have been loaded -->
 <xsl:template match="icon">
     <!-- the name attribute of the "icon" in text as a string -->
-    <xsl:variable name="icon-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="icon-name" select="string(@name)"/>
 
     <!-- for-each is just one node, but sets context for key() -->
     <xsl:variable name="fa-name">
@@ -8061,9 +8053,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="kbd[@name]">
     <!-- the name attribute of the "kbd" in text as a string -->
-    <xsl:variable name="kbdkey-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="kbdkey-name" select="string(@name)"/>
     <!-- Entirely similar HTML/CSS, but will hold a Unicode character -->
     <kbd class="kbdkey">
         <!-- for-each is just one node, but sets context for key() -->
@@ -9482,9 +9472,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="width-percent">
         <xsl:apply-templates select="." mode="get-width-percentage" />
     </xsl:variable>
-    <xsl:variable name="width-fraction">
-        <xsl:value-of select="substring-before($width-percent,'%') div 100" />
-    </xsl:variable>
+    <xsl:variable name="width-fraction" select="substring-before($width-percent,'%') div 100"/>
     <xsl:variable name="aspect-ratio">
         <xsl:apply-templates select="." mode="get-aspect-ratio">
             <xsl:with-param name="default-aspect" select="'1:1'" />
@@ -11277,9 +11265,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- First a variable to massage the author-supplied -->
 <!-- package list to the form MathJax expects        -->
-<xsl:variable name="latex-packages-mathjax">
-    <xsl:value-of select="str:replace($latex-packages, '\usepackage{', '\require{')" />
-</xsl:variable>
+<xsl:variable name="latex-packages-mathjax" select="str:replace($latex-packages, '\usepackage{', '\require{')"/>
 
 
 <!-- MathJax expects math wrapping, and we place in   -->

--- a/xsl/pretext-json-manifest.xsl
+++ b/xsl/pretext-json-manifest.xsl
@@ -71,9 +71,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Since we are describing HTML output, we want filenames   -->
 <!-- describing those files                                   -->
 <xsl:variable name="file-extension" select="'.html'"/>
-<xsl:variable name="chunk-level">
-    <xsl:value-of select="$chunk.level"/>
-</xsl:variable>
+<xsl:variable name="chunk-level" select="number($chunk.level)"/>
 
 <!-- Entry Template               -->
 <!-- Create outermost array       -->

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -459,9 +459,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Font Awesome CSS loading, $icon-table is in -common -->
 <xsl:template match="icon">
     <!-- the name attribute of the "icon" in text as a string -->
-    <xsl:variable name="icon-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="icon-name" select="string(@name)"/>
 
     <!-- for-each is just one node, but sets context for key() -->
     <xsl:for-each select="$icon-table">
@@ -643,9 +641,7 @@ TODO: (overall)
 <!-- few gotchas need adjustment.  So we override.             -->
 <xsl:template match="c">
     <!-- grab content literally -->
-    <xsl:variable name="text">
-        <xsl:value-of select="."/>
-    </xsl:variable>
+    <xsl:variable name="text" select="string(.)"/>
 
     <!-- We wrap verbatim inline text with an HTML "code" element. -->
     <!-- When there are to in close proximity (same paragraph)     -->
@@ -701,9 +697,7 @@ TODO: (overall)
 <!-- are fortunate to be able to encode the dollar sign.  -->
 <xsl:template match="@href" mode="serialize">
     <!-- sanitize value first -->
-    <xsl:variable name="text">
-        <xsl:value-of select="."/>
-    </xsl:variable>
+    <xsl:variable name="text" select="string(.)"/>
     <xsl:variable name="underscore-fixed" select="str:replace($text,             '_',  '%5F')"/>
     <xsl:variable name="asterisk-fixed"   select="str:replace($underscore-fixed, '*',  '%2A')"/>
     <xsl:variable name="dollar-fixed"     select="str:replace($asterisk-fixed,   '$',  '%24')"/>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1438,9 +1438,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <!-- solutions to PROJECT-LIKE -->
         <xsl:for-each select="$project-reps">
-            <xsl:variable name="elt-name">
-                <xsl:value-of select="local-name(.)"/>
-            </xsl:variable>
+            <xsl:variable name="elt-name" select="local-name(.)"/>
             <xsl:variable name="type-name">
                 <xsl:apply-templates select="." mode="type-name"/>
             </xsl:variable>
@@ -2444,9 +2442,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- was really bad page breaks, or worse, the potential for the interior -->
 <!-- box dribbling off the bottom of the page.                            -->
 <xsl:template match="introduction|conclusion" mode="environment">
-    <xsl:variable name="environment-name">
-        <xsl:value-of select="local-name(.)"/>
-    </xsl:variable>
+    <xsl:variable name="environment-name" select="local-name(.)"/>
     <xsl:text>%% </xsl:text>
     <xsl:value-of select="$environment-name"/>
     <xsl:text>: in a structured division&#xa;</xsl:text>
@@ -2700,9 +2696,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Identical to ASIDE-LIKE, but we keep it distinct -->
 <xsl:template match="assemblage" mode="environment">
     <!-- Names of various pieces use the element name -->
-    <xsl:variable name="environment-name">
-        <xsl:value-of select="local-name(.)"/>
-    </xsl:variable>
+    <xsl:variable name="environment-name" select="local-name(.)"/>
     <xsl:text>%% </xsl:text>
     <xsl:value-of select="$environment-name"/>
     <xsl:text>: fairly simple un-numbered block/structure&#xa;</xsl:text>
@@ -2755,9 +2749,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Note: do not integrate into others, as treatment may necessarily vary -->
 <xsl:template match="&ASIDE-LIKE;" mode="environment">
     <!-- Names of various pieces use the element name -->
-    <xsl:variable name="environment-name">
-        <xsl:value-of select="local-name(.)"/>
-    </xsl:variable>
+    <xsl:variable name="environment-name" select="local-name(.)"/>
     <xsl:text>%% </xsl:text>
     <xsl:value-of select="$environment-name"/>
     <xsl:text>: fairly simple un-numbered block/structure&#xa;</xsl:text>
@@ -8091,9 +8083,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="icon">
     <!-- the name attribute of the "icon" in text as a string -->
-    <xsl:variable name="icon-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="icon-name" select="string(@name)"/>
 
     <xsl:variable name="fa-name">
         <xsl:choose>
@@ -8124,9 +8114,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="substring($text, 2)"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:variable name="first-part">
-                <xsl:value-of select="substring-before($text, '-')"/>
-            </xsl:variable>
+            <xsl:variable name="first-part" select="substring-before($text, '-')"/>
             <xsl:value-of select="translate(substring($first-part, 1, 1), &LOWERCASE;, &UPPERCASE;)"/>
             <xsl:value-of select="substring($first-part, 2)"/>
             <xsl:call-template name="camel-case-font-name">
@@ -8151,9 +8139,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="kbd[@name]">
     <!-- the name attribute of the "kbd" in text as a string -->
-    <xsl:variable name="kbdkey-name">
-        <xsl:value-of select="@name"/>
-    </xsl:variable>
+    <xsl:variable name="kbdkey-name" select="string(@name)"/>
 
     <xsl:text>\kbd{</xsl:text>
         <!-- for-each is just one node, but sets context for key() -->


### PR DESCRIPTION
The bigger picture here is I'm trying to automate comparing the output before and after some changes. I'm not there yet, but what we have here is the result of my first experiment. I thought it was worth saving, so for your consideration...

This changes all `xsl:variable` declarations that just had a `xsl:value-of` child to use a `@select` instead.

My half-baked automated testing found no differences between pre- and post- versions of the sample article and WW sample chapter. At first, in all cases, the `@select` from the `value-of` simply migrated to become the `@select` for the `xsl:variable`. Then my testing revealed that in the case of the `document-id` variable in `-common`, this wasn't quite right. For that one, it was necessary and appropriate to wrap a `string()` around the `select` expression.

Two small improvements here:
1. It's a net reduction of 70 lines of code.
2. More importantly, it's good to use `@select` when possible. As we recently discussed, this allows the variable to be explicitly string, number, or boolean. When not using `@select`, the variable is an rtf, and using it downstream doesn't always match with what you naively expect to happen. So making this change, there are fewer "bad examples" for a code contributor to mimic.