### PR TITLE
add the cli.log, built by cli, to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pretext/__pycache__/**
 .vscode
 **/_build
 **/output
+**/cli.log
 **/rsbuild
 **/build
 


### PR DESCRIPTION
After we wired up the CLI to work in the sample-article, if you build it in that folder, you get a cli.log there.  This shouldn't be tracked by git.