### PR TITLE
HTML: Change body/@class in interactive iframe generation

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10028,7 +10028,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="." mode="header-libraries" />
             </head>
                 <!-- ignore MathJax signals everywhere, then enable selectively -->
-                <body class="pretext ignore-math">
+                <body class="ptx-content ignore-math">
                 <!-- potential document-id per-page -->
                 <xsl:call-template name="document-id"/>
                 <!-- React flag -->


### PR DESCRIPTION
This one line should make Sage interacts generate usable output again.