### PR TITLE
Webwork array

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1685,6 +1685,37 @@
 
             </exercise>
 
+            <exercise>
+                <title>Answer Arrays</title>
+                <webwork>
+                  <pg-code>
+                    Context("Point");
+                    $p = Point(0,0);
+                    Context("Vector");
+                    $v = Vector(1,2);
+                    $c = ColumnVector(3,4);
+                    Context("Matrix");
+                    $m = Matrix([[1,2],[3,4]]);
+                  </pg-code>
+                  <statement>
+                    <p>
+                      These answer blanks are all expecting some sort of answer in an array format.
+                    </p>
+                    <p>
+                      <m><var name="$p"/> = {}</m><var name="$p" form="array"/>
+                    </p>
+                    <p>
+                      <m><var name="$v"/> = {}</m><var name="$v" form="array"/>
+                    </p>
+                    <p>
+                      <m><var name="$c"/> = {}</m><var name="$c" form="array"/>
+                    </p>
+                    <p>
+                      <m><var name="$m"/> = {}</m><var name="$m" form="array"/>
+                    </p>
+                  </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -640,7 +640,13 @@
         <fragment xml:id="fillin-character">
             <title>Fill-in blank character</title>
             <code>
-            FillInText = element fillin {attribute characters {xsd:integer}?, empty}
+            FillInText =
+                element fillin {
+                    attribute characters {xsd:integer}?,
+                    attribute rows {xsd:integer}?,
+                    attribute cols {xsd:integer}?,
+                    empty
+                }
             Generator |=
                 FillInText
             </code>

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -246,4 +246,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -272,4 +272,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -249,4 +249,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -244,4 +244,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -254,4 +254,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -288,5 +288,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Activate</localization>
     <!-- Reset an interactive to its original state               -->
     <localization string-id='reset'>Reset</localization>
+    <!-- Describe an array of fill-in-the-blanks, say for a matrix -->
+    <localization string-id='array'>array</localization>
 
 </locale>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -269,7 +269,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- This needs to be defined to *something* (always)       -->
     <!-- else whatever crud ends up on the button kills the cell -->
     <localization string-id='evaluate'>Evaluate</localization>
-    <localization string-id='evaluate'>Evaluate</localization>
     <!-- <localization string-id='code'>Code</localization> -->
     <!-- Interactive exercise feedback messages                   -->
     <!-- These might be part of a feedback message for submitting -->

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -250,4 +250,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -256,4 +256,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -240,4 +240,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='randomize'>Générer une nouvelle version aléatoire</localization>
     <localization string-id='activate'>Activer</localization>
     <localization string-id='reset'>Réinitialiser</localization>
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -229,4 +229,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='correct'>Correct</localization> -->
     <!-- <localization string-id='incorrect'>Incorrect</localization> -->
     <!-- <localization string-id='blank'>Blank</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -244,4 +244,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -245,4 +245,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='randomize'>Casuale</localization>
     <localization string-id='activate'>Attiva</localization>
     <localization string-id='reset'>Azzera</localization>
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -253,4 +253,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -256,4 +256,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='randomize'>Randomize</localization> -->
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
+    <!-- <localization string-id='array'>array</localization> -->
 </locale>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1619,6 +1619,44 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- For a fillin (not in math) that describes itself as an array -->
+<xsl:template match="fillin" mode="fillin-array">
+    <xsl:variable name="rows">
+        <xsl:choose>
+            <xsl:when test="@rows">
+                <xsl:value-of select="@rows"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="1"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="cols">
+        <xsl:choose>
+            <xsl:when test="@cols">
+                <xsl:value-of select="@cols"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="1"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="$rows &gt; 1 or $cols &gt; 1">
+        <xsl:text> (</xsl:text>
+        <xsl:value-of select="$rows"/>
+        <xsl:call-template name="nbsp-character"/>
+        <xsl:call-template name="times-character"/>
+        <xsl:call-template name="nbsp-character"/>
+        <xsl:value-of select="$cols"/>
+        <xsl:text> </xsl:text>
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'array'"/>
+        </xsl:apply-templates>
+        <xsl:text>)</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+
 <!-- Sage Cells -->
 <!-- Contents are text manipulations (below)     -->
 <!-- Two abstract named templates in other files -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8553,6 +8553,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>em;</xsl:text>
         </xsl:attribute>
     </span>
+    <xsl:if test="@rows or @cols">
+        <xsl:apply-templates select="." mode="fillin-array"/>
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="var[@form='checkboxes']">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -8065,6 +8065,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\fillintext{</xsl:text>
     <xsl:value-of select="$characters" />
     <xsl:text>}</xsl:text>
+    <xsl:if test="@rows or @cols">
+        <xsl:apply-templates select="." mode="fillin-array"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- Implication Symbols -->


### PR DESCRIPTION
This makes it so `fillin` can have `@rows` and `@cols`.

Current implementation: if either is present and greater than 1, then the answer blank is followed by ` (m x n array)`. The word "array" is localized. The "x" is the times-character. The spaces in `m x n` are nbsp.