### PR TITLE
WeBWorK: make valid inside PROJECT-LIKE

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -40,7 +40,7 @@
         before you will be able to see any <webwork/> content in your output.  For simple cases, you might be able to run <c>pretext build html -w</c> to process <webwork /> exercises.</alert>
       </p>
       <p>
-        A <tag>webwork</tag> tag must be inside an <tag>exercise</tag>,
+        A <tag>webwork</tag> tag must be inside an <tag>exercise</tag> or a PROJECT-LIKE block,
         <em>optionally</em> preceded by an <tag>introduction</tag>,
         and <em>optionally</em> followed by a <tag>conclusion</tag>.
       </p>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -308,6 +308,18 @@
                 </conclusion>
             </exercise>
 
+            <project>
+                <title>Inside a <tag>project</tag></title>
+                <introduction>
+                    <p>
+                        If you like, you can have a <webwork/> inside a PROJECT-LIKE block.
+                        Just like with an <tag>exercise</tag>, it can be preceded with an optional <tag>introduction</tag>
+                        and followed by an optional <tag>conclusion</tag>.
+                    </p>
+                </introduction>
+                <webwork copy="webwork-add-numbers" seed="511"/>
+            </project>
+
         </section>
 
         <section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1258,7 +1258,8 @@
                        Prelude?,
                        (
                           (Statement, Hint*, Answer*, Solution*) |
-                          (IntroductionStatement?, Task+, ConclusionStatement?)
+                          (IntroductionStatement?, Task+, ConclusionStatement?) |
+                          (IntroductionText?, WebWork, ConclusionText?)
                        ),
                        Postlude?
                     )

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -287,11 +287,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="webwork.divisional.static" select="'yes'" />
 <xsl:param name="webwork.reading.static" select="'yes'" />
 <xsl:param name="webwork.worksheet.static" select="'yes'" />
+<xsl:param name="webwork.project.static" select="'no'" />
 <!-- We make variables instead of using the params directly, so that in EPUB we can overrule -->
 <xsl:variable name="b-webwork-inline-static" select="$webwork.inline.static = 'yes'" />
 <xsl:variable name="b-webwork-divisional-static" select="$webwork.divisional.static = 'yes'" />
 <xsl:variable name="b-webwork-reading-static" select="$webwork.reading.static = 'yes'" />
 <xsl:variable name="b-webwork-worksheet-static" select="$webwork.worksheet.static = 'yes'" />
+<xsl:variable name="b-webwork-project-static" select="$webwork.project.static = 'yes'" />
 
 <xsl:variable name="webwork-reps-version" select="$document-root//webwork-reps[1]/@version"/>
 
@@ -4193,6 +4195,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="block-type"/>
 
     <xsl:choose>
+        <!-- webwork case -->
+        <xsl:when test="webwork-reps">
+            <xsl:apply-templates select="introduction|webwork-reps|conclusion">
+                <xsl:with-param name="b-original" select="$b-original" />
+            </xsl:apply-templates>
+        </xsl:when>
         <xsl:when test="task">
             <xsl:apply-templates select="introduction|task|conclusion">
                 <xsl:with-param name="b-original" select="$b-original"/>
@@ -10290,22 +10298,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- what is born visible under control of a switch -->
 <xsl:template match="webwork-reps">
     <xsl:param name="b-original" select="true()"/>
-    <xsl:variable name="b-has-hint" select="(ancestor::exercises and $b-has-divisional-hint) or
+    <xsl:variable name="b-has-hint" select="(ancestor::*[&PROJECT-FILTER;] and $b-has-project-hint) or
+                                            (ancestor::exercises and $b-has-divisional-hint) or
                                             (ancestor::reading-questions and $b-has-reading-hint) or
                                             (ancestor::worksheet and $b-has-worksheet-hint) or
-                                            (not(ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-hint)" />
-    <xsl:variable name="b-has-answer" select="(ancestor::exercises and $b-has-divisional-answer) or
+                                            (not(ancestor::*[&PROJECT-FILTER;] or ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-hint)" />
+    <xsl:variable name="b-has-answer" select="(ancestor::*[&PROJECT-FILTER;] and $b-has-project-answer) or
+                                              (ancestor::exercises and $b-has-divisional-answer) or
                                               (ancestor::reading-questions and $b-has-reading-answer) or
                                               (ancestor::worksheet and $b-has-worksheet-answer) or
-                                              (not(ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-answer)" />
-    <xsl:variable name="b-has-solution" select="(ancestor::exercises and $b-has-divisional-solution) or
+                                              (not(ancestor::*[&PROJECT-FILTER;] or ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-answer)" />
+    <xsl:variable name="b-has-solution" select="(ancestor::*[&PROJECT-FILTER;] and $b-has-project-solution) or
+                                                (ancestor::exercises and $b-has-divisional-solution) or
                                                 (ancestor::reading-questions and $b-has-reading-solution) or
                                                 (ancestor::worksheet and $b-has-worksheet-solution) or
-                                                (not(ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-solution)"/>
-    <xsl:variable name="b-static" select="(ancestor::exercises and $b-webwork-divisional-static) or
+                                                (not(ancestor::*[&PROJECT-FILTER;] or ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-has-inline-solution)"/>
+    <xsl:variable name="b-static" select="(ancestor::*[&PROJECT-FILTER;] and $b-webwork-project-static) or
+                                          (ancestor::exercises and $b-webwork-divisional-static) or
                                           (ancestor::reading-questions and $b-webwork-reading-static) or
                                           (ancestor::worksheet and $b-webwork-worksheet-static) or
-                                          (not(ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-webwork-inline-static)"/>
+                                          (not(ancestor::*[&PROJECT-FILTER;] or ancestor::exercises or ancestor::reading-questions or ancestor::worksheet) and $b-webwork-inline-static)"/>
     <xsl:choose>
         <!-- We print the static version when that is explicitly directed. -->
         <xsl:when test="($b-static = 'yes')">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6066,7 +6066,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- originally in the source.  We could try to condition on a bare    -->
 <!-- "static" versus "static/stage" but it seems safer to stick with   -->
 <!-- a "choose" and a straightforward match.                           -->
-<xsl:template match="exercise[webwork-reps]" mode="exercise-components">
+<xsl:template match="exercise[webwork-reps]|*[boolean(&PROJECT-FILTER;) and webwork-reps]" mode="exercise-components">
     <xsl:param name="b-original" />
     <xsl:param name="purpose" />
     <xsl:param name="b-component-heading"/>


### PR DESCRIPTION
This makes it so you can have `(introduction?|webwork|conclusion?)` in a PROJECT-LIKE. PROJECT-LIKE is similar enough to inline exercise that this did not take much work.

