### PR TITLE
Fillin overhaul

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -760,7 +760,7 @@
 
             <paragraphs>
                 <title><tage>fillin</tage>, <fillin characters="5" />, fill-in blank</title>
-                <p>A <q>fill in the blank</q> blank.  While meant for use with normal text, it may also be used within mathematics contexts.  The <attr>characters</attr> attribute may be used to hint at how long the line will be, should the default value of 10 be too long or too short.  Here we have set <attr>characters</attr> to the value <c>5</c>.</p>
+                <p>A <q>fill in the blank</q> blank.  May be used in normal text or within mathematics contexts.  The <attr>characters</attr> attribute may be used to hint at how long the line will be.  Here we have set <attr>characters</attr> to the value <c>5</c>. If used inside math, a <attr>fill</attr> attribute (in lieu of <attr>characters</attr>) may be some string of math that will be used to determine width, height, and depth of the blank. In text, the default value of <c>10</c> is used for <attr>characters</attr>. In math, the default value of <c>XXX</c> is used for <attr>fill</attr>.</p>
             </paragraphs>
 
             <paragraphs>
@@ -1514,7 +1514,7 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
         <subsection>
             <title>Fill-In Blanks in Mathematics</title>
 
-            <p>The other mix-in <init>XML</init> element is <tag>fillin</tag> with an optional <attr>characters</attr> attribute that takes an integer value.  You will get a thin horizontal line, on the baseline, which can suggest to a reader that they should supply something within the surrounding mathematics.  The attribute suggests the length of the line<mdash />experiment a bit, since it is not super-precise.</p>
+            <p>The other mix-in <init>XML</init> element is <tag>fillin</tag>. It may use a <attr>fill</attr> attribute with some math string to determine width, height, and depth of the blank. Or it may use a <attr>characters</attr> attribute that takes an integer value to hint at the width.</p>
         </subsection>
 
         <subsection>

--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -126,12 +126,6 @@
         <p>This is meant to help you create a professional electronic <init>PDF</init>.  A print-on-demand service (<xref ref="print-on-demand"/>) will likely want a standalone image (possibly with the front and back, plus a spine, all rolled into one <term>wrap</term> image).  So build your <em>real</em> cover images (<xref ref="cover-design"/>), and then modify them for this use.</p>
     </section>
 
-    <section>
-        <title>Fill-Ins</title>
-
-        <p>The <tag>fillin</tag> element can be rendered as a line near the baseline of the current line of text, or as a complete rectangle (<q>box</q>).  Set <c>latex.fillin.style</c> to the values <c>underline</c> or <c>box</c>.</p>
-    </section>
-
     <section xml:id="latex-icons">
         <title>Icons</title>
 
@@ -200,11 +194,6 @@
                     <cell><c>latex.watermark.scale</c></cell>
                     <cell><c>2.0</c></cell>
                     <cell>Positive rational number</cell>
-                </row>
-                <row>
-                    <cell><c>latex.fillin.style</c></cell>
-                    <cell><c>underline</c></cell>
-                    <cell><c>underline</c>, <c>box</c></cell>
                 </row>
                 <row>
                     <cell><c>latex.preamble.early</c></cell>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -87,6 +87,28 @@
                 </tabular>
             </table>
         </subsection>
+
+        <subsection xml:id="common-fillin-options">
+            <title>Fillin Options</title>
+            <idx><h>common options</h><h>fillin</h></idx>
+            <idx><h>fillin</h><h>options</h></idx>
+
+            <p>The style of fill-in-the-blanks (from a <tag>fillin</tag>) is set by the attributes<ul>
+                <li>
+                    <title>Text Fillin</title>
+                    <p>Set<cd>
+                        <cline>/publication/common/fillin/@textstyle</cline>
+                    </cd> to values <c>underline</c>, <c>box</c>, or <c>shade</c> to influence the style of a fillin within text. The default is <c>underline</c>.</p>
+                </li>
+
+                <li>
+                    <title>Math Fillin</title>
+                    <p>Set<cd>
+                        <cline>/publication/common/fillin/@mathstyle</cline>
+                    </cd> to values <c>underline</c>, <c>box</c>, or <c>shade</c> to influence the style of a fillin within math. The default is <c>shade</c>.</p>
+                </li>
+            </ul></p>
+        </subsection>
     </section>
 
     <section xml:id="publication-file-numbering">

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -341,32 +341,6 @@
         <c>-d</c> specifies a folder to place the PDF output.
         If unspecified, this will be the current working directory.
       </p>
-      <p>
-        There is one string parameter you may pass to <c>pretext</c> using <c>-x</c>.
-        If you use <c>-x</c> with <c>pretext</c>,
-        make sure at least one other switch (<c>-p</c> for example) follows the use of <c>-x</c>.
-      </p>
-      <tabular valign="top">
-        <col />
-        <col width="60%" />
-        <row bottom="major">
-          <cell>stringparam</cell>
-          <cell>options</cell>
-        </row>
-        <row bottom="minor">
-          <cell><c>latex.fillin.style</c></cell>
-          <cell>
-            <p>
-              <c>'underline'</c> (default) means that where there would be an answer blank,
-              it is rendered as an underline.
-            </p>
-            <p>
-              <c>'box'</c> means that where there would be an answer blank,
-              it is rendered as a box outline.
-            </p>
-          </cell>
-        </row>
-      </tabular>
     </subsection>
 
     <subsection>

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -37,6 +37,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- parts of an exercise, where born.                      -->
         <exercise-inline hint="yes"/>
         <exercise-project answer="yes"/>
+        <!-- fillin styles are "underline" (the default for text),  -->
+        <!-- "box", and "shade" (the default for math)              -->
+        <fillin textstyle="underline" mathstyle="shade"/>
     </common>
 
     <!-- we use customizations-two for the oscarlevin style example -->

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1526,7 +1526,7 @@ the xsltproc executable.
 
                 <p>Similarly, within a paragraph, you can identify edits between versions as <insert>inserted text that has been added</insert><idx><h>styling words</h><h>insert</h></idx> with <tag>insert</tag> or as <delete>deleted text that has been removed</delete><idx><h>styling words</h><h>delete</h></idx> with <tag>delete</tag>.  Note that these identified edits are slightly different than <stale>stale text that you want to retain, but which is no longer relevant</stale><idx><h>styling words</h><h>stale</h></idx>, which is accomplished with <tag>stale</tag>.  The original request for stale text came from an instructor with an online list of student topics for presentations, and as students claimed topics they were marked as no longer available for other students.</p>
 
-                <p>If you need a <q>fill-in blank</q>, like this<fillin />, it can be obtained with an empty <tag>fillin</tag> element that defaults to roughly a 10-character width.  You can use the <tag>characters</tag> attribute to make the rule longer or shorter, such as a 40-character blank: <fillin characters="40" />.  The character count is approximate, based on typical character widths within a proportional font carrying English language text.  Adjust to suit, or request a language-specific adjustment if it is critical.</p>
+                <p>If you need a <q>fill-in blank</q>, like this <fillin />, it can be obtained with an empty <tag>fillin</tag> element that defaults to roughly a 10-character width.  You can use the <tag>characters</tag> attribute to make the rule longer or shorter, such as a 40-character blank: <fillin characters="40" />.  The character count is approximate, based on typical character widths within a proportional font carrying English language text.  Adjust to suit, or request a language-specific adjustment if it is critical.</p>
 
                 <p>Long after we started this mess, we added <pretext /> tags to mark up tags and attributes.  The elements are: <tag>tag</tag>, <tag>tage</tag>, <tag>attr</tag>.  Examples of how these render are (respectively): <tag>section</tag>, <tage>hash</tage>, <attr>width</attr>.  Perhaps this document will make greater use of these tags.</p>
 
@@ -4073,20 +4073,23 @@ the xsltproc executable.
                 <exercise>
                     <statement>
                         <p>One of the few things you can place inside of mathematics is a <q>fill-in</q> blank.<idx><h>fill-in blank</h></idx>  We demonstrate a few scenarios here.  See details on syntax in <xref ref="subsection-paragraph-markup" text="type-global" /><ndash />the use is identical within mathematics.<ul>
-                            <li><p>Inside inline math (short, 4 characters): <m>\sin(<fillin characters="4" />)</m></p></li>
+                            <li><p>Inside inline math (short, space for <m>x</m>): <m>\sin(<fillin fill="x" />)</m></p></li>
 
-                            <li><p>Inside inline math (default, 10 characters): <m>\sin(<fillin characters="10" />)</m></p></li>
+                            <li><p>Inside inline math (default, space for <m>XXX</m>): <m>\sin(<fillin />)</m></p></li>
 
-                            <li><p>Inside exponents and subscripts (2 characters each).  In this case, be sure to wrap your exponents and subscripts in braces, as would be good <latex /> practice anyway: <m>x^{5+<fillin characters="2" />}\,y_{<fillin characters="2" />}</m></p></li>
+                            <li><p>Inside exponents and subscripts (each is space for the string <q>12</q>).  In this case, be sure to wrap your exponents and subscripts in braces, as would be good <latex /> practice anyway: <m>x^{5+<fillin fill="12" />}\,y_{<fillin fill="12" />}</m></p></li>
 
-                            <li><p>Inside inline math (too long for this line probably, 40 characters long): <m>\tan(<fillin characters="40" />)</m></p></li>
+                            <li><p>Inside inline math (too long for this line probably, 40 characters long): <m>\tan(<fillin fill="Mxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" />)</m></p></li>
 
-                            <li><p>So use inside a displayed equation<me>16\log\space<fillin characters="8" /></me>like this one.</p></li>
+                            <li><p>So use inside a displayed equation<me>16\log\space<fillin fill="1-x^2" /></me>like this one.</p></li>
 
                             <li><p>Inside the second line of a multi-line display:<md>
                                 <mrow>y &amp;= x^7\,x^8</mrow>
-                                <mrow>  &amp;= x^{<fillin characters="3" />}</mrow>
+                                <mrow>  &amp;= x^{<fillin fill="15" />}</mrow>
                             </md></p></li>
+                            <li><p>
+                                This fillin has the deprecated <attr>characters</attr> attribute for a fillin inside math: <m>1+<fillin characters="5"/>+4=10</m>.
+                            </p></li>
                         </ul></p>
                     </statement>
                 </exercise>
@@ -11125,7 +11128,7 @@ the xsltproc executable.
                 <exercise workspace="2in">
                   <statement>
                     <p>To show that the point <m>P</m> exists (as the common intersection of the <m>\vec{M}_{i}</m>), show that <me>
-                      \vec{A} + \frac{2}{3} \vec{M}_{3} = \frac{2}{3} \vec{M}_{2} = <fillin characters="10"/>
+                      \vec{A} + \frac{2}{3} \vec{M}_{3} = \frac{2}{3} \vec{M}_{2} = <fillin fill="\frac{2}{3} \vec{M}_{1}-\vec{C}"/>
                     </me>.</p>
                   </statement>
                 </exercise>

--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -114,7 +114,6 @@ mini-representations:
 
 #########################################################################
 # PDF versions
-# use -x latex.fillin.style box for box answer blanks instead of underlines
 
 sample-chapter-pdf:
 	-rm -r $(PDFOUT)

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -439,29 +439,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
       <xsl:text>\newcommand{\stale}[1]{\renewcommand{\ULthickness}{\stalethick}\sout{#1}}&#xa;</xsl:text>
     </xsl:if>
   </xsl:if>
-  <!-- 2020-05-28: this "if" was edited in xsl/pretext-latex and is no longer in-sync -->
-  <xsl:if test="$document-root//fillin">
-    <xsl:text>%% Used for fillin answer blank&#xa;</xsl:text>
-    <xsl:text>%% Argument is length in em&#xa;</xsl:text>
-    <xsl:text>%% Length may compress for output to fit in one line&#xa;</xsl:text>
-    <xsl:choose>
-      <xsl:when test="$latex.fillin.style='underline'">
-        <xsl:text>\newcommand{\fillin}[1]{\leavevmode\leaders\vrule height -1.2pt depth 1.5pt \hskip #1em minus #1em \null}&#xa;</xsl:text>
-      </xsl:when>
-      <xsl:when test="$latex.fillin.style='box'">
-        <xsl:text>% Do not indent lines of this macro definition&#xa;</xsl:text>
-        <xsl:text>\newcommand{\fillin}[1]{%&#xa;</xsl:text>
-        <xsl:text>\leavevmode\rule[-0.3\baselineskip]{0.4pt}{\dimexpr 0.8pt+1.3\baselineskip\relax}% Left edge&#xa;</xsl:text>
-        <xsl:text>\nobreak\leaders\vbox{\hrule \vskip 1.3\baselineskip \hrule width .4pt \vskip -0.3\baselineskip}% Top and bottom edges&#xa;</xsl:text>
-        <xsl:text>\hskip #1em minus #1em% Maximum box width and shrinkage&#xa;</xsl:text>
-        <xsl:text>\nobreak\hbox{\rule[-0.3\baselineskip]{0.4pt}{\dimexpr 0.8pt+1.3\baselineskip\relax}}% Right edge&#xa;</xsl:text>
-        <xsl:text>}&#xa;</xsl:text>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:message terminate="yes">PTX:ERROR: invalid value <xsl:value-of select="$latex.fillin.style" />
- for latex.fillin.style stringparam. Should be 'underline' or 'box'.</xsl:message>
-      </xsl:otherwise>
-    </xsl:choose>
+  <xsl:if test="$document-root//fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
+    <xsl:call-template name="fillin-text">
+  </xsl:if>
+  <xsl:if test="$document-root//m/fillin|$document-root//me/fillin|$document-root//men/fillin|$document-root//mrow/fillin">
+      <xsl:call-template name="fillin-math"/>
   </xsl:if>
   <!-- http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/ -->
   <xsl:if test="$document-root//swungdash">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1632,6 +1632,56 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- For a "fillin" within math.                                       -->
+<!-- First, define math fillin macro that is common to LaTeX, MathJax. -->
+<!-- Then below, template for matching on each "fillin".               -->
+<xsl:template name="fillin-math">
+    <xsl:choose>
+        <xsl:when test="$fillin-math-style = 'underline'">
+            <xsl:text>\newcommand{\fillinmath}[1]{\mathchoice</xsl:text>
+            <xsl:text>{\underline{\displaystyle     \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\textstyle        \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\scriptstyle      \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\scriptscriptstyle\phantom{\ \,#1\ \,}}}}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$fillin-math-style = 'box'">
+            <xsl:text>\newcommand{\fillinmath}[1]{\mathchoice</xsl:text>
+            <xsl:text>{\boxed{\displaystyle     \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\textstyle        \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\scriptstyle      \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\scriptscriptstyle\phantom{\,#1\,}}}}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$fillin-math-style = 'shade'">
+            <xsl:text>\definecolor{fillinmathshade}{gray}{0.9}&#xa;</xsl:text>
+            <xsl:text>\newcommand{\fillinmath}[1]{\mathchoice</xsl:text>
+            <xsl:text>{\colorbox{fillinmathshade}{$\displaystyle     \phantom{\,#1\,}$}}</xsl:text>
+            <xsl:text>{\colorbox{fillinmathshade}{$\textstyle        \phantom{\,#1\,}$}}</xsl:text>
+            <xsl:text>{\colorbox{fillinmathshade}{$\scriptstyle      \phantom{\,#1\,}$}}</xsl:text>
+            <xsl:text>{\colorbox{fillinmathshade}{$\scriptscriptstyle\phantom{\,#1\,}$}}}&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="m/fillin|me/fillin|men/fillin|mrow/fillin">
+    <xsl:choose>
+        <xsl:when test="@fill">
+            <xsl:text>\fillinmath{</xsl:text>
+            <xsl:value-of select="@fill"/>
+            <xsl:text>}</xsl:text>
+        </xsl:when>
+        <xsl:when test="@characters">
+            <xsl:text>\fillinmath{</xsl:text>
+                <xsl:call-template name="duplicate-string">
+                    <xsl:with-param name="count" select="@characters" />
+                    <xsl:with-param name="text"  select="'X'" />
+                </xsl:call-template>
+            <xsl:text>}</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>\fillinmath{XXX}</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
 
 <!-- Sage Cells -->
 <!-- Contents are text manipulations (below)     -->
@@ -10681,6 +10731,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="date-string" select="'2022-05-23'" />
         <xsl:with-param name="message" select="'the  oldids  string parameter was used for testing, was deprecated on 2021-03-03, is now obsolete, there is no replacement, relevant code has been removed, and the parameter is being ignored'" />
         <xsl:with-param name="incorrect-use" select="($oldids != '')" />
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2022-05-28  "latex.fillin.style" is deprecated for publisher variables -->
+    <xsl:call-template name="parameter-deprecation-message">
+        <xsl:with-param name="date-string" select="'2022-05-28'" />
+        <xsl:with-param name="message" select="'the  latex.fillin.style  parameter has been replaced by the  common/fillin/@textstyle  and  common/fillin/mathstyle  entries in the publication file. The default style for a text fillin is now  underline  and the default style for a math fillin is now  shade .  To use  box  style for either, set values in the publication file.'" />
+        <xsl:with-param name="incorrect-use" select="($numbering.maximum.level != '')" />
     </xsl:call-template>
     <!--  -->
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8492,7 +8492,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- height and depth of the rule"                                        -->
 <!-- Davide Cervone                                                       -->
 <!-- https://groups.google.com/forum/#!topic/mathjax-users/IEivs1D7ntM    -->
-<xsl:template match="fillin">
+<xsl:template match="fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
     <xsl:variable name="characters">
         <xsl:choose>
             <xsl:when test="@characters">
@@ -8503,26 +8503,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:choose>
-        <xsl:when test="parent::m or parent::me or parent::men or parent::mrow">
-            <xsl:text>\underline{\hspace{</xsl:text>
+    <span class="fillin {$fillin-text-style}" role="img">
+        <xsl:attribute name="aria-label">
+            <xsl:value-of select="$characters" />
+            <xsl:text>-character blank</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="style">
+            <xsl:text>width: </xsl:text>
             <xsl:value-of select="5 * $characters div 11" />
-            <xsl:text>em}}</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-            <span class="fillin" role="img">
-                <xsl:attribute name="aria-label">
-                    <xsl:value-of select="$characters" />
-                    <xsl:text>-character blank</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="style">
-                    <xsl:text>width: </xsl:text>
-                    <xsl:value-of select="5 * $characters div 11" />
-                    <xsl:text>em;</xsl:text>
-                </xsl:attribute>
-            </span>
-        </xsl:otherwise>
-    </xsl:choose>
+            <xsl:text>em;</xsl:text>
+        </xsl:attribute>
+    </span>
 </xsl:template>
 
 <xsl:template match="var[@form='checkboxes']">
@@ -12193,6 +12184,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="math">
                 <xsl:value-of select="$latex-packages-mathjax"/>
                 <xsl:value-of select="$latex-macros"/>
+                <xsl:call-template name="fillin-math"/>
                 <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
                 <xsl:if test="$b-has-sfrac">
                     <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -99,10 +99,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Page Numbers in cross-references -->
 <xsl:param name="latex.pageref" select="''"/>
 <!--  -->
-<!-- Fillin Style Option                                  -->
-<!-- Can be 'underline' or 'box'                          -->
-<xsl:param name="latex.fillin.style" select="'underline'"/>
-<!--  -->
 <!-- Preamble insertions                    -->
 <!-- Insert packages, options into preamble -->
 <!-- early or late                          -->
@@ -1018,35 +1014,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>\newcommand{\stale}[1]{\renewcommand{\ULthickness}{\stalethick}\sout{#1}}&#xa;</xsl:text>
         </xsl:if>
     </xsl:if>
-    <xsl:if test="$document-root//fillin">
-        <xsl:text>%% Used for fillin answer blank&#xa;</xsl:text>
-        <xsl:text>%% Argument is length in em&#xa;</xsl:text>
-        <xsl:text>%% Length may compress for output to fit in one line&#xa;</xsl:text>
-        <!-- \fillincontract is set using \real, which comes from calc package -->
-        <!-- which comes from mtool package, which comes from extpfeil.        -->
-        <!-- So any changes to extpfeil inclusion should be followed up here.  -->
-        <xsl:text>\newlength{\fillincontract}&#xa;</xsl:text>
-        <xsl:choose>
-            <xsl:when test="$latex.fillin.style='underline'">
-                <xsl:text>\newcommand{\fillin}[1]{%&#xa;</xsl:text>
-                <xsl:text>\setlength{\fillincontract}{#1em * \real{0.2}}%&#xa;</xsl:text>
-                <xsl:text>\leavevmode\leaders\vrule height -1.2pt depth 1.5pt \hskip #1em minus \fillincontract \null%&#xa;</xsl:text>
-                <xsl:text>}&#xa;</xsl:text>
-            </xsl:when>
-            <xsl:when test="$latex.fillin.style='box'">
-                <xsl:text>% Do not indent lines of this macro definition&#xa;</xsl:text>
-                <xsl:text>\newcommand{\fillin}[1]{%&#xa;</xsl:text>
-                <xsl:text>\setlength{\fillincontract}{#1em * \real{0.2}}%&#xa;</xsl:text>
-                <xsl:text>\leavevmode\rule[-0.3\baselineskip]{0.4pt}{\dimexpr 0.8pt+1.3\baselineskip\relax}% Left edge&#xa;</xsl:text>
-                <xsl:text>\nobreak\leaders\vbox{\hrule \vskip 1.3\baselineskip \hrule width .4pt \vskip -0.3\baselineskip}% Top and bottom edges&#xa;</xsl:text>
-                <xsl:text>\hskip #1em minus \fillincontract% Maximum box width and shrinkage&#xa;</xsl:text>
-                <xsl:text>\nobreak\hbox{\rule[-0.3\baselineskip]{0.4pt}{\dimexpr 0.8pt+1.3\baselineskip\relax}}% Right edge&#xa;</xsl:text>
-                <xsl:text>}&#xa;</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   the latex.fillin.style parameter should be 'underline' or 'box', not '<xsl:value-of select="$latex.fillin.style"/>'.  Using the default ('underline').</xsl:message>
-            </xsl:otherwise>
-        </xsl:choose>
+    <xsl:if test="$document-root//fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
+        <xsl:call-template name="fillin-text"/>
+    </xsl:if>
+    <xsl:if test="$document-root//m/fillin|$document-root//me/fillin|$document-root//men/fillin|$document-root//mrow/fillin">
+        <xsl:call-template name="fillin-math"/>
     </xsl:if>
     <!-- http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/ -->
     <xsl:if test="$document-root//swungdash">
@@ -2416,6 +2388,41 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="$docinfo/covers/@back"/>
         <xsl:text>}%&#xa;</xsl:text>
     </xsl:if>
+</xsl:template>
+
+<!-- Fill-in-the-blank in text content -->
+<xsl:template name="fillin-text">
+    <xsl:text>%% Used for fillin answer blank in text&#xa;</xsl:text>
+    <xsl:text>%% Relies on calc package, loaded via tcolorbox&#xa;</xsl:text>
+    <xsl:text>%% Argument is intended number of characters of blank&#xa;</xsl:text>
+    <xsl:text>%% Length may compress for output to fit in one line&#xa;</xsl:text>
+    <xsl:text>\newlength{\fillinmaxwidth}&#xa;</xsl:text>
+    <xsl:text>\newlength{\fillincontract}&#xa;</xsl:text>
+    <xsl:text>\newlength{\fillinheight}&#xa;</xsl:text>
+    <xsl:if test="$fillin-text-style = 'shade'">
+        <xsl:text>\definecolor{fillintextshade}{gray}{0.9}</xsl:text>
+    </xsl:if>
+    <xsl:text>\newcommand{\fillintext}[1]{%&#xa;</xsl:text>
+    <xsl:text>\setlength{\fillinmaxwidth}{#1em*\real{0.5}}%&#xa;</xsl:text>
+    <xsl:text>\setlength{\fillincontract}{#1em*\real{0.5}*\real{0.2}}%&#xa;</xsl:text>
+    <xsl:text>\setlength{\fillinheight}{\heightof{\strut}+1.2pt}%&#xa;</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$fillin-text-style = 'underline'">
+            <xsl:text>\nobreak\leaders\vbox{\hrule width 0pt height 0pt \vskip \fillinheight \hrule width 0.3pt height 0.3pt \vskip -1.2pt}%&#xa;</xsl:text>
+            <xsl:text>\hskip 1\fillinmaxwidth minus \fillincontract%&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$fillin-text-style = 'box'">
+            <xsl:text>\rule[-1.2pt]{0.3pt}{\heightof{\strut}+1.8pt}%&#xa;</xsl:text>
+            <xsl:text>\nobreak\hspace{-0.3pt}{\nobreak\leaders\vbox{\hrule width 0.3pt height 0.3pt \vskip \fillinheight \hrule width 0.3pt height 0.3pt \vskip -1.2pt}%&#xa;</xsl:text>
+            <xsl:text>\hskip 1\fillinmaxwidth minus \fillincontract}%&#xa;</xsl:text>
+            <xsl:text>\nobreak\hspace{-0.3pt}\hbox{\rule[-1.2pt]{0.3pt}{\heightof{\strut}+1.8pt}}%&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$fillin-text-style = 'shade'">
+            <xsl:text>\nobreak{\color{fillintextshade}\nobreak\leaders\vbox{\hrule width 0pt height 0pt \vskip 0pt \hrule width 0.3pt height \fillinheight \vskip -1.2pt}%&#xa;</xsl:text>
+            <xsl:text>\hskip 1\fillinmaxwidth minus \fillincontract}%&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+    <xsl:text>}&#xa;</xsl:text>
 </xsl:template>
 
 <!-- PTX Divisions to LaTeX Divisions -->
@@ -8355,10 +8362,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Fill-in blank -->
-<!-- \fillin{} defined in preamble as semantic macro       -->
-<!-- argument is number of "em", Bringhurst suggests 5/11  -->
-<!-- \rule works in text and in math (unlike HTML/MathJax) -->
-<xsl:template match="fillin">
+<!-- \fillintext{} defined in preamble as semantic macro   -->
+<!-- Argument is intended number of characters             -->
+<xsl:template match="fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
     <xsl:variable name="characters">
         <xsl:choose>
             <xsl:when test="@characters">
@@ -8369,8 +8375,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:text>\fillin{</xsl:text>
-    <xsl:value-of select="5 * $characters div 11" />
+    <xsl:text>\fillintext{</xsl:text>
+    <xsl:value-of select="$characters" />
     <xsl:text>}</xsl:text>
 </xsl:template>
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -140,6 +140,37 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Flag Table of Contents, or not, with boolean variable -->
 <xsl:variable name="b-has-toc" select="$toc-level > 0" />
 
+<!-- Fillin styles (underline, box, shade) -->
+<xsl:variable name="fillin-text-style">
+    <xsl:choose>
+        <xsl:when test="$publication/common/fillin/@textstyle = 'box'">
+            <xsl:text>box</xsl:text>
+        </xsl:when>
+        <xsl:when test="$publication/common/fillin/@textstyle = 'shade'">
+            <xsl:text>shade</xsl:text>
+        </xsl:when>
+        <!-- default -->
+        <xsl:otherwise>
+            <xsl:text>underline</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="fillin-math-style">
+    <xsl:choose>
+        <xsl:when test="$publication/common/fillin/@mathstyle = 'underline'">
+            <xsl:text>underline</xsl:text>
+        </xsl:when>
+        <xsl:when test="$publication/common/fillin/@mathstyle = 'box'">
+            <xsl:text>box</xsl:text>
+        </xsl:when>
+        <!-- default -->
+        <xsl:otherwise>
+            <xsl:text>shade</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- ########################### -->
 <!-- Exercise component switches -->
 <!-- ########################### -->


### PR DESCRIPTION
This removes `latex.fillin.style` (so there will need to be an -announce message) just for that.

It puts `publication/common/fillin/@textstyle` and `@mathstyle` in place in publication files. Each may be `underline` (default for text), `box`, or `shade` (default for math).

With shade becoming default for math (an improvement, I think), that is another reason for an -announce message.

The text fillin can compress in LaTeX up to 20% to help with line fitting. The text fillin in HTML puts classes in place, but a separate CSS PR is needed to actually make things happen there.

The math fillin templates are all in -common. In the end I found a way to make that work either way.

Text fillin uses `@characters` with default 10. Math fillin can use `@characters` or like `@fill="\frac{x+1}{2}"` with default `@fill="XXX"`. fill trumps characters. 

This does not improve accessibility for fillins. It's already OK for fillins in text. And things are not good for fillins in math and it stays that way with these commits. But I have a lead on @pkra's aria-label MathJax extension that might work out separately, later. That extension is not playing will with `\phantom` right now.

Lots of doc cutting and editing for this. I tried to pay lots of attention, but a second set of eyes on that would be good.

Not sure how you want to handle schema here. Now two types of fillin, one in math and one not?