### PR TITLE
Add support for landscape figures and tables.

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -404,6 +404,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\usepackage{ifxetex,ifluatex}&#xa;</xsl:text>
     <xsl:text>%% Raster graphics inclusion&#xa;</xsl:text>
     <xsl:text>\usepackage{graphicx}&#xa;</xsl:text>
+    <xsl:text>%% The rotating package provides sidewaysfigure and sidewaystables environments&#xa;</xsl:text>
+    <xsl:text>\usepackage{rotating}&#xa;</xsl:text>
     <xsl:text>%% Color support, xcolor package&#xa;</xsl:text>
     <xsl:text>%% Always loaded, for: add/delete text, author tools&#xa;</xsl:text>
     <xsl:text>%% Here, since tcolorbox loads tikz, and tikz loads xcolor&#xa;</xsl:text>
@@ -8496,6 +8498,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- 2: standard identifier for cross-references   -->
 <!-- 3: empty, or a hard-coded number from -common -->
 <xsl:template match="figure|listing">
+    <xsl:if test="@landscape and $b-latex-print">
+      <xsl:text>\begin{sidewaysfigure}%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>
     <xsl:text>}{</xsl:text>
@@ -8524,6 +8529,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>
     <xsl:text>}%&#xa;</xsl:text>
+    <xsl:if test="@landscape and $b-latex-print">
+      <xsl:text>\end{sidewaysfigure}%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="." mode="pop-footnote-text"/>
 </xsl:template>
 
@@ -8533,6 +8541,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- 2: standard identifier for cross-references    -->
 <!-- 3: empty, or a hard-coded number from -common  -->
 <xsl:template match="table|list">
+    <xsl:if test="@landscape and $b-latex-print">
+      <xsl:text>\begin{sidewaystable}%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>
     <xsl:text>}{</xsl:text>
@@ -8564,6 +8575,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="." mode="environment-name"/>
     <xsl:text>}%&#xa;</xsl:text>
+    <xsl:if test="@landscape and $b-latex-print">
+        <xsl:text>\end{sidewaystable}%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="." mode="pop-footnote-text"/>
 </xsl:template>
 
@@ -8712,8 +8726,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:with-param>
         </xsl:call-template>
     </xsl:variable>
-    <xsl:text>\includegraphics[width=\linewidth]</xsl:text>
-    <xsl:text>{</xsl:text>
+    <xsl:text>\includegraphics[width=\linewidth</xsl:text>
+    <xsl:if test="@rotate">
+      <xsl:text>,angle=</xsl:text>
+      <xsl:value-of select="@rotate"/>
+      <xsl:text>,origin=c</xsl:text>
+    </xsl:if>
+    <xsl:text>]{</xsl:text>
     <xsl:choose>
         <xsl:when test="@pi:generated">
             <xsl:value-of select="$generated-directory"/>


### PR DESCRIPTION
This pull request which adds support for for rotating wide images and tables in latex output.   It uses the latex rotating package.

When a @landscape attribute is added to figures, tables, lists, or listings, the item and its caption/title will be rotated 90° and placed on its own page, but only if publication/latex/@print = 'yes'.   

A landscape figure containing a sidebyside will rotate properly, but because landscaped items move to their own page, putting a landscaped item inside a sidebyside will produce undesirable results.

The PR also includes the ability to rotate bare images by an arbitrary amount with a @rotate attribute,  but I think this feature is a novelty, and probably unnecessary.

The attached pdf demonstrates the results.

[main.pdf](https://github.com/PreTeXtBook/pretext/files/12033075/main.pdf)




