### PR TITLE
Checkbox

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -279,7 +279,7 @@
         to cause the input form to be an array of smaller fields instead of one big field.
       </p>
       <p>
-        A <tag>var</tag> can have <attr>form</attr> with value <c>popup</c> or <c>buttons</c> for multiple choice questions.
+        A <tag>var</tag> can have <attr>form</attr> with value <c>popup</c>, <c>buttons</c>, or <c>checkboxes</c> for multiple choice questions.
       </p>
       <p>
         If you are familiar with PG, then in your <tag>pg-code</tag> you might write a custom evaluator

--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1087,40 +1087,114 @@
                 </webwork>
             </exercise>
 
-            <!--Checkboxes not yet implemented fully. See note in pretext-webwork-pg.xsl -->
-            <!--<exercise>
-                <title>Choose several</title>
-
+            <exercise>
+                <title>Choose a Subset of Options</title>
                 <webwork>
-
                     <pg-code>
-                        $expressions = new_checkbox_multiple_choice();
-                        $expressions -> qa (
-                        "A question can go here, but PTX ignores this",
-                        "\( e^{x^2} e^{1/x} \)$BR",
-                        "\( e^{x^2} e^{x^{-1}} \)$BR",
-                        "\( e^{ (x^3+1) / x } \)$BR",
+                        $checks = CheckboxList(
+                            [
+                                [
+                                    "${BM}e^{x^2} e^{1/x}${EM}",
+                                    "${BM}e^{x^2} e^{x^{-1}}${EM}",
+                                    "${BM}e^{ (x^3+1) / x}${EM}",
+                                    "${BM}\dfrac{ e^{x^2} }{ e^x }${EM}",
+                                    "${BM}e^{x^2} + e^{1/x}${EM}"
+                                ],
+                                "None of the above"
+                            ],
+                            [0, 1, 2]
                         );
-                        $expressions -> extra(
-                        "\( \displaystyle \frac{ e^{x^2} }{ e^x } \)$BR",
-                        "\( e^{x^2} + e^{1/x} \)$BR",
-                        );
-                        $expressions -> makeLast("None of the above");
                     </pg-code>
-
                     <statement>
-                        <p>Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.  There may be more than one correct answer.</p>
-                        <p><var name="$expressions" form="checkboxes"/></p>
+                        <p>
+                            Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.
+                            There may be more than one correct answer.
+                        </p>
+                        <p>
+                            <var name="$checks" form="checkboxes"/>
+                        </p>
                     </statement>
-
                     <solution>
-                        <p>The correct answer is <var name="$expressions"/>.</p>
+                        <p>
+                            The correct answer is <var name="$checks"/>.
+                        </p>
                     </solution>
-
                 </webwork>
-            </exercise>-->
+            </exercise>
 
+            <exercise>
+                <title>Choose a Subset of Options with Automated Labeling</title>
+                <webwork>
+                    <pg-code>
+                        $checks = CheckboxList(
+                            [
+                                [
+                                    "${BM}e^{x^2} e^{1/x}${EM}",
+                                    "${BM}e^{x^2} e^{x^{-1}}${EM}",
+                                    "${BM}e^{ (x^3+1) / x}${EM}",
+                                    "${BM}\dfrac{ e^{x^2} }{ e^x }${EM}",
+                                    "${BM}e^{x^2} + e^{1/x}${EM}"
+                                ],
+                                "None of the above"
+                            ],
+                            [0, 1, 2],
+                            labels => "ABC",   # "abc", "123", "roman", "Roman"
+                        );
+                    </pg-code>
+                    <statement>
+                        <p>
+                            Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.
+                            There may be more than one correct answer.
+                        </p>
+                        <p>
+                            <var name="$checks" form="checkboxes"/>
+                        </p>
+                    </statement>
+                    <solution>
+                        <p>
+                            The correct answer is <var name="$checks"/>.
+                        </p>
+                    </solution>
+                </webwork>
+            </exercise>
+
+            <exercise>
+                <title>Choose a Subset of Options with Explicit Labeling</title>
+                <webwork>
+                    <pg-code>
+                        $checks = CheckboxList(
+                            [
+                                [
+                                    {TACO => "${BM}e^{x^2} e^{1/x}${EM}"},
+                                    {PIZZA => "${BM}e^{x^2} e^{x^{-1}}${EM}"},
+                                    {SUSHI => "${BM}e^{ (x^3+1) / x}${EM}"},
+                                    {BURGER => "${BM}\dfrac{ e^{x^2} }{ e^x }${EM}"},
+                                    {BURRITO => "${BM}e^{x^2} + e^{1/x}${EM}"}
+                                ],
+                                {HUNGRY => "None of the above"}
+                            ],
+                            [0, 1, 2],
+                            displayLabels => 1
+                        );
+                    </pg-code>
+                    <statement>
+                        <p>
+                            Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.
+                            There may be more than one correct answer.
+                        </p>
+                        <p>
+                            <var name="$checks" form="checkboxes"/>
+                        </p>
+                    </statement>
+                    <solution>
+                        <p>
+                            The correct answer is <var name="$checks"/>.
+                        </p>
+                    </solution>
+                </webwork>
+            </exercise>
         </section>
+
         <section>
             <title>Tables</title>
 
@@ -1564,45 +1638,28 @@
             </exercise>
 
             <exercise xml:id="multiple-choice-popup-or-radio-buttons">
-                <!--Checkbox not implemented yet; see note in pretext-webwork-pg.xsl  -->
-                <title>Multiple choice by popup, radio buttons<!--, or checkbox--></title>
+                <title>Multiple Choice by Popup, Radio Buttons, or Checkboxes</title>
 
                 <webwork>
-
-                        <pg-code>
-                            $color1 = PopUp(["?","Red","Blue","Green"], 2);
-
-                            $color2 = RadioButtons(["Red","Blue","Green","None of these"], 1);
-                        </pg-code>
-                        <!-- include below in pg-code once checkboxes implemented
-                            $mc = new_checkbox_multiple_choice();
-                            $mc -> qa (
-                            "A question can go here, but PTX ignores this",
-                            "\( e^{x^2} e^{1/x} \)$BR",
-                            "\( e^{x^2} e^{x^{-1}} \)$BR",
-                            "\( e^{ (x^3+1) / x } \)$BR",
-                            );
-                            $mc -> extra(
-                            "\( \displaystyle \frac{ e^{x^2} }{ e^x } \)$BR",
-                            "\( e^{x^2} + e^{1/x} \)$BR",
-                            );
-                            $mc -> makeLast("None of the above");
-                        -->
-
+                    <pg-code>
+                        $color1 = PopUp(["?","Red","Blue","Green"], 2);
+                        $color2 = RadioButtons(["Red","Blue","Green","None of these"], 1);
+                        $color3 = CheckboxList(["Red","Blue","Green","None of these"], [1]);
+                    </pg-code>
                     <statement>
                         <p>My favorite color is <var name="$color1" form="popup"/>.</p>
 
                         <p>My favorite color is</p>
                         <p><var name="$color2" form="buttons"/></p>
 
-                        <!--<p>Select all expressions that are equivalent to <m>e^{x^2 + 1/x}</m>.  There may be more than one correct answer.</p>
-                        <p><var name="$mc" form="checkboxes"/></p>-->
+                        <p>My favorite color is</p>
+                        <p><var name="$color3" form="checkboxes"/></p>
                     </statement>
 
                     <solution>
                         <p>The correct answer is <var name="$color1"/>.</p>
                         <p>The correct answer is <var name="$color2"/>.</p>
-                        <!--<p>The correct answer is <var name="$mc"/>.</p>-->
+                        <p>The correct answer is <var name="$color3"/>.</p>
                     </solution>
 
                 </webwork>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2466,7 +2466,7 @@
                                       | "limit" | "number" | "point"
                                       | "syntax" | "quantity" | "vector"
                                       }?,
-                    attribute form {"popup"|"buttons"|"none"}?) |
+                    attribute form {"popup"|"buttons"|"checkboxes"|none"}?) |
                     (attribute form {"essay"},
                     attribute width {text}?)
                 }


### PR DESCRIPTION
Now you can have checkbox-style multiple choice questions in a `webwork`. For a long time, something in WeBWorK caused all of the checkbox inputs to have the same HTML id, which led to badness.  That is all fixed now.

At [this page](https://spot.pcc.edu/~ajordan/temp/checkboxes/section-7.html) you can try the last three exercises to see live output.

WeBWorK will always write static PTX for this kind of thing as one of ol, ul, dl. (Which one depends on how checkbox labeling was done, and the three examples show the three styles.) It is almost "legal" PreTeXt, except there is a `@name` attribute on the (ol|ul|dl) that has the name of the corresponding WeBWorK answer. (Something like AnSwEr0001.) We need this in case the checkboxes list is inside a task, so that we know to associate (for example) AnSwEr0003 as an answer to something from within (for example) task 1b.

This works with the AIM server, which is 2.17, plus some small things form 2.18 to make this work. For anyone else with a 2.17 or earlier server, they would need to add `parserCheckboxList.pl` to their macros and make a small edit to `PGbasicmacros.pl`. I haven't thought through yet how/where to document this quirk. But I'm opening the PR for now to discuss it.