### PR TITLE
Fix: remove youtube player_api script tag

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -160,9 +160,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- When hosted, we embed YouTube videos in a slightly different -->
             <!-- manner, and with the next script it is possible to monitor   -->
             <!-- reader events associated with the use of the videos          -->
-            <!-- NB: placed here just for initial testing w/ diffs, -->
-            <!--     could move up above Google Ad section          -->
-            <script type="text/javascript" src="https://www.youtube.com/player_api"></script>
+	    <!-- The Runestone javascript will automatically include the player_api -->
+	    <!-- After it has set up the appropriate events such as API loaded -->
 
             <!-- We only show the Runestone "bust" menu icon if we are building        -->
             <!-- for a Runestone server, so this CSS is only needed in that case.      -->


### PR DESCRIPTION
I have been playing around a bit.  Using `data-video-width="100%'` and omitting `data-video-height` does a passable job.  

the video fills the width, but uses letterboxing to maintain the aspect ratio of the video rather than increasing the height. So you end up with wide videos with lots of black on the side.  See below:
<img width="637" alt="Screen Shot 2022-08-24 at 2 30 59 PM" src="https://user-images.githubusercontent.com/51115/186506715-a2152b49-1473-457d-b49d-cf800a5ab30a.png">

I think it is kind of OK, especially since you can expand it to full screen if you want details.  But it would look nicer if we could somehow give a height hint.  For example I tried `data-video-width="100%"` with `data-video-height="350px"` and that looked very viewable. See below:

<img width="615" alt="Screen Shot 2022-08-24 at 2 29 15 PM" src="https://user-images.githubusercontent.com/51115/186506569-fcfd88f6-de8d-4d15-a9ca-85a0c117cb2b.png">

PS - if you are looking closely you will notice that the margins are not asymmetrical, that is **me** not youtube.