### PR TITLE
WWSC: Makefile .tex recipe

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -125,6 +125,19 @@ mini-pdf:
 	install -d $(PDFOUT)
 	$(PTX)/pretext/pretext -vv -c all -f pdf -p $(MINIPUB) -d $(PDFOUT) $(MINI)
 
+#########################################################################
+# TeX versions
+# use -x latex.fillin.style box for box answer blanks instead of underlines
+
+sample-chapter-latex:
+	-rm -r $(PDFOUT)
+	install -d $(PDFOUT)
+	$(PTX)/pretext/pretext -vv -c all -f latex -p $(SMPCPUB) -d $(PDFOUT) $(SMPC)
+
+mini-latex:
+	-rm -r $(PDFOUT)
+	install -d $(PDFOUT)
+	$(PTX)/pretext/pretext -vv -c all -f latex -p $(MINIPUB) -d $(PDFOUT) $(MINI)
 
 #########################################################################
 # HTML output


### PR DESCRIPTION
This gives

`make mini-latex`

`make sample-chapter-latex`

which will drop .tex files in the scratch PDF folder.