### PR TITLE
Update sre 4

### DIFF
--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -279,8 +279,17 @@ if (!(argv.svg || argv.svgenhanced)) {
   //  Wait for SRE, if needed
   //
   if (needsSRE) {
-    let jsonPath = require.resolve('speech-rule-engine/lib/mathmaps/base.json').replace(/\/base\.json$/, '');
-    Sre.setupEngine({xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js'), json: jsonPath});
+    const feature = {
+      xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js'),
+      json: require.resolve('speech-rule-engine/lib/mathmaps/base.json').replace(/\/base\.json$/, '')
+    };
+    Sre.setupEngine(feature);
+    if (argv.braille) {
+      Sre.setupEngine({locale: 'nemeth'});
+    }
+    if (argv.speech || argv.svgenhanced) {
+      Sre.setupEngine({locale: argv.locale});
+    }
     await Sre.sreReady();
   }
   //

--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -110,7 +110,8 @@ const needsSRE = argv.speech || argv.braille || argv.svgenhanced;
 //
 //  Load SRE if needed for speech or braille
 //
-const {sreReady} = (needsSRE ? require('mathjax-full/js/a11y/sre.js') : {sreReady: Promise.resolve()});
+const {Sre} = needsSRE ? require('mathjax-full/js/a11y/sre.js') :
+      {Sre: {sreReady: Promise.resolve()}};
 
 //
 //  Read the HTML file
@@ -198,11 +199,11 @@ const mmldoc = mathjax.document('', {
 });
 if (argv.svgenhanced) {
   renderActions.svg = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    let out = mmldoc.convert(SRE.toEnriched(math.outputData.mml).toString());
+    let out = mmldoc.convert(Sre.toEnriched(math.outputData.mml).toString());
     math.outputData.pretext.push(out);
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    SRE.setupEngine({speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules});
+    Sre.setupEngine({speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules});
   });
 }
 
@@ -223,11 +224,11 @@ if (argv.mathml) {
 //
 if (argv.speech) {
   renderActions.speech = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    const speech = SRE.toSpeech(math.outputData.mml);
+    const speech = Sre.toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-speech', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    SRE.setupEngine({modality: 'speech', locale: argv.locale, domain: argv.rules});
+    Sre.setupEngine({modality: 'speech', locale: argv.locale, domain: argv.rules});
   });
 }
 
@@ -237,11 +238,11 @@ if (argv.speech) {
 //
 if (argv.braille) {
   renderActions.braille = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
-    const speech = SRE.toSpeech(math.outputData.mml);
+    const speech = Sre.toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-braille', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
   }, () => {
-    SRE.setupEngine({modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default'});
+    Sre.setupEngine({modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default'});
   });
 }
 
@@ -278,8 +279,9 @@ if (!(argv.svg || argv.svgenhanced)) {
   //  Wait for SRE, if needed
   //
   if (needsSRE) {
-    SRE.setupEngine({xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js')});
-    await sreReady();
+    let jsonPath = require.resolve('speech-rule-engine/lib/mathmaps/base.json').replace(/\/base\.json$/, '');
+    Sre.setupEngine({xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js'), json: jsonPath});
+    await Sre.sreReady();
   }
   //
   //  Render the document

--- a/script/mjsre/package.json
+++ b/script/mjsre/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "mathjax-full": "^3.2.0",
-    "speech-rule-engine": "4.0.0-beta.2",
+    "mathjax-full": "^3.2.2",
+    "speech-rule-engine": "4.0.7",
     "yargs": "^15.4.1"
   }
 }


### PR DESCRIPTION
Updates the MathJax integration script to work with latest MathJax (v3.2.2) and SRE (v4.X.X). In particular we take care of:
* Importing the new `Sre` module from MathJax.
* Setting the correct path to SRE's `MathMaps`.
* Waiting for all required locales to be loaded. 

Here we front-load all the locales, before actually rendering any expressions. This has the advantage that the rest of the code can be kept clean of any asynchronous operations. Note, that this is only possible since we are assuming the code is used as a batch script. In the event that the code should ever be integrated dynamically, this needs to be changed, as resetting a locale will not necessarily wait for that locale to be loaded.