### PR TITLE
WeBWorK: recognize DropDown macro

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -1642,7 +1642,7 @@
 
                 <webwork>
                     <pg-code>
-                        $color1 = PopUp(["?","Red","Blue","Green"], 2);
+                        $color1 = DropDown(["Red","Blue","Green"], 1);
                         $color2 = RadioButtons(["Red","Blue","Green","None of these"], 1);
                         $color3 = CheckboxList(["Red","Blue","Green","None of these"], [1]);
                     </pg-code>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -954,10 +954,12 @@
             <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
         </xsl:apply-templates>
         <!-- popup menu multiple choice answers -->
-        <xsl:apply-templates select="." mode="parser">
-            <xsl:with-param name="parser" select="'PopUp'"/>
-            <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
-        </xsl:apply-templates>
+        <xsl:if test="contains(.//pg-code,'PopUp') or contains(.//pg-code,'DropDown')">
+            <xsl:call-template name="macro-padding">
+                <xsl:with-param name="string" select="'parserPopUp.pl'"/>
+                <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
+            </xsl:call-template>
+        </xsl:if>
         <!-- checkboxes multiple choice answers -->
         <xsl:apply-templates select="." mode="parser">
             <xsl:with-param name="parser" select="'CheckboxList'"/>


### PR DESCRIPTION
WeBWorK has a new macro `DropDown` for making a "select" style multiple choice. It's just a better version of `PopUp`. The new `DropDown` has an automatic placeholder. This commit lets PTX recognize the macro and automatically load its library file.