### PR TITLE
update pretext.py for WeBWorK 2.18

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1116,6 +1116,7 @@ def webwork_to_xml(
             displayMode='PTX',
             courseID=courseID,
             userID=userID,
+            course_password=course_password,
             outputformat='raw'
         )
         version_determination_json = requests.get(url=ww_domain_path, params=params_for_version_determination).json()
@@ -1479,7 +1480,7 @@ def webwork_to_xml(
             if ww_image_scheme:
                 image_url = ww_image_url
             else:
-                image_url = ww_domain + "/" + ww_image_full_path
+                image_url = urllib.parse.urljoin(ww_domain,ww_image_full_path)
             # modify PTX problem source to include local versions
             if generated_dir:
                 if "xmlns:pi=" not in response_text:


### PR DESCRIPTION
Two adjustments to fix errors with webwork extraction for severs running 2.18 (to be released later this summer).

Debugging by @Alex-Jordan and testing by me. I've run this version against both a 2.17 server and a 2.18 server for Chapter 1 of APEX, and everything runs as expected.