### PR TITLE
WeBWorK: document using pg-code for statement

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -65,7 +65,7 @@
     </introduction>
 
     <subsection>
-      <title>Using an Existing <webwork/> Problem</title>
+      <title>Using a <webwork/> Problem from the Host Course</title>
       <p>
         If a problem already exists and is accessible from the hosting course's <c>templates/</c> folder,
         then you can simply include it as a <attr>source</attr> attribute.
@@ -162,7 +162,7 @@
         requires using a <tag>pg-code</tag> tag.
         Having at least a little familiarity with coding problems in <webwork/> is necessary,
         although for simpler problems you could get away with mimicking the sample article in <c>mathbook/examples/webwork/</c>.
-        A <tag>statement</tag>, <em>optional</em> <tag>hint</tag>, and <em>optional</em> <tag>solution</tag> follow.
+        An <em>optional</em> <tag>statement</tag>, <em>optional</em> <tag>hint</tag>, and <em>optional</em> <tag>solution</tag> follow.
       </p>
       <pre>
         <![CDATA[
@@ -184,9 +184,17 @@
         ]]>
       </pre>
       <p>
-        If you are familiar with code for <webwork/> PG problems, the <tag>pg-code</tag> contains lines of PG code
-        that would appear in the <q>setup</q> portion of the problem.
-        Typically, this is the code that follows <c>TEXT(beginproblem());</c> and precedes the first <c>BEGIN_TEXT</c> or <c>BEGIN_PGML</c>.
+        Of course exercises should have statements, so if you do not include a <tag>statement</tag> element,
+        then the <tag>pg-code</tag> element should include code that prints the statement.
+        If neither kind of statement is present, there will be an error message when <pretext/>
+        proceesses the problem.
+      </p>
+      <p>
+        The <tag>pg-code</tag> contains lines of PG code
+        that would appear in the <q>setup</q> portion of a problem.
+        Possibly, it also contains code that prints a statement, hint, and/or solution.
+      </p>
+      <p>
         If your code needs any special <webwork/> macro libraries,
         you may load them in a <tag>pg-macros</tag> tag prior to <tag>pg-code</tag>,
         with each such <c>.pl</c> file's name inside a <tag>macro-file</tag> tag.
@@ -194,7 +202,8 @@
         based on the content and attributes you use in the rest of your problem.
       </p>
       <p>
-        Here is a small example. Following the example, we'll continue discussing <tag>statement</tag> and <tag>solution</tag>.
+        Here are two small examples. Following these examples,
+        we'll continue discussing <tag>statement</tag> and <tag>solution</tag>.
       </p>
       <pre>
         <![CDATA[
@@ -218,6 +227,36 @@
         </webwork>
         ]]>
       </pre>
+      <p>
+        Here is the same exercise, with the statement and solution coded directly using PG.
+      </p>
+      <pre>
+        <![CDATA[
+        <webwork>
+          <pg-macros>
+            <macro-file>PCC
+          <pg-code>
+            Context("LimitedNumeric");
+            $a = Compute(random(1, 9, 1));
+            $b = Compute(random(1, 9, 1));
+            $c = $a + $b;
+
+            BEGIN_PGML
+            Compute [`[$a] + [$b]`].
+
+            [@KeyboardInstructions('Type your answer without using the [|+|]* sign.')@]**
+
+            The sum is [_]{$c}{2}.
+            END_PGML
+
+            BEGIN_PGML_SOLUTION
+            [`[$a] + [$b] = [$c]`]
+            END_PGML_SOLUTION
+          </pg-code>
+        </webwork>
+        ]]>
+      </pre>
+
       <p>
         Within a <tag>statement</tag>, <tag>hint</tag>, or <tag>solution</tag>, reference <tag>var</tag> tags by <attr>name</attr>.
       </p>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -176,6 +176,50 @@
 
             </exercise>
 
+            <p>
+                You may author the statement using <pretext/> code,
+                as the examples above do using a <tag>statement</tag> element.
+                Or you may author the statement directly by continuing the
+                <tag>pg-code</tag> element.
+            </p>
+
+            <exercise xml:id="all-pg">
+                <title>All PG code, No Statement</title>
+                <webwork>
+                    <pg-code>
+                        Context("Numeric");
+                        $f = Formula("cos^2(x)+sin^2(x)");
+                        BEGIN_PGML
+                        [`[$f]`] is equal to [_______]{Real(1)}.
+                        END_PGML
+                    </pg-code>
+                </webwork>
+            </exercise>
+
+            <p>
+                Any <tag>statement</tag>, <tag>solution</tag>, or <tag>hint</tag>
+                that follows the <tag>pg-code</tag> will be converted to PG before a <webwork/> renderer processes it.
+            </p>
+
+            <exercise xml:id="pg-statement-ptx-solution">
+                <title>PG Statement, PTX Solution</title>
+                <webwork>
+                    <pg-code>
+                        Context("Numeric");
+                        $f = Formula("cos^2(x)+sin^2(x)");
+                        BEGIN_PGML
+                        [`[$f]`] is equal to [_______]{Real(1)}.
+                        END_PGML
+                    </pg-code>
+                    <solution>
+                        <p>
+                            By the Pythagorean Theorem,
+                            this is <m>1</m>.
+                        </p>
+                    </solution>
+                </webwork>
+            </exercise>
+
             <exercise xml:id="integer-addition-with-control-seed">
                 <title>Controlling Randomness</title>
 

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -107,7 +107,7 @@
     <xsl:text>pgdense['hint_no_solution_yes'] = {}&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_no'] = {}&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_yes'] = {}&#xa;</xsl:text>
-    <xsl:apply-templates select="$document-root//webwork[statement|task|stage|@source]" mode="dictionaries"/>
+    <xsl:apply-templates select="$document-root//webwork[pg-code|statement|task|stage|@source]" mode="dictionaries"/>
 </xsl:template>
 
 <xsl:template match="webwork[@source]" mode="dictionaries">
@@ -133,7 +133,7 @@
     <xsl:text>"&#xa;</xsl:text>
 </xsl:template>
 
-<xsl:template match="webwork[statement|task|stage]" mode="dictionaries">
+<xsl:template match="webwork[pg-code|statement|task|stage]" mode="dictionaries">
     <!-- Define values for the visible-id as key -->
     <xsl:variable name="problem">
         <xsl:apply-templates select="." mode="visible-id" />
@@ -290,7 +290,7 @@
 <!-- level templates follow.                                               -->
 
 
-<xsl:template match="webwork[statement]">
+<xsl:template match="webwork[pg-code|statement]">
     <xsl:param name="b-hint" />
     <xsl:param name="b-solution" />
     <xsl:param name="b-human-readable" />
@@ -848,7 +848,7 @@
         </xsl:if>
         <!-- instructions for entering answers into HTML forms -->
         <!-- utility for randomly generating variable letters -->
-        <xsl:if test=".//instruction or contains(.//pg-code,'RandomVariableName') or contains(.//pg-code,'RandomName') or contains(.//pg-code,'numberWord')">
+        <xsl:if test=".//instruction or contains(.//pg-code,'KeyboardInstructions') or contains(.//pg-code,'RandomVariableName') or contains(.//pg-code,'RandomName') or contains(.//pg-code,'numberWord')">
             <xsl:call-template name="macro-padding">
                 <xsl:with-param name="string" select="'PCCmacros.pl'"/>
                 <xsl:with-param name="b-human-readable" select="$b-human-readable"/>


### PR DESCRIPTION
This documents a feature we have always had*, but I only realized it recently. Formerly we thought of the `pg-code` element as purely for setup code. But there is no reason it cannot include the statement, hint, solution with these things coded using PG directly.

Why would we want this? There is a barrier to using WeBWorK in more books. People can't simply copy-paste more of their PG (or PG taken from online references) into the PTX source. Having to translate some existing PG over to PTX statement, hint, solution can be a burden in some cases. (Even while in other cases, coding it in PTX is more pleasant.)

I acknowledge that this will allow authors to slip features into WW exercises for which we do not have a PTX counterpart. But no more so than with `.pg` problem files that live on the server, which we mostly support. And then we examine the static PTX that comes back looking for bad XML/PTX. Also the WW server drops comments that such and such a feature (eg horizontal rule) does not even have a PTX counterpart. 

*Well, it wasn't really there until with this commit, that adds `webwork[pg-code]` to some template matches.