### PR TITLE
Latex multiline headers

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5710,6 +5710,42 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </table>
 
             <table>
+                <title>One Row Header, Multiline</title>
+                <tabular>
+                    <row header="yes">
+                        <cell>State</cell>
+                        <cell>Population</cell>
+                        <cell>
+                            <line>Area</line>
+                            <line>(sq. mi.)</line>
+                        </cell>
+                        <cell>
+                            <line>Statehood</line>
+                            <line>(Year)</line>
+                        </cell>
+                    </row>
+                    <row>
+                        <cell>Washington</cell>
+                        <cell>7,614,893</cell>
+                        <cell>71,362</cell>
+                        <cell>1889</cell>
+                    </row>
+                    <row>
+                        <cell>Oregon</cell>
+                        <cell>4,217,737</cell>
+                        <cell>98,381</cell>
+                        <cell>1859</cell>
+                    </row>
+                    <row>
+                        <cell>California</cell>
+                        <cell>39,512,223</cell>
+                        <cell>163,696</cell>
+                        <cell>1850</cell>
+                    </row>
+                </tabular>
+            </table>
+
+            <table>
                 <title>Two Row Headers</title>
                 <tabular>
                     <row header="yes">
@@ -5776,6 +5812,42 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </table>
 
             <table>
+                <title>One Vertical Row Header, Multiline</title>
+                <tabular>
+                    <row header="vertical">
+                        <cell>State</cell>
+                        <cell>Population</cell>
+                        <cell>
+                            <line>Area</line>
+                            <line>(sq. mi.)</line>
+                        </cell>
+                        <cell>
+                            <line>Statehood</line>
+                            <line>(Year)</line>
+                        </cell>
+                    </row>
+                    <row>
+                        <cell>Washington</cell>
+                        <cell>7,614,893</cell>
+                        <cell>71,362</cell>
+                        <cell>1889</cell>
+                    </row>
+                    <row>
+                        <cell>Oregon</cell>
+                        <cell>4,217,737</cell>
+                        <cell>98,381</cell>
+                        <cell>1859</cell>
+                    </row>
+                    <row>
+                        <cell>California</cell>
+                        <cell>39,512,223</cell>
+                        <cell>163,696</cell>
+                        <cell>1850</cell>
+                    </row>
+                </tabular>
+            </table>
+
+            <table>
                 <title>Two Vertical Row Headers</title>
                 <tabular>
                     <row header="vertical">
@@ -5819,6 +5891,42 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <cell>Population</cell>
                         <cell>Area (sq. mi.)</cell>
                         <cell>Statehood (Year)</cell>
+                    </row>
+                    <row>
+                        <cell>Washington</cell>
+                        <cell>7,614,893</cell>
+                        <cell>71,362</cell>
+                        <cell>1889</cell>
+                    </row>
+                    <row>
+                        <cell>Oregon</cell>
+                        <cell>4,217,737</cell>
+                        <cell>98,381</cell>
+                        <cell>1859</cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>California</cell>
+                        <cell>39,512,223</cell>
+                        <cell>163,696</cell>
+                        <cell>1850</cell>
+                    </row>
+                </tabular>
+            </table>
+
+            <table>
+                <title>One Row Header, Multiline, with Rules</title>
+                <tabular>
+                    <row header="yes" bottom="major">
+                        <cell>State</cell>
+                        <cell>Population</cell>
+                        <cell>
+                            <line>Area</line>
+                            <line>(sq. mi.)</line>
+                        </cell>
+                        <cell>
+                            <line>Statehood</line>
+                            <line>(Year)</line>
+                        </cell>
                     </row>
                     <row>
                         <cell>Washington</cell>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -9668,14 +9668,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="width" select="$cell-right" />
             </xsl:call-template>
             <xsl:text>}{</xsl:text>
-            <xsl:apply-templates select="." mode="table-cell-content">
+            <xsl:apply-templates select="." mode="table-cell-wrapper">
                 <xsl:with-param name="halign" select="$cell-halign" />
                 <xsl:with-param name="valign" select="$row-valign" />
             </xsl:apply-templates>
             <xsl:text>}</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:apply-templates select="." mode="table-cell-content">
+            <xsl:apply-templates select="." mode="table-cell-wrapper">
                 <xsl:with-param name="halign" select="$cell-halign" />
                 <xsl:with-param name="valign" select="$row-valign" />
             </xsl:apply-templates>
@@ -9936,7 +9936,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="cell" mode="table-cell-content">
+<xsl:template match="cell" mode="table-cell-wrapper">
     <xsl:param name="the-cell" />
     <xsl:param name="halign" />
     <xsl:param name="valign" />
@@ -9974,7 +9974,34 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>%&#xa;</xsl:text>
             <xsl:apply-templates select="p" />
         </xsl:when>
+        <xsl:otherwise>
+            <xsl:if test="$b-header">
+                <xsl:text>{\bfseries{}</xsl:text>
+            </xsl:if>
+            <xsl:if test="$b-vertical-header">
+                <xsl:text>\rotatebox{90}{</xsl:text>
+            </xsl:if>
+            <xsl:apply-templates select="." mode="table-cell-content">
+                <xsl:with-param name="halign" select="$halign" />
+                <xsl:with-param name="valign" select="$valign" />
+            </xsl:apply-templates>
+            <!-- a little space keeps text off a top rule -->
+            <xsl:if test="$b-vertical-header">
+                <xsl:text>\space}</xsl:text>
+            </xsl:if>
+            <xsl:if test="$b-header">
+                <xsl:text>}</xsl:text>
+            </xsl:if>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="cell" mode="table-cell-content">
+    <xsl:param name="halign" />
+    <xsl:param name="valign" />
+    <xsl:choose>
         <xsl:when test="line">
+            <!-- macro for multiline cell -->
             <xsl:text>\tablecelllines{</xsl:text>
             <xsl:call-template name="halign-specification">
                 <xsl:with-param name="align" select="$halign" />
@@ -9990,24 +10017,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>}&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:if test="$b-header">
-                <xsl:text>\textbf{</xsl:text>
-            </xsl:if>
-            <xsl:if test="$b-vertical-header">
-                <xsl:text>\rotatebox{90}{</xsl:text>
-            </xsl:if>
-            <!-- finally - the content of unstructured cell -->
+            <!-- the content of unstructured cell -->
             <xsl:apply-templates/>
-            <!-- a little space keeps text off a top rule -->
-            <xsl:if test="$b-vertical-header">
-                <xsl:text>\space}</xsl:text>
-            </xsl:if>
-            <xsl:if test="$b-header">
-                <xsl:text>}</xsl:text>
-            </xsl:if>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
+
 
 <!-- ########################### -->
 <!-- Labels and Cross-References -->


### PR DESCRIPTION
First commit here adds tables to the sample article with header cells that have multiple line. LaTeX output does not boldface such content. (Discovered while working on a project where a multiline column header would be good to use.)

Second commit changes -latex to use \bfseries around such cells. Sample article output looks good.

There is a comment in the current -latex:
```
<!-- adding \textbf, \bfseries not 100% effective here -->
```
I'm unsure how to provoke how it might not be effective. But it may be that this comment is wrt trying to use a boldface command within the `\tablecelllines` argument. But the approach I've used puts the boldface command around the whole `\tablecelllines` macro.
