### PR TITLE
clean up references to tutorial

### DIFF
--- a/doc/guide/appendices/cli-transition.xml
+++ b/doc/guide/appendices/cli-transition.xml
@@ -25,7 +25,7 @@
       <ul>
         <li>An existing <pretext/> project, in a folder called <c>PROJECT</c>.</li>
         <li>A Python installation at version 3.8 or newer.</li>
-        <li>The PreTeXt-CLI, installed using the instructions in <xref ref="quickstart-getting-pretext"/>.</li>
+        <li>The PreTeXt-CLI, installed using the instructions in <xref ref="processing-CLI"/>.</li>
       </ul>
     </p>
 

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -11,7 +11,7 @@
     <title>Processing, Tools and Workflow</title>
 
     <introduction>
-        <p>This chapter explains in full detail how to convert your source into various output formats, using both the simple <pretext />-CLI as well as other methods to combine your source file with an XSL stylesheet that might provide greater flexibility and control.  It expands on the simple example in <xref ref="quickstart-example" /> and should also be read in conjunction with the chapter on the <c>pretext</c> script (<xref ref="pretext-script" />).</p>
+        <p>This chapter explains in full detail how to convert your source into various output formats, using both the simple <pretext />-CLI as well as other methods to combine your source file with an XSL stylesheet that might provide greater flexibility and control.  It expands on the simple example in <xref ref="tutorial" /> and should also be read in conjunction with the chapter on the <c>pretext</c> script (<xref ref="pretext-script" />).</p>
     </introduction>
 
     <section xml:id="processing-basic">
@@ -39,7 +39,7 @@
         </p>
 
         <p>
-            The <pretext />-CLI, can be installed on the command-line using the command <c>pip install pretextbook</c>, see <xref ref="quickstart-getting-pretext"/>.  To use options 2 and 3 above, you will need to get a copy of <pretext /> from its <url href="https://github.com/PreTeXtBook/pretext" visual="github.com/PreTeXtBook/pretext">GitHub repository</url>.  This can be done using the command <c>git clone https://github.com/PreTeXtBook/pretext.git</c>, or by downloading a zip file directly from the repository.
+            The <pretext />-CLI, can be installed on the command-line using the command <c>pip install pretextbook</c>, see <xref ref="processing-CLI"/>.  To use options 2 and 3 above, you will need to get a copy of <pretext /> from its <url href="https://github.com/PreTeXtBook/pretext" visual="github.com/PreTeXtBook/pretext">GitHub repository</url>.  This can be done using the command <c>git clone https://github.com/PreTeXtBook/pretext.git</c>, or by downloading a zip file directly from the repository.
         </p>
 
         <p>
@@ -52,7 +52,7 @@
         <idx><h>CLI</h></idx>
         <introduction>
         <p>
-            Here we will outline the functionality of the <pretext />-CLI.  Instructions for installing this command line interface can be found in <xref ref="quickstart-getting-pretext"/>.
+            Here we will outline the functionality of the <pretext />-CLI.  Instructions for installing this command line interface can be found in <xref ref="processing-CLI"/>.
         </p>
 
         <p>

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -151,7 +151,7 @@
 
             <p>If you are writing a book, or if you are collaborating with co-authors, then you owe it to yourself and your co-authors to learn how to use revision control<idx>revision control</idx>, which works well with <pretext /> since the source is just text files.  The hands-down favorite is <c>git</c>.  To fully understand it is beyond the scope of this guide but some information is provided in <xref ref="git-author" /> which has hints on how to best use <c>git</c> together with a <pretext /> project.</p>
 
-            <p>If you use the workflow recommended in the <xref ref="quickstart-example"/> using GitHub's codespaces, you will get revision control via git automatically, and VS Code provides a graphical user interface for all the basic operations you need.</p>
+            <p>If you use the workflow recommended in the <xref ref="tutorial"/> using GitHub's codespaces, you will get revision control via git automatically, and VS Code provides a graphical user interface for all the basic operations you need.</p>
         </paragraphs>
 
     </section>
@@ -160,7 +160,7 @@
         <title>Converting Your Source to Output</title>
 
         <p>
-            Once you have content created in <pretext /> files (i.e., <init>XML</init> files), you will want to convert these files into a output format such as <init>HTML</init>, to be viewed in a web browser, or a <init>PDF</init>.  Instructions for doing this will be discussed in <xref ref="quickstart-example"/>, and in even more detail in <xref ref="processing"/>.  Here we provide an overview of how the conversion works to help you understand what is possible.
+            Once you have content created in <pretext /> files (i.e., <init>XML</init> files), you will want to convert these files into a output format such as <init>HTML</init>, to be viewed in a web browser, or a <init>PDF</init>.  Instructions for doing this will be discussed in <xref ref="tutorial"/>, and in even more detail in <xref ref="processing"/>.  Here we provide an overview of how the conversion works to help you understand what is possible.
         </p>
 
         <p>
@@ -182,7 +182,7 @@
     <section xml:id="start-next">
         <title>Where Next?</title>
 
-        <p>To start playing with <pretext /> right away, work through the <xref ref="quickstart-example"/>.  It will guide you through a cloud-based setup (no software install required) and you will create, edit, convert, and deploy your first document.</p>
+        <p>To start playing with <pretext /> right away, work through the <xref ref="tutorial"/>.  It will guide you through a cloud-based setup (no software install required) and you will create, edit, convert, and deploy your first document.</p>
 
         <p>If you would like a general, high-level overview of features skip ahead to <xref ref="overview"/>.</p>
 

--- a/doc/guide/preface.xml
+++ b/doc/guide/preface.xml
@@ -12,7 +12,7 @@
     <paragraphs>
         <title>Introduction</title>
 
-        <p>This part is the place to begin if you are new to <pretext/>.  <xref ref="start-here"/> is the introduction, overview, and philosophy.  Then <xref ref="quickstart-example"/> intends to get you started quickly by authoring a simple example and converting it to <init>HTML</init> and <init>PDF</init> output formats.  Notice that there are three parts which target different roles: the <pubtitle>Author's Guide</pubtitle> (<xref ref="part-author"/>), the <pubtitle>Publisher's Guide</pubtitle> (<xref ref="part-publisher"/>) and the <pubtitle>Developer's Guide</pubtitle> (<xref ref="part-developer"/>).</p>
+        <p>This part is the place to begin if you are new to <pretext/>.  <xref ref="start-here"/> is the introduction, overview, and philosophy.  Then <xref ref="tutorial"/> intends to get you started quickly by showing how to set up a <pretext/> authoring environment and converting a document to <init>HTML</init> and <m>\LaTeX</m> output formats.  Notice that there are three parts which target different roles: the <pubtitle>Author's Guide</pubtitle> (<xref ref="part-author"/>), the <pubtitle>Publisher's Guide</pubtitle> (<xref ref="part-publisher"/>) and the <pubtitle>Developer's Guide</pubtitle> (<xref ref="part-developer"/>).</p>
     </paragraphs>
 
     <paragraphs>


### PR DESCRIPTION
I believe this catches all the dangling xrefs (I did a full CLI build and got no warnings).