### PR TITLE
new version of services

### DIFF
--- a/xsl/support/runestone-services.xml
+++ b/xsl/support/runestone-services.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <all>
 	<js type="list">
-		<item type="str">runtime.d24a93181f625912.bundle.js</item>
+		<item type="str">runtime.2a6a972e6f4ec153.bundle.js</item>
 		<item type="str">637.d54be67956c5c660.bundle.js</item>
-		<item type="str">runestone.aeb994b86db36b29.bundle.js</item>
+		<item type="str">runestone.e00ad9c8384ced97.bundle.js</item>
 	</js>
 	<css type="list">
 		<item type="str">637.fafafbd97df8a0d1.css</item>
 		<item type="str">runestone.e4d5592da655219f.css</item>
 	</css>
 	<cdn-url type="str">https://runestone.academy/cdn/runestone/</cdn-url>
-	<version type="str">6.3.0</version>
+	<version type="str">6.3.6</version>
 </all>


### PR DESCRIPTION
Update to runestone 6.3.6

* Support (mostly) display math in parsons
* MathJax rendering fixes
* Fix disappearing menu for academy builds