### PR TITLE
Dynamic fitb

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8534,7 +8534,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </setup>
                 </exercise>
             </exercises>
-
+    
             <reading-questions>
                 <title>A Reading Question</title>
 
@@ -8555,7 +8555,186 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </subsection>
         </section>
 
-        <section xml:id="section-interactive-code" label="section-interactive-code">
+        <section xml:id="section-dynamic-exercises">
+            <title>Dynamic Exercises</title>
+
+            <introduction>
+                <p>This section demonstrates the use of dynamic randomized exercises built upon the framework of Runestone components. These demonstration problems incorporate a library supporting mathematical expressions both for varying the content of the statement of the exercises as well as the checking of submitted answers.</p>
+            </introduction>
+
+            <exercises>
+                <title>Dynamic Fill-In</title>
+
+                <exercise label="dynamic-fitb-simple-formula">
+                    <title>Fill-In Formula (Dynamic)</title>
+                    <statement>
+                        <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval expr="x1"/></m>,  <m>x=<eval expr="x2"/></m>, and <m>x=<eval expr="x3"/></m> and so that <m>f(0)=<eval expr="y0"/></m>.</p>
+                        <p><m>f(x)=</m> <fillin name="st_cubic" correct="x3"/></p>
+                    </statement>
+                    <solution>
+                        <p>
+                            Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form, 
+                            <me>f(x) = A <eval expr="base_cubic"/></me>
+                            with an unknown scaling multiple <m>A</m>.
+                        </p>
+                        <p>
+                            When we evaluate <m>f(x)</m> at <m>x=0</m> using this formula, we find
+                            <me>f(0) = <eval expr="base_yint"/>A</me>.
+                            Since we also know <m>f(0)=<eval expr="y0"/></m>, we can write down the equation
+                            <me>A <eval expr="base_cubic"/> = <eval expr="y0"/></me>
+                            and find that <m>A=<eval expr="A"/></m>.
+                        </p>
+                        <p>
+                            Consequently, we can write our function in the form
+                            <me>f(x)=<eval expr="cubic"/></me>.
+                        </p>
+                    </solution>
+                    <setup seed="314159">
+                        <de-object name="y0" context="number" mode="random">
+                            <options distribution="discrete" min="-8" max="8" by="1" nonzero="yes"/>
+                        </de-object>
+                        <de-object name="x1" context="number" mode="random">
+                            <options distribution="discrete" min="-8" max="-4" by="1"/>
+                        </de-object>
+                        <de-object name="d1" context="number" mode="random">
+                            <options distribution="discrete" min="1" max="4" by="1"/>
+                        </de-object>
+                        <de-object name="d2" context="number" mode="random">
+                            <options distribution="discrete" min="1" max="4" by="1"/>
+                        </de-object>
+                        <de-object name="x2" context="number" mode="formula">{{x1}}+{{d1}}</de-object>
+                        <de-object name="x3" context="number" mode="formula">{{x2}}+{{d2}}</de-object>
+                        <de-object name="base_cubic" context="formula" mode="formula">
+                            (x-{{x1}})*(x-{{x2}})*(x-{{x3}})
+                        </de-object>
+                        <de-object name="base_yint" context="number" mode="evaluate">
+                            <formula><eval expr="base_cubic"/></formula>
+                            <variable name="x">0</variable>
+                        </de-object>
+                        <de-object name="A" context="number" mode="formula">
+                            {{y0}}/{{base_yint}}
+                        </de-object>
+                        <de-object name="cubic" context="formula" mode="formula">
+                            {{A}}*(x-{{x1}})*(x-{{x2}})*(x-{{x3}})
+                        </de-object>
+                    </setup>
+                    <evaluation>
+                        <evaluate submit="st_cubic">
+                            <test correct="yes">
+                                <eval expr="cubic"/>
+                            </test>
+                        </evaluate>
+                    </evaluation>
+                </exercise>
+                <exercise label="function-decomposition">
+                    <title>Decompose the Function</title>
+                    <statement>
+                        <p>
+                        Consider the function <me>h(x)=<eval expr="composition"/></me>.
+                        Find two nontrivial functions <m>f(x)</m> and <m>g(x)</m> so that <m>h(x) = f(g(x))</m>.
+                        </p>
+                        <p>
+                        <m>f(x) = </m> <fillin width="15" correct="outerFormula" name="fGiven"/> 
+                        and <m>g(x)=</m> <fillin width="15" correct="innerFormula" name="gGiven"/>
+                        </p>
+                    </statement>
+                    <solution>
+                        <p>
+                        Noticing that the expression <m><eval expr="innerFormula"/></m> appears inside parentheses with a power,
+                        it makes sense to think of that as the inner function, defining <m>g(x) = <eval expr="innerFormula"/></m>.
+                        The outer function describes what happens to that.
+                        If we imagined replacing the formula <m><eval expr="innerFormula"/></m> with a box and then call that box our variable <m>x</m>, we find the outer function is given by <m>f(x) = <eval expr="outerFormula"/></m>.
+                        </p>
+                        <p>
+                        This is not the only non-trivial composition. Can you find others?
+                        </p>
+                    </solution>
+                    <setup seed="4321">
+                        <de-object name="a" context="number" mode="random">
+                            <options distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
+                        </de-object>
+                        <de-object name="n" context="number" mode="random">
+                            <options distribution="discrete" min="2" max="5" />
+                        </de-object>
+                        <de-object name="b" context="number" mode="random">
+                            <options distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
+                        </de-object>
+                        <de-object name="c" context="number" mode="random">
+                            <options distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
+                        </de-object>
+                        <de-object name="d" context="number" mode="random">
+                            <options distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
+                        </de-object>
+                        <de-object name="outerFormula" context="formula" mode="formula">{{a}}*x^{{n}}+{{b}}</de-object>
+                        <de-object name="innerFormula" context="formula" mode="formula">{{c}}*x+{{d}}</de-object>
+                        <de-object name="identityFunction" context="formula" mode="formula">x</de-object>
+                        <de-object name="composition" context="formula" mode="substitution">
+                        <formula><eval expr="outerFormula"/></formula>
+                        <variable name="x"><eval expr="innerFormula"/></variable>
+                        </de-object>
+                    </setup>
+                    <evaluation answers-coupled="yes">
+                        <evaluate submit="fGiven">
+                        <test>
+                            <eval expr="identityFunction"/>
+                            <feedback><m>f(x)=x</m> is not allowed for nontrivial compositions.</feedback>
+                        </test>
+                        <test>
+                            <not>
+                                <equal>
+                                    <eval expr="composition"/>
+                                    <de-object context="formula" mode="substitution">
+                                        <formula><eval expr="fGiven"/></formula>
+                                        <variable name="x"><eval expr="gGiven"/></variable>
+                                    </de-object>
+                                </equal>
+                            </not>
+                            <equal>
+                            <eval expr="composition"/>
+                            <de-object context="formula" mode="substitution">
+                                <formula><eval expr="gGiven"/></formula>
+                                <variable name="x"><eval expr="fGiven"/></variable>
+                            </de-object>
+                            </equal>
+                            <feedback>You have composed in the wrong order.</feedback>
+                        </test>
+                        </evaluate>
+                        <evaluate submit="gGiven">
+                        <test>
+                            <eval expr="identityFunction"/>
+                            <feedback><m>g(x)=x</m> is not allowed for nontrivial compositions.</feedback>
+                        </test>
+                        </evaluate>
+                        <evaluate all="yes">
+                            <test correct="yes">
+                                <equal>
+                                    <eval expr="composition"/>
+                                    <de-object context="formula" mode="substitution">
+                                        <formula><eval expr="fGiven"/></formula>
+                                        <variable name="x"><eval expr="gGiven"/></variable>
+                                    </de-object>
+                                </equal>
+                                <not>
+                                    <equal>
+                                        <eval expr="fGiven"/>
+                                        <eval expr="identityFunction"/>
+                                    </equal>
+                                </not>
+                                <not>
+                                    <equal>
+                                        <eval expr="gGiven"/>
+                                        <eval expr="identityFunction"/>
+                                    </equal>
+                                </not>
+                            <feedback>Excellent!</feedback>
+                            </test>
+                        </evaluate>
+                    </evaluation>
+                </exercise>
+            </exercises>
+        </section>
+        
+        <section xml:id="section-interactive-code">
             <title>Interactive Coding</title>
 
             <introduction>

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -123,6 +123,7 @@ def get_destination_directory(directory, xml_source, pub_file, component):
     # simply listed here in alphabetical order
     component_dirs = {
         "asy": "asymptote",
+        "dynamic": "dynamic_subs",
         "latex-image": "latex-image",
         "mom": "problems",
         "preview": "preview",
@@ -323,6 +324,7 @@ def get_cli_arguments():
             "WeBWorK problems in authored, PG, url, and static representations",
         ),
         ("pg-macros", "Server-side macros for WeBWorK problem generation"),
+        ("dynamic", "Expression subsitutions for dynamically generated exercises"),
         ("youtube", "Thumbnails for YouTube videos (JPEG only)"),
         ("play-button", "generate generic static video image"),
         ("qrcode", "QR codes for static versions of interactive content"),
@@ -697,6 +699,10 @@ def main():
         ptx.tracer(xml_source, publication_file, stringparams, args.xmlid, dest_dir)
     elif args.component == "datafile":
         ptx.datafiles_to_xml(xml_source, publication_file, stringparams, args.xmlid, dest_dir)
+    elif args.component == "dynamic":
+        ptx.dynamic_substitutions(
+            xml_source, publication_file, stringparams, args.xmlid, dest_dir
+        )
     elif args.component == "all":
         if args.format == "html":
             ptx.html(

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1009,6 +1009,157 @@ def tracer(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
 
 ################################
 #
+#  Dynamic Exercise Static Representations
+#
+################################
+def dynamic_substitutions(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
+    import asyncio  # get_event_loop()
+
+    # external module, often forgotten
+    # imported here, used only in interior
+    # routine to launch browser
+    try:
+        import playwright.async_api  # launch()
+    except ImportError:
+        global __module_warning
+        raise ImportError(__module_warning.format("playwright"))
+
+    # Interior asynchronous routine to manage the Chromium headless browser.
+    # Use the same page instance for the generation of all interactive previews
+    async def extract_substitutions(dynamic_elements, baseurl, subst_file):
+
+        # dynamic_elements:  list containing the interactive hash/fragment ids [1:]
+        # baseurl:           local server's base url (includes local port)
+        # subst_file:        file containing the substitutions
+
+        # Open playwright's asynchronous api to load a browser and page
+        async with playwright.async_api.async_playwright() as pw:
+            browser = await pw.chromium.launch()
+            page = await browser.new_page()
+
+            msg = 'Storing dynamic substitutions in file {}'
+            log.info(msg.format(subst_file))
+            subst_xml = open(subst_file, "w")
+            subst_xml.write("<xml>")
+            # First index contains original baseurl of hosted site (not used)
+            for dynamic_exercise in dynamic_elements:
+                # loaded page url containing interactive
+                input_page = os.path.join(baseurl, dynamic_exercise + ".html")
+
+                # progress report
+                msg = 'extracting substitutions for exercise with identifier "{}" on page {}'
+                log.info(msg.format(dynamic_exercise, input_page))
+
+                # goto page and wait for content to load
+                await page.goto(input_page, wait_until='domcontentloaded')
+                await page.wait_for_timeout(1000)
+                # see what Runestone substituted into the expressions
+                xpath = "//div[@id='{}-substitutions']".format(dynamic_exercise)
+                elt = page.locator(xpath)
+                exercise_substitutions = await elt.inner_html()
+
+                # add this to the XML of all substitutions
+                # redundancies will be present but don't matter
+                element = '<dynamic-substitution id="{}">'
+                subst_xml.write(element.format(dynamic_exercise))
+                subst_xml.write(exercise_substitutions)
+                subst_xml.write("</dynamic-substitution>")
+
+            subst_xml.write("</xml>")
+            subst_xml.close()
+            await browser.close()
+
+    log.info(
+        "using playwright package to determine substitutions in dynamic exercises from {}".format(
+            xml_source
+        )
+    )
+
+    # Identify dynamic exercises that will be processed
+    ptx_xsl_dir = get_ptx_xsl_path()
+    extraction_xslt = os.path.join(ptx_xsl_dir, "extract-dynamic.xsl")
+    # Where to store the results
+    dyn_subs_file = os.path.join(dest_dir, "dynamic_substitutions.xml")
+    # support publisher file, subtree argument
+    if pub_file:
+        stringparams["publisher"] = pub_file
+    if xmlid_root:
+        stringparams["subtree"] = xmlid_root
+    # Build list of id's into a scratch directory/file
+    tmp_dir = get_temporary_directory()
+    id_filename = os.path.join(tmp_dir, "dynamic-ids.txt")
+    log.debug("Dynamic exercise id list temporarily in {}".format(id_filename))
+    log.debug("Dynamic exercise html files temporarily in {}".format(tmp_dir))
+    # This next call outputs the list of ids 
+    # *and* produce a pile of files (the "standalone") pages
+    xsltproc(extraction_xslt, xml_source, id_filename, tmp_dir, stringparams)
+    # read the list of exercise identifiers just generated
+    id_file = open(id_filename, "r")
+    dynamic_exercises = [f.strip() for f in id_file.readlines() if not f.isspace()]
+
+    # Copy in external resources (e.g., js code)
+    generated_abs, external_abs = get_managed_directories(xml_source, pub_file)
+    if external_abs:
+        external_dir = os.path.join(tmp_dir, "external")
+        shutil.copytree(external_abs, external_dir)
+
+    # Spawn a new process running a local html.server
+    import subprocess
+    import random
+    # Try a standard port and if it fails, try a random port
+    port = 8888
+    looking_for_port = True
+    numAttempt = 0
+    maxAttempts = 10  # In case failure is not due to blocked ports.
+    while looking_for_port and numAttempt < maxAttempts:
+        try:
+            numAttempt = numAttempt + 1
+            log.info(f"Opening subprocess http.server with port={port}")
+            # -u so that stdout and stderr are not cached
+            server = subprocess.Popen(["python", "-u", "-m", "http.server", f"{port}", "-d", tmp_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            # Check if terminated. Allow 1 second to start-up.
+            try:
+                result = server.wait(1)
+                log.debug(f"Server startup failed")
+                port = random.randint(49152, 65535)
+                log.debug(f"Trying port {port} instead")
+            # The exception is success because process did not terminate.
+            except subprocess.TimeoutExpired:
+                looking_for_port = False
+        except OSError:
+            # Not sure if this will ever trigger b/c Python itself should start
+            log.debug(f"Subprocess to open http.server failed")
+            port = random.randint(49152, 65535)
+            log.debug(f"Trying port {port} instead.\n")
+    if numAttempt >= maxAttempts:
+        log.error("Unable to open http.server for interactive previews")
+
+    # filenames lead to placement in current working directory
+    # so change to temporary directory, and copy out
+    # TODO: just write to "dest_dir"?
+    owd = os.getcwd()
+    os.chdir(tmp_dir)
+
+    # event loop and copy, terminating server process even if interrupted
+    try:
+        log.debug("Using http.server subprocess {}".format(server.pid))
+        baseurl = "http://localhost:{}".format(port)
+        asyncio.get_event_loop().run_until_complete(extract_substitutions(dynamic_exercises, baseurl, dyn_subs_file))
+    finally:
+        # close the server and report (debug) results
+        log.info("Closing http.server subprocess")
+        server.kill()
+        log.debug("Log data from http.server:")
+        server_output = server.stderr.read()
+        for line in server_output.split("\n"):
+            log.debug(line)
+
+    # restore working directory
+    os.chdir(owd)
+
+
+################################
+#
 #  WeBWorK Extraction Processing
 #
 ################################

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1102,6 +1102,7 @@ def dynamic_substitutions(xml_source, pub_file, stringparams, xmlid_root, dest_d
     if external_abs:
         external_dir = os.path.join(tmp_dir, "external")
         shutil.copytree(external_abs, external_dir)
+    copy_html_css_js(tmp_dir)
 
     # Spawn a new process running a local html.server
     import subprocess

--- a/xsl/extract-dynamic.xsl
+++ b/xsl/extract-dynamic.xsl
@@ -1,0 +1,77 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2014-2016 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- This stylesheet locates exercise elements that have  -->
+<!-- dynamic content. Create a standalone page for each.  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl"
+>
+
+<!-- Get internal ID's for filenames, etc -->
+<!-- Standard conversion groundwork       -->
+<xsl:import href="./pretext-html.xsl"/>
+
+<!-- Get a "subtree" xml:id value   -->
+<!-- Then walk the XML source tree  -->
+<!-- applying specializations below -->
+<xsl:import href="./extract-identity.xsl" />
+
+<xsl:variable name="b-dynamics-static-seed" select="true()"/>
+
+<xsl:output method="text" encoding="UTF-8"/>
+
+<!-- The  pretext-assembly.xsl  stylesheet is parameterized to create  -->
+<!-- representations of interactive exercises in final "static"        -->
+<!-- versions or precursor "dynamic" versions.  The conversion to HTML -->
+<!-- is the motivation for this parameterization.  See the definition  -->
+<!-- of this variable in  pretext-assembly.xsl  for more detail.       -->
+<!--                                                                   -->
+<!-- Conversions that build on HTML, but produce formats incapable     -->
+<!-- (braille) or unwilling (EPUB, Jupyter) to employ Javascript, or   -->
+<!-- similar, need to override this variable back to "static".         -->
+<xsl:variable name="exercise-style" select="'dynamic'"/>
+
+<!-- exercise/setup indicates the exercise will     -->
+<!-- require Runestone and javascript to generate   -->
+<!-- the content.                                   -->
+<!-- Stylesheet output is text, with "visible-id"   -->
+<!-- of each exercise, one per line, to be captured -->
+<!-- captured in a text file to guide snapshotting  -->
+<!-- Make the standalone page for each exercise     -->
+<!-- with an indication that the exercise uses the  -->
+<!-- static seed.  Results are HTML files           -->
+<!-- (despite this stylesheet having text output).  -->
+<xsl:template match="exercise[@exercise-interactive='fillin' and ./setup]" mode="extraction">
+    <xsl:apply-templates select="." mode="visible-id" />
+    <xsl:text>&#xa;</xsl:text>
+    <!-- (2) Identical content, but now isolated on a reader-friendly page -->
+    <xsl:apply-templates select="." mode="standalone-page" >
+        <xsl:with-param name="content">
+            <xsl:apply-templates select="." />
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1809,6 +1809,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- new dynamic fillin goes here, perhaps:                     -->
             <!-- statement//fillin[(@*|node()) and not(@characters|@fill)]? -->
+            <xsl:when test="statement[ancestor::exercise/setup]">
+                <xsl:text>fillin</xsl:text>
+            </xsl:when>
             <!-- only interactive programs make sense after a "statement" -->
             <xsl:when test="statement and program[(@interactive = 'codelens') or (@interactive = 'activecode')]">
                 <xsl:text>coding</xsl:text>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -470,8 +470,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <!-- static, for multiple conversions, but primarily LaTeX -->
         <xsl:when test="$exercise-style = 'static'">
-            <xsl:variable name="parent-id">
-                <xsl:apply-templates select="ancestor::exercise" mode="visible-id" />
+            <xsl:variable name="parent-id" select="ancestor::exercise/@label">
+               <!--<xsl:apply-templates select="ancestor::exercise" mode="assembly-id" />-->
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
             <xsl:variable name="expression" select="@expr"/>
@@ -1282,6 +1282,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- also applied here.                                               -->
 
 <xsl:template match="audio|video|interactive" mode="assembly-id">
+    <xsl:value-of select="@assembly-id"/>
+</xsl:template>
+
+<xsl:template match="exercise[@exercise-interactive='fillin' and setup]" mode="assembly-id">
     <xsl:value-of select="@assembly-id"/>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -771,7 +771,7 @@ Book (with parts), "section" at level 3
                         <xsl:apply-templates select="text()|var" />
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:apply-templates select="text()|fillin" />
+                        <xsl:apply-templates select="text()|eval|fillin" />
                     </xsl:otherwise>
                 </xsl:choose>
                 <!-- look ahead to absorb immediate clause-ending punctuation   -->
@@ -941,7 +941,7 @@ Book (with parts), "section" at level 3
                 <xsl:apply-templates select="text()|xref|var" />
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="text()|xref|fillin" />
+                <xsl:apply-templates select="text()|xref|eval|fillin" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -1259,7 +1259,7 @@ Book (with parts), "section" at level 3
                 <xsl:apply-templates select="text()|xref|var" />
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="text()|xref|fillin" />
+                <xsl:apply-templates select="text()|xref|eval|fillin" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/xsl/pretext-dynamic.xsl
+++ b/xsl/pretext-dynamic.xsl
@@ -1,0 +1,65 @@
+<?xml version='1.0'?> <!-- As XML file -->
+
+<!--********************************************************************
+Copyright 2022 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "entities.ent">
+    %entities;
+]>
+
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    extension-element-prefixes="exsl"
+>
+
+<xsl:import href="./pretext-html.xsl"/>
+
+<!-- We create HTML5 output.  The @doctype-system attribute will    -->
+<!-- create a header in the old style that browsers will recognize  -->
+<!-- as signaling HTML5.  However  xsltproc  does one better and    -->
+<!-- writes the super-simple <!DOCTYPE html> header.  See all of    -->
+<!-- https://stackoverflow.com/questions/3387127/                   -->
+<!-- (set-html5-doctype-with-xslt)                                  -->
+<!--                                                                -->
+<!-- Since we write output into a single file, likely this          -->
+<!-- declaration is never active, but it serves as a model here for -->
+<!-- subsequent exsl:document elements.                             -->
+
+<xsl:output method="html" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat" />
+
+<!-- It will be a problem if an author decides to name an interactive -->
+<!-- identically but we will consider this highly unlikely.           -->
+<xsl:variable name="main-file" select="'dynamics-needing-static-parsing.html'"/>
+<xsl:variable name="b-dynamics-static-seed" select="true()"/>
+
+<!-- ############## -->
+<!-- Entry Template -->
+<!-- ############## -->
+
+<!-- Build a single page.  Actual use will require copying/placing      -->
+<!-- necessary "external" support files (JS, CSS, iframe HTML content). -->
+<xsl:template match="/">
+    <xsl:apply-templates select="$document-root//exercise[//setup]" mode="standalone-page"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6780,6 +6780,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- assistive "Skip to main content" link    -->
                 <!-- this *must* be first for maximum utility -->
                 <xsl:call-template name="skip-to-content-link" />
+                <xsl:apply-templates select="." mode="primary-navigation"/>
                 <xsl:call-template name="latex-macros" />
                 <xsl:call-template name="enable-editing" />
                  <header id="ptx-masthead" class="ptx-masthead">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -65,6 +65,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Modularize lots of Runestone-specific code    -->
 <!-- Likely need not be an "import" (v. "include") -->
 <xsl:import href="./pretext-runestone.xsl"/>
+<xsl:import href="./pretext-runestone-fitb.xsl"/>
 
 <!-- Routines to provide "View Source" annotations on HTML output   -->
 <!-- as a service on the PreTeXt website. NB: we use an "include"   -->
@@ -200,6 +201,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-has-geogebra"     select="boolean($document-root//interactive[@platform='geogebra'])"/>
 <!-- 2018-04-06:  jsxgraph deprecated -->
 <xsl:variable name="b-has-jsxgraph"     select="boolean($document-root//jsxgraph)"/>
+<xsl:variable name="b-dynamics-static-seed" select="false()"/>
 <!-- Every page has an index button, with a link to the index -->
 <!-- Here we assume there is at most one                      -->
 <!-- (The old style of specifying an index is deprecated)     -->
@@ -4572,6 +4574,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
             </xsl:apply-templates>
         </xsl:when>
+        <!-- Dynamic fillin is broken out separately because the test for -->
+        <!-- correctness as well as feedback is dynamically chosen.       -->
+        <xsl:when test="@exercise-interactive = 'fillin'">
+            <xsl:if test="$b-has-statement">
+                <xsl:apply-templates select="." mode="runestone-to-interactive"/>
+            </xsl:if>
+        </xsl:when>
         <!-- Finally nothing too exceptional, do the usual drill. Consider -->
         <!-- structured versus unstructured, non-interactive.              -->
         <xsl:when test="statement">
@@ -8466,30 +8475,37 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Davide Cervone                                                       -->
 <!-- https://groups.google.com/forum/#!topic/mathjax-users/IEivs1D7ntM    -->
 <xsl:template match="fillin[not(parent::m or parent::me or parent::men or parent::mrow)]">
-    <xsl:variable name="characters">
-        <xsl:choose>
-            <xsl:when test="@characters">
-                <xsl:value-of select="@characters" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>10</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <span class="fillin {$fillin-text-style}" role="img">
-        <xsl:attribute name="aria-label">
-            <xsl:value-of select="$characters" />
-            <xsl:text>-character blank</xsl:text>
-        </xsl:attribute>
-        <xsl:attribute name="style">
-            <xsl:text>width: </xsl:text>
-            <xsl:value-of select="5 * $characters div 11" />
-            <xsl:text>em;</xsl:text>
-        </xsl:attribute>
-    </span>
-    <xsl:if test="@rows or @cols">
-        <xsl:apply-templates select="." mode="fillin-array"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="ancestor::exercise[@exercise-interactive='fillin']">
+            <xsl:apply-imports />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:variable name="characters">
+                <xsl:choose>
+                    <xsl:when test="@characters">
+                        <xsl:value-of select="@characters" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>10</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <span class="fillin {$fillin-text-style}" role="img">
+                <xsl:attribute name="aria-label">
+                    <xsl:value-of select="$characters" />
+                    <xsl:text>-character blank</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="style">
+                    <xsl:text>width: </xsl:text>
+                    <xsl:value-of select="5 * $characters div 11" />
+                    <xsl:text>em;</xsl:text>
+                </xsl:attribute>
+            </span>
+            <xsl:if test="@rows or @cols">
+                <xsl:apply-templates select="." mode="fillin-array"/>
+            </xsl:if>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Implication Symbols -->

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -667,10 +667,12 @@
         <!-- Composition of two formulas (same look as evaluation)                -->
         <!-- Requires descendent nodes: formula and values to substitute          -->
         <xsl:when test="@mode='substitution'">
+            <xsl:value-of select="$prefix"/>
+            <xsl:text>_menv.composeExpression(</xsl:text>
             <xsl:apply-templates select="formula/*" mode="evaluate">
                 <xsl:with-param name="setupMode" select="$setupMode"/>
             </xsl:apply-templates>
-            <xsl:text>.compose({</xsl:text>
+            <xsl:text>, {</xsl:text>
                 <xsl:apply-templates select="variable" mode="evaluation-binding" >
                     <xsl:with-param name="setupMode" select="$setupMode" />
                 </xsl:apply-templates>

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -1,0 +1,810 @@
+<?xml version='1.0'?> <!-- As XML file -->
+
+<!DOCTYPE xsl:stylesheet>
+
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:date="http://exslt.org/dates-and-times"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl date str"
+>
+
+<!-- ==================================================== -->
+<!-- Actual rules for substution when generating HTML     -->
+<!-- ==================================================== -->
+
+
+<!-- Convert fillin tag to an input element on the page -->
+<xsl:template match="exercise[@exercise-interactive='fillin']//fillin">
+    <xsl:param name="b-human-readable" />
+    <xsl:variable name="parent-id">
+        <xsl:apply-templates select="ancestor::exercise" mode="html-id" />
+    </xsl:variable>
+    <xsl:element name="input">
+        <xsl:attribute name="types"><xsl:text>text</xsl:text></xsl:attribute>
+        <xsl:attribute name="id">
+            <xsl:value-of select="$parent-id"/>
+            <xsl:text>-</xsl:text>
+            <xsl:value-of select="@name"/>
+        </xsl:attribute>
+        <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+    </xsl:element>
+</xsl:template>
+
+
+<!-- ========================================================= -->
+<!-- The Runestone element is based on JSON scripts describing -->
+<!-- the exercise, how to set it up, and how to evaluate it.   -->
+<!-- The HTML will contain this JSON and Runestone extracts it -->
+<!-- and inserts it into the HTML page via JS.                 -->
+<!-- ========================================================= -->
+<xsl:template match="exercise[@exercise-interactive='fillin']" mode="runestone-to-interactive">
+    <xsl:variable name="the-id">
+        <xsl:apply-templates select="." mode="html-id"/>
+    </xsl:variable>
+    <div class="runestone">
+        <div data-component="fillintheblank" class="fillintheblank" style="visibility: hidden;">
+            <xsl:attribute name="id">
+                <xsl:value-of select="$the-id"/>
+            </xsl:attribute>
+            <script type="application/json">
+                <xsl:text>{&#xa;</xsl:text>
+                    <!-- A seed is provided to generate consistent static content -->
+                    <xsl:if test="$b-dynamics-static-seed">
+                        <xsl:text>"static_seed": "</xsl:text>
+                        <xsl:choose>
+                            <xsl:when test="setup/@seed">
+                                <xsl:value-of select="setup/@seed"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <!-- Report if a seed is not provided-->
+                                <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="$the-id"/>" is missing setup @seed for static content generation.</xsl:message>
+                                <xsl:text>1234</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:text>",&#xa;</xsl:text>
+                    </xsl:if>
+                    <!-- The formatted HTML presentation of the problem, -->
+                    <!-- with escape codes for dynamic content, all of   -->
+                    <!-- which is serialized and escaped to a string.    -->
+                    <xsl:text>"problemHtml": </xsl:text>
+                    <xsl:call-template name="escape-quote-xml">
+                        <xsl:with-param name="xml_content">
+                            <xsl:apply-templates select="statement" mode="body" />
+                            <xsl:if test="$b-dynamics-static-seed">
+                                <div>
+                                    <xsl:attribute name="id">
+                                        <xsl:apply-templates select="." mode="html-id"/>
+                                        <xsl:text>-substitutions</xsl:text>
+                                    </xsl:attribute>
+                                    <xsl:apply-templates select="(statement|solution)//eval[@expr]" mode="track-evaluation" />
+                                </div>
+                            </xsl:if>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                    <!-- The formatted HTML presentation of the solution, -->
+                    <!-- similar to statement but no fillins              -->
+                    <xsl:text>,&#xa;"solutionHtml": </xsl:text>
+                    <xsl:call-template name="escape-quote-xml">
+                        <xsl:with-param name="xml_content">
+                            <xsl:apply-templates select="solution" mode="body" />
+                        </xsl:with-param>
+                    </xsl:call-template>
+                    <!-- Add packages that need to be loaded as javascript -->
+                    <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
+                    <xsl:if test="setup/de-object">
+                        <xsl:text>"BTM"</xsl:text>
+                    </xsl:if>
+                    <xsl:text>]</xsl:text>
+                    <!-- Names assigned to the blanks. (Inclusion is     -->
+                    <!-- really so that evaluation of answers can refer  -->
+                    <!-- to submitted work by name.                      -->
+                    <xsl:text>,&#xa;"blankNames": {</xsl:text>
+                    <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
+                    <!-- The actual setup code is javascript enclosed in quotes. -->
+                    <!-- The declaration creates the objects that are needed.    -->
+                    <!-- The script is included as an escaped string             -->
+                    <xsl:text>},&#xa;"dyn_vars": </xsl:text>
+                    <xsl:call-template name="dynamic-setup" />
+                    <!-- An array of tests and feedback for answer evaluation    -->
+                    <!-- Each blank has a corresponding array of test/feedback   -->
+                    <!-- response. The test is Javascript (stringified) that     -->
+                    <!-- returns a boolean response. The first test is for       -->
+                    <!-- correctness. The last response is default.              -->
+                    <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
+                    <!-- In case all answers are based on one test               -->
+                    <xsl:variable name="multiAns">
+                        <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
+                    </xsl:variable>
+                    <!-- Generate test/feedback pair for each fillin             -->
+                    <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
+                        <xsl:with-param name="multiAns" select="$multiAns" />
+                    </xsl:apply-templates>
+                    <xsl:text>]</xsl:text>
+                <xsl:text>&#xa;}</xsl:text>
+            </script>
+        </div>
+        <xsl:text>&#xa;</xsl:text>
+    </div>
+</xsl:template>
+
+<!-- Creating a list of blank names. -->
+<xsl:template match="fillin" mode="declare-blanks">
+    <xsl:if test="position()>1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <xsl:if test="@name">
+        <xsl:call-template name="quote-string">
+            <xsl:with-param name="text" select="@name"/>
+        </xsl:call-template>
+        <xsl:text>: </xsl:text>
+        <xsl:value-of select="position()-1"/>
+    </xsl:if>
+</xsl:template>
+
+
+<!-- #eval in a dynamic exercise (has setup) is to evaluate -->
+<!-- an expression that has been previously generated. If   -->
+<!-- in math-mode, we want to see if it is an object that   -->
+<!-- knows how to formulate a LaTeX representation          -->
+<!-- The `toTeX` javascript function is defined in BTM.js   -->
+<xsl:template match="exercise[//setup]//eval[@expr]">
+    <xsl:text>[%= </xsl:text>
+    <xsl:choose>
+        <xsl:when test="ancestor::m|ancestor::me|ancestor::mrow">
+            <xsl:text>toTeX(</xsl:text>
+            <xsl:value-of select="@expr"/>
+            <xsl:text>)</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@expr"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text> %]</xsl:text>
+</xsl:template>
+
+
+<!-- Part of static output content extraction process,   -->
+<!-- this creates elements that will be pulled from the  -->
+<!-- stand-alone page into a generated XML document that -->
+<!-- gives the actual substitution in static mode.       -->
+<xsl:template match="eval[@expr]" mode="track-evaluation">
+    <eval-subst>
+        <xsl:attribute name="expr">
+            <xsl:value-of select="@expr"/>
+        </xsl:attribute>
+        <xsl:apply-templates select="."/>
+    </eval-subst>
+    <xsl-text>&#xa;</xsl-text>
+</xsl:template>
+
+
+<!-- Create the dynamic aspect of the problem.           -->
+<!-- Define all of the mathematical elements as well as  -->
+<!-- objects (e.g. graphs) that might depend on them     -->
+<!-- A script in setup/postSetupScript is executed after -->
+<!-- the environment setup.                              -->
+<!-- A script in setup/postRenderScript is executed      -->
+<!-- after the dynamic creation is complete.             -->
+<xsl:template name="dynamic-setup">
+    <xsl:variable name="js_code">
+        <!-- Initialize the evaluation environment -->
+        <xsl:if test="setup/de-object">
+            <xsl:call-template name="setup-evaluation-environment"/>
+        </xsl:if>
+        <!-- Any direct JS for environment setup   -->
+        <xsl:if test="setup/postSetupScript">
+            <xsl:value-of select="setup/postSetupScript"/>
+        </xsl:if>
+        <!-- Prepare evaluation and feedback       -->
+        <xsl:call-template name="setup-fillin-parsers"/>
+        <!-- Create the call-back for post-render tasks -->
+        <xsl:call-template name="setup-postContent"/>
+    </xsl:variable>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text" select="$js_code"/>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- Parse any settings for the math environment for the problem -->
+<xsl:template name="setup-evaluation-environment">
+    <xsl:text>v._menv = new BTM({</xsl:text>
+        <!-- Setup seeded random number generator  -->
+        <xsl:text>'rand': rand</xsl:text>
+        <!-- FUTURE: Pull additional settings from an environment element -->
+        <xsl:apply-templates select="de-environment" mode="runestone-setup"/>
+    <xsl:text>});&#xa;</xsl:text>
+    <!-- Generate all of the XML-declared math objects -->
+    <xsl:apply-templates select="setup/de-object" mode="runestone-setup"/>
+</xsl:template>
+
+<!-- Environment Setup: Define the mathematical objects -->
+<xsl:template match="de-object" mode="runestone-setup">
+    <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
+    <xsl:text> = v._menv.addMathObject(</xsl:text>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text" select="@name"/>
+    </xsl:call-template>
+    <xsl:text>, </xsl:text>
+    <!-- Get the context of the object here -->
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text">
+            <xsl:choose>
+                <!-- Usually use value of @context but in case strings change. -->
+                <xsl:when test="@context='interval' or @context='set'">
+                    <xsl:text>set</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@context"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="evaluate">
+        <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:text>);&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Runestone requires declaring an array of answer-types for  -->
+<!-- validating and parsing what the user enters as a response. -->
+<xsl:template name="setup-fillin-parsers">
+    <xsl:text>v.types = [</xsl:text>
+    <xsl:apply-templates select="statement//fillin" mode="setup-parsers" />
+    <xsl:text>];&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Create a call-back for what occurs post-rendering.  -->
+<!-- This includes automated tasks as well as any script -->
+<!-- commands in setup/postRenderScript                  -->
+<xsl:template name="setup-postContent">
+    <xsl:text>v.afterContentRender = function() {&#xa;</xsl:text>
+        <xsl:if test="setup/postRenderScript">
+            <xsl:value-of select="setup/postRenderScript"/>
+        </xsl:if>
+    <xsl:text>};&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- Each fillin defines a blank. Establish the list of parsers. -->
+<!-- During setup and called while creating dyn_vars.            -->
+<xsl:template match="fillin" mode="setup-parsers">
+    <xsl:if test="position() > 1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <!-- Future: There may be attributes of the fillin that declare parser type. -->
+    <!-- For now, simply assuming everything is an expression.                   -->
+    <xsl:text>v._menv.getParser()</xsl:text>
+</xsl:template>
+
+
+<!-- ========================================================== -->
+<!-- Evaluation and Feedback                                    -->
+<!-- ========================================================== -->
+
+<!-- Template for answer checking. Actual work done by specialized templates. -->
+<xsl:template match="fillin" mode="dynamic-feedback">
+    <xsl:param name="multiAns"/>
+    <xsl:variable name="curFillIn" select="."/>
+    <xsl:variable name="check" select="ancestor::exercise//evaluation/evaluate[@submit = $curFillIn/@name]" />
+    <xsl:if test="position() > 1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <!-- First check is for correctness. -->
+    <xsl:text>[{"solution_code": </xsl:text>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text">
+            <xsl:choose>
+                <xsl:when test="string-length($multiAns)>0">
+                    <xsl:value-of select="$multiAns"/>
+                </xsl:when>
+                <xsl:when test="$check/test[@correct='yes']">
+                    <xsl:call-template name="create-test">
+                        <xsl:with-param name="submit" select="$curFillIn/@name" />
+                        <xsl:with-param name="test" select="$check/test[@correct='yes']/*[not(self::feedback)]" />
+                    </xsl:call-template>
+                </xsl:when>
+                <!-- If no explicit test, must be on the fillin. -->
+                <xsl:otherwise>
+                    <xsl:text>function() {&#xa;</xsl:text>
+                    <xsl:text>    return _menv.compareExpressions(</xsl:text>
+                    <xsl:value-of select="$curFillIn/@correct"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="$curFillIn/@name"/>
+                    <xsl:text>);&#xa;}</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>()</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>, "feedback": </xsl:text>
+    <xsl:choose>
+        <xsl:when test="$check/test[@correct='yes']/feedback">
+            <xsl:call-template name="quote-string">
+                <xsl:with-param name="text" select="$check/test[@correct='yes']/feedback"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>"Correct."</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>}</xsl:text>
+    <!-- Now add additional checks for feedback. -->
+    <xsl:for-each select="$check/test[not(@correct='yes')]">
+        <xsl:text>, {"solution_code": </xsl:text>
+        <xsl:call-template name="escape-quote-string">
+            <xsl:with-param name="text">
+                <xsl:call-template name="create-test">
+                    <xsl:with-param name="submit" select="$curFillIn/@name" />
+                    <xsl:with-param name="test" select="*[not(self::feedback)]" />
+                </xsl:call-template>
+                <xsl:text>()</xsl:text>
+            </xsl:with-param>
+        </xsl:call-template>
+        <xsl:text>, "feedback": </xsl:text>
+        <xsl:choose>
+            <xsl:when test="feedback">
+                <xsl:call-template name="quote-string">
+                    <xsl:with-param name="text" select="feedback"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>"Try again."</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>}</xsl:text>
+    </xsl:for-each>
+    <!-- Default feedback for the blank. Always evaluates true.   -->
+    <xsl:text>, {"feedback": </xsl:text>
+    <xsl:choose>
+        <!-- Allow the problem to define it: feedback with no test   -->
+        <xsl:when test="$check/feedback">
+            <xsl:call-template name="quote-string">
+                <xsl:with-param name="text" select="$check/feedback"/>
+            </xsl:call-template>
+        </xsl:when>
+        <!-- Maybe this should be a configurable default???   -->
+        <xsl:otherwise>
+            <xsl:text>"Try again."</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>}]</xsl:text>         
+</xsl:template>
+
+<!-- Deal with possibility of global checker for all blanks -->
+<xsl:template match="evaluation" mode="get-multianswer-check">
+    <xsl:variable name="responseTree" select="ancestor::exercise//fillin" />
+    <xsl:if test="count($responseTree) > 1 and ancestor::exercise//evaluation/evaluate[@all='yes']/test">
+        <xsl:call-template name="create-test">
+            <xsl:with-param name="test" select="ancestor::exercise//evaluation/evaluate[@all='yes']/test/*[not(self::feedback)]" />
+        </xsl:call-template>
+    </xsl:if>
+</xsl:template>
+
+<!-- Template for simple answer checkers: no interaction between different fillins. -->
+<!-- Add a post-filter to deal with additional feedback, similar to AnswerHints but allowing more complex logic. -->
+
+<xsl:template name="create-test">
+    <xsl:param name="submit" />
+    <xsl:param name="test" />
+    <xsl:text>function() {&#xa;</xsl:text>
+    <!-- Create a checker function. Initialize a stack of flag variables to track results. -->
+    <xsl:text>    var testResults = new Array();&#xa;</xsl:text>
+    <xsl:choose>
+        <xsl:when test="count($test[not(self::feedback)]) = 1">
+            <xsl:call-template name="checker-simple">
+                <xsl:with-param name="submit" select="$submit" />
+                <xsl:with-param name="curTest" select="$test" />
+                <xsl:with-param name="level" select="0" />
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="checker-layer">
+                <xsl:with-param name="tests" select="$test" />
+                <xsl:with-param name="level" select="0" />
+                <xsl:with-param name="logic" select="'and'" /> <!-- All tests at first layer must be true -->
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>    return (testResults[0]);&#xa;</xsl:text>
+    <xsl:text>}</xsl:text>
+</xsl:template>
+
+
+<!-- This template is called for a simple test (no compound logic). -->
+<xsl:template name="checker-simple">
+    <xsl:param name="curTest" />
+    <xsl:param name="submit" />
+    <xsl:param name="level" select="0" />
+    <xsl:choose>
+        <!-- Test might be coded directly in javascript -->
+        <xsl:when test="name($curTest) = 'raw-js'">
+            <xsl:text>    testResults[</xsl:text>
+            <xsl:value-of select="$level" />
+            <xsl:text>] = </xsl:text>
+            <xsl:value-of select="$curTest"/>
+        </xsl:when>
+        <!-- Test might require logic -->
+        <xsl:when test="name($curTest)='and' or name($curTest)='or' or name($curTest)='not'">
+            <xsl:call-template name="checker-layer">
+                <xsl:with-param name="submit" select="$submit" />
+                <xsl:with-param name="tests" select="$curTest/*" />
+                <xsl:with-param name="level" select="$level+1" />
+                <xsl:with-param name="logic" select="name()" /> <!-- Default: All tests at first layer must be true -->
+            </xsl:call-template>
+            <xsl:text>    testResults[</xsl:text>
+            <xsl:value-of select="$level" />
+            <xsl:text>] = testResults[</xsl:text>
+            <xsl:value-of select="$level+1" />
+            <xsl:text>];&#xa;</xsl:text>
+        </xsl:when>
+        <!-- Otherwise simple test -->
+        <xsl:otherwise>
+            <!-- A test can have an implied equal or an explicit equal -->
+            <!-- At root level, the test might also have a feedback. Skip that. -->
+            <xsl:text>    testResults[</xsl:text>
+            <xsl:value-of select="$level" />
+            <xsl:text>] = </xsl:text>
+            <xsl:text>_menv.compareExpressions(</xsl:text>
+            <xsl:choose>
+                <!-- An equal element must have two expression children. -->
+                <xsl:when test="name($curTest) = 'equal'">
+                    <xsl:apply-templates select="$curTest/*[1]" mode="evaluate"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:apply-templates select="$curTest/*[2]" mode="evaluate"/>
+                </xsl:when>
+                <!-- An implied equal compares the submitted answer to the given expression. -->
+                <xsl:otherwise>   <!-- Must be expression: #var or #de-term -->
+                    <xsl:apply-templates select="$curTest" mode="evaluate"/>
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="$submit" />
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>)</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- A test can also be composite involving a combination of logical tests -->
+<!-- This template works through one layer, recursively dealing with deeper layers as needed -->
+<xsl:template name="checker-layer" >
+    <xsl:param name="submit" />
+    <xsl:param name="tests" />                   <!-- The layer of tests (subtree) -->
+    <xsl:param name="level" select="0" />        <!-- Level (or depth) of the layer -->
+    <xsl:param name="logic" select="'and'" />    <!-- and = all must be true, or = at least one, not = negation -->
+    <xsl:choose>
+        <xsl:when test="$logic = 'and'">         <!-- Treat logic like multipication. A single false (0) makes product zero -->
+            <xsl:text>    testResults[</xsl:text><xsl:value-of select="$level" /><xsl:text>] = 1;&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$logic = 'or'">         <!-- Treat logic like addition. A single true makes sum positive -->
+            <xsl:text>testResults[</xsl:text><xsl:value-of select="$level" /><xsl:text>] = 0;&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+    <xsl:for-each select="$tests">    <!-- Work through the layer of tests one at a time. -->
+        <xsl:choose>
+            <xsl:when test="name()='and'">
+                <xsl:text>    testResults[</xsl:text>
+                <xsl:value-of select="$level+1" />
+                <xsl:text>] = 1;&#xa;</xsl:text>
+                <xsl:call-template name="checker-layer">
+                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="tests" select="./*" />
+                    <xsl:with-param name="level" select="$level+1" />
+                    <xsl:with-param name="logic" select="'and'" /> <!-- Default: All tests at first layer must be true -->
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="name()='or'">
+                <xsl:text>    testResults[</xsl:text>
+                <xsl:value-of select="$level+1" />
+                <xsl:text>] = 0;&#xa;</xsl:text>
+                <xsl:call-template name="checker-layer">
+                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="tests" select="./*" />
+                    <xsl:with-param name="level" select="$level+1" />
+                    <xsl:with-param name="logic" select="'or'" /> <!-- Default: All tests at first layer must be true -->
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="name()='not'">
+                <xsl:call-template name="checker-layer">
+                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="tests" select="./*" />
+                    <xsl:with-param name="level" select="$level+1" />
+                    <xsl:with-param name="logic" select="'not'" /> <!-- Default: All tests at first layer must be true -->
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="checker-simple">
+                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="curTest" select="." />
+                    <xsl:with-param name="level" select="$level+1" />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose> <!-- Deal with the results of that recursive call to a deeper layer. -->
+            <xsl:when test="$logic = 'and'">
+                <xsl:text>    testResults[</xsl:text><xsl:value-of select="$level" />
+                <xsl:text>] &amp;= testResults[</xsl:text><xsl:value-of select="$level+1" /><xsl:text>];&#xa;</xsl:text>
+            </xsl:when>
+            <xsl:when test="$logic = 'or'">
+                <xsl:text>    testResults[</xsl:text><xsl:value-of select="$level" />
+                <xsl:text>] |= testResults[</xsl:text><xsl:value-of select="$level+1" /><xsl:text>];&#xa;</xsl:text>
+            </xsl:when>
+            <xsl:when test="$logic = 'not'">
+                <xsl:text>    testResults[</xsl:text><xsl:value-of select="$level" />
+                <xsl:text>] = !(testResults[</xsl:text><xsl:value-of select="$level+1" /><xsl:text>]);&#xa;</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:for-each>
+</xsl:template>
+
+
+<!-- ================================================ -->
+<!-- Templates for working with evaluation objects    -->
+<!-- ================================================ -->
+
+<!-- Wrapper for calling appropriate javascript commands that  -->
+<!-- will parse the expression for a number appropriately,     -->
+<!-- which could be written as an expression involving symbols -->
+<!-- or a random number                                        -->
+<xsl:template match="de-object[@context='number']" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="@mode='value' or @mode='formula'">
+            <xsl:value-of select="$prefix"/>
+            <xsl:text>_menv.parseExpression(</xsl:text>
+            <xsl:call-template name="quote-strip-string">
+                <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+            <xsl:text>, "number")</xsl:text>
+        </xsl:when>
+        <xsl:when test="@mode='evaluate'">
+            <xsl:value-of select="$prefix"/>
+            <xsl:text>_menv.evaluateMathObject(</xsl:text>
+                <xsl:apply-templates select="formula/*" mode="evaluate">
+                    <xsl:with-param name="setupMode" select="$setupMode"/>
+                </xsl:apply-templates>
+                <xsl:text>, "number", {</xsl:text>
+                <xsl:apply-templates select="variable" mode="evaluation-binding" >
+                    <xsl:with-param name="setupMode" select="$setupMode" />
+                </xsl:apply-templates>
+            <xsl:text>}).reduce()</xsl:text>
+        </xsl:when>
+        <xsl:when test="@mode='random'">
+            <!-- Different types of random number generation -->
+            <xsl:choose>
+                <xsl:when test="options[@distribution='discrete']">
+                    <xsl:variable name="rnd-min">
+                        <xsl:choose>
+                            <xsl:when test="options/@min">
+                                <xsl:value-of select="options/@min"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>0</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:variable name="rnd-max">
+                        <xsl:choose>
+                            <xsl:when test="options/@max">
+                                <xsl:value-of select="options/@max"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>1</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:variable name="rnd-by">
+                        <xsl:choose>
+                            <xsl:when test="options/@by">
+                                <xsl:value-of select="options/@by"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>1</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:variable name="rnd-nonzero">
+                        <xsl:choose>
+                            <xsl:when test="options/@nonzero = 'yes'">
+                                <xsl:text>true</xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>false</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:call-template name="generate-random-number">
+                        <xsl:with-param name="rnd-dist">
+                            <xsl:text>discrete</xsl:text>
+                        </xsl:with-param>
+                        <xsl:with-param name="rnd-options">
+                            <xsl:text>{ min:</xsl:text>
+                            <xsl:value-of select="$rnd-min"/>
+                            <xsl:text>, max:</xsl:text>
+                            <xsl:value-of select="$rnd-max"/>
+                            <xsl:text>, by:</xsl:text>
+                            <xsl:value-of select="$rnd-by"/>
+                            <xsl:text>, nonzero:</xsl:text>
+                            <xsl:value-of select="$rnd-nonzero"/>
+                            <xsl:text>}</xsl:text>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Objects defined as formulas. Several possible modes: -->
+<!-- formula (literal), substitution (composition),       -->
+<!-- derivative and evaluate                              -->
+<xsl:template match="de-object[@context='formula']" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:choose>
+        <!-- Simple formula is provided, with or without pattern matching -->
+        <xsl:when test="@mode='formula'">
+            <xsl:value-of select="$prefix"/>
+            <xsl:text>_menv.parseExpression(</xsl:text>
+            <xsl:call-template name="quote-strip-string">
+                <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+            <xsl:text>, "formula")</xsl:text>
+        </xsl:when>
+        <!-- Composition of two formulas (same look as evaluation)                -->
+        <!-- Requires descendent nodes: formula and values to substitute          -->
+        <xsl:when test="@mode='substitution'">
+            <xsl:apply-templates select="formula/*" mode="evaluate">
+                <xsl:with-param name="setupMode" select="$setupMode"/>
+            </xsl:apply-templates>
+            <xsl:text>.compose({</xsl:text>
+                <xsl:apply-templates select="variable" mode="evaluation-binding" >
+                    <xsl:with-param name="setupMode" select="$setupMode" />
+                </xsl:apply-templates>
+            <xsl:text>}).reduce()</xsl:text>
+        </xsl:when>
+        <!-- Derivative of a formula.                        -->
+        <!-- Requires descendent nodes: formula, variable    -->
+        <xsl:when test="@mode='derivative'">
+            <xsl:apply-templates select="formula" mode="evaluate">
+                <xsl:with-param name="setupMode" select="$setupMode" />
+            </xsl:apply-templates>
+            <xsl:text>.derivative(</xsl:text>
+            <xsl:call-template name="quote-string">
+                <xsl:with-param name="text" select="variable/@name"/>
+            </xsl:call-template>
+            <xsl:text>)</xsl:text>
+        </xsl:when>
+        <!-- Evaluate a formula at specific values.          -->
+        <!-- Values for variables define a binding.          -->
+        <xsl:when test="@mode='evaluate'">
+            <xsl:apply-templates select="formula" mode="evaluate">
+                <xsl:with-param name="setupMode" select="$setupMode"/>
+            </xsl:apply-templates>
+            <xsl:text>.evaluate({</xsl:text>
+            <xsl:apply-templates select="variable" mode="evaluation-binding" >
+                <xsl:with-param name="setupMode" select="$setupMode" />
+            </xsl:apply-templates>
+            <xsl:text>})</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Used during composition or evaluation of a variable-->
+<xsl:template match="variable" mode="evaluation-binding">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:if test="position() > 1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text" select="@name" />
+    </xsl:call-template>
+    <xsl:text>: </xsl:text>
+    <xsl:choose>
+        <xsl:when test="eval or de-object">
+            <xsl:apply-templates select="eval|de-object" mode="evaluate">
+                <xsl:with-param name="setupMode" select="$setupMode" />
+            </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="." />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Generate a random parameter. -->
+<xsl:template name="generate-random-number">
+    <xsl:param name="rnd-dist" />
+    <xsl:param name="rnd-options" />
+    <xsl:text>v._menv.generateRandom(</xsl:text>
+        <xsl:call-template name="quote-string">
+            <xsl:with-param name="text" select="$rnd-dist"/>
+        </xsl:call-template>
+        <xsl:text>, </xsl:text>
+        <xsl:value-of select="$rnd-options"/>
+    <xsl:text>)&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- mode="evaluate" is used during setup and during feedback evaluation            -->
+<!-- Define an expressions that will be parsed in their math context                -->
+<!-- The expression can be defined in terms of the parameters and other expressions -->
+<xsl:template match="de-object[@context='formula' and @mode='formula']|de-term[@context='formula']" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:value-of select="$prefix"/>
+    <xsl:text>_menv.parseExpression(</xsl:text>
+    <xsl:call-template name="quote-strip-string">
+        <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+    <xsl:text>).reduce()</xsl:text>
+</xsl:template>
+
+
+<!-- var elements in expressions (evaluate) are replaced by their name -->
+<!-- During setup, we need to use the context of the `v` object        -->
+<xsl:template match="eval" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:value-of select="$prefix"/>
+    <xsl:value-of select="@expr"/>
+</xsl:template>
+
+<!-- Nothing else is defined for evaluation during setup  -->
+<xsl:template match="/" mode="evaluate"/>
+
+<!-- How to *add* expressions/formulas to the math context -->
+<xsl:template match="de-object[@context='formula' and @mode='formula']|de-term[@context='formula']" mode="runestone-setup-old">
+    <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
+    <xsl:text> = v._menv.addMathObject(</xsl:text>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text" select="@name"/>
+    </xsl:call-template>
+    <xsl:text>, "formula", </xsl:text>
+    <xsl:apply-templates select="." mode="evaluate">
+        <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:text>);&#xa;</xsl:text>
+</xsl:template>
+
+<!-- How to *add* expressions defined by substitution to the math context -->
+<xsl:template match="de-object[@context='formula' and @mode='substitution']|de-term[@context='substitution']" mode="runestone-setup-old">
+    <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
+    <xsl:text> = v._menv.addExpression(</xsl:text>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text" select="@name"/>
+    </xsl:call-template>
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="evaluate">
+        <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:text>);&#xa;</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -177,7 +177,7 @@
         </xsl:attribute>
         <xsl:apply-templates select="."/>
     </eval-subst>
-    <xsl-text>&#xa;</xsl-text>
+    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -557,18 +557,22 @@
             <xsl:text>v.</xsl:text>
         </xsl:if>
     </xsl:variable>
+    <xsl:variable name="de_env">
+        <xsl:value-of select="$prefix"/>
+        <xsl:text>_menv</xsl:text>
+    </xsl:variable>
     <xsl:choose>
         <xsl:when test="@mode='value' or @mode='formula'">
-            <xsl:value-of select="$prefix"/>
-            <xsl:text>_menv.parseExpression(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>.parseExpression(</xsl:text>
             <xsl:call-template name="quote-strip-string">
                 <xsl:with-param name="text" select="."/>
             </xsl:call-template>
             <xsl:text>, "number")</xsl:text>
         </xsl:when>
         <xsl:when test="@mode='evaluate'">
-            <xsl:value-of select="$prefix"/>
-            <xsl:text>_menv.evaluateMathObject(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>.evaluateMathObject(</xsl:text>
                 <xsl:apply-templates select="formula/*" mode="evaluate">
                     <xsl:with-param name="setupMode" select="$setupMode"/>
                 </xsl:apply-templates>
@@ -576,7 +580,9 @@
                 <xsl:apply-templates select="variable" mode="evaluation-binding" >
                     <xsl:with-param name="setupMode" select="$setupMode" />
                 </xsl:apply-templates>
-            <xsl:text>}).reduce()</xsl:text>
+            <xsl:text>}).reduce(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>)</xsl:text>
         </xsl:when>
         <xsl:when test="@mode='random'">
             <!-- Different types of random number generation -->
@@ -654,11 +660,15 @@
             <xsl:text>v.</xsl:text>
         </xsl:if>
     </xsl:variable>
+    <xsl:variable name="de_env">
+        <xsl:value-of select="$prefix"/>
+        <xsl:text>_menv</xsl:text>
+    </xsl:variable>
     <xsl:choose>
         <!-- Simple formula is provided, with or without pattern matching -->
         <xsl:when test="@mode='formula'">
-            <xsl:value-of select="$prefix"/>
-            <xsl:text>_menv.parseExpression(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>.parseExpression(</xsl:text>
             <xsl:call-template name="quote-strip-string">
                 <xsl:with-param name="text" select="."/>
             </xsl:call-template>
@@ -667,8 +677,8 @@
         <!-- Composition of two formulas (same look as evaluation)                -->
         <!-- Requires descendent nodes: formula and values to substitute          -->
         <xsl:when test="@mode='substitution'">
-            <xsl:value-of select="$prefix"/>
-            <xsl:text>_menv.composeExpression(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>.composeExpression(</xsl:text>
             <xsl:apply-templates select="formula/*" mode="evaluate">
                 <xsl:with-param name="setupMode" select="$setupMode"/>
             </xsl:apply-templates>
@@ -676,7 +686,9 @@
                 <xsl:apply-templates select="variable" mode="evaluation-binding" >
                     <xsl:with-param name="setupMode" select="$setupMode" />
                 </xsl:apply-templates>
-            <xsl:text>}).reduce()</xsl:text>
+            <xsl:text>}).reduce(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>)</xsl:text>
         </xsl:when>
         <!-- Derivative of a formula.                        -->
         <!-- Requires descendent nodes: formula, variable    -->
@@ -696,7 +708,9 @@
             <xsl:apply-templates select="formula" mode="evaluate">
                 <xsl:with-param name="setupMode" select="$setupMode"/>
             </xsl:apply-templates>
-            <xsl:text>.evaluate({</xsl:text>
+            <xsl:text>.evaluate(</xsl:text>
+            <xsl:value-of select="$de_env"/>
+            <xsl:text>, {</xsl:text>
             <xsl:apply-templates select="variable" mode="evaluation-binding" >
                 <xsl:with-param name="setupMode" select="$setupMode" />
             </xsl:apply-templates>
@@ -751,17 +765,20 @@
 <!-- The expression can be defined in terms of the parameters and other expressions -->
 <xsl:template match="de-object[@context='formula' and @mode='formula']|de-term[@context='formula']" mode="evaluate">
     <xsl:param name="setupMode" />
-    <xsl:variable name="prefix">
+    <xsl:variable name="de_env">
         <xsl:if test="$setupMode">
             <xsl:text>v.</xsl:text>
         </xsl:if>
+        <xsl:text>_menv</xsl:text>
     </xsl:variable>
-    <xsl:value-of select="$prefix"/>
-    <xsl:text>_menv.parseExpression(</xsl:text>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>.parseExpression(</xsl:text>
     <xsl:call-template name="quote-strip-string">
         <xsl:with-param name="text" select="."/>
     </xsl:call-template>
-    <xsl:text>).reduce()</xsl:text>
+    <xsl:text>).reduce(</xsl:text>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>)</xsl:text>
 </xsl:template>
 
 

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -716,6 +716,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                (@exercise-interactive = 'clickablearea') or
                                (@exercise-interactive = 'select') or
                                (@exercise-interactive = 'fillin-basic') or
+                               (@exercise-interactive = 'fillin') or
                                (@exercise-interactive = 'coding') or
                                (@exercise-interactive = 'shortanswer') or
                                (@exercise-interactive = 'webwork-reps')]

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -796,6 +796,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>"</xsl:text>
 </xsl:template>
 
+<xsl:template name="quote-strip-string">
+    <xsl:param name="text" />
+    <xsl:text>"</xsl:text>
+    <xsl:call-template name="strip-newlines">
+        <xsl:with-param name="text" select="$text" />
+    </xsl:call-template>
+    <xsl:text>"</xsl:text>
+</xsl:template>
+
 <xsl:template name="escape-quote-string">
     <xsl:param name="text" />
     <xsl:call-template name="quote-string">

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -56,6 +56,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:str="http://exslt.org/strings"
     extension-element-prefixes="pi str"
 >
+<!-- Do we need xmlns:exsl="http://exslt.org/common"? -->
 
 <!-- ########################## -->
 <!-- Text Manipulation Routines -->
@@ -786,6 +787,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="sans-return"    select="str:replace($sans-newline,   '&#x0d;', '\r'     )"/>
 
     <xsl:value-of select="$sans-return" />
+</xsl:template>
+
+<xsl:template name="quote-string">
+    <xsl:param name="text" />
+    <xsl:text>"</xsl:text>
+    <xsl:value-of select="$text" />
+    <xsl:text>"</xsl:text>
+</xsl:template>
+
+<xsl:template name="escape-quote-string">
+    <xsl:param name="text" />
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text">
+            <xsl:call-template name="escape-json-string">
+                <xsl:with-param name="text" select="$text"/>
+            </xsl:call-template>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template name="escape-quote-xml">
+    <xsl:param name="xml_content"/>
+    <xsl:variable name="xml_text">
+        <xsl:apply-templates select="exsl:node-set($xml_content)" mode="serialize"/>
+    </xsl:variable>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text" select="$xml_text"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- File Extension -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -54,9 +54,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
     xmlns:pi="http://pretextbook.org/2020/pretext/internal"
     xmlns:str="http://exslt.org/strings"
+    xmlns:exsl="http://exslt.org/common"
     extension-element-prefixes="pi str"
 >
-<!-- Do we need xmlns:exsl="http://exslt.org/common"? -->
 
 <!-- ########################## -->
 <!-- Text Manipulation Routines -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1258,6 +1258,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:variable>
 
+<!-- Dynamic problem substitutions are formed by Python routines    -->
+<!-- in the   pretext.py  module that opens HTML representations    -->
+<!-- on a local http.server process. The summary of all             -->
+<!-- are recorded in the dynamic-substitutions-file.                -->
+<xsl:variable name="dynamic-substitutions-file">
+    <!-- Only relevant if there are dynamic exercises present.      -->
+    <xsl:if test="$original//exercise//setup">
+        <xsl:choose>
+            <!-- Look in the publication file for the generated directory -->
+            <xsl:when test="$publication/source/directories/@generated">
+                <xsl:value-of select="str:replace(concat($generated-directory-source, 'dynamic_subs/dynamic_substitutions.xml'), '&#x20;', '%20')"/>
+            </xsl:when>
+            <!-- no specification, so empty string for filename -->
+            <!-- this will be noted where it is employed        -->
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:if>
+</xsl:variable>
+
 <!-- File of  custom/@name  elements, whose content is a custom -->
 <!-- replacement for a corresponding  custom/@ref  element in   -->
 <!-- the source.                                                -->


### PR DESCRIPTION
Here is a pull request that will implement dynamic fill-in-the-blank (FITB) problems using a library for dynamic generation of mathematical expressions and the RunestoneComponents/fitb/ with added functionality that supports it. Functionality is dependent on a pending release by Runestone of an updated components library.

I tried to keep elements of different functionality in separate commits.

First commit: Editing text utilities that were going to be needed
- **Edit** xsl/pretext-text-utilities: Add some additional templates for quoting text, quoting escaped text, and quoting text after stripping extra white space.

Second commit: Implementation of the HTML version
- **Add** xsl/pretext-runestone-fitb.xsl: creates the RS json structure as well as the parsing of the setup and evaluation blocks
- **Edit** xsl/pretext-runestone.xsl: define a new type of exercise
- **Edit** xsl/pretext-text-utilities: Forgot one of the quote-text utilities in earlier commit
- **Edit** xsl/pretext-assembly.xsl: Add #fillin as one of the Runestone interactive types.
- **Edit** xsl/pretext-common.xsl: Necessary to add #eval as a possible special tag inside math mode for when dynamic content appears
- **Edit** xsl/pretext-html.xsl: Add import of FITB xsl. Note that there is a new variable defined to distinguish whether the mode requires use of the static seeds (used in creating standalone HTML pages to extract information for static version). Also made minor modification for treatment of #fillin to account for new usage.

Third commit: Additional modifications necessary to support the generation of static versions
- **Edit** pretext/pretext: Add option for "-c dynamic" to create a generated file of text substitutions for an instance of dynamic exercises. Defines the dest-dir for substitutions (dynamic_subs --- maybe just dynamic?)
- **Edit** pretext/pretext.py: Define new function `dynamic_substitutions` that generates standalone HTML files in tmp-dir, uses a local http.server and playwright to render a static version, and extract the substitutions to store in generated file.
- **Add** xsl/extract-dynamic.xsl: extraction file for creating the standalone HTML, sets the variable indicating usage of static seeds to true.
- **Edit** xsl/pretext-assembly.xsl: inserts a layer between assembly and exercise to apply the substitutions and strip out all of the dynamic xml for static mode and just copy for dynamic mode
- **Edit** xsl/pretext-common.xsl: needed to add exercises as a type that can require a standalone file name. I added this with other interactives, although maybe it seems to be a different type of object.
- **Add** xsl/pretext-dynamic.xsl: wrapper to implement the standalone page--not currently used but could be wanted if exercises should have stand-alone version. (Should this be deleted for now?)
- **Edit** xsl/pretext-html.xsl: the standalone files weren't functional without adding primary navigation (maybe there was some javascript dependency this enabled?) It appears that standalone pages don't get the same HTML header as a standard page in the document.
- **Edit** xsl/pretext-runestone-fitb.xsl: Had an error that didn't appear until trying to extract substitutions for solutions (don't currently appear in Runestone exercises)
- **Edit** xsl/publisher-variables.xsl: Define the location for the dynamic substitutions (needs to match what is used in the python scripts)

Fourth commit: Addition of examples in sample article
- **Edit** examples/sample-article/sample-article.xml: Added a new section to make it easier to debug. Could probably just be part of the earlier section of other Runestone interactive exercises.

** New/Reuse of Tags ** (hopefully I remembered to list them all)

* exercise/setup: This has an existing usage in Runestone fillin. This was modified to introduce additional tags parsed by the fitb xsl to generate dynamic content
* exercise/evaluation: New tag to contain xml structure defining evaluation and feedback when checking answers. This XML also is parsed separately by fitb xsl
* eval[@expr]: This is the tag for dynamic substitution. Similar to how `var` is used by WeBWorK, except this is *only* used for evaluating the dynamic environment and is not used for an input field.
* fillin: This is the tag adopted for identifying where to put an input field.

The structure of the xml defining the dynamic mathematical objects and the feedback is meant to be sandboxed away from the rest of the PreTeXt markup.

Note: The HTML support for also including JSXGraph natively (no i-frames to be connected to the dynamic content) in these exercises is ready but requires figuring out how this should integrate with the workflow for rendering static images.