### PR TITLE
Webwork extract refactor

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -144,9 +144,9 @@
             <xsl:apply-templates select="." mode="get-seed" />
         </xsl:attribute>
         <!-- 3. source (a problem's file path if it is server-based)               -->
-        <source>
+        <xsl:attribute name="source">
             <xsl:value-of select="@source" />
-        </source>
+        </xsl:attribute>
     </problem>
 </xsl:template>
 


### PR DESCRIPTION
This PR modifies `extract-pg.xsl` to output an XML file, which Python reads with lxml to obtain the data it requires to create webwork-representations.xml.

I am able to successfully build webwork-representations.xml for both the minimal and sample-chapter webwork examples using this script, and they are identical to the current result of the head of the master branch.