### PR TITLE
Math: replace templates for begin-,end-inline-math with wrapper

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1397,8 +1397,8 @@ Book (with parts), "section" at level 3
 <!--                                                     -->
 <!-- Abstract Templates                                  -->
 <!--                                                     -->
-<!-- (1) begin-inline-math, end-inline-math              -->
-<!--       The delimiters for inline mathematics         -->
+<!-- (1) named "inline-math-wrapper"                     -->
+<!--       Provides the delimiters for inline math       -->
 <!--       Stub warnings follow below                    -->
 <!-- (2) get-clause-punctuation                          -->
 <!--       Look at next node, and if a text node,        -->
@@ -1409,57 +1409,59 @@ Book (with parts), "section" at level 3
 <!-- $debug.displaystyle defaults to yes for testing -->
 
 <xsl:template match="m">
-    <!-- Build a textual version of the latex,  -->
-    <!-- applying the rare templates allowed,   -->
-    <!-- save for minor manipulation later.     -->
-    <!-- Note: generic text() template here in  -->
-    <!-- -common should always pass through the -->
-    <!-- text nodes within "m" with no changes  -->
-    <xsl:variable name="raw-latex">
-        <xsl:choose>
-            <xsl:when test="ancestor::static/parent::webwork-reps">
-                <xsl:apply-templates select="text()|var" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="text()|fillin" />
-            </xsl:otherwise>
-        </xsl:choose>
-        <!-- look ahead to absorb immediate clause-ending punctuation   -->
-        <!-- this is useful for HTML/MathJax to prevent bad line breaks -->
-        <!-- The template here in -common is generally useful, but      -->
-        <!-- for LaTeX we override to be a no-op, since not necessary   -->
-        <xsl:apply-templates select="." mode="get-clause-punctuation" />
-    </xsl:variable>
-    <!-- wrap tightly in math delimiters -->
-    <xsl:call-template name="begin-inline-math" />
-    <!-- Prefix will normally be empty and have no effect.  We also have  -->
-    <!-- an undocumented switch to totally kill the possibility entirely. -->
-    <!-- This was added to support testing of braille output.             -->
-    <xsl:if test="not($debug.displaystyle = 'no')">
-        <xsl:apply-templates select="."  mode="display-style-prefix"/>
-    </xsl:if>
-    <!-- we clean whitespace that is irrelevant to LaTeX so that we -->
-    <!--   (1) avoid LaTeX compilation errors                       -->
-    <!--   (2) avoid spurious blank lines leading to new paragraphs -->
-    <!--   (3) provide human-readable source of high quality        -->
-    <!-- sanitize-latex template does not provide a final newline   -->
-    <!-- and we do not add one here either, since it is inline math -->
-    <!-- MathJax is more tolerant, but readability is still useful  -->
-    <xsl:call-template name="sanitize-latex">
-        <xsl:with-param name="text" select="$raw-latex" />
+    <!-- wrap in math delimiters -->
+    <xsl:call-template name="inline-math-wrapper">
+        <xsl:with-param name="math">
+            <!-- Build a textual version of the latex,  -->
+            <!-- applying the rare templates allowed,   -->
+            <!-- save for minor manipulation later.     -->
+            <!-- Note: generic text() template here in  -->
+            <!-- -common should always pass through the -->
+            <!-- text nodes within "m" with no changes  -->
+            <xsl:variable name="raw-latex">
+                <xsl:choose>
+                    <xsl:when test="ancestor::static/parent::webwork-reps">
+                        <xsl:apply-templates select="text()|var" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:apply-templates select="text()|fillin" />
+                    </xsl:otherwise>
+                </xsl:choose>
+                <!-- look ahead to absorb immediate clause-ending punctuation   -->
+                <!-- this is useful for HTML/MathJax to prevent bad line breaks -->
+                <!-- The template here in -common is generally useful, but      -->
+                <!-- for LaTeX we override to be a no-op, since not necessary   -->
+                <xsl:apply-templates select="." mode="get-clause-punctuation" />
+            </xsl:variable>
+            <!-- Prefix will normally be empty and have no effect.  We also have  -->
+            <!-- an undocumented switch to totally kill the possibility entirely. -->
+            <!-- This was added to support testing of braille output.             -->
+            <xsl:if test="not($debug.displaystyle = 'no')">
+                <xsl:apply-templates select="."  mode="display-style-prefix"/>
+            </xsl:if>
+            <!-- we clean whitespace that is irrelevant to LaTeX so that we -->
+            <!--   (1) avoid LaTeX compilation errors                       -->
+            <!--   (2) avoid spurious blank lines leading to new paragraphs -->
+            <!--   (3) provide human-readable source of high quality        -->
+            <!-- sanitize-latex template does not provide a final newline   -->
+            <!-- and we do not add one here either, since it is inline math -->
+            <!-- MathJax is more tolerant, but readability is still useful  -->
+            <xsl:call-template name="sanitize-latex">
+                <xsl:with-param name="text" select="$raw-latex" />
+            </xsl:call-template>
+        </xsl:with-param>
     </xsl:call-template>
-    <xsl:call-template name="end-inline-math" />
 </xsl:template>
 
-<xsl:template name="begin-inline-math">
-     <xsl:message>PTX:ERROR:   the "begin-inline-math" template needs an implementation in the current conversion</xsl:message>
-     <xsl:text>[[[</xsl:text>
- </xsl:template>
+<!-- This template needs an override in each output mode. -->
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
+    <xsl:message>PTX:ERROR:   the "wrapper" modal template for inline math needs an implementation in the current conversion</xsl:message>
+    <xsl:text>[[[</xsl:text>
+    <xsl:value-of select="$math"/>
+    <xsl:text>]]]</xsl:text>
+</xsl:template>
 
-<xsl:template name="end-inline-math">
-     <xsl:message>PTX:ERROR:   the "end-inline-math" template needs an implementation in the current conversion</xsl:message>
-     <xsl:text>]]]</xsl:text>
- </xsl:template>
 
 <!-- Display Style LaTeX markup for inline math -->
 <!--                                                     -->
@@ -1992,50 +1994,52 @@ Book (with parts), "section" at level 3
 <!-- the textcomp package, then math delimiters will    -->
 <!-- move down into the "when" parts of the "choose"    -->
 <xsl:template match="@tag" mode="tag-symbol">
-    <xsl:call-template name="begin-inline-math" />
-    <xsl:choose>
-        <!-- Stars -->
-        <xsl:when test=". = 'star'">
-            <xsl:text>\star</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'dstar'">
-            <xsl:text>\star\star</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'tstar'">
-            <xsl:text>\star\star\star</xsl:text>
-        </xsl:when>
-        <!-- Dagger -->
-        <xsl:when test=". = 'dagger'">
-            <xsl:text>\dagger</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'ddagger'">
-            <xsl:text>\dagger\dagger</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'tdagger'">
-            <xsl:text>\dagger\dagger\dagger</xsl:text>
-        </xsl:when>
-        <!-- Hash -->
-        <xsl:when test=". = 'hash'">
-            <xsl:text>\#</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'dhash'">
-            <xsl:text>\#\#</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'thash'">
-            <xsl:text>\#\#\#</xsl:text>
-        </xsl:when>
-        <!-- Maltese -->
-        <xsl:when test=". = 'maltese'">
-            <xsl:text>\maltese</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'dmaltese'">
-            <xsl:text>\maltese\maltese</xsl:text>
-        </xsl:when>
-        <xsl:when test=". = 'tmaltese'">
-            <xsl:text>\maltese\maltese\maltese</xsl:text>
-        </xsl:when>
-    </xsl:choose>
-    <xsl:call-template name="end-inline-math" />
+    <xsl:call-template name="inline-math-wrapper">
+        <xsl:with-param name="math">
+            <xsl:choose>
+                <!-- Stars -->
+                <xsl:when test=". = 'star'">
+                    <xsl:text>\star</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'dstar'">
+                    <xsl:text>\star\star</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'tstar'">
+                    <xsl:text>\star\star\star</xsl:text>
+                </xsl:when>
+                <!-- Dagger -->
+                <xsl:when test=". = 'dagger'">
+                    <xsl:text>\dagger</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'ddagger'">
+                    <xsl:text>\dagger\dagger</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'tdagger'">
+                    <xsl:text>\dagger\dagger\dagger</xsl:text>
+                </xsl:when>
+                <!-- Hash -->
+                <xsl:when test=". = 'hash'">
+                    <xsl:text>\#</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'dhash'">
+                    <xsl:text>\#\#</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'thash'">
+                    <xsl:text>\#\#\#</xsl:text>
+                </xsl:when>
+                <!-- Maltese -->
+                <xsl:when test=". = 'maltese'">
+                    <xsl:text>\maltese</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'dmaltese'">
+                    <xsl:text>\maltese\maltese</xsl:text>
+                </xsl:when>
+                <xsl:when test=". = 'tmaltese'">
+                    <xsl:text>\maltese\maltese\maltese</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:with-param>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- Intertext -->
@@ -8257,9 +8261,17 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
 <!-- Music -->
 <!-- ##### -->
 
+<!-- Uses inline math rendering -->
+<xsl:template match="n|scaledeg|timesignature|chord">
+    <xsl:call-template name="inline-math-wrapper">
+        <xsl:with-param name="math">
+            <xsl:apply-templates select="." mode="inner-music"/>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
 <!-- Note -->
-<xsl:template match="n">
-    <xsl:call-template name="begin-inline-math"/>
+<xsl:template match="n" mode="inner-music">
     <!-- Test that pitch class is NOT castable as a number -->
     <xsl:if test="not(number(@pc) = number(@pc))">
         <xsl:text>\text{</xsl:text>
@@ -8292,35 +8304,29 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         <xsl:value-of select="@octave"/>
         <xsl:text>}</xsl:text>
     </xsl:if>
-    <xsl:call-template name="end-inline-math"/>
 </xsl:template>
 
 <!-- Scale Degrees -->
-<xsl:template match="scaledeg">
+<xsl:template match="scaledeg" mode="inner-music">
     <!-- Arabic numeral with circumflex accent above)-->
-    <xsl:call-template name="begin-inline-math"/>
     <xsl:text>\hat{</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>}</xsl:text>
-    <xsl:call-template name="end-inline-math"/>
     <!-- TODO: unclear if trailing space is necessary -->
     <xsl:text> </xsl:text>
 </xsl:template>
 
 <!-- Time Signatures -->
-<xsl:template match="timesignature">
-    <xsl:call-template name="begin-inline-math"/>
+<xsl:template match="timesignature" mode="inner-music">
     <xsl:text>\begin{smallmatrix}</xsl:text>
     <xsl:value-of select="@top"/>
     <xsl:text>\\</xsl:text>
     <xsl:value-of select="@bottom"/>
     <xsl:text>\end{smallmatrix}</xsl:text>
-    <xsl:call-template name="end-inline-math"/>
 </xsl:template>
 
 <!-- Chord -->
-<xsl:template match="chord">
-    <xsl:call-template name="begin-inline-math"/>
+<xsl:template match="chord" mode="inner-music">
     <xsl:text>\left.</xsl:text>
     <!-- Root -->
     <xsl:choose>
@@ -8456,7 +8462,6 @@ Neither: A structural node that is simply a (visual) subdivision of a chunk
         </xsl:choose>
     </xsl:if>
     <xsl:text>\right.</xsl:text>
-    <xsl:call-template name="end-inline-math"/>
 </xsl:template>
 
 <!-- Chord Alteration -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5243,13 +5243,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- to be part of MathJax configuration, but   -->
 <!-- also free up the dollar sign               -->
 
-<!-- These two templates provide the delimiters for -->
-<!-- inline math, so we can adjust with overides.   -->
-<xsl:template name="begin-inline-math">
-    <xsl:text>\(</xsl:text>
-</xsl:template>
 
-<xsl:template name="end-inline-math">
+<!-- This template wraps inline math in delimiters -->
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
+    <xsl:text>\(</xsl:text>
+    <xsl:value-of select="$math"/>
     <xsl:text>\)</xsl:text>
 </xsl:template>
 
@@ -7698,9 +7697,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="."/>
     </xsl:variable>
     <xsl:variable name="math-pi">
-        <xsl:call-template name="begin-inline-math" />
-        <xsl:text>\pi</xsl:text>
-        <xsl:call-template name="end-inline-math" />
+        <xsl:call-template name="inline-math-wrapper">
+            <xsl:with-param name="math" select="'\pi'"/>
+        </xsl:call-template>
     </xsl:variable>
     <xsl:value-of select="str:replace($mag,'\pi',string($math-pi))"/>
 </xsl:template>
@@ -11812,10 +11811,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>latex-macros</xsl:text>
             </xsl:attribute>
         </xsl:if>
-        <xsl:call-template name="begin-inline-math" />
-        <xsl:value-of select="$latex-packages-mathjax" />
-        <xsl:value-of select="$latex-macros" />
-        <xsl:call-template name="end-inline-math" />
+        <xsl:call-template name="inline-math-wrapper">
+            <xsl:with-param name="math">
+                <xsl:value-of select="$latex-packages-mathjax"/>
+                <xsl:value-of select="$latex-macros"/>
+            </xsl:with-param>
+        </xsl:call-template>
     </div>
 </xsl:template>
 

--- a/xsl/pretext-json-manifest.xsl
+++ b/xsl/pretext-json-manifest.xsl
@@ -139,11 +139,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="containing-filename"/>
 </xsl:template>
 
-<!-- Necessary, override any definition in "pretext-tex.xsl" -->
-<xsl:template name="begin-inline-math">
+<!-- Necessary, override any definition in "pretext-text.xsl" -->
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
     <xsl:text>\(</xsl:text>
-</xsl:template>
-<xsl:template name="end-inline-math">
+    <xsl:value-of select="$math"/>
     <xsl:text>\)</xsl:text>
 </xsl:template>
 

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -368,11 +368,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:call-template name="markdown-cell">
         <xsl:with-param name="content">
             <xsl:call-template name="begin-string" />
-            <xsl:call-template name="begin-inline-math" />
-            <xsl:value-of select="$latex-packages-mathjax" />
-            <!-- Sequence replacements if \gt and/or \amp need to go -->
-            <xsl:value-of select="str:replace($latex-macros,'\newcommand{\lt}{&lt;}&#xa;', '')"/>
-            <xsl:call-template name="end-inline-math" />
+            <xsl:call-template name="inline-math-wrapper">
+                <xsl:with-param name="math">
+                    <xsl:value-of select="$latex-packages-mathjax" />
+                    <!-- Sequence replacements if \gt and/or \amp need to go -->
+                    <xsl:value-of select="str:replace($latex-macros,'\newcommand{\lt}{&lt;}&#xa;', '')"/>
+                </xsl:with-param>
+            </xsl:call-template>
             <xsl:call-template name="end-string" />
         </xsl:with-param>
     </xsl:call-template>
@@ -453,7 +455,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- breaks.  Replacements late in the conversion will make    -->
 <!-- these the "\n" acceptable in JSON.                        -->
 
-<!-- These two templates provide the delimiters for inline math.     -->
+<!-- This template wraps inline math in delimiters                   -->
 <!-- The Jupyter notebook appears to support the AMS-style for       -->
 <!-- inline math ( \(, \) ).  But in doing so, it fails to prevent   -->
 <!-- Markdown syntax from mucking up the math.  For example, two     -->
@@ -462,11 +464,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- be escaped, but easier to just deal with "plain text" dollar    -->
 <!-- signs as a possibility.  There is no issue for display          -->
 <!-- mathematics, presumably since we use environments, exclusively. -->
-<xsl:template name="begin-inline-math">
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
     <xsl:text>$</xsl:text>
-</xsl:template>
-
-<xsl:template name="end-inline-math">
+    <xsl:value-of select="$math"/>
     <xsl:text>$</xsl:text>
 </xsl:template>
 

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6579,13 +6579,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- items (titles, index), so use the "fixltx2e" package, -->
 <!-- which declares \MakeRobust\( and \MakeRobust\)        -->
 
-<!-- These two templates provide the delimiters for -->
-<!-- inline math, implementing abstract templates.  -->
-<xsl:template name="begin-inline-math">
+<!-- This template wraps inline math in delimiters -->
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
     <xsl:text>\(</xsl:text>
-</xsl:template>
-
-<xsl:template name="end-inline-math">
+    <xsl:value-of select="$math"/>
     <xsl:text>\)</xsl:text>
 </xsl:template>
 
@@ -10833,9 +10831,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="title-full"/>
     <xsl:call-template name="rangle-character"/>
     <xsl:text> </xsl:text>
-    <xsl:call-template name="begin-inline-math"/>
-    <xsl:text>\equiv</xsl:text>
-    <xsl:call-template name="end-inline-math"/>
+    <xsl:call-template name="inline-math-wrapper">
+        <xsl:with-param name="math" select="'\equiv'"/>
+    </xsl:call-template>
     <!-- sortby first, @ separator, then tt version -->
     <xsl:text>\index{</xsl:text>
     <xsl:value-of select="@xml:id" />

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -170,11 +170,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Until we think of something better, we just -->
 <!-- bracket raw LaTeX that appears inline       -->
 <!-- This can be overridden, if necessary        -->
-<xsl:template name="begin-inline-math">
+<xsl:template name="inline-math-wrapper">
+    <xsl:param name="math"/>
     <xsl:text>[</xsl:text>
-</xsl:template>
-
-<xsl:template name="end-inline-math">
+    <xsl:value-of select="$math"/>
     <xsl:text>]</xsl:text>
 </xsl:template>
 

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -107,10 +107,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- put macros and packages early for MJ to find         -->
             <!-- give the div an @id so we can trash it as a leftover -->
             <div id="latex-macros">
-                <xsl:call-template name="begin-inline-math"/>
-                <xsl:value-of select="$latex-packages-mathjax"/>
-                <xsl:value-of select="$latex-macros-html"/>
-                <xsl:call-template name="end-inline-math"/>
+                <xsl:call-template name="inline-math-wrapper">
+                    <xsl:with-param name="math">
+                        <xsl:value-of select="$latex-packages-mathjax"/>
+                        <xsl:value-of select="$latex-macros-html"/>
+                    </xsl:with-param>
+                </xsl:call-template>
             </div>
             <!-- modal template to bypass everything but math -->
             <xsl:apply-templates select="$root" mode="cruise"/>


### PR DESCRIPTION
…template

This removes `begin-inline-math` and `end-inline-math` templates across the board. It effectively replaces them with a wrapper template `inline-math-wrapper`, which needs to be defined in each of the "main" stylesheets just like `begin-inline-math` and `end-inline-math` needed to be.

The wrapper applies to element nodes in an obvious way.

At least once, there was a place where `begin-inline-math` and `end-inline-math` surrounded the printing of an attribute value. So the wrapper template applies to attributes too.

And several places, `begin-inline-math` and `end-inline-math` were used around a string. In such places, now `exsl:node-set` turns the string into a text() node variable, and then the wrapper template applies to that text() node.

With the sample article, I get no differences in latex.

I get one difference in HTML that is harmless, and possibly desirable depending on your point of view. Formerly, where math delimiters surround the defining of LaTeX macros, there was a line break at the end right before the closing `\)`. But now what happens is the whitespace cleaning removes that line break, so the `\)` is on the same line as the last macro definition.

I have not tested `-text`, `-json-manifest`, `-jupyter`, and `extract-math`. The changes are all very similar to some change in `-html` or `-latex`.

See mention of this idea in #1589 at https://github.com/rbeezer/mathbook/pull/1589#issuecomment-905768674