### PR TITLE
LaTeX: rename image environment to imageptx

### DIFF
--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -65,7 +65,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   <xsl:text>\newcommand{\tabularfont}{}&#xa;</xsl:text>
   <xsl:text>\usepackage[xparse, raster]{tcolorbox}&#xa;</xsl:text>
   <xsl:text>\tcbset{colback=white, colframe=white}&#xa;</xsl:text>
-  <xsl:text>\NewTColorBox{image}{mmm}{boxrule=0.25pt, colframe=gray, left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
+  <xsl:text>\NewTColorBox{imageptx}{mmm}{boxrule=0.25pt, colframe=gray, left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
   <xsl:text>\RenewTColorBox{definition}{m}{colback=teal!30!white, colbacktitle=teal!30!white, coltitle=black, colframe=gray, boxrule=0.5pt, sharp corners=downhill, titlerule = 0.25pt, title={#1}}&#xa;</xsl:text>
   <xsl:text>\RenewTColorBox{theorem}{m}{colback=pink!30!white, colbacktitle=pink!30!white, coltitle=black, colframe=gray, boxrule=0.5pt, sharp corners=downhill, titlerule = 0.25pt, title={#1}}&#xa;</xsl:text>
   <xsl:text>\RenewTColorBox{proof}{}{boxrule=0.25pt, colframe=gray, colback=white, before upper={Proof:}, after upper={\qed}}&#xa;</xsl:text>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1282,7 +1282,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%% arguments are left-margin, width, right-margin, as multiples of&#xa;</xsl:text>
         <xsl:text>%% \linewidth, and are guaranteed to be positive and sum to 1.0&#xa;</xsl:text>
         <xsl:text>\tcbset{ imagestyle/.style={bwminimalstyle} }&#xa;</xsl:text>
-        <xsl:text>\NewTColorBox{image}{mmm}{imagestyle,left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
+        <xsl:text>\NewTColorBox{imageptx}{mmm}{imagestyle,left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
     </xsl:if>
     <!-- Tables -->
     <xsl:if test="$document-root//tabular">
@@ -9090,7 +9090,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="layout-parameters" />
     </xsl:variable>
     <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
-    <xsl:text>\begin{image}</xsl:text>
+    <xsl:text>\begin{imageptx}</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$layout/left-margin div 100"/>
     <xsl:text>}</xsl:text>
@@ -9101,7 +9101,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:value-of select="$layout/right-margin div 100"/>
     <xsl:text>}%&#xa;</xsl:text>
     <xsl:apply-templates select="." mode="image-inclusion" />
-    <xsl:text>\end{image}%&#xa;</xsl:text>
+    <xsl:text>\end{imageptx}%&#xa;</xsl:text>
 </xsl:template>
 
 <!-- Second: images already constrained by side-by-side panels -->


### PR DESCRIPTION
Addressing an issue reported by Michael in the forum:
https://groups.google.com/g/pretext-support/c/3CNb8Z4P7J4/m/jXGMacyPAAAJ

