### PR TITLE
Mathword

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -11845,6 +11845,7 @@ the xsltproc executable.
                 </statement>
                 <solution xml:id="solution-antiderivative">
                     <p>An antiderivative of <m>x^2</m> is <m>F(x)=x^3/3</m>, so by the FTC,<me>\definiteintegral{2}{4}{x^2}{x}=F(4)-F(2)=\frac{1}{3}\left(4^3-2^3\right)=\frac{56}{3}</me>!?!      This is indeed an exciting result, but we are mostly interested in seeing that the sentence-ending punctuation is absorbed properly into the displayed equation.</p>
+                    <p>On a related note, we are interested in seeing that math-adjacent non-whitespace characters (not counting things like quote characters introduced by a <tag>q</tag> element) do not line break awkwardly, so we present some math <m>x</m>, some irrational numbers (<m>\pi</m>, <m>e</m>), and remind you that <m>\lim_{x\to0}\frac{\sin x}{x}</m> has <q><m>0/0</m></q>-indeterminate form. Also, <q>Beware the <m>x</m>-axis!</q></p>
                 </solution>
             </exercise>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5246,7 +5246,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- if we do this routinely for inline math also.  If MathJax ever     -->
 <!-- gets better at this, then we can set this switch to 'display',     -->
 <!-- as for LaTeX.                                                      -->
-<xsl:variable name="math.punctuation.include" select="'all'"/>
+<xsl:variable name="math.punctuation.include" select="'display'"/>
 
 <!-- Inline Mathematics ("m") -->
 
@@ -5256,6 +5256,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- to be part of MathJax configuration, but   -->
 <!-- also free up the dollar sign               -->
 
+<!-- Override the  template from -common so that we may wrap -->
+<!-- a nonbreaking span around adjacent text.                -->
+<xsl:template name="math-adjacent-text-wrapper">
+    <xsl:param name="content"/>
+    <span style="white-space: nowrap;">
+        <xsl:value-of select="$content"/>
+    </span>
+</xsl:template>
 
 <!-- This template wraps inline math in delimiters -->
 <xsl:template name="inline-math-wrapper">


### PR DESCRIPTION
This replaces #1589.

Summary: it scraps the punctuation pull-in for inline math. Replacing it with something that pulls in all adjacent text (both in front and behind). It does not put what it's pulled into the math delimiters. In `-common`, it just prints it before and after the math. But in `-html`, there is  an overriding template that uses a `span.mathword` styled for no line breaking.

No diff in the sample article LaTeX.

The diff with the sample article in HTML is good, replacing things like `\(3+4\text{.}\)` with `<span class="mathword">\(3+4\).</span>`. And things like `(\(\int\))` with `<span class="mathword">(\(\int\))</span>`.

There is a separate commit with an addition to the sample article to take a closer look. See the solution to 42a here:
http://spot.pcc.edu/~ajordan/temp/exercises.html
There is an `x,` and you should not be able to get the comma to move to the next line, even though the comma is not inside the math.

