### PR TITLE
Use localization on toc help text

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11815,7 +11815,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="*" mode="primary-navigation-toc">
-    <button class="toc-toggle button" aria-label="Show or hide table of contents">
+    <button class="toc-toggle button">
+        <xsl:attribute name="title">
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'toc'"/>
+            </xsl:apply-templates>
+        </xsl:attribute>
         <xsl:call-template name="insert-symbol">
             <xsl:with-param name="name" select="'menu'"/>
         </xsl:call-template>


### PR DESCRIPTION
Bug fix - TOC button help text was not localized. This does that and moves help text to "title" from "aria-label" so it also works as a tooltip for icon only views of TOC