### PR TITLE
WeBWorK: localize terms used by pretext-webwork.js

### DIFF
--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -227,4 +227,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='evaluate'>Evalueer</localization>
     <localization string-id='evaluate'>Evalueer</localization>
     <!-- <localization string-id='code'>Kode</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -253,4 +253,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='evaluate'>Evaluate</localization>
 -->
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -230,4 +230,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Avaluar</localization>
     <localization string-id='code'>Codi</localization>
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -225,4 +225,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Ohodnotit</localization>
     <localization string-id='code'>Kód</localization>
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -235,4 +235,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Though at least one Sage cell installation uses Auswerten instead -->
     <localization string-id='evaluate'>Ausführen</localization>
 <!--    <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -248,4 +248,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='evaluate'>Evaluate</localization>
     <localization string-id='evaluate'>Evaluate</localization>
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <localization string-id='correct'>Correct</localization>
+    <localization string-id='incorrect'>Incorrect</localization>
+    <localization string-id='blank'>Blank</localization>
 </locale>

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -231,4 +231,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Evaluate</localization>
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -237,4 +237,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='evaluate'>Aja</localization>
     <localization string-id='evaluate'>Aja</localization>
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -221,4 +221,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Évaluer</localization>
     <localization string-id='code'>Code</localization>
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -216,4 +216,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Évaluer</localization>
     <localization string-id='code'>Code</localization>
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -225,4 +225,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Evaluate</localization>
     <!-- <localization string-id='code'>Kód</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -226,4 +226,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- else whatever crud ends up on the button kills the cell -->
     <localization string-id='evaluate'>Calcola</localization>
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -234,4 +234,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Executar</localization>
     <localization string-id='code'>Código</localization>
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -237,4 +237,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Translate at first opportunity, please                  -->
     <localization string-id='evaluate'>Evaluate</localization>
     <!-- <localization string-id='code'>Code</localization> -->
+    <!-- Interactive exercise feedback messages                          -->
+    <!-- These might be part of a feedback message for submitting        -->
+    <!-- an answer, e.g. "Correct!" or "Correct: 50%".                   -->
+    <!-- <localization string-id='correct'>Correct</localization> -->
+    <!-- <localization string-id='incorrect'>Incorrect</localization> -->
+    <!-- <localization string-id='blank'>Blank</localization> -->
 </locale>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10365,6 +10365,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="data-seed" >
             <xsl:value-of select="static/@seed"/>
         </xsl:attribute>
+        <xsl:attribute name="data-localize-correct">
+            <xsl:call-template name="type-name">
+                <xsl:with-param name="string-id" select="'correct'"/>
+                <xsl:with-param name="lang" select="$document-language"/>
+            </xsl:call-template>
+        </xsl:attribute>
+        <xsl:attribute name="data-localize-incorrect">
+            <xsl:call-template name="type-name">
+                <xsl:with-param name="string-id" select="'incorrect'"/>
+                <xsl:with-param name="lang" select="$document-language"/>
+            </xsl:call-template>
+        </xsl:attribute>
+        <xsl:attribute name="data-localize-blank">
+            <xsl:call-template name="type-name">
+                <xsl:with-param name="string-id" select="'blank'"/>
+                <xsl:with-param name="lang" select="$document-language"/>
+            </xsl:call-template>
+        </xsl:attribute>
         <xsl:choose>
             <xsl:when test="server-data/@problemSource">
                 <xsl:attribute name="data-problemSource">


### PR DESCRIPTION
This puts localized versions of strings like "Correct" into a data attribute for an embedded WW exercise. The javascript will grab that and use it for feedback messages. I think I'll wait to edit the javascript until this PR is resolved, unless there is a reason to do that first.

Also, I understand that you are refactoring localization. With the current tools, I felt like I needed to use the "type-name" template. I understand "type-name" to refer to the name of an element type, like "Theorem" for a `<theorem>`. That's not what this localization is doing; it's just looking for localized versions of certain words. So did I do this the wrong way? Or will your refactor be more general than just names of element types?