### PR TITLE
Description var

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1272,7 +1272,7 @@
                         <image width="50%">
                             <description>
                                 a rectangle whose width is labeled <var name="$b"/> cm
-                                and height is labeled <var name="$b"/> cm
+                                and height is labeled <var name="$a"/> cm
                             </description>
                             <latex-image>
                                 \begin{tikzpicture}
@@ -1341,6 +1341,9 @@
                             a printed at sign, and a percent sign used as a comment marker.
                         </p>
                         <image width="50%">
+                            <description>
+                                this image has pictures of text with special characters like $, %, and @
+                            </description>
                             <latex-image>
                                 \begin{tikzpicture}
                                     \node at (0,0) {I need about \$3.50.};

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1937,7 +1937,7 @@
                     attribute margins {text}?,
                     attribute archive {text}?,
                     attribute decorative {"yes" | "no"}?,
-                    element description {TextShort}?,
+                    element description {(TextShort | WWVariable)*}?,
                     (
                         element latex-image {text} |
                         element asymptote {text} |


### PR DESCRIPTION
Briefly discussed in drop-in today. This started as just adding `var` to the schema as a legal child of a `webwork//image/description`.

I also noticed an issue and an omission in the sample chapter.

And I rewrote/condensed some of the code in `extract-pg` surrounding images and their descriptions.