### PR TITLE
WeBWorK: remove p whose only child is a fillin when first writing sta…

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1044,8 +1044,8 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                 os.remove(os.path.join(ww_images_dir, ptx_image_filename))
 
         # Start appending XML children
-        # Use "webwork-reps" as parent tag for the various representations of a problem
         response_root = ET.fromstring(response_text)
+        # Use "webwork-reps" as parent tag for the various representations of a problem
         webwork_reps = ET.SubElement(webwork_representations,'webwork-reps')
         webwork_reps.set('version',ww_reps_version)
         webwork_reps.set("{%s}id" % (XML),'extracted-' + problem)
@@ -1141,6 +1141,10 @@ def webwork_to_xml(xml_source, pub_file, stringparams, abort_early, server_param
                             solution.append(chcopy)
 
         static_webwork_level(static,response_root)
+        # Remove elements we'd rather not keep
+        # p with only a single fillin, not counting those inside an li without preceding siblings
+        for unwanted in static.xpath("//p[not(normalize-space(text()))][count(fillin)=1 and count(*)=1][not(parent::li) or (parent::li and preceding-sibling::*)]"):
+            unwanted.getparent().remove(unwanted)
 
         # Add elements for interactivity
         if (ww_reps_version == '2'):

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10419,15 +10419,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </xsl:template>
 
-<!-- In WeBWorK problems, a p whose only child is a fillin blank     -->
-<!-- almost certainly means a question has been asked, and below it  -->
-<!-- there is an entry field. In print, there is no need to print    -->
-<!-- that entry field and removing it can save a lot of vertical     -->
-<!-- space. This is in constrast with fillins in the middle of a p,  -->
-<!-- where answer blanks need to be printed because of the fill      -->
-<!-- in the blank nature of the quesiton.                            -->
-<xsl:template match="p[not(normalize-space(text()))][count(fillin)=1 and count(*)=1][not(parent::li)]|p[not(normalize-space(text()))][count(fillin)=1 and count(*)=1][parent::li][preceding-sibling::*]" />
-
 <!-- ############################# -->
 <!-- MyOpenMath Embedded Exercises -->
 <!-- ############################# -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6688,18 +6688,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%&#xa;</xsl:text>
 </xsl:template>
 
-<!-- In WeBWorK problems, a p whose only child is a fillin blank     -->
-<!-- almost certainly means a question has been asked, and below it  -->
-<!-- there is an entry field. In print, there is no need to print    -->
-<!-- that entry field and removing it can save a lot of vertical     -->
-<!-- space. This is in constrast with fillins in the middle of a p,  -->
-<!-- where answer blanks need to be printed because of the fill      -->
-<!-- in the blank nature of the quesiton.                            -->
-<xsl:template match="p[not(normalize-space(text()))][count(fillin)=1 and count(*)=1][not(parent::li)]|p[not(normalize-space(text()))][count(fillin)=1 and count(*)=1][parent::li][preceding-sibling::*]" />
-
-
-
-
 <!-- For a memo, not indenting the first paragraph helps -->
 <!-- with alignment and the to/from/subject/date block   -->
 <!-- TODO: maybe memo header should set this up          -->


### PR DESCRIPTION
…tic representation

As discussed in drop-in today. Right before writing WW representations to disk, eliminate any p whose only child is a fillin. Except don't do that when the p is inside an li. Except do do that if there is a preceding sibling.

And then we can remove the expensive templates in -latex and -html.

Only diff in representations file is removal of those p, as expected.

Sample article goes from 28905 ms down to 13949 ms for building .tex!