### PR TITLE
Fix: Use an import from the CLI to produce relative pathnames 

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -24,15 +24,15 @@
 
 import pretext as ptx
 
-# Set up logging (replacing _verbose/_debug).  
-# Use log.info(<string>) or log.debug(<string>).  
-# Also available now are log.critical(), log.error(), and log.warning(). 
+# Set up logging (replacing _verbose/_debug).
+# Use log.info(<string>) or log.debug(<string>).
+# Also available now are log.critical(), log.error(), and log.warning().
 # 0-level verbosity will be set to only show log.critical() messages.
 import logging
 #ptxlogger will be compatible with the CLI logger.
 log = logging.getLogger('ptxlogger')
 log.setLevel(logging.DEBUG)
-# Create stream handler for console output.  
+# Create stream handler for console output.
 # Later we will set the level with log.setLevel(logging.[level])
 console_log = logging.StreamHandler()
 log_format = logging.Formatter('PTX:%(levelname)-8s: %(message)s')
@@ -700,19 +700,6 @@ def main():
                 stringparams,
                 None,
                 "zip",
-                extra_stylesheet,
-                out_file,
-                dest_dir,
-            )
-        # Top-secret (undocumented): just like "html", only
-        # also builds  mapping.json  for CAT + CodeChat work
-        elif args.format == "html-mapping":
-            ptx.html(
-                xml_source,
-                publication_file,
-                stringparams,
-                args.xmlid,
-                "html-with-mapping",
                 extra_stylesheet,
                 out_file,
                 dest_dir,


### PR DESCRIPTION
Specifically, relative path names in the HTML mapping from source paths (relative to the project path) to XML IDs.

The history: the original add in b4395ea3, which performed the mapping for all HTML builds, was made optional in ea4acc57 due to security concerns -- the mapping file contains potentially confidential information (username / local filesystem paths) to the mapping file, which might be published to the web. This update now make the mapping default behavior, but only stores a relative path to address the security concerns.