### PR TITLE
Wwlateximage

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -374,22 +374,17 @@
       <subsubsection>
         <title>Using <c>TikZ</c></title>
         <p>
-          In a problem statement (or hint, or solution), you may use an <tag>image</tag> with a <tag>latex-image</tag> child
-          that has <attr>syntax</attr> set to <c>PGtikz</c>. (This requires the <webwork/> server to be version 2.16 or later.)
+          In a problem statement (or hint, or solution), you may use an <tag>image</tag> with a <tag>latex-image</tag> child,
+          as long as the host <webwork/> server is version 2.16 or later.
+          See <xref ref="topic-latex-images"/> for generalities about using <tag>latex-image</tag>.
         </p>
         <p>
-          The content of the <tag>latex-image</tag> should be TikZ code
-          that one might insert inside a <c>\begin{tikzpicture}...\end{tikzpicture}</c>
-          when writing a TeX document.
-          That is, you should not include <c>\begin{tikzpicture}</c> and <c>\end{tikzpicture}</c>
-          in your image code.
+          However, if a <tag>latex-image</tag> is inside a <tag>webwork</tag>,
+          you must use <c>\(...\)</c> instead of <c>$...$</c> to encase any inline math in the image.
+          And if you have display math, that should use <c>\[...\]</c> instead of <c>$$...$$</c>.
         </p>
         <p>
-          You must use <c>\(...\)</c> instead of <c>$...$</c> to encase inline math.
-          And if you have display math in the TikZ image, that should use <c>\[...\]</c> instead of <c>$$...$$</c>.
-        </p>
-        <p>
-          Your image code can use variables that you defined in the <tag>pg-code</tag> section.
+          Your latex-image code can use variables that you defined in the <tag>pg-code</tag> section.
           Scalar variables may be used simply by using their perl names including the dollar sign sigil.
           For example, <c>\draw ($a,$b) -- ($c,$d);</c> where <c>$a</c>, <c>$b</c>, <c>$c</c>, and <c>$d</c> are variables.
           However, any instance of <c>\$</c> in code will be interpreted as an escaped dollar sign first,
@@ -401,35 +396,34 @@
         </p>
         <p>
           In perl, <c>$</c>, <c>@</c>, and <c>%</c> each have special meaning.
-          So you may wonder about using them in your TikZ code.
-          The short answer is that you should use them just as you would use them in a regular <latex/>/TikZ document.
+          So you may wonder about using them in your latex-image code.
+          The short answer is that you should use them just as you would use them in a regular <latex/> document.
           So when you would like a dollar sign, write <c>\$</c>.
           For a percent sign, use <c>\%</c>.
           An <q>at</q> character does not need escaping, so write <c>@</c>.
         </p>
         <p>
-          As mentioned above, <em>do not</em> use a dollar sign for math.
+          As mentioned above, do not use a dollar sign to encase math.
           If you want to put a <latex/> comment in the code,
           you may write it in the usual way like <c>% This is a comment</c>.
         </p>
         <p>
-          Your project's <tag>docinfo</tag> may contain a <tag>latex-image-preamble</tag> element
-          with attribue <attr>syntax</attr> set to <c>PGtikz</c>.
-          If so, all TikZ images inside a <tag>webwork</tag> will load that <tag>latex-image-preamble</tag>
-          so you may control styling and other things globally.
-          However, the host course on the <webwork/> server must first be given some additional attention.
+          Your project's <tag>docinfo</tag> may contain a <tag>latex-image-preamble</tag> element.
+          If so, and if that preamble content should affect the latex-images inside the <tag>webwork</tag>,
+          then you need to get that preamble content up on the <webwork/> host course.
+          In many cases, you will <em>need</em> to get that preamble content up on the host course for the image to even compile.
           See <xref ref="webwork-pg-macros"/>.
         </p>
         <p>
           When the <webwork/> server makes one of these images for the first time,
-          it caches the image. Generally, if you then edit the TikZ source code,
+          it caches the image. Generally, if you then edit the image source code,
           the <webwork/> server will not rebuild the image. So while you are developing an image,
           you may want to put <c>$refreshCachedImages = 1;</c> into your <tag>pg-code</tag>
           for the problem. This will force the <webwork/> server to rebuild the image.
-          Once the image is stable, remove that line from the <tag>pg-code</tag>.
+          <alert>Once the image is stable, remove that line from the <tag>pg-code</tag>.</alert>
           Otherwise every time someone views the image in an embedded interactive HTML exercise,
           the <webwork/> server will rebuild the image. Beyond the extra strain on the server,
-          this will cause a lag for your readers to see the image.
+          this will cause a lag for your readers.
         </p>
         <p>
           See the <webwork/> sample chapter for examples.

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -157,8 +157,7 @@
     <title>PG Macros from the <pretext/> Source</title>
     <p>
       The project's <webwork/> exercises may rely on PG macros that are written into the project's source.
-      For example, the exercises might have TikZ images that rely on <tag>docinfo/latex-image-preamble</tag>
-      with <attr>syntax</attr> set to <c>PGtikz</c>.
+      For example, the exercises might have TikZ images that rely on <tag>docinfo/latex-image-preamble</tag>.
     </p>
     <p>
       For this, a PG macro library file must be built and placed in the host course's <c>templates/macros/</c>

--- a/examples/showcase/source/webwork.ptx
+++ b/examples/showcase/source/webwork.ptx
@@ -184,10 +184,12 @@
           This Venn Diagram groups animals by certain characteristics.
         </p>
         <image width="50%">
-          <latex-image syntax="PGtikz">
-            \draw[fill=red, opacity=0.5] (0,0) circle (2cm) node[below left=1.5cm, opacity=1] {Has a Bill} node[below left, opacity=1] {Duck};
-            \draw[fill=green, opacity=0.5] (60:2cm) circle (2cm) node [above=2.1cm, opacity=1] {Is Venemous} node[above=0.5cm, opacity=1] {Jellyfish};
-            \draw[fill=blue, opacity=0.5] (0:2cm) circle (2cm) node [below right=1.5cm, opacity=1] {Has Fur} node[below right, opacity=1] {Beaver};
+          <latex-image>
+            \begin{tikzpicture}
+              \draw[fill=red, opacity=0.5] (0,0) circle (2cm) node[below left=1.5cm, opacity=1] {Has a Bill} node[below left, opacity=1] {Duck};
+              \draw[fill=green, opacity=0.5] (60:2cm) circle (2cm) node [above=2.1cm, opacity=1] {Is Venemous} node[above=0.5cm, opacity=1] {Jellyfish};
+              \draw[fill=blue, opacity=0.5] (0:2cm) circle (2cm) node [below right=1.5cm, opacity=1] {Has Fur} node[below right, opacity=1] {Beaver};
+            \end{tikzpicture}
           </latex-image>
         </image>
         <p>

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -51,8 +51,8 @@
 
         <!-- 
         This initialism specifies the filename of the macro file (WWSC.pl) that 
-        must be present in the WeBWorK server to be able to generate the Pretext 
-        Tikz figures. Make sure this macro file is in your server (a copy is
+        must be present in the WeBWorK server to be able to generate latex-image
+        images. Make sure this macro file is in your server (a copy is
         included in  pg-macros folder), and that the macro filename is changed 
         if the initialism is changed.
         -->
@@ -71,10 +71,6 @@
         </feedback>
 
         <latex-image-preamble>
-            \usepackage{tikz}
-        </latex-image-preamble>
-
-        <latex-image-preamble syntax="PGtikz">
             \usepackage{pgfplots}
             \pgfplotsset{
                 every axis/.append style={
@@ -85,7 +81,6 @@
                 }
             }
         </latex-image-preamble>
-
     </docinfo>
 
     <article xml:id="sample-ww-chapter">
@@ -1192,10 +1187,10 @@
             </p>
             <p>
                 If your <webwork/> server is version 2.16 or later,
-                <webwork/> problems can process TikZ code. Here is an example.
+                <webwork/> problems can process <tag>latex-image</tag> code. Here is an example.
             </p>
             <exercise>
-                <title>A static TikZ graph</title>
+                <title>A static <tag>latex-image</tag> graph</title>
                 <webwork>
                     <pg-code>
                         Context("IntegerFunctions");
@@ -1218,18 +1213,20 @@
                                 the effect is that each of the 1+2+3+4+5+6 blue balls corresponds
                                 to one pair from the 7 orange balls
                             </description>
-                            <latex-image syntax="PGtikz">
-                                \draw[dashed] (0.5-0.5*6.5,-0.866025*6.5) -&#x2d; (7-0.5*6.5,-0.866025*6.5);
-                                \draw[very thick] (2-0.5*7,-0.866025*7) -&#x2d; (2-0.5*4,-0.866025*4) -&#x2d; (5-0.5*7,-0.866025*7);
-                                \foreach \x in {1,...,6}
-                                    \foreach \y in {1,...,\x}
-                                        \shade[ball color=blue!30] (\y-0.5*\x,-0.866025*\x) circle (0.2cm);
-                                \foreach \y in {1,...,7}
-                                    \shade[ball color=orange!40] (\y-0.5*7,-0.866025*7) circle (0.2cm);
-                                \node at (2.5,-0.5) [anchor=north west]{\(\color{blue}\sum\limits_{k=1}^nk\color{black}\)};
-                                \shade[ball color=blue] (2-0.5*4,-0.866025*4) circle (0.2cm);
-                                \shade[ball color=orange] (2-0.5*7,-0.866025*7) circle (0.2cm);
-                                \shade[ball color=orange] (5-0.5*7,-0.866025*7) circle (0.2cm);
+                            <latex-image>
+                                \begin{tikzpicture}
+                                    \draw[dashed] (0.5-0.5*6.5,-0.866025*6.5) -&#x2d; (7-0.5*6.5,-0.866025*6.5);
+                                    \draw[very thick] (2-0.5*7,-0.866025*7) -&#x2d; (2-0.5*4,-0.866025*4) -&#x2d; (5-0.5*7,-0.866025*7);
+                                    \foreach \x in {1,...,6}
+                                        \foreach \y in {1,...,\x}
+                                            \shade[ball color=blue!30] (\y-0.5*\x,-0.866025*\x) circle (0.2cm);
+                                    \foreach \y in {1,...,7}
+                                        \shade[ball color=orange!40] (\y-0.5*7,-0.866025*7) circle (0.2cm);
+                                    \node at (2.5,-0.5) [anchor=north west]{\(\color{blue}\sum\limits_{k=1}^nk\color{black}\)};
+                                    \shade[ball color=blue] (2-0.5*4,-0.866025*4) circle (0.2cm);
+                                    \shade[ball color=orange] (2-0.5*7,-0.866025*7) circle (0.2cm);
+                                    \shade[ball color=orange] (5-0.5*7,-0.866025*7) circle (0.2cm);
+                                \end{tikzpicture}
                             </latex-image>
                         </image>
                         <instruction>
@@ -1243,7 +1240,7 @@
             </exercise>
 
             <exercise>
-                <title>A randomized TikZ graph</title>
+                <title>A randomized <tag>latex-image</tag> graph</title>
                 <introduction>
                     <p>
                         These images may depend on the random seed.
@@ -1265,8 +1262,10 @@
                                 a rectangle whose width is labeled <var name="$b"/> cm
                                 and height is labeled <var name="$b"/> cm
                             </description>
-                            <latex-image syntax="PGtikz">
-                                \draw[fill=blue!20] (0,0) -&#x2d;++ (6,0) node[pos=0.5,below] {\($b\)\,cm} -&#x2d;++ (0,4) node[pos=0.5,right] {\($a\)\,cm} -&#x2d;++ (-6,0) -&#x2d; cycle;
+                            <latex-image>
+                                \begin{tikzpicture}
+                                    \draw[fill=blue!20] (0,0) -&#x2d;++ (6,0) node[pos=0.5,below] {\($b\)\,cm} -&#x2d;++ (0,4) node[pos=0.5,right] {\($a\)\,cm} -&#x2d;++ (-6,0) -&#x2d; cycle;
+                                \end{tikzpicture}
                             </latex-image>
                         </image>
                         <p>
@@ -1277,11 +1276,11 @@
             </exercise>
 
             <exercise>
-                <title>A TikZ graph affected by <tag>latex-image-preamble</tag></title>
+                <title>A <tag>latex-image</tag> graph affected by <tag>latex-image-preamble</tag></title>
                 <introduction>
                     <p>
-                        This sample chapter's <tag>docinfo</tag> has a <tag>latex-image-preamble</tag>
-                        with <attr>syntax</attr> set to <c>PGtikz</c>. This exercise has graph styling that is affected by that.
+                        This sample chapter's <tag>docinfo</tag> has a <tag>latex-image-preamble</tag>.
+                        This exercise has graph styling that is affected by that.
                     </p>
                 </introduction>
                 <webwork>
@@ -1301,10 +1300,12 @@
                                 the graph of a polynomial that crosses the x-axis at <var name="$roots[0]"/>,
                                 <var name="$roots[1]"/>, and <var name="$roots[2]"/>.
                             </description>
-                            <latex-image syntax="PGtikz">
-                                \begin{axis}
-                                    \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
-                                \end{axis}
+                            <latex-image>
+                                \begin{tikzpicture}
+                                    \begin{axis}
+                                        \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
+                                    \end{axis}
+                                \end{tikzpicture}
                             </latex-image>
                         </image>
                         <p>
@@ -1331,16 +1332,17 @@
                             a printed at sign, and a percent sign used as a comment marker.
                         </p>
                         <image width="50%">
-                            <latex-image syntax="PGtikz">
-                                \node at (0,0) {I need about \$3.50.};
-                                \node at (0,1) {You gotta give 110\%.};  %This is a comment.
-                                \node at (0,2) {Send email user@domain.com.};
+                            <latex-image>
+                                \begin{tikzpicture}
+                                    \node at (0,0) {I need about \$3.50.};
+                                    \node at (0,1) {You gotta give 110\%.};  %This is a comment.
+                                    \node at (0,2) {Send email user@domain.com.};
+                                \end{tikzpicture}
                             </latex-image>
                         </image>
                     </statement>
                 </webwork>
             </exercise>
-
 
             <!-- TODO: Support for packages, such as pgfplots -->
 
@@ -1364,7 +1366,7 @@
                         $solgr = init_graph(-1,-1,4,4,
                         axes=>[0,0],
                         grid=>[5,5],
-                        size=>[300,300]
+                        size=>[300,180]
                         );
                         add_functions($solgr, "x^3/$a^3 for x in &lt;-1,4&gt; using color:blue and weight:2");
                         $solgr->moveTo(0,1);
@@ -2337,6 +2339,53 @@
                     </exercise>
                 </exercisegroup>
             </exercises>
+        </section>
+
+        <section xml:id="section-deprecations">
+            <title>Deprecations</title>
+
+            <p>
+                This section is for testing if deprecated features are still supported
+            </p>
+
+            <exercise>
+                <introduction>
+                    <p>
+                        Once upon a time a <tab>latex-image</tab> inside a <tab>webwork</tab>
+                        needed to have an <attr>syntax</attr> attribute with value <c>PGtikz</c>.
+                        This exercise is here to test that we can still honor such exercises in a project's source.
+                    </p>
+                </introduction>
+                <webwork>
+                    <pg-code>
+                        @roots = (-3..3)[NchooseK(7,3)];
+                        @roots = num_sort(@roots);
+                        $answer = List(@roots);
+                        $xmin = min(-1,@roots)-1;
+                        $xmax = max(1,@roots)+1;
+                        $refreshCachedImages = 1;
+                    </pg-code>
+                    <statement>
+                        <p>
+                            What are the roots of this polynomial?
+                        </p>
+                        <image width="50%">
+                            <description>
+                                the graph of a polynomial that crosses the x-axis at <var name="$roots[0]"/>,
+                                <var name="$roots[1]"/>, and <var name="$roots[2]"/>.
+                            </description>
+                            <latex-image syntax="PGtikz">
+                                \begin{axis}
+                                    \addplot[domain=$xmin:$xmax,smooth] {(x-$roots[0])*(x-$roots[1])*(x-$roots[2])};
+                                \end{axis}
+                            </latex-image>
+                        </image>
+                        <p>
+                            <var name="$answer" width="20"/>
+                        </p>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <backmatter>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1040,6 +1040,23 @@ def webwork_to_xml(
             )
         log.info(msg)
 
+        # If and only if the server is version 2.16, we adjust PG code to use PGtikz.pl
+        # instead of PGlateximage.pl
+        if ww_major_version == 2 and ww_minor_version == 16 and origin[problem] == "ptx":
+            pgdense[problem] = pgdense[problem].replace('PGlateximage.pl','PGtikz.pl')
+            pgdense[problem] = pgdense[problem].replace('createLaTeXImage','createTikZImage')
+            pgdense[problem] = pgdense[problem].replace('BEGIN_LATEX_IMAGE','BEGIN_TIKZ')
+            pgdense[problem] = pgdense[problem].replace('END_LATEX_IMAGE','END_TIKZ')
+            pghuman[problem] = pghuman[problem].replace('PGlateximage.pl','PGtikz.pl')
+            pghuman[problem] = pghuman[problem].replace('createLaTeXImage','createTikZImage')
+            pghuman[problem] = pghuman[problem].replace('BEGIN_LATEX_IMAGE','BEGIN_TIKZ')
+            pghuman[problem] = pghuman[problem].replace('END_LATEX_IMAGE','END_TIKZ')
+            # We crudely remove tikzpicture environment delimiters
+            pgdense[problem] = pgdense[problem].replace('\\begin{tikzpicture}','')
+            pgdense[problem] = pgdense[problem].replace('\\end{tikzpicture}','')
+            pghuman[problem] = pghuman[problem].replace('\\begin{tikzpicture}','')
+            pghuman[problem] = pghuman[problem].replace('\\end{tikzpicture}','')
+
         # make base64 for PTX problems
         if origin[problem] == "ptx":
             if ww_reps_version == "2":

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1596,7 +1596,6 @@
                     attribute decorative {"yes" | "no"}?,
                     element description {(TextShort | WWVariable)*}?,
                     element latex-image {
-                        attribute syntax {"PGtikz"},
                         text
                     }?
                 }
@@ -2398,7 +2397,6 @@
                 }
             Configuration |=
                 element latex-image-preamble {
-                    attribute syntax {"PGtikz"}?,
                     text
                 }
             Configuration |=

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -548,7 +548,7 @@
         <xsl:with-param name="text" select=".//pg-code" />
     </xsl:call-template>
     <!-- if there are latex-image in the problem, put their code here -->
-    <xsl:apply-templates select=".//image[latex-image/@syntax = 'PGtikz']" mode="latex-image-code"/>
+    <xsl:apply-templates select=".//image[latex-image]" mode="latex-image-code"/>
 </xsl:template>
 
 <!-- default template, for complete presentation -->
@@ -862,10 +862,10 @@
                 <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
             </xsl:call-template>
         </xsl:if>
-        <!-- when there is a PGtikz graph -->
-        <xsl:if test=".//latex-image[@syntax = 'PGtikz']">
+        <!-- when there is a latex-image graph -->
+        <xsl:if test=".//latex-image">
             <xsl:call-template name="macro-padding">
-                <xsl:with-param name="string" select="'PGtikz.pl'"/>
+                <xsl:with-param name="string" select="'PGlateximage.pl'"/>
                 <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
             </xsl:call-template>
         </xsl:if>
@@ -1322,7 +1322,7 @@
     <xsl:value-of select="@name"/>
 </xsl:template>
 
-<xsl:template match="latex-image[@syntax = 'PGtikz']/var" mode="latex-image">
+<xsl:template match="latex-image/var" mode="latex-image">
     <xsl:value-of select="@name" />
 </xsl:template>
 
@@ -1554,7 +1554,7 @@
     <xsl:text>)@]* </xsl:text>
 </xsl:template>
 
-<xsl:template match="image[latex-image/@syntax = 'PGtikz']" mode="components">
+<xsl:template match="image[latex-image]" mode="components">
     <xsl:variable name="visible-id">
         <xsl:apply-templates select="." mode="visible-id"/>
     </xsl:variable>
@@ -1593,26 +1593,26 @@
     <xsl:apply-templates select="text()|var"/>
 </xsl:template>
 
-<xsl:template match="image[latex-image/@syntax = 'PGtikz']" mode="latex-image-code">
+<xsl:template match="image[latex-image]" mode="latex-image-code">
     <xsl:variable name="visible-id">
         <xsl:apply-templates select="." mode="visible-id"/>
     </xsl:variable>
     <xsl:variable name="pg-name" select="concat('$', translate($visible-id,'-','_'))"/>
     <xsl:value-of select="$pg-name"/>
-    <xsl:text> = createTikZImage();&#xa;</xsl:text>
-    <xsl:if test="$docinfo/latex-image-preamble[@syntax = 'PGtikz']">
+    <xsl:text> = createLaTeXImage();&#xa;</xsl:text>
+    <xsl:if test="$docinfo/latex-image-preamble">
         <xsl:value-of select="$pg-name"/>
         <xsl:text>->addToPreamble(latexImagePreamble());&#xa;</xsl:text>
     </xsl:if>
-    <xsl:variable name="pg-tikz-code">
+    <xsl:variable name="pg-latex-image-code">
         <xsl:apply-templates select="latex-image/text()|latex-image/var" mode="latex-image"/>
     </xsl:variable>
     <xsl:value-of select="$pg-name"/>
-    <xsl:text>->BEGIN_TIKZ&#xa;</xsl:text>
+    <xsl:text>->BEGIN_LATEX_IMAGE&#xa;</xsl:text>
     <xsl:call-template name="sanitize-text">
-        <xsl:with-param name="text" select="$pg-tikz-code"/>
+        <xsl:with-param name="text" select="$pg-latex-image-code"/>
     </xsl:call-template>
-    <xsl:text>&#xa;END_TIKZ&#xa;</xsl:text>
+    <xsl:text>&#xa;END_LATEX_IMAGE&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="text()" mode="latex-image">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -674,6 +674,27 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </task>
 </xsl:template>
 
+<!-- 2022-07-10 webwork//latex-image[syntax='PGtikz'] deprecated    -->
+<!-- to just a normal latex-image. The text content for the code    -->
+<!-- must be wrapped in a tikzpicture environment.                  -->
+<xsl:template match="latex-image[@syntax='PGtikz']" mode="repair">
+    <xsl:copy>
+        <!-- we drop the @syntax attribute -->
+        <xsl:apply-templates select="node()|@*[not(local-name(.) = 'syntax')]" mode="repair"/>
+    </xsl:copy>
+</xsl:template>
+<xsl:template match="latex-image[@syntax='PGtikz']/text()" mode="repair">
+    <xsl:text>\begin{tikzpicture}&#xa;</xsl:text>
+    <xsl:call-template name="sanitize-latex">
+        <xsl:with-param name="text">
+            <xsl:copy>
+                <xsl:apply-templates select="."/>
+            </xsl:copy>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#xa;\end{tikzpicture}&#xa;</xsl:text>
+</xsl:template>
+
 
 <!-- ############## -->
 <!-- Identification -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10778,6 +10778,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'an ad-hoc &quot;stage&quot; element in a scaffolded WeBWorK problem has been replaced by a standard PreTeXt &quot;task&quot; element, so make simple subsitutions.  We will attempt to honor your request'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2022-07-10  deprecate latex-image with @syntax="PGtikz" -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="$document-root//latex-image[@syntax='PGtikz']" />
+        <xsl:with-param name="date-string" select="'2022-07-10'" />
+        <xsl:with-param name="message" select="'a &quot;latex-image&quot; with &quot;@syntax&quot; attribute set to &quot;PGtikz&quot; is deprecated in favor of a plain &quot;latex-image&quot;.  After removing the attribute, the &quot;latex-image&quot; code needs to be placed inside a &quot;tikzpicture&quot; invironment. Until you make such changes to your source, we will attempt to honor your request'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/support/pretext-pg-macros.xsl
+++ b/xsl/support/pretext-pg-macros.xsl
@@ -73,18 +73,15 @@
 </xsl:template>
 
 <xsl:template match="book|article" mode="latex-image-preamble">
-    <xsl:if test="$docinfo/latex-image-preamble[@syntax = 'PGtikz']">
+    <xsl:if test="$docinfo/latex-image-preamble">
         <xsl:text># Return a string containing the latex-image-preamble contents.&#xa;</xsl:text>
-        <xsl:text># To be used by TikZImage objects as in:&#xa;</xsl:text>
+        <xsl:text># To be used by LaTeXImage objects as in:&#xa;</xsl:text>
         <xsl:text># $image->addToPreamble(latexImagePreamble())&#xa;</xsl:text>
-        <!-- If PTX latex-image evolves to "know" it is a tikz image, xypic image, etc. -->
-        <!-- then this perl subroutine might evolve to accept an argument identifying   -->
-        <!-- which type of latex-image-preamble to use.                                 -->
         <xsl:text>&#xa;</xsl:text>
         <xsl:text>sub latexImagePreamble {&#xa;</xsl:text>
         <xsl:text>return &lt;&lt;'END_LATEX_IMAGE_PREAMBLE'&#xa;</xsl:text>
         <xsl:call-template name="sanitize-text">
-            <xsl:with-param name="text" select="$docinfo/latex-image-preamble[@syntax = 'PGtikz']" />
+            <xsl:with-param name="text" select="$docinfo/latex-image-preamble" />
         </xsl:call-template>
         <xsl:text>&#xa;</xsl:text>
         <xsl:text>END_LATEX_IMAGE_PREAMBLE&#xa;</xsl:text>


### PR DESCRIPTION
This cleans up the situation with `latex-image` in a `webwork`. No more `synatx='PGtikz'`. Just write `latex-image` code like you would anywhere else. (Except author must take special care with dollar signs.)

So `synatx='PGtikz'` is removed from schema.

There is a deprecation warning.

If you still use `synatx='PGtikz'`, the repair phase takes care of that and makes your source ready for a 2.17 WW server.

If it turns out you are actually contacting a 2.16 WW server during the representations collecting, then the python script adjusts at the last moment, reverting to 2.16 structure. 

Once this is resolved, I will revisit #1610.