### PR TITLE
Image description

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -114,7 +114,24 @@
 
         <p>If you wish to construct technical diagrams, with editable source, and perhaps including the use of <latex/> macros, <pretext/> provides support for authoring with graphics languages such as Asymptote, TikZ, PGF, PSTricks, and xy-pic in addition to using Sage code to describe a plot or image.  In most cases output can be obtained as smoothly-scalable <init>SVG</init> images, in addition to other formats like <init>PDF</init> or <init>PNG</init>.  Making all this happen is one of the more technical aspects of <pretext/>, so read the details in <xref ref="topic-images"/> along with frequent references there to the <c>pretext</c> script described in <xref ref="pretext-script"/>.</p>
 
-        <p>For accessibility, every <tag>image</tag> should either have a <tag>description</tag> child, or it should explicitly declare itself to be a decorative image setting <attr>decorative</attr> to the value <c>yes</c>. A description should minimally describe the important information in the image that is not already present in the surrounding text. Some screen readers may cut off reading a full descritption after the first 125 characters. For a complex technical diagram or an image from which the reader is expected to extract important information on their own, it can be challenging to write a description with the 125-character limit. It may be advisable to seek advice from an expert.</p>
+        <p>
+            For accessibility, every <tag>image</tag> should either have a description or it should
+            explicitly declare itself to be a decorative image setting <attr>decorative</attr> to
+            the value <c>yes</c>. Descriptions are of two types. A <tag>short-description</tag>
+            should minimally describe the important information in the image that is not already
+            present in the surrounding text. It should have no element children except possibly
+            <tag>var</tag> children. This content will be used as the <attr>alt</attr> attribute
+            for the HTML <tag>img</tag>. Some screen readers may cut off reading this content after
+            the first 100<ndash/>140 characters, therefore you should keep this element short.
+            A <tag>description</tag> element should be structured with <tag>p</tag> and
+            <tag>tabular</tag> children and has no technical limit on length. It may describe the
+            image more completely. The content of the <tag>description</tag> should describe the
+            image, but should not be necessary for a sighted reader to take in the important
+            features of the image. (If there are features of the image that need to be explained to
+            all readers, this should happen in the main body of the text.) An <tag>image</tag> may
+            have one or both types of description, but it is incorrect to have neither unless
+            <attr>decorative</attr> is set to value <c>yes</c>.
+        </p>
     </section>
 
     <section xml:id="overview-lists">

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2278,17 +2278,32 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
             <p>To use these images, you simply provide the complete filename, with a relative path.  A subdirectory such as <c>images</c> is a good choice for a place to put them.  It is your responsibility to place these images where the <latex /> output will find them or where the HTML output will find them.  Your <pretext/> source would look like:</p>
 
             <pre>
-            <![CDATA[<image source="images/crocodiles.png" width="50%" />]]>
+            <![CDATA[<image source="images/crocodiles.png" width="50%"/>]]>
             </pre>
 
             <p>Typically you would wrap this in a <tag>figure</tag> that might have an <attr>xml:id</attr> attribute for cross-references, with or without a caption.  There is no <attr>height</attr> attribute, so the aspect ratio of your image is your responsibility outside of <pretext />.  The <attr>width</attr> attribute is a percentage of the available width of the text (outside of a <tag>sidebyside</tag> panel).</p>
 
-            <p>You may also provide a <tag>description</tag> which will aid accessibility for electronic formats.  Keep such readers in mind and provide as much description as possible.  Keep the markup simple, since this will typically migrate to an HTML attribute that cannot contain any structure.  Be careful to avoid double-quotes.  For example:</p>
+            <p>
+                You should also provide a <tag>description</tag> and/or <tag>short-description</tag>
+                as a child of the <tag>image</tag>, or else explicitly declare the image to be
+                decorative with an attribute <attr>decorative</attr> set to <c>yes</c>.
+                A <tag>short-description</tag> should be text-only (but perhaps with <tag>var</tag>
+                children) and be less than 100<ndash/>140 characters long. A <tag>description</tag>
+                should be structured with <tag>p</tag> and <tag>tabular</tag> elements. For example:
+            </p>
 
             <pre>
             <![CDATA[
             <image source="images/crocodiles.jpeg" width="50%">
-                <description>Five crocodiles partially submerged.</description>
+                <short-description>Five crocodiles partially submerged.</short-description>
+                <description>
+                    <p>
+                        Five crocodiles are in a pond. Three of them have their eyes above
+                        the water line, looking in the direction of the camera. The other
+                        two are in the background and only their tails are visible above
+                        the water line.
+                    </p>
+                </description>
             </image>
             ]]>
             </pre>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1936,7 +1936,8 @@
                     attribute archive {text}?,
                     attribute source {text},
                     attribute decorative {"yes" | "no"}?,
-                    element description {TextShort}?
+                    element description {(Paragraph | Tabular)+}?,
+                    element short-description {text}?
                 }
             ImageCode =
                 element image {
@@ -1946,7 +1947,8 @@
                     attribute margins {text}?,
                     attribute archive {text}?,
                     attribute decorative {"yes" | "no"}?,
-                    element description {(TextShort | WWVariable)*}?,
+                    element description {(Paragraph | Tabular)+}?,
+                    element short-description {(text | WWVariable)+}?
                     (
                         element latex-image {text} |
                         element asymptote {text} |
@@ -1962,7 +1964,8 @@
                     attribute pg-name {text}?,
                     attribute width {text}?,
                     attribute decorative {"yes" | "no"}?,
-                    element description {(TextShort | WWVariable)*}?,
+                    element description {(Paragraph | Tabular)+}?,
+                    element short-description {(text | WWVariable)+}?
                     element latex-image {
                         text
                     }?


### PR DESCRIPTION
Replacement for #1754.

Not to be considered for a merge at this time. Looking for feedback on these changes to doc and schema.

Next steps:

- pre-processor to convert current `description` to new `description` or to `short-description` depending on its content.
- HTML processing of these new flavors of image description. Too include accessibility testing by local experts.
- EPUB processing of these new flavors of image description.
- LaTeX processing of these new flavors of image description.
