### PR TITLE
Fix errors in beamer template

### DIFF
--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -19,6 +19,11 @@ You should have received a copy of the GNU General Public License
 along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "./entities.ent">
+    %entities;
+]>
+
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -440,7 +445,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
   </xsl:if>
   <xsl:if test="$document-root//fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
-    <xsl:call-template name="fillin-text">
+    <xsl:call-template name="fillin-text"/>
   </xsl:if>
   <xsl:if test="$document-root//m/fillin|$document-root//me/fillin|$document-root//men/fillin|$document-root//mrow/fillin">
       <xsl:call-template name="fillin-math"/>
@@ -608,7 +613,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- 
+<!--
 <xsl:template match="sidebyside">
   <xsl:text>\begin{tcbraster}[arc=0pt, raster columns=</xsl:text>
   <xsl:value-of select="count(*)"/>


### PR DESCRIPTION
I noticed (when `xsltproc` choked on it) that a couple of errors were introduced in the last update to this template.

These changes should ensure that the `pretext-beamer.xsl` template runs successfully. (I make no claim to have improved the output in any way.)

Two problems resolved:

1. On (what was) line 442, `<xsl:call-template name="fillin-text">` should be self-closing.
2. The use of `&PROOF-LIKE;` requires the `entities.ent` file to be loaded. I added some lines at the top to ensure this happens.