### PR TITLE
Ww tikz intro

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -70,6 +70,7 @@ DTD = $(MB)/schema/dtd
 
 # XML to apply templates to
 SMPCHP = $(WWEXAMPLE)/sample-chapter/sample-chapter.xml
+SMPCHPPUB = $(WWEXAMPLE)/sample-chapter/publication.xml
 MINI = $(WWEXAMPLE)/minimal/mini.xml
 
 # These paths are subdirectories of
@@ -79,6 +80,7 @@ HTMLOUT    = $(SCRATCH)/html
 PDFOUT     = $(SCRATCH)/pdf
 EPUBOUT    = $(SCRATCH)/epub
 WWOUT      = $(SCRATCH)/webwork-representations
+IMGOUT     = $(SCRATCH)/images
 
 # Some aspects of producing these examples require a WeBWorK server.
 # Either specify only the protocol and domain (like https://webwork.yourschool.edu)
@@ -100,6 +102,15 @@ SERVER = https://webwork-ptx.aimath.org
 #  webwork-representations.xml which holds multiple versions of each problem.
 #  Also locally store images from the WeBWorK server.
 
+#  BUILD TREE FOR SAMPLE CHAPTER
+#  make sample-chapter-check
+#  make sample-chapter-representations
+#      make sample-chapter-images
+#          make sample-chapter-html
+#          make samepl-chapter-epub (planned)
+#      make sample-chapter-pdf
+#      make sample-chapter-problem-sets
+
 #  For HTML and problem set output, we turn off dates in file headers,
 #  so when we use these for testing we can get more accurate diffs.
 #  Dates are useful for single file output (or at least less of an
@@ -109,7 +120,7 @@ SERVER = https://webwork-ptx.aimath.org
 
 sample-chapter-representations:
 	install -d $(WWOUT)
-	-rm $(WWOUT)/webwork-representations.ptx
+	-rm $(WWOUT)/*.*
 	$(MB)/pretext/pretext -v -c webwork -d $(WWOUT) -s $(SERVER) $(SMPCHP)
 
 mini-representations:
@@ -117,8 +128,8 @@ mini-representations:
 	-rm $(WWOUT)/webwork-representations.ptx
 	$(MB)/pretext/pretext -v -c webwork -d $(WWOUT) -s $(SERVER) $(MINI)
 
+
 # LaTeX and PDF versions
-# See prerequisite above about merge files.
 # xsltproc may be passed --stringparam latex.fillin.style box for box answer blanks
 
 sample-chapter-pdf:
@@ -146,13 +157,22 @@ mini-pdf:
 	xelatex webwork-mini.tex; \
 	xelatex webwork-mini.tex; \
 
+
+# Generated images (excluding the ones that the WW server generates)
+sample-chapter-images:
+	install -d $(WWOUT)
+	-rm -r $(IMGOUT) || :
+	install -d $(IMGOUT)
+	$(MB)/pretext/pretext -c latex-image -p $(SMPCHPPUB) -f all -d $(IMGOUT) $(SMPCHP)
+
+
 # HTML output
-# See prerequisite above about merge files.
 sample-chapter-html:
 	install -d $(HTMLOUT)
 	-rm $(HTMLOUT)/*.html
 	-rm $(HTMLOUT)/knowl/*.html
 	cp -a $(WWEXAMPLE)/sample-chapter/images $(HTMLOUT)
+	cp -a $(IMGOUT)/*.svg $(HTMLOUT)/images
 	cp -a $(WWOUT)/*.svg $(HTMLOUT)/images
 	cp -a $(WWOUT)/*.png $(HTMLOUT)/images
 	cp $(WWOUT)/webwork-representations.ptx $(WWEXAMPLE)/sample-chapter
@@ -170,7 +190,7 @@ mini-html:
 #  Make an archive of webwork problem sets for each "section" (as specified
 #  by chunk level) with set definition files, set header files, and problem
 #  files in a file tree. Separate problem sets for inline and divisional
-#  problems. Requires the merged PTX file from above.
+#  problems.
 
 sample-chapter-problem-sets:
 	install -d $(PGOUT)

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -64,6 +64,10 @@
              <!-- <text>My Button Text</text>  -->
         </feedback>
 
+        <latex-image-preamble>
+            \usepackage{tikz}
+        </latex-image-preamble>
+
         <latex-image-preamble syntax="PGtikz">
             \usepackage{pgfplots}
             \pgfplotsset{

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1389,10 +1389,28 @@
                                 \end{axis}
                             </latex-image>
                         </image>
+                        <!-- same thing, just to have a 2nd graph for testing -->
+                        <image width="50%">
+                            <latex-image syntax="PGtikz">
+                                \begin{axis}
+                                    \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
+                                \end{axis}
+                            </latex-image>
+                        </image>
                         <p>
                             <var name="$answer" width="20"/>
                         </p>
                     </statement>
+                    <solution>
+                        <!-- same thing, just to have a 3rd graph for testing -->
+                        <image width="50%">
+                            <latex-image syntax="PGtikz">
+                                \begin{axis}
+                                    \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
+                                \end{axis}
+                            </latex-image>
+                        </image>
+                    </solution>
                 </webwork>
             </exercise>
 
@@ -1404,9 +1422,6 @@
                     </p>
                 </introduction>
                 <webwork>
-                    <pg-code>
-                        $refreshCachedImages = 1;
-                    </pg-code>
                     <statement>
                         <p>
                             The code below has a printed dollar sign, a printed percent sign,
@@ -1481,6 +1496,59 @@
                     </solution>
                 </webwork>
             </exercise>
+
+            <exercises>
+                <exercisegroup cols="2">
+                    <introduction>
+                        <p>
+                            This exercisegroup has a PGtikz image in its introduction.
+                        </p>
+                        <image width="50%">
+                          <latex-image syntax="PGtikz">
+                            \draw (0,0) --++ (4,0) node[below,pos=0.5] {\(L\)} --++ (0,3) node[right,pos=0.5] {\(W\)} --++ (-4,-3) node[above,sloped,pos=0.5] {\(D\)} --++ (0,3) --++ (4,0);
+                          </latex-image>
+                        </image>
+                    </introduction>
+                    <exercise>
+                        <webwork>
+                            <statement>
+                                <p>
+                                    Find <m>D</m> when <m>L=4</m> and <m>W=3</m>.
+                                </p>
+                                <p>
+                                    <var name="'5'" width="10"/>
+                                </p>
+                            </statement>
+                            <solution>
+                                <image>
+                                  <latex-image syntax="PGtikz">
+                                    \draw (0,0) --++ (4,0) node[below,pos=0.5] {\(4\)} --++ (0,3) node[right,pos=0.5] {\(3\)} --++ (-4,-3) node[above,sloped,pos=0.5] {\(5\)} --++ (0,3) --++ (4,0);
+                                  </latex-image>
+                                </image>
+                            </solution>
+                        </webwork>
+                    </exercise>
+                    <exercise>
+                        <webwork>
+                            <statement>
+                                <p>
+                                    Find <m>D</m> when <m>L=12</m> and <m>W=5</m>.
+                                </p>
+                                <p>
+                                    <var name="'13'" width="10"/>
+                                </p>
+                            </statement>
+                            <solution>
+                                <image>
+                                  <latex-image syntax="PGtikz">
+                                    \draw (0,0) --++ (4,0) node[below,pos=0.5] {\(12\)} --++ (0,3) node[right,pos=0.5] {\(5\)} --++ (-4,-3) node[above,sloped,pos=0.5] {\(13\)} --++ (0,3) --++ (4,0);
+                                  </latex-image>
+                                </image>
+                            </solution>
+                        </webwork>
+                    </exercise>
+                </exercisegroup>
+            </exercises>
         </section>
 
         <section>

--- a/xsl/extract-latex-image.xsl
+++ b/xsl/extract-latex-image.xsl
@@ -228,7 +228,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
         <xsl:text>\usepackage{amsmath,amssymb}&#xa;</xsl:text>
-        <xsl:value-of select="$latex-image-preamble"/>
+        <xsl:choose>
+            <xsl:when test="latex-image[@syntax='PGtikz']">
+                <xsl:value-of select="$latex-image-preamble-PGtikz"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$latex-image-preamble"/>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:text>\ifdefined\tikzset&#xa;</xsl:text>
         <xsl:text>\tikzset{ampersand replacement = \amp}&#xa;</xsl:text>
         <xsl:text>\fi&#xa;</xsl:text>
@@ -239,7 +246,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- We save off the code for discovery and possible          -->
         <!-- manipulation for scaling and spacing as tactile graphics -->
         <xsl:variable name="the-latex-image">
-            <xsl:apply-templates select="latex-image"/>
+            <xsl:choose>
+                <xsl:when test="parent::introduction/parent::exercisegroup and latex-image[@syntax='PGtikz']">
+                    <xsl:text>\begin{tikzpicture}</xsl:text>
+                    <xsl:apply-templates select="latex-image"/>
+                    <xsl:text>\end{tikzpicture}</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="latex-image"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:variable>
         <!-- Analyze the type of image we have, and save markers as universal  -->
         <!-- variables.  An empty result will signal a "latex-image" we cannot -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2067,6 +2067,17 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:variable>
 
+<xsl:variable name="latex-image-preamble-PGtikz">
+    <xsl:choose>
+        <xsl:when test="$docinfo/latex-image-preamble[@syntax='PGtikz']">
+            <xsl:call-template name="sanitize-text">
+                <xsl:with-param name="text" select="$docinfo/latex-image-preamble[@syntax='PGtikz'][1]" />
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise/>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- ############## -->
 <!-- LaTeX Preamble -->
 <!-- ############## -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -8980,6 +8980,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}%&#xa;</xsl:text>
 </xsl:template>
 
+<xsl:template match="image[latex-image/@syntax='PGtikz']" mode="image-inclusion">
+    <!-- Only applies to images in an exercisegroup/introduction -->
+    <!-- where there are webwork exercises. These need the       -->
+    <!-- tikzpicture environment wrapped around it.              -->
+    <xsl:text>\resizebox{\linewidth}{!}{%&#xa;</xsl:text>
+    <xsl:text>\begin{tikzpicture}&#xa;</xsl:text>
+    <xsl:apply-templates select="latex-image"/>
+    <xsl:text>\end{tikzpicture}&#xa;</xsl:text>
+    <xsl:text>}%&#xa;</xsl:text>
+</xsl:template>
+
 <!-- EXPERIMENTAL -->
 <!-- We allow some mark-up inside the "latex-image" element, -->
 <!-- which was formerly assumed to be purely text.  Then we  -->


### PR DESCRIPTION
Second commit here adds a `PGtikz` image to an exercisegroup's introduction. 

First commit lays down the infrastructure to make it happen.

They are separated to help you do a before/after diff. It is expected that you will see changes. In particular, the names for the perl variables storing each image get a new numbering scheme, local to their problem.

When #1606 is resolved, I may have related documentation to add. I started that here, but soon realized it would conflict.