### PR TITLE
Add a database attr for sql activecode

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -3197,6 +3197,8 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
 
             <p>Note also that a data file may be provided independently for consumption by an ActiveCode program.  See <xref ref="topic-datafile"/>.</p>
 
+            <p>ActiveCode elements that are language <c>sql</c> can make use of an SQLite database file. This is different than a <c>datafile</c> (which is expected to be text or an image). To include a database file, use the <attr>database</attr> on the <tag>program</tag> element and specify the file to load as a string relative to the <attr>@external</attr> top-level directory</p>
+
             <p>If you want to include code from one or more preceding <tag>program</tag> elements, use the <attr>include</attr> attribute whose value is a list (comma-separated or space-separated) of <attr>xml:id</attr>s for the code you want included.</p>
         </subsection>
 

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1906,6 +1906,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:attribute name="data-wasm">
                                     <xsl:text>/_static</xsl:text>
                                 </xsl:attribute>
+                                <!-- A SQL database can be provided for automated  -->
+                                <!-- testing of correct answers via unit tests.    -->
+                                <!-- This is a location in the external directory. -->
+                                <xsl:if test="@database">
+                                    <xsl:attribute name="data-dburl">
+                                        <xsl:choose>
+                                            <xsl:when test="$b-managed-directories">
+                                                <xsl:value-of select="$external-directory"/>
+                                                <xsl:value-of select="@database"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:value-of select="@database"/>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:attribute>
+                                </xsl:if>
                             </xsl:if>
                             <!-- the code itself as text -->
                             <xsl:call-template name="sanitize-text">


### PR DESCRIPTION
It looks like an option to specify something that turns into the data-dburl attribute needed in HTML output didn't make it into activecode. There is an option to do so in hparsons. This copies the code from there to allow activecode elements of language SQL to specify a database file.

Also adds some minimal documentation to the guide.