### PR TITLE
Documentation (guide) updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ doc/guide/webwork-representations.ptx
 script/mjsre/node_modules/
 script/mjsre/package-lock.json
 pretext/__pycache__/**
+.error_schema.log
+*~
 .vscode
 **/_build
 **/output
+**/generated
+**/rsbuild
+**/build
+

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -1,20 +1,20 @@
-The PreTeXt Guide
-=================
+# The PreTeXt Guide
 
 PDF and HTML versions of this guide are available at the [PreTeXt](https://pretextbook.org) site in the Documentation area.
 
 If you wish to build from source, possibly as part of contributing improvements, follow these steps:
 
 1.  To build LaTeX for input to `pdflatex`:
-        cd /path/to/mathbook
-        xsltproc -xinclude -o guide.tex xsl/pretext-latex.xsl doc/guide/guide.xml
+    cd /path/to/guide
+    pretext build latex -d -w
 1.  And for HTML output:
-        cd /path/to/mathbook
-        xsltproc -xinclude xsl/pretext-html.xsl doc/guide/guide.xml
+    cd /path/to/guide
+    pretext build html -d -w
+1.  The preceeding two steps will attempt to build all of the webwork representations and diagrams needed for your book. You may be missing some of the prerequisites, such as Sage that will need to be installed before a full build can be completed.
 1.  You might prefer to set your default directory to someplace outside the PreTeXt distribution and include full paths to the XSL and XML files in the `xsltproc` command, so your output is not mixed in with your source.
-1.  Note, we do not include directions here for the multiple steps necessary to have the WeBWorK examples built correctly.  You will get an error message, but the rest of your ouput should not be affected.
 
-If you are contributing new material, note that there are three important elements in use.  Please make use of them in your contribution.
-* `tag` - for element names
-* `tage` - for names of empty elements
-* `attr` - for names of attributes
+If you are contributing new material, note that there are three important elements in use. Please make use of them in your contribution.
+
+-   `tag` - for element names
+-   `tage` - for names of empty elements
+-   `attr` - for names of attributes

--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -21,7 +21,17 @@
 
         <p>An <tag>article</tag> starts divisions from <tag>section</tag>, though it may choose to have no divisions at all.  <tag>paragraphs</tag> are exceptional.  They lack a full set of features, but can be used to divide anything, in books or in articles, though they are always terminal since you cannot divide them further.  You will have noticed that we prefer the generic term <term>division</term><idx><h>division</h><seealso>structural division</seealso></idx> (rather than <q>section</q>) since a <tag>section</tag> is a very particular division.</p>
 
-        <p>A division may be unstructured, in which case you fill it with paragraphs and lists and figures and theorems and so on.  But if you choose to structure a division it must look like an optional <tag>introduction</tag>, followed by multiple divisions of the next finer granularity, with an optional <tag>conclusion</tag>.  Either version may have a single <tag>exercises</tag> division at the end.  The structured version may have more than one <tag>exercises</tag>.  Finally, there may be a single <tag>references</tag> within a division.</p>
+        <p>A division may be unstructured, in which case you fill it with paragraphs and lists and figures and theorems and so on.  But if you choose to structure a division it must look like the following:
+        <ul>
+        <li>An optional <tag>introduction</tag> </li>
+        <li>One or more divisions of the next finer granularity</li>
+        <li>An optional <tag>conclusion</tag>.</li>
+        </ul>  
+        Either version may have a single <tag>exercises</tag> division at the end.  
+        
+        The structured version may have more than one <tag>exercises</tag>.  Finally, there may be a single <tag>references</tag> within a division.</p>
+
+        <p>The <tag>introduction</tag> and <tag>conclusion</tag> divisions are meant to be short, and may not contain any other numbered tag.  No exercises, theorems, listings, etc. If you want to have an introductory division with any of the numbered elements you are free to omit the <tag>introduction</tag> and use the next finer subdivision with a <tag>title</tag> of <q>Introduction</q></p>
 
         <p>Every division tag can carry an <attr>xml:id</attr> attribute, and it is a good practice to (a) provide one, (b) use a very short list of words describing the content, and (c) adopt a consistent pattern of your choosing.  Do not use numbers, you may later regret it.  These are optional, and with practice you will learn how best to use them. See <xref ref="overview-cross-references" /> just below for more on this.</p>
 

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -830,6 +830,7 @@
                     <li>Typically a block does not contain another block, except that the more planar ones can appear as part of a more textual one.</li>
 
                     <li>When numbered, all blocks generally run consecutively.  (In <latex/>-speak, <q>on the same counter.</q>)  Numbering FIGURE-LIKE and PROJECT-LIKE independently is in transition at this writing (2021-07-07).</li>
+                    <li>Depending on the output format of your document, some block types may be initially hidden to improve the visual flow.  The user must click on the heading for the block to reveal its contents.  You can change this behavior by configuring your publication file.  See <xref ref="publication-file-online"/>.  We will make note of the elements that are hidden by default for html output.</li>
                 </ul>
             </list>
 
@@ -854,7 +855,7 @@
                     <li>
                         <title>EXAMPLE-LIKE</title>
                         <p><tag>example</tag>, <tag>question</tag>, <tag>problem</tag></p>
-                        <p>A worked problem meant as exposition.  It can be structured with <tag>task</tag>, <tag>hint</tag>, <tag>answer</tag>, and <tag>solution</tag> just like an <tag>exercise</tag> or PROJECT-LIKE, but the <tag>hint</tag>, <tag>answer</tag>, and <tag>solution</tag> cannot be electively removed from output, and they do not migrate to collections of solutions elsewhere.</p>
+                        <p>A worked problem meant as exposition.  It can be structured with <tag>task</tag>, <tag>hint</tag>, <tag>answer</tag>, and <tag>solution</tag> just like an <tag>exercise</tag> or PROJECT-LIKE, but the <tag>hint</tag>, <tag>answer</tag>, and <tag>solution</tag> cannot be electively removed from output, and they do not migrate to collections of solutions elsewhere. Hidden by default for html output formats.</p>
                     </li>
 
                     <li>
@@ -872,7 +873,7 @@
                     <li>
                         <title>THEOREM-LIKE</title>
                         <p><tag>theorem</tag>, <tag>corollary</tag>, <tag>lemma</tag>, <tag>algorithm</tag>, <tag>proposition</tag>, <tag>claim</tag>, <tag>fact</tag>, <tag>identity</tag></p>
-                        <p>Mathematical results, which can have an (optional) proof.</p>
+                        <p>Mathematical results, which can have an (optional) <tag>proof</tag>.  Proofs are hidden by default in html output.</p>
                     </li>
 
                     <li>
@@ -912,7 +913,7 @@
         <subsection>
             <title>Other Blocks</title>
 
-            <p>There are other blocks which can be achieved using just one element.  Examples are <tag>poem</tag> and <tag>assemblage</tag>.  An <tag>exercise</tag> can take on different behaviors, depending on its placement (see <xref ref="topic-exercises"/>).  One such placement is as a child of a division, which we call an <term>inline exercise</term>, and this would be regarded as a block, very similar to a PROJECT-LIKE.</p>
+            <p>There are other blocks which can be achieved using just one element.  Examples are <tag>poem</tag> and <tag>assemblage</tag>.  An <tag>exercise</tag> can take on different behaviors, depending on its placement (see <xref ref="topic-exercises"/>).  One such placement is as a child of a division, which we call an <term>inline exercise</term>, and this would be regarded as a block, very similar to a PROJECT-LIKE.  Inline exercises are hidden by default in html output.</p>
 
             <p>A paragraph (<tag>p</tag>) can appear many places and is a primary component of blocks.  But when it is a child of a division, it shares some charateristics with other blocks.  There are a number of peers of a <tag>p</tag> which would then also qualify:  <tag>pre</tag>, <tag>blockquote</tag>, <tag>image</tag>, <tag>video</tag>, <tag>program</tag>, <tag>console</tag>, and <tag>tabular</tag>.  None of these can have a title or number, making them less useful, but widening the possibilities for placement.</p>
         </subsection>
@@ -2829,6 +2830,8 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
         <p>A <tag>program</tag> will be treated as verbatim text (see <xref ref="overview-verbatim-literal"/>), subject to all the exceptions for exceptional characters (see <xref ref="overview-exceptional-characters"/>).  Indentation will be preserved, though an equal amount of leading whitespace will be stripped from every line, so as to keep the code shifted left as far as possible.  So you can indent your code consistently along with your <init>XML</init> indentation.  For this reason it is best to indent with spaces, and not tabs.  A mix will almost surely end badly, and in some programming languages tabs are discouraged (e.g. Python).</p>
 
         <p>The <attr>language</attr> attribute may be used to get some degree of language-specific syntax highlighting.  We will eventually provide a table of attribute values here.  They are always lowercase, and a first guess might succeed.</p>
+
+        <p>the <attr>interactive</attr> attribute may have the values <q>activecode</q>, <q>codelens</q>, or <q>no</q>.  The activecode value is used to indicate that in an interactive output format like html that the program should be executable in the browser.  Some languages like Java and C++ require the  output to be for a runestone server in order to get the program to compile and run. Other languages like Python, SQL, and Javascript can run right in the browser.  The codelens option will provide a visualization of the code and allow the reader to step through a program line by line and observe the changes in variables and other data structures. </p>
 
         <p>A <tag>console</tag> is a transcript of an interactive session in a terminal or console at a command-line.  It is a sequence of the following elements, in this order, possibly repeated many times as a group: <tag>prompt</tag>, <tag>input</tag>, and <tag>output</tag>.  The <tag>output</tag> is optional, and a <tag>prompt</tag> is only displayed when there is an immediately subsequent <tag>input</tag> (which could be empty).  The content is treated as verbatim text (see <xref ref="overview-verbatim-literal"/>), subject to all the exceptions for exceptional characters (see <xref ref="overview-exceptional-characters"/>).</p>
 

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -141,7 +141,7 @@
         </p>
 
         <p>
-            For the majority of authors who are starting out with <pretext />, a simpler workflow is available: the PreTeXt-CLI (CLI is <em>Command Line Interface</em>).  This is a Python program that implements the most common conversion tasks that previously required <c>xsltproc</c> and the pretext script.
+            For the majority of authors who are starting out with <pretext />, a simpler workflow is available: the PreTeXt-CLI (CLI is <em>Command Line Interface</em>).  This is a Python program that implements the most common conversion tasks that previously required <c>xsltproc</c> and the pretext script.  If you are ready to install and get started see <xref ref="xref-getting-pretext" />.
         </p>
     </section>
 

--- a/doc/guide/project.ptx
+++ b/doc/guide/project.ptx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file provides the overall configuration for your PreTeXt
+    project. To edit the content of your document, open `source/main.ptx`
+    (default location).
+-->
+<project>
+  <targets>
+    <target name="html">
+      <format>html</format>
+      <source>guide.xml</source>
+      <publication>publication.xml</publication>
+      <output-dir>output/html</output-dir>
+    </target>
+    <target name="latex">
+      <format>latex</format>
+      <source>guide.xml</source>
+      <output-dir>output/latex</output-dir>
+    </target>
+    <target name="pdf" pdf-method="pdflatex">
+      <format>pdf</format>
+      <source>guide.xml</source>
+      <output-dir>output/pdf</output-dir>
+    </target>
+  </targets>
+  <executables>
+    <latex>latex</latex>
+    <pdflatex>pdflatex</pdflatex>
+    <xelatex>xelatex</xelatex>
+    <pdfsvg>pdf2svg</pdfsvg>
+    <asy>asy</asy>
+    <sage>sage</sage>
+    <pdfpng>convert</pdfpng>
+    <pdfeps>pdftops</pdfeps>
+    <pdfcrop>pdf-crop-margins</pdfcrop>
+    <pageres>pageres</pageres>
+    <node>node</node>
+    <liblouis>file2brl</liblouis>
+  </executables>
+</project>

--- a/doc/guide/publication.xml
+++ b/doc/guide/publication.xml
@@ -25,22 +25,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <index-page ref="guide-toc"/>
         <baseurl href="https://pretextbook.org/doc/guide/html/"/>
         <css style="default" colors="blue_red"/>
-        <analytics google-gst="UA-48811660-1"
-                   statcounter-project="9664088"
-                   statcounter-security="6e60c510"/>
+        <analytics google-gst="UA-48811660-1" statcounter-project="9664088" statcounter-security="6e60c510"/>
         <search google-cx="008832104071767086392:woji51c1uko"/>
     </html>
 
     <!-- Relative path, relative to "main" source file -->
-    <source webwork-problems="webwork-representations.xml"/>
+    <source webwork-problems="webwork-representations.xml">
+        <directories external="images" generated="generated"/>
+    </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->
-    <webwork
-        server="https://webwork-ptx.aimath.org"
-        course="anonymous"
-        coursepassword="anonymous"
-        user="anonymous"
-        userpassword="anonymous"
-        />
+    <webwork server="https://webwork-ptx.aimath.org" course="anonymous" coursepassword="anonymous" user="anonymous" userpassword="anonymous" />
 
 </publication>


### PR DESCRIPTION
I am not very good at reading documentation from start to finish.  I am more apt to look at the TOC or do a search for something close to what I want to do.  So, I'm attemping to do both read through the documentation, but also think about how someone might arrive at a page who has a converted Runestone book and has a particular task in mind. 

I'm not sure if you are ready for me (or anyone) to update this guide for all of the interactive exercises?

I also added a project.ptx file so that one can `pretext build html -d -w` to build the guide for themselves.