### PR TITLE
WeBWorK: give password when determining WeBWorK version

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1116,6 +1116,7 @@ def webwork_to_xml(
             displayMode='PTX',
             courseID=courseID,
             userID=userID,
+            course_password=course_password,
             outputformat='raw'
         )
         version_determination_json = requests.get(url=ww_domain_path, params=params_for_version_determination).json()


### PR DESCRIPTION
WeBWorK 2.18 requires this additional parameter.