### PR TITLE
Image leavevmode

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -11254,6 +11254,62 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </figure>
                     </sidebyside>
                 </figure>
+
+                <p>
+                    For <latex/>, in some circumstances it is desirable to print the image on the next line, but backed up by some amount.
+                    This <q>top-aligns</q> the image with a number of some sort off to the left. The following are tests for this behavior.
+                    Here is a list.
+                    <ol>
+                        <li>
+                            <image margins="0% 70%" source="images/nz-landscape.jpg"/>
+                        </li>
+                        <li>
+                            <image source="images/nz-landscape.jpg"/>
+                        </li>
+                    </ol>
+                </p>
+
+                <exercise>
+                    <task>
+                        <statement>
+                            <image margins="0% 70%" source="images/nz-landscape.jpg"/>
+                        </statement>
+                    </task>
+                    <task>
+                        <statement>
+                            <image source="images/nz-landscape.jpg"/>
+                        </statement>
+                    </task>
+                </exercise>
+
+                <exercises>
+                    <exercise>
+                        <task>
+                            <statement>
+                                <image margins="0% 70%" source="images/nz-landscape.jpg"/>
+                            </statement>
+                        </task>
+                        <task>
+                            <statement>
+                                <image source="images/nz-landscape.jpg"/>
+                            </statement>
+                        </task>
+                    </exercise>
+
+                    <exercisegroup cols="2">
+                        <exercise>
+                            <statement>
+                                <image margins="0% 70%" source="images/nz-landscape.jpg"/>
+                            </statement>
+                        </exercise>
+                        <exercise>
+                            <statement>
+                                <image source="images/nz-landscape.jpg"/>
+                            </statement>
+                        </exercise>
+                    </exercisegroup>
+                </exercises>
+
             </subsection>
 
             <subsection xml:id="atomic-video">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -8417,12 +8417,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="stage" mode="leave-vertical-mode">
-    <xsl:if test="not(preceding-sibling::stage)">
-        <xsl:text>\leavevmode\par\noindent%&#xa;</xsl:text>
-    </xsl:if>
-</xsl:template>
-
 <xsl:template match="figure|table|list|listing" mode="environment-name">
     <!-- subfigures, etc -->
     <xsl:if test="ancestor::*[self::figure]">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1176,8 +1176,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%% arguments are left-margin, width, right-margin, as multiples of&#xa;</xsl:text>
         <xsl:text>%% \linewidth, and are guaranteed to be positive and sum to 1.0&#xa;</xsl:text>
         <xsl:text>\tcbset{ imagestyle/.style={bwminimalstyle} }&#xa;</xsl:text>
-        <xsl:text>\NewTColorBox{image}{mmm}{imagestyle,left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
+        <xsl:text>\NewTColorBox{tcbimage}{mmm}{imagestyle,left skip=#1\linewidth,width=#2\linewidth}&#xa;</xsl:text>
+        <xsl:text>%% Wrapper environment for tcbimage environment with a fourth argument&#xa;</xsl:text>
+        <xsl:text>%% Fourth argument, if nonempty, is a vertical space adjustment&#xa;</xsl:text>
+        <xsl:text>%% and implies image will be preceded by \leavevmode\nopagebreak&#xa;</xsl:text>
+        <xsl:text>%% Intended use is for alignment with a list marker&#xa;</xsl:text>
+        <xsl:text>\NewDocumentEnvironment{image}{mmmm}{\notblank{#4}{\leavevmode\nopagebreak\vspace{#4}}{}\begin{tcbimage}{#1}{#2}{#3}}{\end{tcbimage}%&#xa;}</xsl:text>
     </xsl:if>
+
     <!-- Tables -->
     <xsl:if test="$document-root//tabular">
         <xsl:text>%% For improved tables&#xa;</xsl:text>
@@ -8594,9 +8600,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$layout/right-margin div 100"/>
+    <xsl:text>}</xsl:text>
+    <xsl:text>{</xsl:text>
+    <xsl:apply-templates select="." mode="vertical-adjustment"/>
     <xsl:text>}%&#xa;</xsl:text>
     <xsl:apply-templates select="." mode="image-inclusion" />
     <xsl:text>\end{image}%&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="image" mode="vertical-adjustment">
+    <xsl:choose>
+        <!-- When the image is the first thing in an exercisegroup (tcbraster) exercise -->
+        <!-- NB: ancestor::exercisegroup would catch too many cases                     -->
+        <xsl:when test="parent::statement/parent::exercise/parent::exercisegroup or parent::exercise/parent::exercisegroup and not(preceding-sibling::*)">
+            <xsl:text>-0.5\baselineskip</xsl:text>
+        </xsl:when>
+        <!-- When the image is the first thing in a list item, project-like, (not exercisegroup) exercise, or task -->
+        <xsl:when test="(parent::li|parent::statement|parent::exercise|parent::task|parent::*[PROJECT-FILTER]) and not(preceding-sibling::*)">
+            <xsl:text>-1.5\baselineskip</xsl:text>
+        </xsl:when>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Second: images already constrained by side-by-side panels -->


### PR DESCRIPTION
Two pictures are worth 2000 words. So, before in LaTeX:

<img width="360" alt="Screen Shot 2023-03-18 at 2 30 32 PM" src="https://user-images.githubusercontent.com/4732672/226141271-82fe1c89-9fd2-48ae-b849-112b64349cf3.png">

And after:

<img width="360" alt="Screen Shot 2023-03-18 at 2 24 40 PM" src="https://user-images.githubusercontent.com/4732672/226140874-5eadb9ca-bca8-4c8d-b145-1690157d5beb.png">

This PR applies `\leavevmode` before atomic images that you would want to be in line with a number off to the left (from a list, exercise project). Then it backs up by an appropriate amount of space so the image is "top aligned" with the number. The "backing up" is either  by `1.5\baselineskip` or `0.5\baselineskip` depending on the situation. These values are explained in the comments.


