### PR TITLE
HTML: add space character to fillin spans

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8806,6 +8806,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="5 * $characters div 11" />
             <xsl:text>em;</xsl:text>
         </xsl:attribute>
+        <xsl:text> </xsl:text>
     </span>
     <xsl:if test="@rows or @cols">
         <xsl:apply-templates select="." mode="fillin-array"/>


### PR DESCRIPTION
This puts a space character in the span for a text fillin. Without this, the span is empty, which makes it more challenging to style.