### PR TITLE
Consistently use styled spaces in headings

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -858,11 +858,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <span class="type">
         <xsl:apply-templates select="." mode="type-name" />
     </span>
-    <xsl:text> </xsl:text>
+    <xsl:call-template name="space-styled"/>
     <span class="codenumber">
         <xsl:apply-templates select="." mode="number" />
     </span>
-    <xsl:text> </xsl:text>
+    <xsl:call-template name="space-styled"/>
     <span class="title">
         <xsl:apply-templates select="." mode="title-full" />
     </span>
@@ -883,7 +883,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <span class="type">
         <xsl:apply-templates select="." mode="type-name"/>
     </span>
-    <xsl:text> </xsl:text>
+    <xsl:call-template name="space-styled"/>
     <!-- be selective about displaying numbers at birth-->
     <xsl:variable name="is-numbered">
         <xsl:apply-templates select="." mode="is-specialized-own-number"/>
@@ -893,7 +893,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="number"/>
         </xsl:if>
     </span>
-    <xsl:text> </xsl:text>
+    <xsl:call-template name="space-styled"/>
     <span class="title">
         <xsl:apply-templates select="." mode="title-full" />
     </span>


### PR DESCRIPTION
At the moment, some headings look like
```html
<h1 class="heading">
      <span class="type">Theorem</span
      ><span class="space"> </span
      ><span class="codenumber">1</span
      ><span class="period">.</span
      ><span class="space"> </span
      ><span class="title">First Theorem.</span>
</h1>
```

and others like

```html
<h1 class="heading">
      <span class="type">Definition</span>
      <span class="codenumber">1</span
      ><span class="period">.</span>
      <span class="title">First Definition.</span>
</h1>
```

with the spaces unwrapped in a `<span>`. This PR ensures spaces in headings are always wrapped in a span.

@davidfarmer I assume this won't have strange CSS side effects?