### PR TITLE
WeBWorK: prepare for static multiple choice as list

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1629,7 +1629,7 @@ def webwork_to_xml(
                         for child in hnt:
                             chcopy = copy.deepcopy(child)
                             hint.append(chcopy)
-                answer_names = read.xpath(".//fillin/@name|.//var/@name")
+                answer_names = read.xpath(".//fillin/@name|.//var/@name|.//ul/@name|.//ol/@name|.//dl/@name")
                 answer_hashes = response_root.find("./answerhashes")
                 if answer_hashes is not None:
                     for ans in list(answer_hashes):


### PR DESCRIPTION
Right now, static multiple choice come back from a WW server as a `var` element. I'm working toward eliminating that with future versions of WeBWorK. In the future (possibly 2.18, but hard to say right now) they will always come back as:

* `ul` for radio buttons, popup, and checkboxes that don't use labels
* `ol` for checkboxes that use automatically enumerated labels
* `dl` for checkboxes that use ad hoc labels

They still need an attribute to associate them with an answer. This is especially important for an exercise with tasks, or else we have no way to associate an answer from the server with one particular task.

All that is to say, this commit helps me with some development happening right now on the WeBWorK side. 