### PR TITLE
Proof of concept for extended dev schema

### DIFF
--- a/schema/build.sh
+++ b/schema/build.sh
@@ -69,6 +69,7 @@ xsltproc ${MBXSL}/pretext-litprog.xsl pretext.xml
 
 # System trang conversion to RELAX-NG XML schema
 trang -I rnc -O rng pretext.rnc pretext.rng
+trang -I rnc -O rng pretext-dev.rnc pretext-dev.rng
 
 # System trang conversion to W3C XSD schema
 # "abstract groups" make schema browser too obtuse

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -1,10 +1,10 @@
 
-            grammar {
+                    grammar {
+
+                    include "pretext.rnc"
                 
-            include "pretext.rnc"
-            
-                    Interactive =
-                    element interactive {
+            Interactive =
+                element interactive {
                     UniqueID?,
                     PermanentID?,
                     attribute aspect { text }?,
@@ -16,41 +16,76 @@
                     attribute version { text }?,
                     (Slate | SideBySideNoCaption | SideBySideGroupNoCaption)*,
                     element instructions { BlockText* | text }?
-                    }
+                }
 
-                    Slate =
-                    element slate {
+            Slate =
+                element slate {
                     UniqueID?,
                     attribute surface { text },
                     (attribute source { text } | attribute material { text })?,
                     attribute aspect { text }?,
                     (Paragraph | Tabular | SideBySideNoCaption)*
-                    }
+                }
 
-                    # add Interactives where used
-                    BlockStatement |= Interactive
+            # add Interactives where used
+            BlockStatement |= Interactive
 
-                    Figure |= element figure { MetaDataCaption, Interactive }
+            Figure |= element figure { MetaDataCaption, Interactive }
 
-                    SideBySide |= element sidebyside {
-                        SidebySideAttributes,
-                        (Interactive | Slate)+
-                    }
+            SideBySide |= element sidebyside {
+                SidebySideAttributes,
+                (Interactive | Slate)+
+            }
 
-                    SideBySideNoCaption |= element sidebyside {
-                        SidebySideAttributes,
-                        (Interactive | Slate)+
-                    }
+            SideBySideNoCaption |= element sidebyside {
+                SidebySideAttributes,
+                (Interactive | Slate)+
+            }
 
-                    Exercises |= element exercises {
-                    MetaDataAltTitleOptional,
-                    IntroductionDivision?,
-                    (
-                    (Exercise | ExerciseGroup)+ |
-                    Subexercises+ | Interactive
-                    ),
-                    ConclusionDivision?
-                    }
-            
+            Exercises |= element exercises {
+                MetaDataAltTitleOptional,
+                IntroductionDivision?,
+                (
+                (Exercise | ExerciseGroup)+ |
+                Subexercises+ | Interactive
+                ),
+                ConclusionDivision?
             }
             
+            ColophonFront |=
+                element colophon {
+                    MetaDataTarget,
+                    element credit {
+                        element role {TextShort},
+                        element entity {TextLong}
+                    }*,
+                    element edition {text}?,
+                    element website {
+                        element name {TextShort},
+                        element address {text}
+                    }?,
+                    element copyright {
+                        element year {TextShort},
+                        element holder {text},
+                        element minilicense {TextShort}?,
+                        element shortlicense {
+                            TextLong &
+                            Footnote*
+                        }?
+                    }?
+                }
+            
+            Configuration |=
+                element blurb {
+                    attribute shelf {text},
+                    text
+                }
+            
+            Configuration |=
+                element document-id {
+                    attribute edition {text},
+                    text
+                }
+            
+                    }
+                

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -297,5 +297,44 @@
                     ConclusionDivision?
                 }
             
+            Url |=
+                element url {
+                    attribute href {text},
+                    (
+                        (attribute visual {text},
+                        TextShort
+                        )| TextShort |
+                        (
+                        attribute visual {text}?
+                        )
+                    )
+                }    
+            
+            MathDisplay |=
+                element me {
+                    MetaDataTarget?,
+                    mixed {(Xref | FillInMath | WWVariable)*}
+                } |
+                element men {
+                    MetaDataTarget?,
+                    mixed {(Xref | FillInMath | WWVariable)*}
+                } |
+                element md {
+                    attribute number {"yes" | "no"}?,
+                    attribute break {"yes" | "no"}?,
+                    attribute alignment {text}?,
+                    attribute alignat-columns {text}?,
+                    MathRow,
+                    (MathRow | MathIntertext)*
+                } |
+                element mdn {
+                    attribute number {"yes" | "no"}?,
+                    attribute break {"yes" | "no"}?,
+                    attribute alignment {text}?,
+                    attribute alignat-columns {text}?,
+                    MathRow,
+                    (MathRow | MathIntertext)*
+                }
+            
                 }
             

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -336,5 +336,9 @@
                     (MathRow | MathIntertext)*
                 }
             
+            UniqueID |=
+                attribute xml:id {text}?,
+                attribute label {text}?   
+            
                 }
             

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -1,0 +1,56 @@
+
+            grammar {
+                
+            include "pretext.rnc"
+            
+                    Interactive =
+                    element interactive {
+                    UniqueID?,
+                    PermanentID?,
+                    attribute aspect { text }?,
+                    attribute width { text }?,
+                    attribute platform { text }?,
+                    attribute preview { text }?,
+                    attribute iframe { text }?,
+                    attribute source { text }?,
+                    attribute version { text }?,
+                    (Slate | SideBySideNoCaption | SideBySideGroupNoCaption)*,
+                    element instructions { BlockText* | text }?
+                    }
+
+                    Slate =
+                    element slate {
+                    UniqueID?,
+                    attribute surface { text },
+                    (attribute source { text } | attribute material { text })?,
+                    attribute aspect { text }?,
+                    (Paragraph | Tabular | SideBySideNoCaption)*
+                    }
+
+                    # add Interactives where used
+                    BlockStatement |= Interactive
+
+                    Figure |= element figure { MetaDataCaption, Interactive }
+
+                    SideBySide |= element sidebyside {
+                        SidebySideAttributes,
+                        (Interactive | Slate)+
+                    }
+
+                    SideBySideNoCaption |= element sidebyside {
+                        SidebySideAttributes,
+                        (Interactive | Slate)+
+                    }
+
+                    Exercises |= element exercises {
+                    MetaDataAltTitleOptional,
+                    IntroductionDivision?,
+                    (
+                    (Exercise | ExerciseGroup)+ |
+                    Subexercises+ | Interactive
+                    ),
+                    ConclusionDivision?
+                    }
+            
+            }
+            

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -340,40 +340,35 @@
                 attribute xml:id {text}?,
                 attribute label {text}?   
             
-            #True/False
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    element statement {
-                        attribute correct {"yes"|"no"},
-                        Paragraph
-                    }, 
-                    Feedback?, Hint*, Answer*, Solution*
-                }
-            #Multiple Choice
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    StatementExercise,
-                    element choices {
-                        attribute randomize {"yes"|"no"}?,
-                        Choice+
-                    },
-                    Hint*, Answer*, Solution*
-                }
+            TrueFalse =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                element statement {
+                    attribute correct {"yes"|"no"},
+                    Paragraph
+                }, 
+                Feedback?, Hint*, Answer*, Solution*
+            MultipleChoice =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                element choices {
+                    attribute randomize {"yes"|"no"}?,
+                    Choice+
+                },
+                Hint*, Answer*, Solution*
             Choice = 
                 element choice {
                     attribute correct {"yes"|"no"}?,
-                    BlockText,
-                    Feedback?
+                    ((mixed {BlockText?})
+                    | (StatementExercise, Feedback?))
                 }
-            # Parsons
-            Exercise |=
-                element exercise {
+            Parsons =
                     MetaDataTitleOptional,
                     attribute number {text}?,
+                    attribute language {text}?,
+                    attribute adaptive {"yes"|"no"}?,
+                    attribute indentation {text}?,
                     StatementExercise,
                     element blocks {
                         attribute layout {"horizontal"}?,
@@ -381,7 +376,6 @@
                         Block+
                     },
                     Hint*, Answer*, Solution*
-                }
             Block = 
                 element block {
                     attribute order {xsd:integer}?,
@@ -396,18 +390,15 @@
                         }+ 
                     ))
                 }
-            # Matching
-            Exercise |= 
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    StatementExercise,
-                    Feedback?,
-                    element matches {
-                        Match+
-                    },
-                    Hint*, Answer*, Solution*
-                }
+            Matching = 
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                Feedback?,
+                element matches {
+                    Match+
+                },
+                Hint*, Answer*, Solution*
             Match =
                 element match {
                     attribute order {xsd:integer}?,
@@ -418,17 +409,14 @@
                         mixed {BlockText?}
                     }
                 }
-            # Free response
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    (
-                    (ExerciseBody, Response?) |
-                    (StatementExercise, Response?, Hint*, Answer*, Solution*) |
-                    (IntroductionStatement?, Task+, ConclusionStatement?) 
-                    )
-                }
+            FreeResponse =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                (
+                (ExerciseBody, Response?) |
+                (StatementExercise, Response?, Hint*, Answer*, Solution*) |
+                (IntroductionStatement?, Task+, ConclusionStatement?) 
+                )
             Response =
                 element response {empty}
             # General feedback element    
@@ -437,6 +425,21 @@
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
+            # Include all exercise types in exercise and activity    
+            Exercise |=
+                element exercise {
+                    TrueFalse |
+                    MultipleChoice |
+                    Parsons |
+                    Matching |
+                    FreeResponse
+                }
+            ProjectLike |=
+                TrueFalse |
+                MultipleChoice |
+                Parsons |
+                Matching |
+                FreeResponse
             
                 }
             

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -340,5 +340,103 @@
                 attribute xml:id {text}?,
                 attribute label {text}?   
             
+            #True/False
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    element statement {
+                        attribute correct {"yes"|"no"},
+                        Paragraph
+                    }, 
+                    Feedback?, Hint*, Answer*, Solution*
+                }
+            #Multiple Choice
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    element choices {
+                        attribute randomize {"yes"|"no"}?,
+                        Choice+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Choice = 
+                element choice {
+                    attribute correct {"yes"|"no"}?,
+                    BlockText,
+                    Feedback?
+                }
+            # Parsons
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    element blocks {
+                        attribute layout {"horizontal"}?,
+                        attribute randomize {"yes"|"no"}?,
+                        Block+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Block = 
+                element block {
+                    attribute order {xsd:integer}?,
+                    ((
+                        attribute correct {"yes"|"no"}?,
+                        mixed {BlockText?}
+                    ) | 
+                    (
+                        element choice {
+                            attribute correct {"yes"|"no"}?,
+                            mixed {BlockText?}
+                        }+ 
+                    ))
+                }
+            # Matching
+            Exercise |= 
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    Feedback?,
+                    element matches {
+                        Match+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Match =
+                element match {
+                    attribute order {xsd:integer}?,
+                    element premise {
+                        mixed {BlockText?}
+                    },
+                    element response {
+                        mixed {BlockText?}
+                    }
+                }
+            # Free response
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    (
+                    (ExerciseBody, Response?) |
+                    (StatementExercise, Response?, Hint*, Answer*, Solution*) |
+                    (IntroductionStatement?, Task+, ConclusionStatement?) 
+                    )
+                }
+            Response =
+                element response {empty}
+            # General feedback element    
+            Feedback = 
+                element feedback {
+                    MetaDataTitleOptional,
+                    BlockSolution+
+                }
+            
                 }
             

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -97,5 +97,12 @@
                 element reasoning {ProofLike} |
                 element explanation {ProofLike}
             
+            Figure |= 
+                element figure {
+                    MetaDataCaption,
+                    Tabular
+                }
+
+            
                     }
                 

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -115,8 +115,27 @@
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | WorksheetExercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment |
-                Demonstration
-            
+                Demonstration |WorksheetSideBySide
+            # Allow exercise in sidebyside
+            WorksheetSideBySide = 
+                element sidebyside {
+                    SidebySideAttributes,
+                    (
+                        Figure |
+                        Poem |
+                        Tabular |
+                        Image |
+                        Video |
+                        Program |
+                        Console |
+                        Paragraph |
+                        Preformatted |
+                        List |
+                        Stack |
+                        WorksheetExercise |
+                        WorksheetTask
+                    )+
+                }     
             # Exercises and tasks can have workspace if they don't contain additional tasks:
             WorksheetExercise = 
                 element exercise {
@@ -133,6 +152,7 @@
                 element exercise {
                     MetaDataTitleOptional,
                     attribute number {text}?,
+                    attribute workspace {text}?,
                     (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
                 }
             WorksheetTask = 
@@ -147,16 +167,17 @@
             WorksheetTask |=
                 element task {
                     MetaDataTitleOptional,
+                    attribute workspace {text}?,
                     (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
                 } 
-
             # Main worksheet definition    
             Worksheet = 
                 element worksheet {
                     WorksheetAttributes,
                     MetaDataAltTitleOptional,
                     (Objectives? & IntroductionDivision?),
-                    (element page {WorksheetBlock+} | WorksheetBlock+),
+                    (
+                    element page {WorksheetBlock+|empty}+ | WorksheetBlock+),
                     (Outcomes? & ConclusionDivision?)
                 } 
 
@@ -176,7 +197,7 @@
                     |
                         (
                             (Objectives? & IntroductionDivision?),
-                            Section,
+                            (Section | Worksheet),
                             (Section | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionDivision?)
@@ -198,7 +219,7 @@
                     |
                         (
                             (Objectives? & IntroductionDivision?),
-                            Subsection,
+                            (Subsection | Worksheet),
                             (Subsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionDivision?)
@@ -220,7 +241,7 @@
                     |
                         (
                             (Objectives? & IntroductionDivision?),
-                            Subsubsection,
+                            (Subsubsection | Worksheet),
                             (Subsubsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionDivision?)
@@ -253,7 +274,7 @@
                     |
                         (
                             (Objectives? & IntroductionDivision?),
-                            Subsection,
+                            (Subsection | Worksheet),
                             (Subsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionDivision?)
@@ -276,7 +297,7 @@
                     |
                         (
                             (Objectives? & IntroductionDivision?),
-                            Section,
+                            (Section | Worksheet),
                             (Section | Worksheet | ReadingQuestions | Exercises | Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionDivision?)
                         )

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -83,9 +83,19 @@
             
             Configuration |=
                 element document-id {
-                    attribute edition {text},
+                    attribute edition {text}?,
                     text
                 }
+            
+            ProofLike = 
+                MetaDataTitleOptional,
+                (BlockStatement | Case)+
+            Proof |=
+                element proof {ProofLike} |
+                element argument {ProofLike} |
+                element justification {ProofLike} |
+                element reasoning {ProofLike} |
+                element explanation {ProofLike}
             
                     }
                 

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -1,8 +1,8 @@
 
-                    grammar {
+                grammar {
 
-                    include "pretext.rnc"
-                
+                include "pretext.rnc"
+            
             Interactive =
                 element interactive {
                     UniqueID?,
@@ -104,5 +104,198 @@
                 }
 
             
-                    }
-                
+            WorksheetAttributes =
+                attribute margin { text }?,
+                attribute top { text }?,
+                attribute bottom { text }?,
+                attribute right { text }?,
+                attribute left { text }?                
+
+            WorksheetBlock = 
+                BlockStatement | Remark | Computation | Theorem | Proof | Definition |
+                Axiom | Example | WorksheetExercise | Project |
+                Poem | Assemblage | ListGenerator | Fragment |
+                Demonstration
+            
+            # Exercises and tasks can have workspace if they don't contain additional tasks:
+            WorksheetExercise = 
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    attribute workspace {text}?,
+                    (
+                    ExerciseBody |
+                    (StatementExercise, Hint*, Answer*, Solution*) |
+                    (IntroductionText?, WebWork, ConclusionText?)
+                    )
+                }
+            WorksheetExercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
+                }
+            WorksheetTask = 
+                element task {
+                    MetaDataTitleOptional,
+                    attribute workspace {text}?,
+                    (
+                        BlockStatement+ |
+                        (Statement, Hint*, Answer*, Solution*)
+                    )
+                } 
+            WorksheetTask |=
+                element task {
+                    MetaDataTitleOptional,
+                    (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
+                } 
+
+            # Main worksheet definition    
+            Worksheet = 
+                element worksheet {
+                    WorksheetAttributes,
+                    MetaDataAltTitleOptional,
+                    (Objectives? & IntroductionDivision?),
+                    (element page {WorksheetBlock+} | WorksheetBlock+),
+                    (Outcomes? & ConclusionDivision?)
+                } 
+
+            # Insert worksheets into divisions (merge with division when adopted)
+            Chapter |=
+                element chapter {
+                    MetaDataLinedTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? & ReadingQuestions? & Exercises? &
+                             Solutions? & References? & Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? & IntroductionDivision?),
+                            Section,
+                            (Section | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? & ConclusionDivision?)
+                        )
+                    )
+                }
+            Section |=
+                element section {
+                    MetaDataLinedTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? & ReadingQuestions? & Exercises? &
+                             Solutions? & References? & Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? & IntroductionDivision?),
+                            Subsection,
+                            (Subsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? & ConclusionDivision?)
+                        )
+                    )
+                }
+            Subsection |=
+                element subsection {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? & ReadingQuestions? & Exercises? &
+                             Solutions? & References? & Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? & IntroductionDivision?),
+                            Subsubsection,
+                            (Subsubsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? & ConclusionDivision?)
+                        )
+                    )
+                }
+            Subsubsection |=
+                element subsubsection {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    Objectives?,
+                    (BlockDivision | Paragraphs | Commentary)+,
+                    (Worksheet? & ReadingQuestions? & Exercises? &
+                     Solutions? & References? & Glossary?),
+                    Outcomes?
+                }
+            ArticleAppendix |=
+                element appendix {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary |
+                             NotationList)+,
+                            (Worksheet? & ReadingQuestions? & Exercises? &
+                             Solutions? & References? & Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? & IntroductionDivision?),
+                            Subsection,
+                            (Subsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? & ConclusionDivision?)
+                        )
+                    )
+                }
+            BookAppendix |=
+                element appendix {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary |
+                             NotationList)+,
+                            (Worksheet? & ReadingQuestions? & Exercises? &
+                             Solutions? & References? & Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? & IntroductionDivision?),
+                            Section,
+                            (Section | Worksheet | ReadingQuestions | Exercises | Solutions | References | Glossary)*,
+                            (Outcomes? & ConclusionDivision?)
+                        )
+                    )
+                }
+            
+            Solutions |=
+                element solutions {
+                    MetaDataAltTitleOptional,
+                    attribute inline {text}?,
+                    attribute divisional {text}?,
+                    attribute project {text}?,
+                    attribute worksheet {text}?,
+                    attribute reading {text}?,
+                    attribute scope {text}?,
+                    attribute admit {"all"|"odd"|"even"}?,
+                    IntroductionDivision?,
+                    ConclusionDivision?
+                }
+            
+                }
+            

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -962,4 +962,12 @@
       </element>
     </choice>
   </define>
+  <define name="UniqueID" combine="choice">
+    <optional>
+      <attribute name="xml:id"/>
+    </optional>
+    <optional>
+      <attribute name="label"/>
+    </optional>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -191,8 +191,38 @@
   </define>
   <define name="Configuration" combine="choice">
     <element name="document-id">
-      <attribute name="edition"/>
+      <optional>
+        <attribute name="edition"/>
+      </optional>
       <text/>
     </element>
+  </define>
+  <define name="ProofLike">
+    <ref name="MetaDataTitleOptional"/>
+    <oneOrMore>
+      <choice>
+        <ref name="BlockStatement"/>
+        <ref name="Case"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <define name="Proof" combine="choice">
+    <choice>
+      <element name="proof">
+        <ref name="ProofLike"/>
+      </element>
+      <element name="argument">
+        <ref name="ProofLike"/>
+      </element>
+      <element name="justification">
+        <ref name="ProofLike"/>
+      </element>
+      <element name="reasoning">
+        <ref name="ProofLike"/>
+      </element>
+      <element name="explanation">
+        <ref name="ProofLike"/>
+      </element>
+    </choice>
   </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="pretext.rng"/>
+  <define name="Interactive">
+    <element name="interactive">
+      <optional>
+        <ref name="UniqueID"/>
+      </optional>
+      <optional>
+        <ref name="PermanentID"/>
+      </optional>
+      <optional>
+        <attribute name="aspect"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <optional>
+        <attribute name="platform"/>
+      </optional>
+      <optional>
+        <attribute name="preview"/>
+      </optional>
+      <optional>
+        <attribute name="iframe"/>
+      </optional>
+      <optional>
+        <attribute name="source"/>
+      </optional>
+      <optional>
+        <attribute name="version"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="Slate"/>
+          <ref name="SideBySideNoCaption"/>
+          <ref name="SideBySideGroupNoCaption"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <element name="instructions">
+          <choice>
+            <zeroOrMore>
+              <ref name="BlockText"/>
+            </zeroOrMore>
+            <text/>
+          </choice>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="Slate">
+    <element name="slate">
+      <optional>
+        <ref name="UniqueID"/>
+      </optional>
+      <attribute name="surface"/>
+      <optional>
+        <choice>
+          <attribute name="source"/>
+          <attribute name="material"/>
+        </choice>
+      </optional>
+      <optional>
+        <attribute name="aspect"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="Paragraph"/>
+          <ref name="Tabular"/>
+          <ref name="SideBySideNoCaption"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- add Interactives where used -->
+  <define name="BlockStatement" combine="choice">
+    <ref name="Interactive"/>
+  </define>
+  <define name="Figure" combine="choice">
+    <element name="figure">
+      <ref name="MetaDataCaption"/>
+      <ref name="Interactive"/>
+    </element>
+  </define>
+  <define name="SideBySide" combine="choice">
+    <element name="sidebyside">
+      <ref name="SidebySideAttributes"/>
+      <oneOrMore>
+        <choice>
+          <ref name="Interactive"/>
+          <ref name="Slate"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="SideBySideNoCaption" combine="choice">
+    <element name="sidebyside">
+      <ref name="SidebySideAttributes"/>
+      <oneOrMore>
+        <choice>
+          <ref name="Interactive"/>
+          <ref name="Slate"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Exercises" combine="choice">
+    <element name="exercises">
+      <ref name="MetaDataAltTitleOptional"/>
+      <optional>
+        <ref name="IntroductionDivision"/>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <choice>
+            <ref name="Exercise"/>
+            <ref name="ExerciseGroup"/>
+          </choice>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="Subexercises"/>
+        </oneOrMore>
+        <ref name="Interactive"/>
+      </choice>
+      <optional>
+        <ref name="ConclusionDivision"/>
+      </optional>
+    </element>
+  </define>
+</grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -128,4 +128,71 @@
       </optional>
     </element>
   </define>
+  <define name="ColophonFront" combine="choice">
+    <element name="colophon">
+      <ref name="MetaDataTarget"/>
+      <zeroOrMore>
+        <element name="credit">
+          <element name="role">
+            <ref name="TextShort"/>
+          </element>
+          <element name="entity">
+            <ref name="TextLong"/>
+          </element>
+        </element>
+      </zeroOrMore>
+      <optional>
+        <element name="edition">
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <element name="website">
+          <element name="name">
+            <ref name="TextShort"/>
+          </element>
+          <element name="address">
+            <text/>
+          </element>
+        </element>
+      </optional>
+      <optional>
+        <element name="copyright">
+          <element name="year">
+            <ref name="TextShort"/>
+          </element>
+          <element name="holder">
+            <text/>
+          </element>
+          <optional>
+            <element name="minilicense">
+              <ref name="TextShort"/>
+            </element>
+          </optional>
+          <optional>
+            <element name="shortlicense">
+              <interleave>
+                <ref name="TextLong"/>
+                <zeroOrMore>
+                  <ref name="Footnote"/>
+                </zeroOrMore>
+              </interleave>
+            </element>
+          </optional>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="Configuration" combine="choice">
+    <element name="blurb">
+      <attribute name="shelf"/>
+      <text/>
+    </element>
+  </define>
+  <define name="Configuration" combine="choice">
+    <element name="document-id">
+      <attribute name="edition"/>
+      <text/>
+    </element>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -265,7 +265,31 @@
       <ref name="ListGenerator"/>
       <ref name="Fragment"/>
       <ref name="Demonstration"/>
+      <ref name="WorksheetSideBySide"/>
     </choice>
+  </define>
+  <!-- Allow exercise in sidebyside -->
+  <define name="WorksheetSideBySide">
+    <element name="sidebyside">
+      <ref name="SidebySideAttributes"/>
+      <oneOrMore>
+        <choice>
+          <ref name="Figure"/>
+          <ref name="Poem"/>
+          <ref name="Tabular"/>
+          <ref name="Image"/>
+          <ref name="Video"/>
+          <ref name="Program"/>
+          <ref name="Console"/>
+          <ref name="Paragraph"/>
+          <ref name="Preformatted"/>
+          <ref name="List"/>
+          <ref name="Stack"/>
+          <ref name="WorksheetExercise"/>
+          <ref name="WorksheetTask"/>
+        </choice>
+      </oneOrMore>
+    </element>
   </define>
   <!-- Exercises and tasks can have workspace if they don't contain additional tasks: -->
   <define name="WorksheetExercise">
@@ -309,6 +333,9 @@
       <optional>
         <attribute name="number"/>
       </optional>
+      <optional>
+        <attribute name="workspace"/>
+      </optional>
       <group>
         <optional>
           <ref name="IntroductionStatement"/>
@@ -350,6 +377,9 @@
   <define name="WorksheetTask" combine="choice">
     <element name="task">
       <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="workspace"/>
+      </optional>
       <group>
         <optional>
           <ref name="IntroductionStatement"/>
@@ -377,11 +407,16 @@
         </optional>
       </interleave>
       <choice>
-        <element name="page">
-          <oneOrMore>
-            <ref name="WorksheetBlock"/>
-          </oneOrMore>
-        </element>
+        <oneOrMore>
+          <element name="page">
+            <choice>
+              <oneOrMore>
+                <ref name="WorksheetBlock"/>
+              </oneOrMore>
+              <empty/>
+            </choice>
+          </element>
+        </oneOrMore>
         <oneOrMore>
           <ref name="WorksheetBlock"/>
         </oneOrMore>
@@ -448,7 +483,10 @@
               <ref name="IntroductionDivision"/>
             </optional>
           </interleave>
-          <ref name="Section"/>
+          <choice>
+            <ref name="Section"/>
+            <ref name="Worksheet"/>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Section"/>
@@ -523,7 +561,10 @@
               <ref name="IntroductionDivision"/>
             </optional>
           </interleave>
-          <ref name="Subsection"/>
+          <choice>
+            <ref name="Subsection"/>
+            <ref name="Worksheet"/>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Subsection"/>
@@ -598,7 +639,10 @@
               <ref name="IntroductionDivision"/>
             </optional>
           </interleave>
-          <ref name="Subsubsection"/>
+          <choice>
+            <ref name="Subsubsection"/>
+            <ref name="Worksheet"/>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Subsubsection"/>
@@ -715,7 +759,10 @@
               <ref name="IntroductionDivision"/>
             </optional>
           </interleave>
-          <ref name="Subsection"/>
+          <choice>
+            <ref name="Subsection"/>
+            <ref name="Worksheet"/>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Subsection"/>
@@ -791,7 +838,10 @@
               <ref name="IntroductionDivision"/>
             </optional>
           </interleave>
-          <ref name="Section"/>
+          <choice>
+            <ref name="Section"/>
+            <ref name="Worksheet"/>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Section"/>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -853,4 +853,113 @@
       </optional>
     </element>
   </define>
+  <define name="Url" combine="choice">
+    <element name="url">
+      <attribute name="href"/>
+      <choice>
+        <group>
+          <attribute name="visual"/>
+          <ref name="TextShort"/>
+        </group>
+        <ref name="TextShort"/>
+        <optional>
+          <attribute name="visual"/>
+        </optional>
+      </choice>
+    </element>
+  </define>
+  <define name="MathDisplay" combine="choice">
+    <choice>
+      <element name="me">
+        <optional>
+          <ref name="MetaDataTarget"/>
+        </optional>
+        <mixed>
+          <zeroOrMore>
+            <choice>
+              <ref name="Xref"/>
+              <ref name="FillInMath"/>
+              <ref name="WWVariable"/>
+            </choice>
+          </zeroOrMore>
+        </mixed>
+      </element>
+      <element name="men">
+        <optional>
+          <ref name="MetaDataTarget"/>
+        </optional>
+        <mixed>
+          <zeroOrMore>
+            <choice>
+              <ref name="Xref"/>
+              <ref name="FillInMath"/>
+              <ref name="WWVariable"/>
+            </choice>
+          </zeroOrMore>
+        </mixed>
+      </element>
+      <element name="md">
+        <optional>
+          <attribute name="number">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="break">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="alignment"/>
+        </optional>
+        <optional>
+          <attribute name="alignat-columns"/>
+        </optional>
+        <ref name="MathRow"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="MathRow"/>
+            <ref name="MathIntertext"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+      <element name="mdn">
+        <optional>
+          <attribute name="number">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="break">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="alignment"/>
+        </optional>
+        <optional>
+          <attribute name="alignat-columns"/>
+        </optional>
+        <ref name="MathRow"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="MathRow"/>
+            <ref name="MathIntertext"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </choice>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -225,4 +225,10 @@
       </element>
     </choice>
   </define>
+  <define name="Figure" combine="choice">
+    <element name="figure">
+      <ref name="MetaDataCaption"/>
+      <ref name="Tabular"/>
+    </element>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -231,4 +231,626 @@
       <ref name="Tabular"/>
     </element>
   </define>
+  <define name="WorksheetAttributes">
+    <optional>
+      <attribute name="margin"/>
+    </optional>
+    <optional>
+      <attribute name="top"/>
+    </optional>
+    <optional>
+      <attribute name="bottom"/>
+    </optional>
+    <optional>
+      <attribute name="right"/>
+    </optional>
+    <optional>
+      <attribute name="left"/>
+    </optional>
+  </define>
+  <define name="WorksheetBlock">
+    <choice>
+      <ref name="BlockStatement"/>
+      <ref name="Remark"/>
+      <ref name="Computation"/>
+      <ref name="Theorem"/>
+      <ref name="Proof"/>
+      <ref name="Definition"/>
+      <ref name="Axiom"/>
+      <ref name="Example"/>
+      <ref name="WorksheetExercise"/>
+      <ref name="Project"/>
+      <ref name="Poem"/>
+      <ref name="Assemblage"/>
+      <ref name="ListGenerator"/>
+      <ref name="Fragment"/>
+      <ref name="Demonstration"/>
+    </choice>
+  </define>
+  <!-- Exercises and tasks can have workspace if they don't contain additional tasks: -->
+  <define name="WorksheetExercise">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <optional>
+        <attribute name="workspace"/>
+      </optional>
+      <choice>
+        <ref name="ExerciseBody"/>
+        <group>
+          <ref name="StatementExercise"/>
+          <zeroOrMore>
+            <ref name="Hint"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Answer"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Solution"/>
+          </zeroOrMore>
+        </group>
+        <group>
+          <optional>
+            <ref name="IntroductionText"/>
+          </optional>
+          <ref name="WebWork"/>
+          <optional>
+            <ref name="ConclusionText"/>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="WorksheetExercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <group>
+        <optional>
+          <ref name="IntroductionStatement"/>
+        </optional>
+        <oneOrMore>
+          <ref name="WorksheetTask"/>
+        </oneOrMore>
+        <optional>
+          <ref name="ConclusionStatement"/>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <define name="WorksheetTask">
+    <element name="task">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="workspace"/>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <ref name="BlockStatement"/>
+        </oneOrMore>
+        <group>
+          <ref name="Statement"/>
+          <zeroOrMore>
+            <ref name="Hint"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Answer"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Solution"/>
+          </zeroOrMore>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="WorksheetTask" combine="choice">
+    <element name="task">
+      <ref name="MetaDataTitleOptional"/>
+      <group>
+        <optional>
+          <ref name="IntroductionStatement"/>
+        </optional>
+        <oneOrMore>
+          <ref name="WorksheetTask"/>
+        </oneOrMore>
+        <optional>
+          <ref name="ConclusionStatement"/>
+        </optional>
+      </group>
+    </element>
+  </define>
+  <!-- Main worksheet definition    -->
+  <define name="Worksheet">
+    <element name="worksheet">
+      <ref name="WorksheetAttributes"/>
+      <ref name="MetaDataAltTitleOptional"/>
+      <interleave>
+        <optional>
+          <ref name="Objectives"/>
+        </optional>
+        <optional>
+          <ref name="IntroductionDivision"/>
+        </optional>
+      </interleave>
+      <choice>
+        <element name="page">
+          <oneOrMore>
+            <ref name="WorksheetBlock"/>
+          </oneOrMore>
+        </element>
+        <oneOrMore>
+          <ref name="WorksheetBlock"/>
+        </oneOrMore>
+      </choice>
+      <interleave>
+        <optional>
+          <ref name="Outcomes"/>
+        </optional>
+        <optional>
+          <ref name="ConclusionDivision"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <!-- Insert worksheets into divisions (merge with division when adopted) -->
+  <define name="Chapter" combine="choice">
+    <element name="chapter">
+      <ref name="MetaDataLinedTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="Objectives"/>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="BlockDivision"/>
+              <ref name="Paragraphs"/>
+              <ref name="Commentary"/>
+            </choice>
+          </oneOrMore>
+          <interleave>
+            <optional>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="ReadingQuestions"/>
+            </optional>
+            <optional>
+              <ref name="Exercises"/>
+            </optional>
+            <optional>
+              <ref name="Solutions"/>
+            </optional>
+            <optional>
+              <ref name="References"/>
+            </optional>
+            <optional>
+              <ref name="Glossary"/>
+            </optional>
+          </interleave>
+          <optional>
+            <ref name="Outcomes"/>
+          </optional>
+        </group>
+        <group>
+          <interleave>
+            <optional>
+              <ref name="Objectives"/>
+            </optional>
+            <optional>
+              <ref name="IntroductionDivision"/>
+            </optional>
+          </interleave>
+          <ref name="Section"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="Section"/>
+              <ref name="Worksheet"/>
+              <ref name="ReadingQuestions"/>
+              <ref name="Exercises"/>
+              <ref name="Solutions"/>
+              <ref name="References"/>
+              <ref name="Glossary"/>
+            </choice>
+          </zeroOrMore>
+          <interleave>
+            <optional>
+              <ref name="Outcomes"/>
+            </optional>
+            <optional>
+              <ref name="ConclusionDivision"/>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Section" combine="choice">
+    <element name="section">
+      <ref name="MetaDataLinedTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="Objectives"/>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="BlockDivision"/>
+              <ref name="Paragraphs"/>
+              <ref name="Commentary"/>
+            </choice>
+          </oneOrMore>
+          <interleave>
+            <optional>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="ReadingQuestions"/>
+            </optional>
+            <optional>
+              <ref name="Exercises"/>
+            </optional>
+            <optional>
+              <ref name="Solutions"/>
+            </optional>
+            <optional>
+              <ref name="References"/>
+            </optional>
+            <optional>
+              <ref name="Glossary"/>
+            </optional>
+          </interleave>
+          <optional>
+            <ref name="Outcomes"/>
+          </optional>
+        </group>
+        <group>
+          <interleave>
+            <optional>
+              <ref name="Objectives"/>
+            </optional>
+            <optional>
+              <ref name="IntroductionDivision"/>
+            </optional>
+          </interleave>
+          <ref name="Subsection"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="Subsection"/>
+              <ref name="Worksheet"/>
+              <ref name="ReadingQuestions"/>
+              <ref name="Exercises"/>
+              <ref name="Solutions"/>
+              <ref name="References"/>
+              <ref name="Glossary"/>
+            </choice>
+          </zeroOrMore>
+          <interleave>
+            <optional>
+              <ref name="Outcomes"/>
+            </optional>
+            <optional>
+              <ref name="ConclusionDivision"/>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Subsection" combine="choice">
+    <element name="subsection">
+      <ref name="MetaDataAltTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="Objectives"/>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="BlockDivision"/>
+              <ref name="Paragraphs"/>
+              <ref name="Commentary"/>
+            </choice>
+          </oneOrMore>
+          <interleave>
+            <optional>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="ReadingQuestions"/>
+            </optional>
+            <optional>
+              <ref name="Exercises"/>
+            </optional>
+            <optional>
+              <ref name="Solutions"/>
+            </optional>
+            <optional>
+              <ref name="References"/>
+            </optional>
+            <optional>
+              <ref name="Glossary"/>
+            </optional>
+          </interleave>
+          <optional>
+            <ref name="Outcomes"/>
+          </optional>
+        </group>
+        <group>
+          <interleave>
+            <optional>
+              <ref name="Objectives"/>
+            </optional>
+            <optional>
+              <ref name="IntroductionDivision"/>
+            </optional>
+          </interleave>
+          <ref name="Subsubsection"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="Subsubsection"/>
+              <ref name="Worksheet"/>
+              <ref name="ReadingQuestions"/>
+              <ref name="Exercises"/>
+              <ref name="Solutions"/>
+              <ref name="References"/>
+              <ref name="Glossary"/>
+            </choice>
+          </zeroOrMore>
+          <interleave>
+            <optional>
+              <ref name="Outcomes"/>
+            </optional>
+            <optional>
+              <ref name="ConclusionDivision"/>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Subsubsection" combine="choice">
+    <element name="subsubsection">
+      <ref name="MetaDataAltTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="Objectives"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="BlockDivision"/>
+          <ref name="Paragraphs"/>
+          <ref name="Commentary"/>
+        </choice>
+      </oneOrMore>
+      <interleave>
+        <optional>
+          <ref name="Worksheet"/>
+        </optional>
+        <optional>
+          <ref name="ReadingQuestions"/>
+        </optional>
+        <optional>
+          <ref name="Exercises"/>
+        </optional>
+        <optional>
+          <ref name="Solutions"/>
+        </optional>
+        <optional>
+          <ref name="References"/>
+        </optional>
+        <optional>
+          <ref name="Glossary"/>
+        </optional>
+      </interleave>
+      <optional>
+        <ref name="Outcomes"/>
+      </optional>
+    </element>
+  </define>
+  <define name="ArticleAppendix" combine="choice">
+    <element name="appendix">
+      <ref name="MetaDataAltTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="Objectives"/>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="BlockDivision"/>
+              <ref name="Paragraphs"/>
+              <ref name="Commentary"/>
+              <ref name="NotationList"/>
+            </choice>
+          </oneOrMore>
+          <interleave>
+            <optional>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="ReadingQuestions"/>
+            </optional>
+            <optional>
+              <ref name="Exercises"/>
+            </optional>
+            <optional>
+              <ref name="Solutions"/>
+            </optional>
+            <optional>
+              <ref name="References"/>
+            </optional>
+            <optional>
+              <ref name="Glossary"/>
+            </optional>
+          </interleave>
+          <optional>
+            <ref name="Outcomes"/>
+          </optional>
+        </group>
+        <group>
+          <interleave>
+            <optional>
+              <ref name="Objectives"/>
+            </optional>
+            <optional>
+              <ref name="IntroductionDivision"/>
+            </optional>
+          </interleave>
+          <ref name="Subsection"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="Subsection"/>
+              <ref name="Worksheet"/>
+              <ref name="ReadingQuestions"/>
+              <ref name="Exercises"/>
+              <ref name="Solutions"/>
+              <ref name="References"/>
+              <ref name="Glossary"/>
+            </choice>
+          </zeroOrMore>
+          <interleave>
+            <optional>
+              <ref name="Outcomes"/>
+            </optional>
+            <optional>
+              <ref name="ConclusionDivision"/>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="BookAppendix" combine="choice">
+    <element name="appendix">
+      <ref name="MetaDataAltTitle"/>
+      <zeroOrMore>
+        <ref name="AuthorByline"/>
+      </zeroOrMore>
+      <choice>
+        <group>
+          <optional>
+            <ref name="Objectives"/>
+          </optional>
+          <oneOrMore>
+            <choice>
+              <ref name="BlockDivision"/>
+              <ref name="Paragraphs"/>
+              <ref name="Commentary"/>
+              <ref name="NotationList"/>
+            </choice>
+          </oneOrMore>
+          <interleave>
+            <optional>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="ReadingQuestions"/>
+            </optional>
+            <optional>
+              <ref name="Exercises"/>
+            </optional>
+            <optional>
+              <ref name="Solutions"/>
+            </optional>
+            <optional>
+              <ref name="References"/>
+            </optional>
+            <optional>
+              <ref name="Glossary"/>
+            </optional>
+          </interleave>
+          <optional>
+            <ref name="Outcomes"/>
+          </optional>
+        </group>
+        <group>
+          <interleave>
+            <optional>
+              <ref name="Objectives"/>
+            </optional>
+            <optional>
+              <ref name="IntroductionDivision"/>
+            </optional>
+          </interleave>
+          <ref name="Section"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="Section"/>
+              <ref name="Worksheet"/>
+              <ref name="ReadingQuestions"/>
+              <ref name="Exercises"/>
+              <ref name="Solutions"/>
+              <ref name="References"/>
+              <ref name="Glossary"/>
+            </choice>
+          </zeroOrMore>
+          <interleave>
+            <optional>
+              <ref name="Outcomes"/>
+            </optional>
+            <optional>
+              <ref name="ConclusionDivision"/>
+            </optional>
+          </interleave>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Solutions" combine="choice">
+    <element name="solutions">
+      <ref name="MetaDataAltTitleOptional"/>
+      <optional>
+        <attribute name="inline"/>
+      </optional>
+      <optional>
+        <attribute name="divisional"/>
+      </optional>
+      <optional>
+        <attribute name="project"/>
+      </optional>
+      <optional>
+        <attribute name="worksheet"/>
+      </optional>
+      <optional>
+        <attribute name="reading"/>
+      </optional>
+      <optional>
+        <attribute name="scope"/>
+      </optional>
+      <optional>
+        <attribute name="admit">
+          <choice>
+            <value>all</value>
+            <value>odd</value>
+            <value>even</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="IntroductionDivision"/>
+      </optional>
+      <optional>
+        <ref name="ConclusionDivision"/>
+      </optional>
+    </element>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <include href="pretext.rng"/>
   <define name="Interactive">
     <element name="interactive">
@@ -969,5 +969,270 @@
     <optional>
       <attribute name="label"/>
     </optional>
+  </define>
+  <!-- True/False -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <element name="statement">
+        <attribute name="correct">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+        <ref name="Paragraph"/>
+      </element>
+      <optional>
+        <ref name="Feedback"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- Multiple Choice -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <ref name="StatementExercise"/>
+      <element name="choices">
+        <optional>
+          <attribute name="randomize">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <oneOrMore>
+          <ref name="Choice"/>
+        </oneOrMore>
+      </element>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Choice">
+    <element name="choice">
+      <optional>
+        <attribute name="correct">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="BlockText"/>
+      <optional>
+        <ref name="Feedback"/>
+      </optional>
+    </element>
+  </define>
+  <!-- Parsons -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <ref name="StatementExercise"/>
+      <element name="blocks">
+        <optional>
+          <attribute name="layout">
+            <value>horizontal</value>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="randomize">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <oneOrMore>
+          <ref name="Block"/>
+        </oneOrMore>
+      </element>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Block">
+    <element name="block">
+      <optional>
+        <attribute name="order">
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <choice>
+        <group>
+          <optional>
+            <attribute name="correct">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+          <mixed>
+            <optional>
+              <ref name="BlockText"/>
+            </optional>
+          </mixed>
+        </group>
+        <oneOrMore>
+          <element name="choice">
+            <optional>
+              <attribute name="correct">
+                <choice>
+                  <value>yes</value>
+                  <value>no</value>
+                </choice>
+              </attribute>
+            </optional>
+            <mixed>
+              <optional>
+                <ref name="BlockText"/>
+              </optional>
+            </mixed>
+          </element>
+        </oneOrMore>
+      </choice>
+    </element>
+  </define>
+  <!-- Matching -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <ref name="StatementExercise"/>
+      <optional>
+        <ref name="Feedback"/>
+      </optional>
+      <element name="matches">
+        <oneOrMore>
+          <ref name="Match"/>
+        </oneOrMore>
+      </element>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="Match">
+    <element name="match">
+      <optional>
+        <attribute name="order">
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <element name="premise">
+        <mixed>
+          <optional>
+            <ref name="BlockText"/>
+          </optional>
+        </mixed>
+      </element>
+      <element name="response">
+        <mixed>
+          <optional>
+            <ref name="BlockText"/>
+          </optional>
+        </mixed>
+      </element>
+    </element>
+  </define>
+  <!-- Free response -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <optional>
+        <attribute name="number"/>
+      </optional>
+      <choice>
+        <group>
+          <ref name="ExerciseBody"/>
+          <optional>
+            <ref name="Response"/>
+          </optional>
+        </group>
+        <group>
+          <ref name="StatementExercise"/>
+          <optional>
+            <ref name="Response"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="Hint"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Answer"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="Solution"/>
+          </zeroOrMore>
+        </group>
+        <group>
+          <optional>
+            <ref name="IntroductionStatement"/>
+          </optional>
+          <oneOrMore>
+            <ref name="Task"/>
+          </oneOrMore>
+          <optional>
+            <ref name="ConclusionStatement"/>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Response">
+    <element name="response">
+      <empty/>
+    </element>
+  </define>
+  <!-- General feedback element    -->
+  <define name="Feedback">
+    <element name="feedback">
+      <ref name="MetaDataTitleOptional"/>
+      <oneOrMore>
+        <ref name="BlockSolution"/>
+      </oneOrMore>
+    </element>
   </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -970,67 +970,61 @@
       <attribute name="label"/>
     </optional>
   </define>
-  <!-- True/False -->
-  <define name="Exercise" combine="choice">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
+  <define name="TrueFalse">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <element name="statement">
+      <attribute name="correct">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+      <ref name="Paragraph"/>
+    </element>
+    <optional>
+      <ref name="Feedback"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
+  </define>
+  <define name="MultipleChoice">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <ref name="StatementExercise"/>
+    <element name="choices">
       <optional>
-        <attribute name="number"/>
-      </optional>
-      <element name="statement">
-        <attribute name="correct">
+        <attribute name="randomize">
           <choice>
             <value>yes</value>
             <value>no</value>
           </choice>
         </attribute>
-        <ref name="Paragraph"/>
-      </element>
-      <optional>
-        <ref name="Feedback"/>
       </optional>
-      <zeroOrMore>
-        <ref name="Hint"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Answer"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Solution"/>
-      </zeroOrMore>
+      <oneOrMore>
+        <ref name="Choice"/>
+      </oneOrMore>
     </element>
-  </define>
-  <!-- Multiple Choice -->
-  <define name="Exercise" combine="choice">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
-      <optional>
-        <attribute name="number"/>
-      </optional>
-      <ref name="StatementExercise"/>
-      <element name="choices">
-        <optional>
-          <attribute name="randomize">
-            <choice>
-              <value>yes</value>
-              <value>no</value>
-            </choice>
-          </attribute>
-        </optional>
-        <oneOrMore>
-          <ref name="Choice"/>
-        </oneOrMore>
-      </element>
-      <zeroOrMore>
-        <ref name="Hint"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Answer"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Solution"/>
-      </zeroOrMore>
-    </element>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
   </define>
   <define name="Choice">
     <element name="choice">
@@ -1042,48 +1036,68 @@
           </choice>
         </attribute>
       </optional>
-      <ref name="BlockText"/>
-      <optional>
-        <ref name="Feedback"/>
-      </optional>
+      <choice>
+        <mixed>
+          <optional>
+            <ref name="BlockText"/>
+          </optional>
+        </mixed>
+        <group>
+          <ref name="StatementExercise"/>
+          <optional>
+            <ref name="Feedback"/>
+          </optional>
+        </group>
+      </choice>
     </element>
   </define>
-  <!-- Parsons -->
-  <define name="Exercise" combine="choice">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
+  <define name="Parsons">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <optional>
+      <attribute name="language"/>
+    </optional>
+    <optional>
+      <attribute name="adaptive">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentation"/>
+    </optional>
+    <ref name="StatementExercise"/>
+    <element name="blocks">
       <optional>
-        <attribute name="number"/>
+        <attribute name="layout">
+          <value>horizontal</value>
+        </attribute>
       </optional>
-      <ref name="StatementExercise"/>
-      <element name="blocks">
-        <optional>
-          <attribute name="layout">
-            <value>horizontal</value>
-          </attribute>
-        </optional>
-        <optional>
-          <attribute name="randomize">
-            <choice>
-              <value>yes</value>
-              <value>no</value>
-            </choice>
-          </attribute>
-        </optional>
-        <oneOrMore>
-          <ref name="Block"/>
-        </oneOrMore>
-      </element>
-      <zeroOrMore>
-        <ref name="Hint"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Answer"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Solution"/>
-      </zeroOrMore>
+      <optional>
+        <attribute name="randomize">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="Block"/>
+      </oneOrMore>
     </element>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
   </define>
   <define name="Block">
     <element name="block">
@@ -1128,32 +1142,29 @@
       </choice>
     </element>
   </define>
-  <!-- Matching -->
-  <define name="Exercise" combine="choice">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
-      <optional>
-        <attribute name="number"/>
-      </optional>
-      <ref name="StatementExercise"/>
-      <optional>
-        <ref name="Feedback"/>
-      </optional>
-      <element name="matches">
-        <oneOrMore>
-          <ref name="Match"/>
-        </oneOrMore>
-      </element>
-      <zeroOrMore>
-        <ref name="Hint"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Answer"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Solution"/>
-      </zeroOrMore>
+  <define name="Matching">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <ref name="StatementExercise"/>
+    <optional>
+      <ref name="Feedback"/>
+    </optional>
+    <element name="matches">
+      <oneOrMore>
+        <ref name="Match"/>
+      </oneOrMore>
     </element>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
   </define>
   <define name="Match">
     <element name="match">
@@ -1178,48 +1189,45 @@
       </element>
     </element>
   </define>
-  <!-- Free response -->
-  <define name="Exercise" combine="choice">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
-      <optional>
-        <attribute name="number"/>
-      </optional>
-      <choice>
-        <group>
-          <ref name="ExerciseBody"/>
-          <optional>
-            <ref name="Response"/>
-          </optional>
-        </group>
-        <group>
-          <ref name="StatementExercise"/>
-          <optional>
-            <ref name="Response"/>
-          </optional>
-          <zeroOrMore>
-            <ref name="Hint"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Answer"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Solution"/>
-          </zeroOrMore>
-        </group>
-        <group>
-          <optional>
-            <ref name="IntroductionStatement"/>
-          </optional>
-          <oneOrMore>
-            <ref name="Task"/>
-          </oneOrMore>
-          <optional>
-            <ref name="ConclusionStatement"/>
-          </optional>
-        </group>
-      </choice>
-    </element>
+  <define name="FreeResponse">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <choice>
+      <group>
+        <ref name="ExerciseBody"/>
+        <optional>
+          <ref name="Response"/>
+        </optional>
+      </group>
+      <group>
+        <ref name="StatementExercise"/>
+        <optional>
+          <ref name="Response"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="Hint"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="Answer"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="Solution"/>
+        </zeroOrMore>
+      </group>
+      <group>
+        <optional>
+          <ref name="IntroductionStatement"/>
+        </optional>
+        <oneOrMore>
+          <ref name="Task"/>
+        </oneOrMore>
+        <optional>
+          <ref name="ConclusionStatement"/>
+        </optional>
+      </group>
+    </choice>
   </define>
   <define name="Response">
     <element name="response">
@@ -1234,5 +1242,26 @@
         <ref name="BlockSolution"/>
       </oneOrMore>
     </element>
+  </define>
+  <!-- Include all exercise types in exercise and activity    -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <choice>
+        <ref name="TrueFalse"/>
+        <ref name="MultipleChoice"/>
+        <ref name="Parsons"/>
+        <ref name="Matching"/>
+        <ref name="FreeResponse"/>
+      </choice>
+    </element>
+  </define>
+  <define name="ProjectLike" combine="choice">
+    <choice>
+      <ref name="TrueFalse"/>
+      <ref name="MultipleChoice"/>
+      <ref name="Parsons"/>
+      <ref name="Matching"/>
+      <ref name="FreeResponse"/>
+    </choice>
   </define>
 </grammar>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1,6 +1,6 @@
 
-            grammar {
-            
+                    grammar {
+                
             start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary
             
             Pretext =
@@ -1553,12 +1553,12 @@
             NotationList =
                 element notation-list {empty}
             
-            Demonstration = element demonstration {
-                Title,
-                Paragraph,
-                Sage
-            }
-            
+                    Demonstration = element demonstration {
+                    Title,
+                    Paragraph,
+                    Sage
+                    }
+                
             DocInfo =
                 element docinfo {
                     XMLBase?,
@@ -1627,5 +1627,5 @@
                     }?
                 }
             
-            }
-            
+                    }
+                

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2155,6 +2155,116 @@
     </section>
 
     <section>
+        <title>Exercises (experimental)</title>
+        <p>
+            We can have exercises that are interactive, such as true/false, multiple choices, Parson's problems, etc.
+        </p>
+
+        <fragment xml:id="exercise-dev">
+            <title>Exercises (experimental)</title>
+            <code>
+            #True/False
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    element statement {
+                        attribute correct {"yes"|"no"},
+                        Paragraph
+                    }, 
+                    Feedback?, Hint*, Answer*, Solution*
+                }
+            #Multiple Choice
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    element choices {
+                        attribute randomize {"yes"|"no"}?,
+                        Choice+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Choice = 
+                element choice {
+                    attribute correct {"yes"|"no"}?,
+                    BlockText,
+                    Feedback?
+                }
+            # Parsons
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    element blocks {
+                        attribute layout {"horizontal"}?,
+                        attribute randomize {"yes"|"no"}?,
+                        Block+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Block = 
+                element block {
+                    attribute order {xsd:integer}?,
+                    ((
+                        attribute correct {"yes"|"no"}?,
+                        mixed {BlockText?}
+                    ) | 
+                    (
+                        element choice {
+                            attribute correct {"yes"|"no"}?,
+                            mixed {BlockText?}
+                        }+ 
+                    ))
+                }
+            # Matching
+            Exercise |= 
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    StatementExercise,
+                    Feedback?,
+                    element matches {
+                        Match+
+                    },
+                    Hint*, Answer*, Solution*
+                }
+            Match =
+                element match {
+                    attribute order {xsd:integer}?,
+                    element premise {
+                        mixed {BlockText?}
+                    },
+                    element response {
+                        mixed {BlockText?}
+                    }
+                }
+            # Free response
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    (
+                    (ExerciseBody, Response?) |
+                    (StatementExercise, Response?, Hint*, Answer*, Solution*) |
+                    (IntroductionStatement?, Task+, ConclusionStatement?) 
+                    )
+                }
+            Response =
+                element response {empty}
+            # General feedback element    
+            Feedback = 
+                element feedback {
+                    MetaDataTitleOptional,
+                    BlockSolution+
+                }
+            </code>
+        </fragment> 
+    </section>
+
+    <section>
         <title>Bibliography</title>
 
         <p>This is all stop-gap and will change radically.  But it seems to work for now.  So these rules should not be taken as definitive, at all.</p>
@@ -3086,6 +3196,7 @@
             <fragref ref="reference-dev"/>
             <fragref ref="mathematics-dev"/>
             <fragref ref="label"/>
+            <fragref ref="exercise-dev"/>
             <code>
                 }
             </code>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2163,40 +2163,35 @@
         <fragment xml:id="exercise-dev">
             <title>Exercises (experimental)</title>
             <code>
-            #True/False
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    element statement {
-                        attribute correct {"yes"|"no"},
-                        Paragraph
-                    }, 
-                    Feedback?, Hint*, Answer*, Solution*
-                }
-            #Multiple Choice
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    StatementExercise,
-                    element choices {
-                        attribute randomize {"yes"|"no"}?,
-                        Choice+
-                    },
-                    Hint*, Answer*, Solution*
-                }
+            TrueFalse =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                element statement {
+                    attribute correct {"yes"|"no"},
+                    Paragraph
+                }, 
+                Feedback?, Hint*, Answer*, Solution*
+            MultipleChoice =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                element choices {
+                    attribute randomize {"yes"|"no"}?,
+                    Choice+
+                },
+                Hint*, Answer*, Solution*
             Choice = 
                 element choice {
                     attribute correct {"yes"|"no"}?,
-                    BlockText,
-                    Feedback?
+                    ((mixed {BlockText?})
+                    | (StatementExercise, Feedback?))
                 }
-            # Parsons
-            Exercise |=
-                element exercise {
+            Parsons =
                     MetaDataTitleOptional,
                     attribute number {text}?,
+                    attribute language {text}?,
+                    attribute adaptive {"yes"|"no"}?,
+                    attribute indentation {text}?,
                     StatementExercise,
                     element blocks {
                         attribute layout {"horizontal"}?,
@@ -2204,7 +2199,6 @@
                         Block+
                     },
                     Hint*, Answer*, Solution*
-                }
             Block = 
                 element block {
                     attribute order {xsd:integer}?,
@@ -2219,18 +2213,15 @@
                         }+ 
                     ))
                 }
-            # Matching
-            Exercise |= 
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    StatementExercise,
-                    Feedback?,
-                    element matches {
-                        Match+
-                    },
-                    Hint*, Answer*, Solution*
-                }
+            Matching = 
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                Feedback?,
+                element matches {
+                    Match+
+                },
+                Hint*, Answer*, Solution*
             Match =
                 element match {
                     attribute order {xsd:integer}?,
@@ -2241,17 +2232,14 @@
                         mixed {BlockText?}
                     }
                 }
-            # Free response
-            Exercise |=
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    (
-                    (ExerciseBody, Response?) |
-                    (StatementExercise, Response?, Hint*, Answer*, Solution*) |
-                    (IntroductionStatement?, Task+, ConclusionStatement?) 
-                    )
-                }
+            FreeResponse =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                (
+                (ExerciseBody, Response?) |
+                (StatementExercise, Response?, Hint*, Answer*, Solution*) |
+                (IntroductionStatement?, Task+, ConclusionStatement?) 
+                )
             Response =
                 element response {empty}
             # General feedback element    
@@ -2260,6 +2248,21 @@
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
+            # Include all exercise types in exercise and activity    
+            Exercise |=
+                element exercise {
+                    TrueFalse |
+                    MultipleChoice |
+                    Parsons |
+                    Matching |
+                    FreeResponse
+                }
+            ProjectLike |=
+                TrueFalse |
+                MultipleChoice |
+                Parsons |
+                Matching |
+                FreeResponse
             </code>
         </fragment> 
     </section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1507,6 +1507,24 @@
     </section>
 
     <section>
+        <title>Figure (experimental)</title>
+        <p>
+            We add tabular as a valid child of a figure.
+        </p>
+        <fragment xml:id="figure-dev">
+            <title>Figure (experimental)</title>
+            <code>
+            Figure |= 
+                element figure {
+                    MetaDataCaption,
+                    Tabular
+                }
+
+            </code>
+        </fragment>
+    </section>
+
+    <section>
         <title>Side-By-Side Layout</title>
 
         <p>Page width or screen width, both are at a premium.  Height goes on forever (barring physical page breaks) and we have many devices for demarcating that flow.  But sometimes you need to organize items horizontally, <ie/> side-by-side.  We place the components of a <c>sidebyside</c> into generic regions of specified width called <term>panels</term>.</p>
@@ -2772,6 +2790,7 @@
             <fragref ref="frontmatter-dev"/>
             <fragref ref="docinfo-dev"/>
             <fragref ref="proof-like"/>
+            <fragref ref="figure-dev"/>
 
             <code>
                     }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2366,6 +2366,42 @@
     </section>
 
     <section>
+        <title>Front matter (experimental)</title>
+
+        <p>A few simple tweaks to frontmatter elements.</p>
+
+        <p>We give an alternative definition of the ColophonFront to include footnotes in the shortlicense.  This is the only change currently.</p>
+
+        <fragment xml:id="frontmatter-dev">
+            <title>Front matter (dev)</title>
+            <code>
+            ColophonFront |=
+                element colophon {
+                    MetaDataTarget,
+                    element credit {
+                        element role {TextShort},
+                        element entity {TextLong}
+                    }*,
+                    element edition {text}?,
+                    element website {
+                        element name {TextShort},
+                        element address {text}
+                    }?,
+                    element copyright {
+                        element year {TextShort},
+                        element holder {text},
+                        element minilicense {TextShort}?,
+                        element shortlicense {
+                            TextLong &amp;
+                            Footnote*
+                        }?
+                    }?
+                }
+            </code>    
+        </fragment>
+    </section>
+
+    <section>
         <title>Contributors</title>
 
         <p>A single <c>contributors</c> element may be placed into a <c>preface</c> and is a list of <c>contributor</c>.  It can be optionally preceded, or followed, by all the usual things that can go into any preface.  An AuthorByline is a special instance of acknowledging a contributor on a division.</p>
@@ -2586,15 +2622,56 @@
     </section>
 
     <section>
-        <title>Hierarchical Structure</title>
+        <title>Document Information (experimental)</title>
 
-        <p>We collect all the specifications, roughly in a top-down order, so the generated schema files have a rational ordering to them, even if the order presented here is different.</p>
+        <p>We extend the <c>docinfo</c> to include new elements. We
+                add each to the <c>Configuration</c> group.</p>
+
+        <p>A textbook can have a blurb (roughly what you would expect on the back of the book), and optionally a <attr>shelf</attr> that tells Runestone how to categorize the book.</p>
+
+        <fragment xml:id="blurb">
+            <title>Blurb</title>
+            <code>
+            Configuration |=
+                element blurb {
+                    attribute shelf {text},
+                    text
+                }
+            </code>
+        </fragment>
+
+        <fragment xml:id="document-id">
+            <title>Document ID</title>
+            <code>
+            Configuration |=
+                element document-id {
+                    attribute edition {text},
+                    text
+                }
+            </code>
+        </fragment>
+
+        <p>Now we collect these to add to the dev schema.</p>
+        <fragment xml:id="docinfo-dev">
+            <title>Experimental Document Info</title>
+            <fragref ref="blurb"/>
+            <fragref ref="document-id"/>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Hierarchical
+                Structure</title>
+
+        <p>We collect all the specifications, roughly in a top-down order, so
+                the generated schema files have a rational ordering to them, even if the order
+                presented here is different.</p>
 
         <fragment filename="pretext.rnc">
             <title>Hierarchical Structure</title>
             <code>
-            grammar {
-            </code>
+                    grammar {
+                </code>
             <fragref ref="start-elements" />
             <fragref ref="gross-structure" />
             <fragref ref="document-types" />
@@ -2651,52 +2728,59 @@
             <fragref ref="bad-bank" />
             <fragref ref="docinfo" />
             <code>
-            }
-            </code>
-        </fragment>
-    </section>
+                    }
+                </code>
+            </fragment>
+        </section>
 
     <section>
-        <title>Development Schema</title>
+        <title>Development
+                Schema</title>
         
-        <p>Here we collect all fragments that are still experimental and put them in a rnc file that includes the stable schema.</p>
+        <p>Here we collect all fragments that are still experimental and put them
+                in a rnc file that includes the stable schema.</p>
 
         <fragment filename="pretext-dev.rnc">
             <title>Development Schema</title>
             <code>
-            grammar {
-                
-            include "pretext.rnc"
-            </code>
+                    grammar {
+
+                    include "pretext.rnc"
+                </code>
             <fragref ref="interactive" />
+            <fragref ref="frontmatter-dev"/>
+            <fragref ref="docinfo-dev"/>
+
             <code>
-            }
-            </code>
-        </fragment>
-    </section>
+                    }
+                </code>
+            </fragment>
+        </section>
 
     <section xml:id="badbank">
-        <title>Bad Bank</title>
+        <title>Bad
+                Bank</title>
 
         <fragment xml:id="bad-bank">
             <title>Bad bank</title>
             <code>
-            Demonstration = element demonstration {
-                Title,
-                Paragraph,
-                Sage
-            }
-            </code>
-        </fragment>
-    </section>
+                    Demonstration = element demonstration {
+                    Title,
+                    Paragraph,
+                    Sage
+                    }
+                </code>
+            </fragment>
+        </section>
 
     <backmatter>
         <appendix xml:id="fragment-list">
-            <title>Fragments</title>
+            <title>
+                    Fragments</title>
 
             <list-of elements="fragment"/>
-        </appendix>
-    </backmatter>
+            </appendix>
+        </backmatter>
 
     </article>
 </pretext>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2530,6 +2530,18 @@
     </section>
 
     <section>
+        <title>Labels as Unique IDs (experimental)</title>
+        <p>We assume that everywhere an xml:id can go, we can also now put a label.</p>
+        <fragment xml:id="label">
+            <title>Labels as Unique IDs</title>
+            <code>
+            UniqueID |=
+                attribute xml:id {text}?,
+                attribute label {text}?   
+            </code>
+        </fragment>
+    </section>
+    <section>
         <title>Miscellaneous</title>
 
         <p>Provisional items, with uncertain futures.</p>
@@ -3073,6 +3085,7 @@
             <fragref ref="solutions-dev"/>
             <fragref ref="reference-dev"/>
             <fragref ref="mathematics-dev"/>
+            <fragref ref="label"/>
             <code>
                 }
             </code>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -382,6 +382,223 @@
         </fragment>
     </section>
 
+    <section>
+        <title>Solutions (experimental)</title>
+
+        <p>The solutions division can now have additional attributes: <attr>scope</attr>, <attr>reading</attr>, and <attr>worksheet</attr>.  We collect these three here.</p>
+
+        <fragment xml:id="solutions-dev">
+            <title>Solutions (experimental)</title>
+            <code>
+            Solutions |=
+                element solutions {
+                    MetaDataAltTitleOptional,
+                    attribute inline {text}?,
+                    attribute divisional {text}?,
+                    attribute project {text}?,
+                    attribute worksheet {text}?,
+                    attribute reading {text}?,
+                    attribute scope {text}?,
+                    attribute admit {"all"|"odd"|"even"}?,
+                    IntroductionDivision?,
+                    ConclusionDivision?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Worksheets (experimental)</title>
+
+        <p>A worksheet is a specialized division, allowing for some additional control of spacing, to allow for workspace.</p>
+
+        <p>The attributes on a worksheet include margin information to control layout.  Inside a worksheet we can have either a number of <tag>page</tag> elements that holding the content or just the content itself.</p>
+
+        <p>The contents of a worksheet can include the same blocks as a division, namely BlockDivision.</p>
+        <fragment xml:id="worksheet">
+            <title>Worksheets (experimental)</title>
+            <code>
+            WorksheetAttributes =
+                attribute margin { text }?,
+                attribute top { text }?,
+                attribute bottom { text }?,
+                attribute right { text }?,
+                attribute left { text }?                
+
+            WorksheetBlock = 
+                BlockStatement | Remark | Computation | Theorem | Proof | Definition |
+                Axiom | Example | WorksheetExercise | Project |
+                Poem | Assemblage | ListGenerator | Fragment |
+                Demonstration
+            
+            # Exercises and tasks can have workspace if they don't contain additional tasks:
+            WorksheetExercise = 
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    attribute workspace {text}?,
+                    (
+                    ExerciseBody |
+                    (StatementExercise, Hint*, Answer*, Solution*) |
+                    (IntroductionText?, WebWork, ConclusionText?)
+                    )
+                }
+            WorksheetExercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    attribute number {text}?,
+                    (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
+                }
+            WorksheetTask = 
+                element task {
+                    MetaDataTitleOptional,
+                    attribute workspace {text}?,
+                    (
+                        BlockStatement+ |
+                        (Statement, Hint*, Answer*, Solution*)
+                    )
+                } 
+            WorksheetTask |=
+                element task {
+                    MetaDataTitleOptional,
+                    (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
+                } 
+
+            # Main worksheet definition    
+            Worksheet = 
+                element worksheet {
+                    WorksheetAttributes,
+                    MetaDataAltTitleOptional,
+                    (Objectives? &amp; IntroductionDivision?),
+                    (element page {WorksheetBlock+} | WorksheetBlock+),
+                    (Outcomes? &amp; ConclusionDivision?)
+                } 
+
+            # Insert worksheets into divisions (merge with division when adopted)
+            Chapter |=
+                element chapter {
+                    MetaDataLinedTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                             Solutions? &amp; References? &amp; Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? &amp; IntroductionDivision?),
+                            Section,
+                            (Section | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? &amp; ConclusionDivision?)
+                        )
+                    )
+                }
+            Section |=
+                element section {
+                    MetaDataLinedTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                             Solutions? &amp; References? &amp; Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? &amp; IntroductionDivision?),
+                            Subsection,
+                            (Subsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? &amp; ConclusionDivision?)
+                        )
+                    )
+                }
+            Subsection |=
+                element subsection {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary)+,
+                            (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                             Solutions? &amp; References? &amp; Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? &amp; IntroductionDivision?),
+                            Subsubsection,
+                            (Subsubsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? &amp; ConclusionDivision?)
+                        )
+                    )
+                }
+            Subsubsection |=
+                element subsubsection {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    Objectives?,
+                    (BlockDivision | Paragraphs | Commentary)+,
+                    (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                     Solutions? &amp; References? &amp; Glossary?),
+                    Outcomes?
+                }
+            ArticleAppendix |=
+                element appendix {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary |
+                             NotationList)+,
+                            (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                             Solutions? &amp; References? &amp; Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? &amp; IntroductionDivision?),
+                            Subsection,
+                            (Subsection | Worksheet | ReadingQuestions | Exercises |
+                             Solutions | References | Glossary)*,
+                            (Outcomes? &amp; ConclusionDivision?)
+                        )
+                    )
+                }
+            BookAppendix |=
+                element appendix {
+                    MetaDataAltTitle,
+                    AuthorByline*,
+                    (
+                        (
+                            Objectives?,
+                            (BlockDivision | Paragraphs | Commentary |
+                             NotationList)+,
+                            (Worksheet? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                             Solutions? &amp; References? &amp; Glossary?),
+                            Outcomes?
+                        )
+                    |
+                        (
+                            (Objectives? &amp; IntroductionDivision?),
+                            Section,
+                            (Section | Worksheet | ReadingQuestions | Exercises | Solutions | References | Glossary)*,
+                            (Outcomes? &amp; ConclusionDivision?)
+                        )
+                    )
+                }
+            </code>
+        </fragment>
+    </section>
 
     <section>
         <title>Paragraphs</title>
@@ -2782,19 +2999,20 @@
         <fragment filename="pretext-dev.rnc">
             <title>Development Schema</title>
             <code>
-                    grammar {
+                grammar {
 
-                    include "pretext.rnc"
-                </code>
+                include "pretext.rnc"
+            </code>
             <fragref ref="interactive" />
             <fragref ref="frontmatter-dev"/>
             <fragref ref="docinfo-dev"/>
             <fragref ref="proof-like"/>
             <fragref ref="figure-dev"/>
-
+            <fragref ref="worksheet"/>
+            <fragref ref="solutions-dev"/>
             <code>
-                    }
-                </code>
+                }
+            </code>
             </fragment>
         </section>
 

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1240,6 +1240,27 @@
     </section>
 
     <section>
+        <title>Proof-like (experimental)</title>
+        <p>
+            We extend the types of elements that are types of proofs, as well as create a <c>ProofLike</c> named pattern for what can go in them.
+        </p>
+
+        <fragment xml:id="proof-like">
+            <title>Proofs, and similar</title>
+            <code>
+            ProofLike = 
+                MetaDataTitleOptional,
+                (BlockStatement | Case)+
+            Proof |=
+                element proof {ProofLike} |
+                element argument {ProofLike} |
+                element justification {ProofLike} |
+                element reasoning {ProofLike} |
+                element explanation {ProofLike}
+            </code>
+        </fragment>
+    </section>
+    <section>
         <title>Axioms and Other Mathematical Statements</title>
 
         <p>Mathematical statements that do not have proofs (in other words, no proof is known, or a proof is not appropriate).</p>
@@ -2645,7 +2666,7 @@
             <code>
             Configuration |=
                 element document-id {
-                    attribute edition {text},
+                    attribute edition {text}?,
                     text
                 }
             </code>
@@ -2750,6 +2771,7 @@
             <fragref ref="interactive" />
             <fragref ref="frontmatter-dev"/>
             <fragref ref="docinfo-dev"/>
+            <fragref ref="proof-like"/>
 
             <code>
                     }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1052,6 +1052,44 @@
         </fragment>
     </section>
 
+    <section>
+        <title>Mathematics (experimental)</title>
+        
+        <p>We include some additions to math elements, including allowing permid on displayed math and allowing xrefs inside displayed math.</p>
+
+
+        <fragment xml:id="mathematics-dev">
+            <title>Mathematics (experimental)</title>
+            <code>
+            MathDisplay |=
+                element me {
+                    MetaDataTarget?,
+                    mixed {(Xref | FillInMath | WWVariable)*}
+                } |
+                element men {
+                    MetaDataTarget?,
+                    mixed {(Xref | FillInMath | WWVariable)*}
+                } |
+                element md {
+                    attribute number {"yes" | "no"}?,
+                    attribute break {"yes" | "no"}?,
+                    attribute alignment {text}?,
+                    attribute alignat-columns {text}?,
+                    MathRow,
+                    (MathRow | MathIntertext)*
+                } |
+                element mdn {
+                    attribute number {"yes" | "no"}?,
+                    attribute break {"yes" | "no"}?,
+                    attribute alignment {text}?,
+                    attribute alignat-columns {text}?,
+                    MathRow,
+                    (MathRow | MathIntertext)*
+                }
+            </code>
+        </fragment>
+    </section>
+
 
     <section>
         <title>Blocks</title>
@@ -1261,6 +1299,29 @@
             </code>
         </fragment>
 
+    </section>
+
+    <section>
+        <title>References (experimental)</title>
+        <p>Here we collect experimental versions of reference-like elements.  Specifically, changes to Url, that only recommend a visual element when the URL element contains content.</p>
+
+        <fragment xml:id="reference-dev">
+            <title>References (experimental)</title>
+            <code>
+            Url |=
+                element url {
+                    attribute href {text},
+                    (
+                        (attribute visual {text},
+                        TextShort
+                        )| TextShort |
+                        (
+                        attribute visual {text}?
+                        )
+                    )
+                }    
+            </code>
+        </fragment>
     </section>
 
     <section>
@@ -3010,6 +3071,8 @@
             <fragref ref="figure-dev"/>
             <fragref ref="worksheet"/>
             <fragref ref="solutions-dev"/>
+            <fragref ref="reference-dev"/>
+            <fragref ref="mathematics-dev"/>
             <code>
                 }
             </code>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -429,8 +429,27 @@
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | WorksheetExercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment |
-                Demonstration
-            
+                Demonstration |WorksheetSideBySide
+            # Allow exercise in sidebyside
+            WorksheetSideBySide = 
+                element sidebyside {
+                    SidebySideAttributes,
+                    (
+                        Figure |
+                        Poem |
+                        Tabular |
+                        Image |
+                        Video |
+                        Program |
+                        Console |
+                        Paragraph |
+                        Preformatted |
+                        List |
+                        Stack |
+                        WorksheetExercise |
+                        WorksheetTask
+                    )+
+                }     
             # Exercises and tasks can have workspace if they don't contain additional tasks:
             WorksheetExercise = 
                 element exercise {
@@ -447,6 +466,7 @@
                 element exercise {
                     MetaDataTitleOptional,
                     attribute number {text}?,
+                    attribute workspace {text}?,
                     (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
                 }
             WorksheetTask = 
@@ -461,16 +481,17 @@
             WorksheetTask |=
                 element task {
                     MetaDataTitleOptional,
+                    attribute workspace {text}?,
                     (IntroductionStatement?, WorksheetTask+, ConclusionStatement?)
                 } 
-
             # Main worksheet definition    
             Worksheet = 
                 element worksheet {
                     WorksheetAttributes,
                     MetaDataAltTitleOptional,
                     (Objectives? &amp; IntroductionDivision?),
-                    (element page {WorksheetBlock+} | WorksheetBlock+),
+                    (
+                    element page {WorksheetBlock+|empty}+ | WorksheetBlock+),
                     (Outcomes? &amp; ConclusionDivision?)
                 } 
 
@@ -490,7 +511,7 @@
                     |
                         (
                             (Objectives? &amp; IntroductionDivision?),
-                            Section,
+                            (Section | Worksheet),
                             (Section | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionDivision?)
@@ -512,7 +533,7 @@
                     |
                         (
                             (Objectives? &amp; IntroductionDivision?),
-                            Subsection,
+                            (Subsection | Worksheet),
                             (Subsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionDivision?)
@@ -534,7 +555,7 @@
                     |
                         (
                             (Objectives? &amp; IntroductionDivision?),
-                            Subsubsection,
+                            (Subsubsection | Worksheet),
                             (Subsubsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionDivision?)
@@ -567,7 +588,7 @@
                     |
                         (
                             (Objectives? &amp; IntroductionDivision?),
-                            Subsection,
+                            (Subsection | Worksheet),
                             (Subsection | Worksheet | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionDivision?)
@@ -590,7 +611,7 @@
                     |
                         (
                             (Objectives? &amp; IntroductionDivision?),
-                            Section,
+                            (Section | Worksheet),
                             (Section | Worksheet | ReadingQuestions | Exercises | Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionDivision?)
                         )

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1644,11 +1644,11 @@
     </section>
 
     <section>
-        <title>Interactive Elements</title>
+        <title>Legacy Interactive Elements</title>
 
         <p>Some specific interactive goodies.  These are being phased-out in favor of a more general <tag>interactive</tag> element.</p>
 
-        <fragment xml:id="interactive">
+        <fragment xml:id="interactive-musescore">
             <title>Interactives</title>
             <code>
             MuseScore =
@@ -1656,6 +1656,66 @@
                     attribute musescoreuser {text},
                     attribute musescore {text}
                 }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Interactive Elements (experimental)</title>
+        
+        <p>A general <tag>interactive</tag> element.</p>
+        
+        <fragment xml:id="interactive">
+            <title>Interactives</title>
+            <code>
+            Interactive =
+                element interactive {
+                    UniqueID?,
+                    PermanentID?,
+                    attribute aspect { text }?,
+                    attribute width { text }?,
+                    attribute platform { text }?,
+                    attribute preview { text }?,
+                    attribute iframe { text }?,
+                    attribute source { text }?,
+                    attribute version { text }?,
+                    (Slate | SideBySideNoCaption | SideBySideGroupNoCaption)*,
+                    element instructions { BlockText* | text }?
+                }
+
+            Slate =
+                element slate {
+                    UniqueID?,
+                    attribute surface { text },
+                    (attribute source { text } | attribute material { text })?,
+                    attribute aspect { text }?,
+                    (Paragraph | Tabular | SideBySideNoCaption)*
+                }
+
+            # add Interactives where used
+            BlockStatement |= Interactive
+
+            Figure |= element figure { MetaDataCaption, Interactive }
+
+            SideBySide |= element sidebyside {
+                SidebySideAttributes,
+                (Interactive | Slate)+
+            }
+
+            SideBySideNoCaption |= element sidebyside {
+                SidebySideAttributes,
+                (Interactive | Slate)+
+            }
+
+            Exercises |= element exercises {
+                MetaDataAltTitleOptional,
+                IntroductionDivision?,
+                (
+                (Exercise | ExerciseGroup)+ |
+                Subexercises+ | Interactive
+                ),
+                ConclusionDivision?
+            }
             </code>
         </fragment>
     </section>
@@ -2564,7 +2624,7 @@
             <fragref ref="image" />
             <fragref ref="tabular" />
             <fragref ref="sage" />
-            <fragref ref="interactive" />
+            <fragref ref="interactive-musescore" />
             <fragref ref="audiovideo" />
             <fragref ref="exercise" />
             <fragref ref="poetry" />
@@ -2590,6 +2650,25 @@
             <fragref ref="listgenerator" />
             <fragref ref="bad-bank" />
             <fragref ref="docinfo" />
+            <code>
+            }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Development Schema</title>
+        
+        <p>Here we collect all fragments that are still experimental and put them in a rnc file that includes the stable schema.</p>
+
+        <fragment filename="pretext-dev.rnc">
+            <title>Development Schema</title>
+            <code>
+            grammar {
+                
+            include "pretext.rnc"
+            </code>
+            <fragref ref="interactive" />
             <code>
             }
             </code>


### PR DESCRIPTION
As discussed and requested on the [pretext-dev](https://groups.google.com/g/pretext-dev/c/crogb8-meWs/m/WJukDjmpAgAJ), here is a proposal for how to set up a secondary development schema that can be validated against instead of (or in addition to) the current stable schema.  A very rough attempt at implementing `<interactive>` is provided (but not knowing its current status, I made guesses based on the sample article).  Results in fewer schema violations, but would need much improvement to completely capture what interactives are supposed to be.

Basic setup is this:

* New features under development get their own section in a reasonable place in `schema/pretext.xml` along with the rest of the schema.  This includes providing their definitions just like any other element, but will also mean giving additional definitions to the elements that are meant to include them (using the `|=` notation for `combine="choice"`).  
* The `<fragment>` gets an `@xml:id` just like any other, and while the feature is still under development, it is then referenced in a second collection of fragments at the end of the file (with `filename="pretext-dev.rnc"`; see line 2659).  
* Once the feature is ready for the stable schema, this reference can be moved to the main collection of fragments.  
* Additionally, the additional definitions of elements that can include the feature can be cleaned up: merge them into the correct place in the original definition of the including element.
* Processing the `xml` file with `xsl/pretext-litprog.xsl` creates both files.  Then use trang to convert both to `.rng`.  (No ideas/opinions about whether this should be included as part of the other versions of the schema.)

If this all seems reasonable, then I'd be happy to make a first pass at adding other experimental features to capture whatever is in the sample article.  