### PR TITLE
Resolve sample article interactives jumping focus by making perspecti…

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -7772,8 +7772,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <figure>
                     <caption>GeoGebra: from scratch</caption>
                     <interactive xml:id="geogebra-seed-head" platform="geogebra" width="50%" aspect="1:1">
-                        <slate xml:id="seed-head" surface="geogebra" aspect="1:1">
-                            setPerspective("G");
+                        <slate xml:id="seed-head" surface="geogebra" aspect="1:1" perspective="G">
                             setRounding("3s");
                             setCoordSystem(-1,1,-1,1);
                             setGridVisible(false);

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9959,6 +9959,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:value-of select="@geogebra" />
                 <xsl:text>",&#xa;</xsl:text>
             </xsl:when>
+            <xsl:otherwise>
+                <xsl:if test="@perspective">
+                    <xsl:text>perspective:"</xsl:text>
+                    <xsl:value-of select="@perspective"/>
+                    <xsl:text>",&#xa;</xsl:text>
+                </xsl:if>
+            </xsl:otherwise>
         </xsl:choose>
         <xsl:text>width:</xsl:text><xsl:value-of select="$width" />
         <xsl:text>,&#xa;</xsl:text>


### PR DESCRIPTION
See Issue #1086.

Using an attribute when creating the Geogebra applet avoids the setting of focus in the script. Propose that we add the attribute to the Geogebra slate and take it out of the script.