### PR TITLE
WeBWorK: PG archiving via pretext.py

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -100,6 +100,18 @@ PGOUT      = $(SCRATCH)/pg
 # testing purposes.This should not be taken as necessary or best
 # practice for a real PreTeXt project using WeBWorK problems.
 
+
+#########################################################################
+#  Construct macros file. This must be uploaded into the macros folder
+#  of the server's host course before building representations below.
+#  There are no macros for the minimal example, so omitted
+
+sample-chapter-macros:
+	install -d $(PGOUT)/macros
+	cd $(PGOUT)/macros; \
+	$(PTX)/pretext/pretext -v -c pg-macros -p $(SMPCPUB) $(SMPC)
+
+
 #########################################################################
 #  Extract webwork problems into a single XML file.
 #  Location is within generated folder (named in the publisher file),
@@ -177,13 +189,13 @@ sample-chapter-problem-sets:
 	install -d $(PGOUT)
 	cd $(PGOUT); \
 	rm -r Integrating_WeBWorK_into_Textbooks; \
-	xsltproc -stringparam publisher $(SMPCPUB) -stringparam chunk.level 1 -stringparam debug.datedfiles no $(PTXXSL)/pretext-ww-problem-sets.xsl $(SMPC)
+	$(PTX)/pretext/pretext -v -c all -f webwork-sets -z -x chunk.level 1 debug.datedfiles no -p $(SMPCPUB) $(SMPC)
 
 mini-problem-sets:
 	install -d $(PGOUT)
 	cd $(PGOUT); \
 	rm -r WeBWorK_Minimal_Example; \
-	xsltproc -stringparam publisher $(MINIPUB) -stringparam chunk.level 1 -stringparam debug.datedfiles no $(PTXXSL)/pretext-ww-problem-sets.xsl $(MINI)
+	$(PTX)/pretext/pretext -v -c all -f webwork-sets -z -x chunk.level 1 debug.datedfiles no -p $(MINIPUB) $(MINI)
 
 
 #########################################################################

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -376,6 +376,7 @@ def get_cli_arguments():
         ),
         ("sagenb", "Sage worksheet conversion (removed)"),
         ("all", "All available output formats"),
+        ("webwork-sets", "Folder tree of PG files, set defintions, and set headers"),
     ]
     format_help = "Output formats are:\n" + "\n".join(
         ["  {} - {}".format(info[0], info[1]) for info in format_info]
@@ -466,6 +467,13 @@ def get_cli_arguments():
         help="abort script upon recoverable errors",
         action="store_true",
         dest="abort",
+    )
+    parser.add_argument(
+        "-z",
+        "--tgz",
+        help="output a compressed tar archive",
+        action="store_true",
+        dest="tgz",
     )
     # Needs help-file, once public
     # Will default to False
@@ -656,7 +664,7 @@ def main():
             dest_dir,
         )
     elif args.component == "pg-macros":
-        ptx.pg_macros(xml_source, dest_dir)
+        ptx.pg_macros(xml_source, publication_file, stringparams, dest_dir)
     elif args.component == "youtube":
         ptx.youtube_thumbnail(
             xml_source, publication_file, stringparams, args.xmlid, dest_dir
@@ -781,6 +789,8 @@ def main():
             ptx.assembly(
                 xml_source, publication_file, stringparams, out_file, dest_dir, "pg-problems"
             )
+        elif args.format == "webwork-sets":
+            ptx.webwork_sets(xml_source, publication_file, stringparams, dest_dir, args.tgz)
         # 2020-05-19 MathBookXMLtoSWS class removed
         elif args.format == "sagenb":
             raise NotImplementedError(


### PR DESCRIPTION
This removes the last direct use of xsltproc from the sample chapter Makefile. In its place, it uses `pretext/pretext`, with a new function for making a WeBWorK archive.

Also I added the recipe for making the sample chapter's PG macro library file to the Makefile. You won't need that because the host course already has the macro library up. But now the Makefile has a complete model.

As we discussed today, once this is merged and in the nightly CLI build, I will ask @oscarlevin to build CLI tools that execute `pretext -c pg-macros` and `pretext -c ww-archive`. Possibly nothing new is needed? Just a target in your project file with `<format>pg-macros</format>` or `<format>ww-aarchive</format>`?

And then I will update documentation in the guide.

