### PR TITLE
LaTeX: prevent an underline fillin at the start of a line from collap…

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -2408,7 +2408,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\setlength{\fillinheight}{\heightof{\strut}+1.2pt}%&#xa;</xsl:text>
     <xsl:choose>
         <xsl:when test="$fillin-text-style = 'underline'">
-            <xsl:text>\nobreak\leaders\vbox{\hrule width 0pt height 0pt \vskip \fillinheight \hrule width 0.3pt height 0.3pt \vskip -1.2pt}%&#xa;</xsl:text>
+            <xsl:text>\null\nobreak\leaders\vbox{\hrule width 0pt height 0pt \vskip \fillinheight \hrule width 0.3pt height 0.3pt \vskip -1.2pt}%&#xa;</xsl:text>
             <xsl:text>\hskip 1\fillinmaxwidth minus \fillincontract%&#xa;</xsl:text>
         </xsl:when>
         <xsl:when test="$fillin-text-style = 'box'">


### PR DESCRIPTION
…sing

This addresses issue #929, which was still a problem even after the recent refactor. But at least now I understand how to fix it.

I tested the macro in a .tex file I wrote from scratch. I doctored it so that a fillin happened right after a natural line break, and it was collapsing as in #929. But then this edit fixes that. And I also tested that it doesn't harm fillins in other places.

The same change is not needed for box or shade.