### PR TITLE
Allow multiple macros elements

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1512,7 +1512,9 @@ Book (with parts), "section" at level 3
     <xsl:variable name="latex-left-justified">
         <xsl:call-template name="sanitize-text">
             <xsl:with-param name="text">
-                <xsl:value-of select="$docinfo/macros" />
+                <xsl:for-each select="$docinfo/macros">
+                    <xsl:value-of select="." />
+                </xsl:for-each>
             </xsl:with-param>
         </xsl:call-template>
     </xsl:variable>


### PR DESCRIPTION
Allowing multiple `<macros>` lets the user specify alternative notation for different versions without having to duplicate the entire set of macros, by using `@component` on macro subsets.

The schema already allows _one-or-more_ `Configuration` elements as child of `<docinfo>` so I don't think any changes are needed there.

The string `docinfo/macros` also shows up in `xsl/pretext-beamer.xsl` --- not sure if that needs tweaking.

Tested against html, latex, and pdf outputs.