### PR TITLE
remove old alert-warning classes

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -542,7 +542,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="the-id">
         <xsl:apply-templates select="parent::exercise" mode="html-id"/>
     </xsl:variable>
-    <div class="runestone alert alert-warning">
+    <div class="runestone ">
         <!-- ul can have multiple answer attribute -->
         <ul data-component="multiplechoice" data-multipleanswers="false">
             <xsl:attribute name="id">
@@ -607,7 +607,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="the-id">
         <xsl:apply-templates select="parent::exercise" mode="html-id"/>
     </xsl:variable>
-    <div class="runestone alert alert-warning">
+    <div class="runestone ">
         <!-- ul can have multiple answer attribute -->
         <ul data-component="multiplechoice">
             <xsl:attribute name="id">
@@ -682,7 +682,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- determine this option before context switches -->
     <xsl:variable name="b-natural" select="not(parent::exercise/@language) or (parent::exercise/@language = 'natural')"/>
     <div class="runestone" style="max-width: none;">
-        <div data-component="parsons" class="alert alert-warning parsons">
+        <div data-component="parsons" class=" parsons">
             <xsl:attribute name="id">
                 <xsl:apply-templates select="parent::exercise" mode="html-id"/>
             </xsl:attribute>
@@ -957,7 +957,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- this is the logical negation of the previous, so could be "otherwise" -->
         <xsl:when test="($hosting = 'browser') or $b-host-runestone">
-            <div class="runestone explainer ac_section alert alert-warning">
+            <div class="runestone explainer ac_section ">
                 <div data-component="activecode">
                     <xsl:attribute name="id">
                         <xsl:value-of select="$hid"/>

--- a/xsl/support/runestone-services.xml
+++ b/xsl/support/runestone-services.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <all>
     <js type="list">
-        <item type="str">runtime.dae47fcea5a0b194.bundle.js</item>
-        <item type="str">637.d54be67956c5c660.bundle.js</item>
-        <item type="str">runestone.61f83a67b708750a.bundle.js</item>
-    </js>
+        <item type="str">runtime.45581e16620a950c.bundle.js</item>
+	<item type="str">vendors-node_modules_bootstrap_dist_js_bootstrap_js-node_modules_jquery-ui_jquery-ui_js-node_-72cd89.51d9dde4e5162190.bundle.js</item>
+	<item type="str">runestone.7ebb98f3907a79d3.bundle.js</item>
+	</js>
     <css type="list">
-        <item type="str">637.fafafbd97df8a0d1.css</item>
-        <item type="str">runestone.d062db89aaf1dddd.css</item>
+	<item type="str">vendors-node_modules_bootstrap_dist_js_bootstrap_js-node_modules_jquery-ui_jquery-ui_js-node_-72cd89.cd688d1623c9932e.css</item>
+	<item type="str">runestone.2c801624658a5cbb.css</item>
     </css>
     <cdn-url type="str">https://runestone.academy/cdn/runestone/</cdn-url>
-    <version type="str">6.0.8</version>
+    <version type="str">test</version>
 </all>


### PR DESCRIPTION
This removes old class names from the runestone component top level container.

Points the "web" build at a test build that has updated javascript and css for a new look that does not style components using the old alert-warning class for component backgrounds.
