### PR TITLE
Reveal-slides = when defn source-number not supplied do not print empty brackets

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2019 Andrew Rechnitzer, Steven Clontz, Robert A. Beezer
+Copyright 2019-2022 Andrew Rechnitzer, Steven Clontz, Robert A. Beezer
 
 This file is part of PreTeXt.
 
@@ -504,7 +504,14 @@ dfn {
 <xsl:template match="definition">
   <div class="boxed definition">
     <h3>
-      <xsl:apply-templates select="." mode="type-name" /> (<xsl:value-of select="@source-number"/>):
+      <xsl:choose>
+	<xsl:when test="@source-number">
+	  <xsl:apply-templates select="." mode="type-name" /> (<xsl:value-of select="@source-number"/>):
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:apply-templates select="." mode="type-name" />:
+	</xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="." mode="title-full" />
     </h3>
     <xsl:apply-templates select="statement"/>


### PR DESCRIPTION
Very minor change to pretext->reveal translation. 
* Previously the defn template would attempt to print source-number even if not there resulting in empty brackets in the title line of the defn in the slide.
* Now this tests to see if source-number is supplied and prints accordingly.
* Also updated the copyright line.

Also some minor tweaks to center side-by-side and so that images work with decktape.