### PR TITLE
Sanatize code element in titles for html title element

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2769,6 +2769,11 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="."/>
 </xsl:template>
 
+<!-- We do not wrap an "c" element as part of a plain title -->
+<xsl:template match="c" mode="plain-title-edit">
+    <xsl:value-of select="."/>
+</xsl:template>
+
 <!-- We dumb-down quotation marks to "straight" ASCII. -->
 <!-- These behave well in output as attribute values,  -->
 <!-- the HTML serialization seems "smart" enough to    -->


### PR DESCRIPTION
Currently, if a user uses `<c>` elements in a title of a chunked page, a bunch of junk gets put into the html title element, making the title bar of the browser ugly.

Just like what is done for math, the `<c>` tag should now not be a problem.