### PR TITLE
Guide: Correct publication file element name for project component visibility

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -81,7 +81,7 @@
                         <cell><attr>statement</attr>, <attr>hint</attr>, <attr>answer</attr>, <attr>solution</attr></cell>
                     </row>
                     <row>
-                        <cell><c>common/project</c></cell>
+                        <cell><c>common/exercise-project</c></cell>
                         <cell><attr>statement</attr>, <attr>hint</attr>, <attr>answer</attr>, <attr>solution</attr></cell>
                     </row>
                 </tabular>


### PR DESCRIPTION
The section of the Guide on using the publication file to control exercise component visibility has a bit of a contradictory statement regarding using `project` or `exercise-project` as the element name in the publication file. Just using `project` as the tabular calls for at present results in `exploration` not hiding all the things that are set to `no`, even though `project` appears to do what is expected. By using `exercise-project` in the publication file, this behavior is unified across `project` and `exploration`. It's possible that this PR is in error and something should be changed in the processing of the publication file, but this seems to get things into the state that is described before the tabular.