### PR TITLE
WeBWorK: declare server and credentials using publication file

### DIFF
--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -213,7 +213,7 @@
       </p>
       <console>
         <prompt>$ </prompt>
-        <input>pretext -c webwork -p &lt;publisher&gt; -s &lt;server&gt; aota.ptx</input>
+        <input>pretext -c webwork -p &lt;publisher&gt; aota.ptx</input>
       </console>
       <p>
         <c>aota.ptx</c> in the example is the root file for your <pretext/> project.
@@ -231,21 +231,12 @@
       </p>
       <p>
         <c>-p</c> specifies the publication file, as described in <xref ref="publication-file-reference"/>.
-      </p>
-      <p>
-        <c>-s</c> specifies the <webwork/> server.
-        The <webwork/> server needs to be version 2.14 or later, specified with its protocol and domain,
-        like <c>https://webwork-ptx.aimath.org</c>.
-        It is <em>important</em> to get the protocol correct for your server (<c>http</c> versus <c>https</c>).
-        If you do not have a server, you may use <c>https://webwork-ptx.aimath.org</c>.
-      </p>
-      <p>
-        If any of your hosting course, user for that course, password for the site, or password for the course user are not <q>anonymous</q>,
-        then specify the server like
-        <cd>-s "(https://webwork-ptx.aimath.org,courseID,userID,site_password,course_password)"</cd>
-        The <c>site_password</c> is probably <q>anonymous</q>,
-        but could be something different. Only server administrators can set this.
-        Again, it is <em>important</em> to get the protocol correct for your server (<c>http</c> versus <c>https</c>).
+        In the publication file, the element <tag>webwork</tag> may have attributes <attr>server</attr>,
+        <attr>course</attr>, <attr>coursepassword</attr>, <attr>user</attr>, and <attr>userpassword</attr>.
+        If absent, these default to <c>https://webwork-ptx.aimath.org</c>, <c>anonymous</c>, <c>anonymous</c>,
+        <c>anonymous</c>, and <c>anonymous</c> respectively. If you specify a server, you must correctly
+        specify the protocol (<c>http</c> versus <c>https</c>). And it must be version 2.14 or later.
+        Do not include a trailing slash.
       </p>
     </subsection>
 

--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -83,14 +83,6 @@ HTMLOUT    = $(SCRATCH)/html
 EPUBOUT    = $(SCRATCH)/epub
 PGOUT      = $(SCRATCH)/pg
 
-# Some aspects of producing these examples require a WeBWorK server.
-# Either specify only the protocol and domain (like https://webwork.yourschool.edu)
-# or specify a 5-tuple with quotes exactly as in this example
-# SERVER = "(https://webwork-ptx.aimath.org,courseID,userID,password,course_password)"
-# NOTE: it is IMPORTANT to get the protocol correct for your server (HTTP versus HTTPS)
-SERVER = https://webwork-ptx.aimath.org
-
-
 
 ##################
 # Targets for make
@@ -113,10 +105,10 @@ SERVER = https://webwork-ptx.aimath.org
 #  within "webwork" subfolder
 
 sample-chapter-representations:
-	$(PTX)/pretext/pretext -v -c webwork -p $(SMPCPUB) -s $(SERVER) $(SMPC)
+	$(PTX)/pretext/pretext -v -c webwork -p $(SMPCPUB) $(SMPC)
 
 mini-representations:
-	$(PTX)/pretext/pretext -v -c webwork -p $(MINIPUB) -s $(SERVER) $(MINI)
+	$(PTX)/pretext/pretext -v -c webwork -p $(MINIPUB) $(MINI)
 
 
 #########################################################################
@@ -219,13 +211,13 @@ WWOUT        = $(SCRATCH)/webwork-representations
 sample-chapter-representations-not-managed:
 	-rm -r $(WWOUT)
 	install -d $(WWOUT)
-	$(PTX)/pretext/pretext -vv -c webwork -d $(WWOUT) -s $(SERVER) $(SMPC)
+	$(PTX)/pretext/pretext -vv -c webwork -p $(SMPCPUBNOMAN) -d $(WWOUT) $(SMPC)
 
 # DO NOT MODEL YOUR PROJECT AFTER THIS
 mini-representations-not-managed:
 	-rm -r $(WWOUT)
 	install -d $(WWOUT)
-	$(PTX)/pretext/pretext -vv -c webwork -d $(WWOUT) -s $(SERVER) $(MINI)
+	$(PTX)/pretext/pretext -vv -c webwork -p $(MINIPUBNOMAN) -d $(WWOUT) $(MINI)
 
 
 #########################################################################

--- a/examples/webwork/sample-chapter/publication.xml
+++ b/examples/webwork/sample-chapter/publication.xml
@@ -25,4 +25,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
       <directories generated="generated" external="external"/>
     </source>
 
+    <!-- These are the defaults but written explicitly here to serve as a model. -->
+    <webwork
+        server="https://webwork-ptx.aimath.org"
+        course="anonymous"
+        coursepassword="anonymous"
+        user="anonymous"
+        userpassword="anonymous"
+        />
+
 </publication>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -96,6 +96,27 @@
     <xsl:text>localization = '</xsl:text>
     <xsl:value-of select="$document-language"/>
     <xsl:text>'&#xa;</xsl:text>
+    <!-- Record the server address and credentials from publisher variables -->
+    <!-- This will be an empty dictionary if there was no publication file. -->
+    <xsl:text>server_params_pub = {&#xa;</xsl:text>
+    <xsl:if test="$publisher">
+        <xsl:text>    "ww_domain":"</xsl:text>
+        <xsl:value-of select="$webwork-server"/>
+        <xsl:text>",&#xa;</xsl:text>
+        <xsl:text>    "courseID":"</xsl:text>
+        <xsl:value-of select="$webwork-course"/>
+        <xsl:text>",&#xa;</xsl:text>
+        <xsl:text>    "userID":"</xsl:text>
+        <xsl:value-of select="$webwork-user"/>
+        <xsl:text>",&#xa;</xsl:text>
+        <xsl:text>    "password":"</xsl:text>
+        <xsl:value-of select="$webwork-userpassword"/>
+        <xsl:text>",&#xa;</xsl:text>
+        <xsl:text>    "course_password":"</xsl:text>
+        <xsl:value-of select="$webwork-coursepassword"/>
+        <xsl:text>"&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:text>}&#xa;</xsl:text>
     <!-- Initialize empty dictionaries, then define key-value pairs -->
     <xsl:text>origin = {}&#xa;</xsl:text>
     <xsl:text>copiedfrom = {}&#xa;</xsl:text>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1116,6 +1116,59 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
+<!-- WeBWorK server location and credentials for the daemon course -->
+<xsl:variable name="webwork-server">
+    <xsl:choose>
+        <xsl:when test="$publication/webwork/@server">
+            <xsl:value-of select="$publication/webwork/@server"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>https://webwork-ptx.aimath.org</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="webwork-course">
+    <xsl:choose>
+        <xsl:when test="$publication/webwork/@course">
+            <xsl:value-of select="$publication/webwork/@course"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>anonymous</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="webwork-coursepassword">
+    <xsl:choose>
+        <xsl:when test="$publication/webwork/@coursepassword">
+            <xsl:value-of select="$publication/webwork/@coursepassword"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>anonymous</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="webwork-user">
+    <xsl:choose>
+        <xsl:when test="$publication/webwork/@user">
+            <xsl:value-of select="$publication/webwork/@user"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>anonymous</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="webwork-userpassword">
+    <xsl:choose>
+        <xsl:when test="$publication/webwork/@userpassword">
+            <xsl:value-of select="$publication/webwork/@userpassword"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>anonymous</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+
 <!-- WeBWork problem representations are formed by the           -->
 <!-- pretext/pretext script communicating with a WeBWorK server. -->
 <xsl:variable name="webwork-representations-file">


### PR DESCRIPTION
Makes it so that the WeBWorK server and corresponding credentials can be (should be) handled using the publication file.

If the old way (`-s`) is still used along with a publication file, there is a warning that the `-s` argument will be ignored.

If the old way is used without a publication file, there is a suggestion to start using a publication file.

This is accomplished by `extract-pg.xsl`, which has access to the publisher variables, writing out the server parameters into a python dictionary. Later in the python routine, these are used (when present) to identify the WW server. When absent, it relies on the `-s` argument.

Documentation in the publisher guide (webwork section) is updated.