### PR TITLE
Add "datafile" attribute to <program>.

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1734,6 +1734,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                     </xsl:otherwise>
                                 </xsl:choose>
                             </xsl:attribute>
+                            
+                            <!-- allow @datafile attribute on <program> -->
+                            <xsl:if test="@datafile">
+                                <xsl:attribute name="data-datafile">
+                                <xsl:choose>
+                                    <xsl:when test="$b-managed-directories">
+                                        <xsl:value-of select="$external-directory"/>
+                                        <xsl:value-of select="@datafile"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="@datafile"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                                </xsl:attribute>
+                            </xsl:if>
+
                             <!-- SQL (only) needs an attribute so it can find some code -->
                             <xsl:if test="$active-language = 'sql'">
                                 <xsl:attribute name="data-wasm">


### PR DESCRIPTION
The runestone `:datafile:` option specifies where to find a file if an ActiveCode script needs to open and read a file. This PR adds that attribute to `<program>`