### PR TITLE
Schema: Allow additional modular files

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -70,7 +70,7 @@
         <fragment xml:id="start-elements">
             <title>Start elements</title>
             <code>
-            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary
+            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary
             </code>
         </fragment>
     </section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -70,7 +70,7 @@
         <fragment xml:id="start-elements">
             <title>Start elements</title>
             <code>
-            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary
+            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Worksheet | Figure | Webwork
             </code>
         </fragment>
     </section>


### PR DESCRIPTION
This PR contains two commits.  The first allows `<backmatter>` to be in its own `<xi:include>`-ed file.  The second allows figures, worksheets, and webwork elements to do the same.  It's not as clear that the second group should be isolated to their own files (although the `pretext new demo` template has them.  In any event, I don't think this hurts since it is still required that these elements are included in the right spot based on the rest of the schema.