### PR TITLE
WeBWorK: bring back task-reveal option

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3079,7 +3079,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <pi:pub-attribute name="coursepassword" default="anonymous" freeform="yes"/>
         <pi:pub-attribute name="user" default="anonymous" freeform="yes"/>
         <pi:pub-attribute name="userpassword" default="anonymous" freeform="yes"/>
-        <pi:pub-attribute name="task-reveal" default="" options="all"/>
+        <pi:pub-attribute name="task-reveal" default="all" options="preceding-correct"/>
     </webwork>
     <revealjs>
         <appearance>


### PR DESCRIPTION
Looks like in the shuffle, this was lost. This was the first pub variable put into the new scheme, even before the new scheme was refactored. So I'm not entirely surprised.