### PR TITLE
No footnotes in footnotes, even for URLs

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4120,7 +4120,9 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
                 <cline>&lt;url href="https://example.com/" visual="example.com"/&gt;</cline>
             </cd>This will render as <url href="https://example.com/" visual="example.com"/>.  Note that there is no footnote since the visual version is already apparent.</p>
 
-            <p>If you want to squelch the automatic footnote on a <tag>url</tag> element with content, you can explicitly set the <attr>visual</attr> attribute to an empty string as <c>visual=""</c>.  This signal will inhibit the automatic footnote.  This should be a <em>very rare</em> occurence, since you are denying readers of some formats from seeing even a hint of the actual <init>URL</init>.  One example of this is a regular footnote, which contains a <init>URL</init>.  The automatic footnote, inside another footnote, becomes problematic in some conversions.  Better to squelch the footnote-within-a-footnote, and just list nearby a <init>URL</init>, likely using the <tag>c</tag> element to get a monospace font.</p>
+            <p>If you want to squelch the automatic footnote on a <tag>url</tag> element with content, you can explicitly set the <attr>visual</attr> attribute to an empty string as <c>visual=""</c>.  This signal will inhibit the automatic footnote.  This should be a <em>very rare</em> occurence, since you are denying readers of some formats from seeing even a hint of the actual <init>URL</init>.</p>
+
+            <p>An extreme example of this behavior is a regular footnote which contains a <init>URL</init>.  Because an automatic footnote, inside another footnote, becomes problematic in some conversions, we squelch the footnote-within-a-footnote. A best practice here is to just list nearby a <init>URL</init>, likely using the <tag>c</tag> element to get a monospace font.</p>
 
             <p>A <tag>url</tag> inside a <tag>title</tag> has been accounted for, but should be used with caution.</p>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2647,7 +2647,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <p>We are not fans of footnotes, they are totally unstructured.<fn><url href="https://en.wikipedia.org/wiki/Carleson%27s_theorem" visual="">Carleson's Theorem</url></fn>
                 A URL in a footnote migrates around, and so care must be taken.<fn><url href="http://example.com/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789%58-._~:/?#[]@!$&amp;'()*+,;="/></fn>
                 This paragraph has two footnotes, one with a real URL from Jesse Oldroyd, another with a fake URL from the above suite.
-                For good measure, we repeat the URL found in the first footnote (which lacks its own footnote by design):
+                For good measure, we repeat the URL found in the first footnote (which lacks its own footnote by design<fn>And if you do provide a link like <url href="https://en.wikipedia.org/wiki/Carleson%27s_theorem" visual="en.wikipedia.org/wiki/Carleson%27s_theorem">Carleson's Theorem</url> in a footnote, provide an easy-to-read reference, such as <c>en.wikipedia.org/wiki/Carleson%27s_theorem</c> since the extra footnote and any visual will be squelched.</fn>):
                 <url href="https://en.wikipedia.org/wiki/Carleson%27s_theorem" visual="">Carleson's Theorem</url>.
                 And we include a no-content version of the same link, with a visual version provided and employed:
                 <url href="https://en.wikipedia.org/wiki/Carleson%27s_theorem" visual="en.wikipedia.org/wiki/Carleson%27s_theorem"/>.</p>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -746,63 +746,66 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- we drop the @visual attribute, a decision we might revisit -->
         <xsl:apply-templates select="node()|@*[not(local-name(.) = 'visual')]" mode="enrichment"/>
     </xsl:copy>
-    <!-- manufacture a footnote with (private) attribute -->
-    <!-- as a signal to conversions as to its origin     -->
-    <xsl:choose>
-        <!-- explicitly opt-out, so no footnote -->
-        <xsl:when test="@visual = ''"/>
-        <!-- go for it, as requested by author -->
-        <xsl:when test="@visual">
-            <fn pi:url="{@visual}"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <!-- When an author has not made an effort to provide a visual   -->
-            <!-- alternative, then attempt some obvious clean-up of the      -->
-            <!-- default, and if not possible, settle for an ugly visual URL -->
-            <!--                                                             -->
-            <!-- We get a candidate visual URI from the @href attribute      -->
-            <!-- link/reference/location may be external -->
-            <!-- (@href) or internal (dataurl[@source]) -->
-            <xsl:variable name="uri">
-                <xsl:choose>
-                    <!-- "url" and "dataurl" both support external @href -->
-                    <xsl:when test="@href">
-                        <xsl:value-of select="@href"/>
-                    </xsl:when>
-                    <!-- a "dataurl" might be local, @source is         -->
-                    <!-- indication, so prefix with a base URL,         -->
-                    <!-- add "external" directory, via template useful  -->
-                    <!-- also for visual URL formulation in -assembly   -->
-                    <!-- N.B. we are using the base URL, since this is  -->
-                    <!-- the most likely need by employing conversions. -->
-                    <!-- It would eem duplicative in a conversion to    -->
-                    <!-- HTML, so could perhaps be killed in that case. -->
-                    <!-- But it is what we want for LaTeX, and perhaps  -->
-                    <!-- for EPUB, etc.                                 -->
-                    <xsl:when test="self::dataurl and @source">
-                        <xsl:apply-templates select="." mode="static-url"/>
-                    </xsl:when>
-                    <!-- empty will be non-functional -->
-                    <xsl:otherwise/>
-                </xsl:choose>
-            </xsl:variable>
-            <!-- And clean-up automatically in the prevalent cases -->
-            <xsl:variable name="truncated-href">
-                <xsl:choose>
-                    <xsl:when test="substring(@href, 1, 8) = 'https://'">
-                        <xsl:value-of select="substring($uri, 9)"/>
-                    </xsl:when>
-                    <xsl:when test="substring(@href, 1, 7) = 'http://'">
-                        <xsl:value-of select="substring($uri, 8)"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="$uri"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:variable>
-            <fn pi:url="{$truncated-href}"/>
-        </xsl:otherwise>
-    </xsl:choose>
+    <!-- Now make footnote, as long as we don't create a footnote in a footnote -->
+    <xsl:if test="not(self::url and ancestor::fn)">
+        <!-- manufacture a footnote with (private) attribute -->
+        <!-- as a signal to conversions as to its origin     -->
+        <xsl:choose>
+            <!-- explicitly opt-out, so no footnote -->
+            <xsl:when test="@visual = ''"/>
+            <!-- go for it, as requested by author -->
+            <xsl:when test="@visual">
+                <fn pi:url="{@visual}"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- When an author has not made an effort to provide a visual   -->
+                <!-- alternative, then attempt some obvious clean-up of the      -->
+                <!-- default, and if not possible, settle for an ugly visual URL -->
+                <!--                                                             -->
+                <!-- We get a candidate visual URI from the @href attribute      -->
+                <!-- link/reference/location may be external -->
+                <!-- (@href) or internal (dataurl[@source]) -->
+                <xsl:variable name="uri">
+                    <xsl:choose>
+                        <!-- "url" and "dataurl" both support external @href -->
+                        <xsl:when test="@href">
+                            <xsl:value-of select="@href"/>
+                        </xsl:when>
+                        <!-- a "dataurl" might be local, @source is         -->
+                        <!-- indication, so prefix with a base URL,         -->
+                        <!-- add "external" directory, via template useful  -->
+                        <!-- also for visual URL formulation in -assembly   -->
+                        <!-- N.B. we are using the base URL, since this is  -->
+                        <!-- the most likely need by employing conversions. -->
+                        <!-- It would eem duplicative in a conversion to    -->
+                        <!-- HTML, so could perhaps be killed in that case. -->
+                        <!-- But it is what we want for LaTeX, and perhaps  -->
+                        <!-- for EPUB, etc.                                 -->
+                        <xsl:when test="self::dataurl and @source">
+                            <xsl:apply-templates select="." mode="static-url"/>
+                        </xsl:when>
+                        <!-- empty will be non-functional -->
+                        <xsl:otherwise/>
+                    </xsl:choose>
+                </xsl:variable>
+                <!-- And clean-up automatically in the prevalent cases -->
+                <xsl:variable name="truncated-href">
+                    <xsl:choose>
+                        <xsl:when test="substring(@href, 1, 8) = 'https://'">
+                            <xsl:value-of select="substring($uri, 9)"/>
+                        </xsl:when>
+                        <xsl:when test="substring(@href, 1, 7) = 'http://'">
+                            <xsl:value-of select="substring($uri, 8)"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$uri"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <fn pi:url="{$truncated-href}"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
 </xsl:template>
 
 


### PR DESCRIPTION
We were still creating footnotes for URLs located in footnotes.  These commits fix that problem, and provide light guidance for alternate strategy.