### PR TITLE
Add .logical to an auto-inserted div.para if it contains a block element

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5923,7 +5923,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </xsl:when>
                     <!-- No good test for unstructured? -->
                     <xsl:otherwise>
-                        <div class="para">
+                        <div>
+                            <xsl:attribute name="class">
+                                <xsl:text>para</xsl:text>
+                                <!-- Just like for explicitly added <p>'s, if we contain a block  -->
+                                <!-- element, an additional "logical" class should be added       -->
+                                <xsl:if test="ol|ul|dl|me|men|md|mdn|cd">
+                                    <xsl:text> logical</xsl:text>
+                                </xsl:if>
+                            </xsl:attribute>
                             <!-- Create a derived id, if original.  Somewhat  -->
                             <!-- contrived so it doesn't collide with another. -->
                             <xsl:if test="$b-original">


### PR DESCRIPTION
Currently when
```
<ul>
  <li>
    <p><ul><li>foo</li></ul></p>
  </li>
</ul>
```
is processed, the resulting `p` turns into a `div.para.logical`. However, 
```
<ul>
  <li>
    <ul><li>foo</li></ul>
  </li>
</ul>
```
gets an auto-inserted `p` which turns to a `div.para` even though it contains a block element. This PR makes the behavior of the auto-inserted `p` consistent.