### PR TITLE
make opening files more robust to avoid permission error on windows

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -82,7 +82,7 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
     # Trying to correct baseline for inline math in Kindle, so we
     # insert a \mathstrut into all the inline math before feeding to MathJax
     if math_format == "kindle":
-        with fileinput.FileInput(mjinput, inplace=True, backup=".bak") as file:
+        with fileinput.FileInput(mjinput, inplace=True) as file:
             for line in file:
                 print(line.replace(r"\(", r"\(\mathstrut "), end="")
 
@@ -133,7 +133,7 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
     owd = os.getcwd()
     os.chdir(tmp_dir)
     html_file = mjoutput
-    with fileinput.FileInput(html_file, inplace=True, backup=".bak") as file:
+    with fileinput.FileInput(html_file, inplace=True) as file:
         for line in file:
             print(xhtml_elt.sub(repl, line), end="")
     os.chdir(owd)
@@ -2111,7 +2111,7 @@ def epub(xml_source, pub_file, out_file, dest_dir, math_format, stringparams):
     html_elt = re.compile(orig)
     for root, dirs, files in os.walk(xhtml_dir):
         for fn in files:
-            with fileinput.FileInput(fn, inplace=True, backup=".bak") as file:
+            with fileinput.FileInput(fn, inplace=True) as file:
                 for line in file:
                     print(html_elt.sub(repl, line), end="")
     os.chdir(owd)

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -32,6 +32,7 @@
 
 # Set up logging package:
 import logging
+from turtle import back
 log = logging.getLogger('ptxlogger')
 
 #############################
@@ -112,8 +113,8 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
     mj_option = "--" + mj_var
     mj_tag = "mj-" + mj_var
     mjpage_cmd = node_exec_cmd + [mjsre_page, mj_option, mjinput]
-    outfile = open(mjoutput, "w")
-    subprocess.run(mjpage_cmd, stdout=outfile)
+    with open(mjoutput, "w") as outfile:
+        subprocess.run(mjpage_cmd, stdout=outfile)
 
     # the 'mjpage' executable converts spaces inside of a LaTeX
     # \text{} into &nbsp; entities, which is a good idea, and
@@ -132,8 +133,9 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
     owd = os.getcwd()
     os.chdir(tmp_dir)
     html_file = mjoutput
-    for line in fileinput.input(html_file, inplace=1):
-        print(xhtml_elt.sub(repl, line), end="")
+    with fileinput.FileInput(html_file, inplace=True, backup=".bak") as file:
+        for line in file:
+            print(xhtml_elt.sub(repl, line), end="")
     os.chdir(owd)
 
     # clean up and package MJ representations, font data, etc
@@ -2109,8 +2111,9 @@ def epub(xml_source, pub_file, out_file, dest_dir, math_format, stringparams):
     html_elt = re.compile(orig)
     for root, dirs, files in os.walk(xhtml_dir):
         for fn in files:
-            for line in fileinput.input(fn, inplace=1):
-                print(html_elt.sub(repl, line), end="")
+            with fileinput.FileInput(fn, inplace=True, backup=".bak") as file:
+                for line in file:
+                    print(html_elt.sub(repl, line), end="")
     os.chdir(owd)
 
     # EPUB stylesheet writes an XHTML file with


### PR DESCRIPTION
The previous line 116 left the file open, causing a permission error on windows.  Switched to the `with open(..) as file:` pattern.  Followed a similar pattern for the two "inplace" substitutions later (so they now match what substitutions were done in the kindle version (lines 85-87).  

Tested before and after on the epub-sampler and only build times changed.