### PR TITLE
WeBWorK: delimit table cell content better

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -2166,6 +2166,26 @@
                     </statement>
                 </webwork>
             </exercise>
+
+            <exercise>
+                <introduction>
+                    <p>
+                        This exercise has a single quote in it.
+                        A single quote is the first option for a delimiter for perl's q
+                        function which is used by extract-pg.xsl in table cells.
+                        So if working, it should move on to the next delimiter option.
+                    </p>
+                </introduction>
+                <webwork>
+                    <statement>
+                        <tabular>
+                            <row>
+                                <cell>What's up, Doc?</cell>
+                            </row>
+                        </tabular>
+                    </statement>
+                </webwork>
+            </exercise>
         </section>
 
         <section>


### PR DESCRIPTION
#1876 changed how table cell contents are delimited, to use &#x00a6;. This PR changes it to use the existing `mode="delimit"` template instead, which I had forgotten existed.

At the same time, now that I know more about perl's `q` function, a bug is fixed with that template. A big that was probably never encountered by a real user, but a bug nonetheless.