### PR TITLE
WeBWorK: support --restrict argument

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -305,7 +305,7 @@
 
         </section>
 
-        <section>
+        <section xml:id="section-the-quadratic-formula">
             <title>The Quadratic Formula</title>
 
             <p>In the previous section, we saw relatively simple <webwork /> questions. This section demonstrates how even very complicated <webwork /> problems can still behave well.</p>

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -638,6 +638,7 @@ def main():
             xml_source,
             publication_file,
             stringparams,
+            args.xmlid,
             args.abort,
             args.server,
             dest_dir,

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -886,7 +886,7 @@ def tracer(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
 
 
 def webwork_to_xml(
-    xml_source, pub_file, stringparams, abort_early, server_params, dest_dir
+    xml_source, pub_file, stringparams, xmlid_root, abort_early, server_params, dest_dir
 ):
     import urllib.parse  # urlparse()
     import base64  # b64encode()
@@ -901,9 +901,11 @@ def webwork_to_xml(
         global __module_warning
         raise ImportError(__module_warning.format("requests"))
 
-    # support publisher file, but not subtree argument
+    # support publisher file, subtree argument
     if pub_file:
         stringparams["publisher"] = pub_file
+    if xmlid_root:
+        stringparams["subtree"] = xmlid_root
     log.info(
         "string parameters passed to extraction stylesheet: {}".format(stringparams)
     )

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -62,6 +62,11 @@
 <xsl:import href="./pretext-assembly.xsl"/>
 <xsl:import href="./pretext-common.xsl"/>
 
+<!-- Get a "subtree" xml:id value   -->
+<!-- Then walk the XML source tree  -->
+<!-- applying specializations below -->
+<xsl:import href="./extract-identity.xsl" />
+
 <!-- Override the corresponding param in pretext-assembly so that webwork  -->
 <!-- copies can be made.                                                   -->
 <xsl:variable name="b-extracting-pg" select="true()"/>
@@ -92,7 +97,7 @@
 <!--#######################################################################-->
 
 <!-- Initialize empty dictionaries, then define key-value pairs             -->
-<xsl:template match="/">
+<xsl:template match="*" mode="extraction-wrapper">
     <xsl:text>localization = '</xsl:text>
     <xsl:value-of select="$document-language"/>
     <xsl:text>'&#xa;</xsl:text>
@@ -128,10 +133,10 @@
     <xsl:text>pgdense['hint_no_solution_yes'] = {}&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_no'] = {}&#xa;</xsl:text>
     <xsl:text>pgdense['hint_yes_solution_yes'] = {}&#xa;</xsl:text>
-    <xsl:apply-templates select="$document-root//webwork[statement|task|@source]" mode="dictionaries"/>
+    <xsl:apply-imports/>
 </xsl:template>
 
-<xsl:template match="webwork[@source]" mode="dictionaries">
+<xsl:template match="webwork[@source]" mode="extraction">
     <!-- Define values for the visible-id as key -->
     <xsl:variable name="problem">
         <xsl:value-of select="@webwork-id"/>
@@ -154,7 +159,7 @@
     <xsl:text>"&#xa;</xsl:text>
 </xsl:template>
 
-<xsl:template match="webwork[statement|task]" mode="dictionaries">
+<xsl:template match="webwork[statement|task]" mode="extraction">
     <!-- Define values for the visible-id as key -->
     <xsl:variable name="problem">
         <xsl:value-of select="@webwork-id"/>


### PR DESCRIPTION
This adds support for `-r` for building WeBWorK representations restricted to a subtree.

To test, temporarily edit `examples/webwork/Makefile` to have these recipes:

```
sample-chapter-representations:
	$(PTX)/pretext/pretext -v -r section-the-quadratic-formula -c webwork -p $(SMPCPUB) $(SMPC)
```

```
sample-chapter-html:
	-rm -r $(WWEXAMPLE)/sample-chapter/generated/latex-image
	$(PTX)/pretext/pretext -c latex-image -r section-the-quadratic-formula -f svg -p $(SMPCPUB) $(SMPC)
	-rm -r $(HTMLOUT)
	install -d $(HTMLOUT)
	$(PTX)/pretext/pretext -vv -c all -r section-the-quadratic-formula -f html -p $(SMPCPUB) -x webwork.divisional.static no debug.datedfiles no -d $(HTMLOUT) $(SMPC); \
```

All that is changed is the `-r` option.

Then run `make sample-chapter-representations` and you will see that only three WW are processed.

And then run `make sample-chapter-html` and open the resulting HTML in the scratch folder. All three WW exercise function.
