### PR TITLE
html: Add versioning which helps avoid cached js and css files

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11767,7 +11767,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{$html.js.server}/js/lib/jquery.sticky.js" ></script>
     <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
-    <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js"></script>
+    <script>miniversion=0.6</script>
+    <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js?x=1"></script>
 </xsl:template>
 
 <!-- Font header -->


### PR DESCRIPTION
Small change which helps developers avoid aggressive caching of Javascript files.

Changing this line in pretext-html.xsl
`<script>miniversion=0.6</script>`
will force reloading of various dynamically added files.

Changing this line
`<script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js?x=1"></script>`
will force reloading the main `pretext_add_on.js` file.

No doubt there are better ways, but this seems to be adequate for now.