### PR TITLE
Worksheets: honor workspace on webwork exercise in HTML

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -4217,7 +4217,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:if>
             <!-- optionally, an indication of workspace -->
             <!-- for a print version of a worksheet     -->
-            <xsl:apply-templates select="." mode="worksheet-workspace"/>
+            <xsl:choose>
+                <xsl:when test="self::static">
+                    <xsl:apply-templates select="ancestor::exercise" mode="worksheet-workspace"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="." mode="worksheet-workspace"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:when>
         <!-- TODO: contained "if" should just be a new "when"? (look around for similar)" -->
         <xsl:otherwise>


### PR DESCRIPTION
If you author an `exercise` and put a `@workspace` on it, and you put a `webwork` in the exercise, the work space is not being recognized in HTML. This is because the template is matching on the `webwork-reps/static` and the `static` doesn't have the `@workspace`. This looks up to the `exercise` in that case.

It still doesn't address workspace on a task in a webwork, but that will be a larger project since the workspace will have to survive the trip to the WW server.