### PR TITLE
French quotation marks html and Latex

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8773,12 +8773,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Left (Double) Quote -->
 <xsl:template name="lq-character">
-    <xsl:text>&#x201c;</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are << rather than " -->
+            <xsl:text>&#x00AB;&#xa0;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>&#x201c;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Right (Double) Quote -->
 <xsl:template name="rq-character">
-    <xsl:text>&#x201d;</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are >> rather than " -->
+            <xsl:text>&#xa0;&#x00BB;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>&#x201d;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Left Double Bracket -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -7846,12 +7846,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Left (Double) Quote -->
 <xsl:template name="lq-character">
-    <xsl:text>``</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are << rather than " -->
+            <xsl:text>{}\guillemotleft~ </xsl:text> <!-- guillemet preceded by space followed by non breaking space -->
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>``</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Right (Double) Quote -->
 <xsl:template name="rq-character">
-    <xsl:text>''</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are >> rather than " -->
+            <xsl:text>~\guillemotright{} </xsl:text> <!-- guillemet preceded by non breaking space and followed by a space -->
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>''</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Left Double Bracket -->
@@ -8109,11 +8123,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- right thing.  Double quotes are unmolested since     -->
 <!-- they will work fine even in consecutive runs         -->
 <!-- We have to override the RTF routines here.           -->
-
 <xsl:template match="q">
-    <xsl:text>``</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are << rather than " -->
+            <xsl:text>{}\guillemotleft~ </xsl:text> <!-- guillemet followed by non breaking space -->
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>``</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates />
-    <xsl:text>''</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$document-language = 'fr-CA' or $document-language = 'fr-FR'"> <!-- If french, double quotation marks are >> rather than " -->
+            <xsl:text>~\guillemotright{} </xsl:text> <!-- guillemet preceded by non breaking space followed by space -->
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>''</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- We look left (up the tree) and right   -->


### PR DESCRIPTION
Added code so that <lsq/>,<rsq/> and <q/> are french when fr-CA or fr-FR are selected as document language.