### PR TITLE
Guide: Update CLI documentation for v2.0

### DIFF
--- a/doc/guide/appendices/cli-v1vsv2.xml
+++ b/doc/guide/appendices/cli-v1vsv2.xml
@@ -30,7 +30,6 @@
     <program language="xml">
       <input>
       <![CDATA[
-
       <?xml version="1.0" encoding="utf-8"?>
       <project>
         <targets>
@@ -70,10 +69,8 @@
           <liblouis>file2brl</liblouis>
         </executables>
       </project>
-
       ]]>
     </input>
-
     </program>
     </listing>
 
@@ -82,7 +79,6 @@
     <program language="xml">
       <input>
       <![CDATA[
-
       <?xml version="1.0" encoding="utf-8"?>
       <project ptx-version="2">
         <targets>
@@ -112,7 +108,6 @@
           </target>
         </targets>
       </project>
-
       ]]>
     </input>
     </program>
@@ -127,7 +122,6 @@
     <program language="xml">
       <input>
       <![CDATA[
-
       <?xml version="1.0" encoding="utf-8"?>
       <project ptx-version="2" publication="publication">
         <targets>
@@ -149,7 +143,6 @@
           </target>
         </targets>
       </project>
-
       ]]>
     </input>
     </program>
@@ -201,7 +194,7 @@
           <p>
             In version 1, you could generate webwork sets using the "webwork-sets" format.  In version 2, this is replaced by setting the <attr>format</attr> attribute to <q>webwork</q> in the <tag>target</tag> element.  Such a target can be compressed using the <attr>compression</attr> attribute.
           </p>
-          
+
         </li>
         <li>
           <title>Local asymptote</title>

--- a/doc/guide/appendices/cli-v1vsv2.xml
+++ b/doc/guide/appendices/cli-v1vsv2.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--      PreTeXt Author's Guide                              -->
+<!--                                                          -->
+<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<appendix xml:id="cli-v1vsv2">
+  <title>CLI versions 1 vs 2</title>
+  <author>Oscar Levin</author>
+
+
+    <p>
+      This appendix describes the differences between the PreTeXt-CLI version 1.x and 2.x.  
+      Generally, projects started in version 1 of the CLI will continue to work in version 2.  
+    </p>
+
+    <p>
+      The primary difference between the versions of the CLI is the format of the project manifest (<c>project.ptx</c>): in version 1, most properties were described as <init>XML</init> elements, where they are now given as attributes.  The functions of each attribute for the version 2 manifest is described in <xref ref="cli-project-manifest"/>.  Here we illustrate how these relate to the <em>legacy</em> elements.
+    </p>
+
+    <p>
+      In <xref ref="listing-v1-manifest"/> we show a project manifest containing almost all options available.  Then <xref ref="listing-v2-manifest"/> shows the same project manifest in version 2 format. 
+    </p>
+
+    <listing xml:id="listing-v1-manifest">
+      <caption>Example of version 1 project manifest</caption>
+    <program language="xml">
+      <input>
+      <![CDATA[
+
+      <?xml version="1.0" encoding="utf-8"?>
+      <project>
+        <targets>
+          <target name="web">
+            <format>html</format>
+            <source>source/main.ptx</source>
+            <publication>publication/publication.ptx</publication>
+            <output-dir>output/web</output-dir>
+          </target>
+          <target name="print" pdf-method="xelatex">
+            <format>pdf</format>
+            <source>source/main.ptx</source>
+            <publication>publication/publication.ptx</publication>
+            <output-dir>output/print</output-dir>
+            <output-filename>mybook.pdf</output-filename>
+          </target>
+          <target name="runestone">
+            <format>html</format>
+            <source>source/main.ptx</source>
+            <publication>publication/rs-publication.ptx</publication>
+            <output-dir>published/mydoc-id</output-dir>
+            <stringparam key="author.tools" value="yes"/>
+            <stringparam key="html.css.extra" value="external/custom-styles.css" />
+            <xsl>xsl/runestone.xsl</xsl>
+          </target>
+        </targets>
+        <executables>
+          <latex>latex</latex>
+          <pdflatex>pdflatex</pdflatex>
+          <xelatex>xelatex</xelatex>
+          <pdfsvg>pdf2svg</pdfsvg>
+          <asy>asy</asy>
+          <sage>sage</sage>
+          <pdfpng>convert</pdfpng>
+          <pdfeps>pdftops</pdfeps>
+          <node>node</node>
+          <liblouis>file2brl</liblouis>
+        </executables>
+      </project>
+
+      ]]>
+    </input>
+
+    </program>
+    </listing>
+
+    <listing xml:id="listing-v2-manifest">
+      <caption>Example of version 2 project manifest</caption>
+    <program language="xml">
+      <input>
+      <![CDATA[
+
+      <?xml version="1.0" encoding="utf-8"?>
+      <project ptx-version="2">
+        <targets>
+          <target 
+            name="web"
+            format="html"
+            source="source/main.ptx"
+            publication="publication/publication.ptx"
+            output-dir="output/web" />
+          <target 
+            name="print"
+            format="pdf"
+            pdf-method="xelatex"
+            source="source/main.ptx"
+            publication="publication/publication.ptx"
+            output-dir="output/print" 
+            output-filename="mybook.pdf" />
+          <target 
+            name="runestone"
+            format="html"
+            platform="runestone"
+            source="source/main.ptx"
+            publication="publication/rs-publication.ptx"
+            output-dir="published/mydoc-id"
+            xsl="xsl/runestone.xsl">
+            <stringparams author.tools="yes" html.css.extra="external/custom-styles.css" />
+          </target>
+        </targets>
+      </project>
+
+      ]]>
+    </input>
+    </program>
+    </listing>
+
+    <p>
+      One advantage of version 2 of the CLI is that many of the options are now optional, or can be applied at the project level to all targets.  The example shown above can be further simplified, as shown in <xref ref="listing-v2-manifest-simple"/>, since most values are the defaults anyway.
+    </p>
+
+    <listing xml:id="listing-v2-manifest-simple">
+      <caption>Simplified project manifest in version 2 format</caption>
+    <program language="xml">
+      <input>
+      <![CDATA[
+
+      <?xml version="1.0" encoding="utf-8"?>
+      <project ptx-version="2" publication="publication">
+        <targets>
+          <target 
+            name="web"
+            format="html" />
+          <target 
+            name="print"
+            format="pdf"
+            output-filename="mybook.pdf" />
+          <target 
+            name="runestone"
+            format="html"
+            platform="runestone"
+            publication="rs-publication.ptx"
+            output-dir="published/mydoc-id"
+            xsl="xsl/runestone.xsl">
+            <stringparams author.tools="yes" html.css.extra="external/custom-styles.css" />
+          </target>
+        </targets>
+      </project>
+
+      ]]>
+    </input>
+    </program>
+    </listing>
+
+    <p>
+      Attributes for the <tag>project</tag> element that describe paths are common roots for any paths specified in <tag>target</tag> elements.  
+    </p>
+
+    <p>
+      Notice that there is no longer a place to specify your <em>executables</em> in the manifest.  This is because your executables are generally specific to a particular system, not a project.  So instead, you specify executables in the file <c>executables.ptx</c> which is ignored by git.  As with the version 2 manifest, the name or path to the executables are given as values of attributes.  An example is shown in <xref ref="listing-v2-executables"/>.
+    </p>
+
+
+
+    <p>
+      The project manifest can be further simplified by setting attributes for the <tag>project</tag> element.  See <xref ref="cli-project-manifest"/> for details.
+    </p>
+
+    <p>
+      Hopefully the examples above make it clear how the two versions compare for basic options.  Below we list a few more differences between how you specify options in the version 1 and version 2 manifests.
+      <dl>
+        <li>
+          <title><attr>ptx-version</attr></title>
+          <p>
+            For the CLI to know you are using a version 2 manifest, you <em>must</em> include the <attr>ptx-version</attr> attribute in the <tag>project</tag> element, with value <q>2</q>.
+          </p>
+        </li>
+        <li>
+          <title>string parameters</title>
+          <p>
+            In version 1, you would specify string parameters as a sequence of <tag>stringparam</tag> elements, each with <attr>key</attr> and <attr>value</attr> attributes.  In version 2, you use a single <tag>stringparams</tag> element with attributes for each key set to the value for the string parameter's value.  See the example in <xref ref="listing-v2-manifest"/>
+          </p>
+        </li>
+        <li>
+          <title>zipped output</title>
+          <p>
+            In version 1, you could get a zipped version of your html output by setting the format of the target to <c>html-zipped</c>.  In version 2, this is replaced by setting the <attr>compression</attr> attribute to <q>zip</q> in the <tag>target</tag> element.
+          </p>
+        </li>
+        <li>
+          <title>Braille options</title>
+          <p>
+            In version 2, you specify what embossing method you use for Braille formatted targets using the <attr>braille-mode</attr> attribute, with value either <q>emboss</q> or <q>electronic</q>.
+          </p>
+        </li>
+        <li>
+          <title>WeBWorK Sets</title>
+          <p>
+            In version 1, you could generate webwork sets using the "webwork-sets" format.  In version 2, this is replaced by setting the <attr>format</attr> attribute to <q>webwork</q> in the <tag>target</tag> element.  Such a target can be compressed using the <attr>compression</attr> attribute.
+          </p>
+          
+        </li>
+        <li>
+          <title>Local asymptote</title>
+          <p>
+            In version 2, you can require that asymptote elements are generated using a local version of asymptote (instead of the server).  You can specify this by setting the <attr>asy-method</attr> attribute to <q>local</q>, in either the <tag>target</tag> element, or as an attribute of <tag>project</tag> to use this method for all targets.
+          </p>
+        </li>
+      </dl>
+    </p>
+
+</appendix>

--- a/doc/guide/appendices/windows-cli.xml
+++ b/doc/guide/appendices/windows-cli.xml
@@ -369,7 +369,7 @@
       </p>
 
       <p>
-        To install the CLI, simply type <c>pip install pretextbook</c>.
+        To install the CLI, simply type <c>pip install pretext</c>.
       </p>
 
       <p>

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -280,7 +280,6 @@
                 Assuming you ran this command in a terminal, the easiest way to continue working is to open a new terminal tab to run <c>pretext build</c> again; the local server will continue in the original terminal until you stop it with <kbd>CTRL</kbd>+<kbd>C</kbd>.
             </p>
 
-            
             <warning>
                 <p>
                     When using <c>pretext view</c>, your project is only viewable on your local machine (even if you are working in a Codespace or on CoCalc).  To make the output available to the public, you will need to copy the output to a web server, or use the <c>pretext deploy</c> command, described below.
@@ -316,7 +315,7 @@
             <insight>
 
                 <p>
-                    You can deploy multiple targets, starting with the 2.0 release of the CLI.  To do this, you will need to specify a <attr>deploy-dir</attr> attribute in your project manifest for each target you want to deploy.  Additionally, you should create a folder in the root of your project called <c>site</c> and create a landing page for your project.  The <c>site</c> folder and the output folders for each specified project will all be copied to <c>output/stage</c>.  We recommend using the flag <c>--stage-only</c> so you can preview you complete site before deploying it.  
+                    You can deploy multiple targets, starting with the 2.0 release of the CLI.  To do this, you will need to specify a <attr>deploy-dir</attr> attribute in your project manifest for each target you want to deploy.  Additionally, you should create a folder in the root of your project called <c>site</c> and create a landing page for your project.  The <c>site</c> folder and the output folders for each specified project will all be copied to <c>output/stage</c>.  We recommend using the flag <c>--stage-only</c> so you can preview you complete site before deploying it.
                 </p>
             </insight>
         </subsection>
@@ -346,11 +345,9 @@
                         </p>
                     </li>
                     <li>
-                        
                         <p>
                             To be even more precise, if the element you wish to generate has an <attr>xml:id</attr>, you can generate just that element using the <c>-x</c> flag.  For example, if your <tag>latex-image</tag> has id <q>img-circle</q>, generate it with <c>pretext generate -x img-circle</c>
                         </p>
-            
                     </li>
                     <li>
                         <p>
@@ -383,8 +380,7 @@
                 <caption>Example of a very simple project manifest.</caption>
             <program language="xml">
                 <input>
-                <![CDATA[ 
-
+                <![CDATA[
                 <?xml version="1.0" encoding="utf-8"?>
                 <project ptx-version="2">
                 <targets>
@@ -393,7 +389,6 @@
                     <target name="print" format="pdf" />
                 </targets>
                 </project>
-
                 ]]>
                 </input>
             </program>
@@ -410,11 +405,11 @@
 
             <p>
                 <idx><h>CLI</h><h>format</h></idx>
-                The second required attribute of <tag>target</tag> is <attr>format</attr>, which must be one of html, pdf, latex, custom, epub, kindle, or braille (although the last three of these are still experimental, as of 9/1/2023).  
+                The second required attribute of <tag>target</tag> is <attr>format</attr>, which must be one of html, pdf, latex, custom, epub, kindle, or braille (although the last three of these are still experimental, as of 9/1/2023).
             </p>
 
             <p>
-                With just these attributes, as with he manifest in <xref ref="cli-project-manifest-example"/>, the CLI assumes your project uses default values throughout.  In particular, 
+                With just these attributes, as with he manifest in <xref ref="cli-project-manifest-example"/>, the CLI assumes your project uses default values throughout.  In particular,
                 <ul>
                     <li><p>The source is <c>source/main.ptx</c>.</p></li>
                     <li><p>The publication if is <c>publication/publication.ptx</c>.</p></li>
@@ -461,7 +456,6 @@
                     <row>
                         <cell><attr>asy-method</attr></cell><cell><p>Optional, default: "server".  Valid values: "server" or "local". Used to specify whether asymptote images should be generated using the "server" asymptote version or a "local" asymptote install.</p></cell>
                     </row>
-                    
                 </tabular>
             </table>
 
@@ -510,13 +504,13 @@
                     </row>
                     <row>
                         <cell><attr>asy-method</attr></cell><cell><p>Optional, default: "server".  Valid values: "server" or "local". Overrides the <attr>asy-method</attr> attribute on <tag>project</tag>.</p></cell>
-                    </row>                    
+                    </row>
                 </tabular>
             </table>
-            
+
             <example xml:id="example-manifest">
                 <title>Example Project Manifest</title>
-                
+
                 <p>
                     To illustrate how the relative paths work, with attributes on both <tag>project</tag> and <tag>targets</tag> elements, consider the following manifest:
                 </p>
@@ -526,14 +520,14 @@
                 <?xml version="1.0" encoding="utf-8"?>
                 <project ptx-version="2" source="src" output-dir="out">
                     <targets>
-                        <target 
-                            name="web" 
-                            format="html" 
+                        <target
+                            name="web"
+                            format="html"
                             output-dir="web" />
-                        <target 
-                            name="print" 
-                            format="pdf" 
-                            source="main-print.ptx" 
+                        <target
+                            name="print"
+                            format="pdf"
+                            source="main-print.ptx"
                             publication="pub/publication.ptx"/>
                     </targets>
                 </project>
@@ -541,7 +535,7 @@
                 </input>
             </program>
                 <p>
-                    Here, the web target, with format html, will build from the root <pretext/> file "src/main.ptx", using the publication file "publication/publication.ptx", and will place the output in the folder "out/web".  
+                    Here, the web target, with format html, will build from the root <pretext/> file "src/main.ptx", using the publication file "publication/publication.ptx", and will place the output in the folder "out/web".
                 </p>
                 <p>
                     The print target, with format pdf, will build from the file "src/main-print.ptx", using the publication file "publication/pub/publication.ptx", and will place the output in the folder "out/print".

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -49,6 +49,7 @@
 
     <section xml:id="processing-CLI">
         <title>The <pretext />-CLI</title>
+        <author>Oscar Levin</author>
         <idx><h>CLI</h></idx>
         <introduction>
         <p>
@@ -115,7 +116,7 @@
             </p>
 
             <p>
-                To verify that the CLI is installed, type <c>pretext --version</c> (or <c>python -m pretext --version</c>) and you should get back a number (1.4.2, for example).
+                To verify that the CLI is installed, type <c>pretext --version</c> (or <c>python -m pretext --version</c>) and you should get back a number (1.7.5, for example).
             </p>
 
             <p>
@@ -143,17 +144,17 @@
             </console>
 
             <p>
-                If you ever want to downgrade to previous version, you can do that with <c>pip</c> as well.  For example, to install version 1.1.0:
+                If you ever want to downgrade to previous version, you can do that with <c>pip</c> as well.  For example, to install version 1.7.5:
             </p>
 
             <console>
-                <input>pip install pretext=="1.1.0"</input>
+                <input>pip install pretext=="1.7.5"</input>
             </console>
-            <note>
+            <warning>
                 <p>
                     If you installed the <pretext />-CLI before version 1.0, you need to manually uninstall the package <c>pretextbook</c> (which is what the CLI was called during early development).  Run <c>pip uninstall pretextbook</c> and then <c>pip install pretext</c> te get caught up.
                 </p>
-            </note>
+            </warning>
             </paragraphs>
         </subsection>
 
@@ -171,7 +172,7 @@
             </console>
 
             <p>
-                This creates a new book in the folder <q>new-pretext-project</q> (which you can safely rename).  For a new article, use <c>pretext new article</c>.
+                This creates a new book in the folder <q>new-pretext-project</q> (which you can safely rename).  For a new article, use <c>pretext new article</c>.  You might also try <c>pretext new demo</c> to get a project that shows off more features available.
             </p>
 
             <p>
@@ -184,15 +185,15 @@
                         </p>
                     </li>
                     <li>
-                        <title>generate-assets</title>
+                        <title>generated-assets</title>
                         <p>
-                            A folder that will hold assets (such as images) generated from source, using the <c>pretext generate</c> command.  You should not manually edit any contents of this folder.
+                            A folder that will hold assets (such as images) generated from source, using the <c>pretext build</c> or <c>pretext generate</c> commands.  You should not manually edit any contents of this folder.
                         </p>
                     </li>
                     <li>
                         <title>publication</title>
                         <p>
-                            A folder to hold your publication files.  One publication file is included, but you can have as many as you want.  See <xref ref="publication-file-reference"/>.
+                            A folder to hold your <q>publication</q> files used to customize how your output looks.  One publication file is included, but you can have as many as you want.  See <xref ref="publication-file-reference"/>.
                         </p>
                     </li>
                     <li>
@@ -268,90 +269,25 @@
             </console>
 
             <p>
-                This will direct you to open a local server at a provided address (perhaps <url href="http://localhost:8000" visual="http://localhost:8000"/>).  Replace <q>web</q> in the above with other build targets as appropriate.
+                This will direct you to open a file running in a local server (that the CLI started for you) at a provided address (perhaps <url href="http://localhost:8128/output/web" visual="http://localhost:8128/output/web"/>).  Once you have run <c>pretext view</c> once, you can navigate to other output targets by navigating to a different url (maybe <url href="http://localhost:8128/output/print" visual="http://localhost:8128/output/print"/>) or just rerun the <c>pretext view</c> command with a different target name.
             </p>
 
             <p>
-                If you are on your own machine (i.e., not CoCalc), <c>pretext view</c> will attempt to open your default program for the type of file you are opening.  You can prevent this attempt using the <c>--no-launch</c> flag.
+                Running <c>pretext view</c> will attempt to open your default program for the type of file you are opening.  You can prevent this attempt using the <c>--no-launch</c> flag.
             </p>
 
             <p>
-                The <c>pretext view</c> command accepts a useful option for small projects that allow you to automatically rebuild your source every time you save it.  Try:
+                Assuming you ran this command in a terminal, the easiest way to continue working is to open a new terminal tab to run <c>pretext build</c> again; the local server will continue in the original terminal until you stop it with <kbd>CTRL</kbd>+<kbd>C</kbd>.
             </p>
 
-            <console>
-                <input>pretext view web --watch</input>
-            </console>
-
-            <p>
-               (You can use <c>-w</c> as a shorthand for <c>--watch</c>.) This currently only supports HTML-format targets.
-            </p>
-
-            <p>
-                When you are done, stop the server by hitting <c>CTRL+C</c>
-            </p>
-
-            <insight>
+            
+            <warning>
                 <p>
-                    In addition to the <em>watch</em> option <c>-w</c>, you can use the flags <c>-b</c> to build before viewing, <c>-g</c> to generate assets before viewing, or combine these with <c>-bg</c>.
+                    When using <c>pretext view</c>, your project is only viewable on your local machine (even if you are working in a Codespace or on CoCalc).  To make the output available to the public, you will need to copy the output to a web server, or use the <c>pretext deploy</c> command, described below.
                 </p>
-            </insight>
-
-            <p>
-                Note that the project is only viewable on your local machine (even if you are working in CoCalc).  To make the output available to the public, you will need to copy the output to a web server, or use the <c>pretext deploy</c> command, described below.
-            </p>
+            </warning>
         </subsection>
-        <subsection>
-            <title>Generating assets: <c>pretext generate</c></title>
-            <idx><h><c>generate</c></h></idx>
-            <idx><h><c>pretext generate</c></h></idx>
-            <idx><h>CLI</h><h><c>generate</c></h></idx>
-            <p>
-                Some <pretext /> elements require special processing: <webwork/> exercises, <tag>latex-image</tag>, <tag>sageplot</tag>, and <tag>asymptote</tag> images, as well as previews for embedded youtube videos or interactive elements.  We call these elements <q>assets</q> or <q>generated assets</q>.  To generate the assets, run the following command.
-            </p>
 
-            <console>
-                <input>pretext generate</input>
-            </console>
-
-            <insight>
-                <p>
-                    You can also generate assets and build at the same time, using <c>pretext build -g web</c> which will generate all assets for the target named <q>web</q>.
-                </p>
-            </insight>
-
-            <p>
-                This will generate all assets in the default formats for the first target in the project manifest.  If you need formats for another target, you can specify the target name with the <c>-t</c> flag, as in, for the target named <q>print</q>,
-            </p>
-
-            <console>
-                <input>pretext generate -t print</input>
-            </console>
-
-            <p>
-                Generating assets can be time consuming, so likely you will not want to repeat this step unless you have edited one of the elements of a particular asset type.  To further speed up the process, you can limit which sorts of assets you generate.  For example, if you edit a few <tag>latex-image</tag> elements, you can just generate these (for the first target in the manifest) with,
-            </p>
-
-            <console>
-                <input>pretext generate latex-image</input>
-            </console>
-
-            <p>
-                Valid choices for what types of assets you can generate in this specific way are: <c>webwork</c>, <c>latex-image</c>, <c>sageplot</c>, <c>asymptote</c>, <c>interactive</c>, <c>youtube</c>, <c>codelense</c>, and <c>datafile</c>.
-            </p>
-
-            <p>
-                To be even more precise, if the element you wish to generate has an <attr>xml:id</attr>, you can generate just that element using the <c>-x</c> flag.  For example, if your <tag>latex-image</tag> has id <q>img-circle</q>, generate it with,
-            </p>
-
-            <console>
-                <input>pretext generate -x img-circle</input>
-            </console>
-
-            <p>
-                Finally, there might be times you would like to get all output formats for the assets you are generating.  You can accomplish this using the <c>--all-formats</c> flag.
-            </p>
-        </subsection>
 
         <subsection>
             <title>Hosting your project: <c>pretext deploy</c></title>
@@ -372,11 +308,56 @@
             </console>
 
             <p>
-                This copies the contents of the html output folder into <c>docs</c>, commits the changes, and pushes them to GitHub.  All you need to do then is ensure that you enable the pages feature in your GitHub repository (<c>Settings</c>, then <c>Pages</c>, then set to deploy from a branch: gh-pages).
+                If you watch the terminal, you will either get directions for how to set up your repository, or will simply be told what the live website for your project is.
+            </p>
+            <p>
+                Behind the scenes, this command copies the contents of the output folders you want to deploy to a folder <c>output/stage</c>, and then moves the entire contents of that folder to the <c>gh-pages</c> branch of your github repository.  If you have not already created a <c>gh-pages</c> branch, the CLI will create one for you.  If you have not already set up your repository to track your source files, the CLI will walk you through the steps you need to get set up.
+            </p>
+            <insight>
+
+                <p>
+                    You can deploy multiple targets, starting with the 2.0 release of the CLI.  To do this, you will need to specify a <attr>deploy-dir</attr> attribute in your project manifest for each target you want to deploy.  Additionally, you should create a folder in the root of your project called <c>site</c> and create a landing page for your project.  The <c>site</c> folder and the output folders for each specified project will all be copied to <c>output/stage</c>.  We recommend using the flag <c>--stage-only</c> so you can preview you complete site before deploying it.  
+                </p>
+            </insight>
+        </subsection>
+
+        <subsection>
+            <title>Generating assets: <c>pretext generate</c></title>
+            <idx><h><c>generate</c></h></idx>
+            <idx><h><c>pretext generate</c></h></idx>
+            <idx><h>CLI</h><h><c>generate</c></h></idx>
+            <p>
+                Some <pretext /> elements require special processing: <webwork/> exercises, <tag>latex-image</tag>, <tag>sageplot</tag>, and <tag>asymptote</tag> images, as well as previews for embedded youtube videos or interactive elements.  We call these elements <q>assets</q> or <q>generated assets</q>.  \
             </p>
 
             <p>
-                If your project is not already tracked on GitHub, the CLI will walk you through the steps you need to get set up.
+                Prior to version 1.7 of the CLI, you would need to run <c>pretext generate -t [target]</c> (where <q>[target]</q> is the name of a target, like <q>web</q>) in order to generate assets.  Since then, you can still do this, but it is usually not necessary: whenever you build a target, the CLI will automatically generate any assets that are out of date.  If you want to force the generation of assets, you can use the <c>-g</c> flag when building (e.g., <c>pretext build web -g</c>).  If you really don't want to automatically regenerate assets, you can use the <c>--no-generate</c> flag when building (e.g., <c>pretext build web --no-generate</c>).
+            </p>
+
+            <p>
+                If you are using an older version of the CLI, or if you want to generate assets without building, the following instructions can help you limit what you generate.
+                <ul>
+                    <li>
+                        <p>
+                            You can limit which sorts of assets you generate.  For example, if you edit a few <tag>latex-image</tag> elements, you can just generate these (for the first target in the manifest) with <c>pretext generate latex-image</c>.
+                        </p>
+                        <p>
+                            Valid choices for what types of assets you can generate in this specific way are: <c>webwork</c>, <c>latex-image</c>, <c>sageplot</c>, <c>asymptote</c>, <c>interactive</c>, <c>youtube</c>, <c>codelense</c>, and <c>datafile</c>.
+                        </p>
+                    </li>
+                    <li>
+                        
+                        <p>
+                            To be even more precise, if the element you wish to generate has an <attr>xml:id</attr>, you can generate just that element using the <c>-x</c> flag.  For example, if your <tag>latex-image</tag> has id <q>img-circle</q>, generate it with <c>pretext generate -x img-circle</c>
+                        </p>
+            
+                    </li>
+                    <li>
+                        <p>
+                            Finally, there might be times you would like to get all output formats for the assets you are generating.  You can accomplish this using the <c>--all-formats</c> flag on <c>pretext generate</c>
+                        </p>
+                    </li>
+                </ul>
             </p>
         </subsection>
 
@@ -387,118 +368,238 @@
             <idx><h>CLI</h><h>project manifest</h></idx>
             <idx><h><c>project.ptx</c></h></idx>
             <p>
-                The project manifest, always named <q>project.ptx</q>, contains information about each <term>target</term> you will build, as well as the names of <term>executables</term> of external tools that might be needed for building targets and generating assets.
+                The project manifest, always named <q>project.ptx</q>, contains information about each <term>target</term> you will build.  Prior to version 2.0 of the CLI, it also contained the names of <term>executables</term> of external tools that might be needed for building targets and generating assets.  (In 2.0 and later, if you need to change the default names or paths to executables, you will use a separate <c>executables.ptx</c> file.)
             </p>
 
             <p>
-                The CLI looks for this file, so you should have only one.  If you have a project that was not created using <c>pretext new</c>, you can get a copy of the file by running <c>pretext init</c>.  You can also get the most recent template version of the manifest by running <c>pretext init --refresh</c>, which will create time-stamped versions of the files for you to copy from to your current manifest.
+                The CLI looks for this file, so you should have only one.  If you have a project that was not created using <c>pretext new</c>, you can get a copy of the file by running <c>pretext init</c>.  You can also get the most recent template version of the manifest by running <c>pretext init --refresh</c>, which will create time-stamped versions of the files (so your files with matching names don't get overwritten) for you to copy from.
             </p>
 
             <p>
-                While we use the .ptx extension, the manifest is not technically a pretext document, since it does not agree with the schema.  However, it must have a specific structure to be used with the CLI.  Below we show a sample manifest (you can also look at the result of <c>pretext new</c> or <c>pretext init</c>).
+                While we use the <c>.ptx</c> extension, the manifest is not technically a pretext document, since it does not agree with the schema.  However, it must have a specific structure to be used with the CLI.  An example of a simple manifest is given in <xref ref="cli-project-manifest-example"/>.  Note this is version 2 manifest; for a comparison of <q>legacy</q> manifests and the current format, see <xref ref="cli-v1vsv2"/>.
             </p>
 
-            <pre>
-            <![CDATA[
-            <?xml version="1.0" encoding="utf-8"?>
-            <project>
-              <targets>
-                <target name="web">
-                  <format>html</format>
-                  <source>source/main.ptx</source>
-                  <publication>publication/publication.ptx</publication>
-                  <output-dir>output/web</output-dir>
-                </target>
-                <target name="print" pdf-method="xelatex">
-                  <format>pdf</format>
-                  <source>source/main.ptx</source>
-                  <publication>publication/publication.ptx</publication>
-                  <output-dir>output/print</output-dir>
-                </target>
-                <target name="print-latex">
-                  <format>latex</format>
-                  <source>source/main.ptx</source>
-                  <publication>publication/publication.ptx</publication>
-                  <output-dir>output/print-latex</output-dir>
-                </target>
-                <target name="subset">
-                  <format>html</format>
-                  <source>source/main.ptx</source>
-                  <publication>publication/publication.ptx</publication>
-                  <output-dir>output/subset</output-dir>
-                  <stringparam key="debug.skip-knowls" value="yes"/>
-                  <xmlid-root>ch_first</xmlid-root>
-                </target>
-              </targets>
-              <executables>
-                <latex>latex</latex>
-                <pdflatex>pdflatex</pdflatex>
-                <xelatex>xelatex</xelatex>
-                <pdfsvg>pdf2svg</pdfsvg>
-                <asy>asy</asy>
-                <sage>sage</sage>
-                <pdfpng>convert</pdfpng>
-                <pdfeps>pdftops</pdfeps>
-                <node>node</node>
-                <liblouis>file2brl</liblouis>
-              </executables>
-            </project>
-            ]]>
-            </pre>
+            <listing xml:id="cli-project-manifest-example">
+                <caption>Example of a very simple project manifest.</caption>
+            <program language="xml">
+                <input>
+                <![CDATA[ 
+
+                <?xml version="1.0" encoding="utf-8"?>
+                <project ptx-version="2">
+                <targets>
+                    <target name="web" format="html" />
+                    <target name="rs" format="html" platform="runestone" />
+                    <target name="print" format="pdf" />
+                </targets>
+                </project>
+
+                ]]>
+                </input>
+            </program>
+            </listing>
 
             <p>
-                <idx><h>CLI</h><h>executables</h></idx>
-                Inside the root <tag>project</tag>, we have <tag>targets</tag> and <tag>executables</tag>.  The latter contains the commands you would call on the terminal to execute the specified command.  You can likely leave this as is, but if a command is not on your PATH, you could put the full path to the executable here.
+                The manifest contains a single <tag>project</tag> element with a <attr>ptx-version</attr> attribute.  This attribute is required and must be set to <q>2</q> for the CLI to recognize the file as a valid manifest.  Additional optional attributes of <tag>project</tag> can also be specified, which we will describe below.  The <tag>project</tag> element has a single child, <tag>targets</tag>, which contains a list of <tag>target</tag> elements.
             </p>
 
             <p>
                 <idx><h>CLI</h><h>targets</h></idx>
-                Each element of <tag>targets</tag> is a <tag>target</tag> that has a <attr>name</attr> attribute.  The name (e.g., web, print) is what you specify when you run build, view, or generate assets for a specific target (so <c>pretext build web</c>, <c>pretext view web</c> or <c>pretext generate -t web</c>).
+                Each <tag>target</tag> must have a <attr>name</attr> attribute.  The name (e.g., web, print) is what you specify when you run <c>build</c>, <c>view</c>, or <c>generate</c> for a specific target (so <c>pretext build web</c>, <c>pretext view web</c> or <c>pretext generate -t web</c>).
             </p>
 
             <p>
                 <idx><h>CLI</h><h>format</h></idx>
-                The children of a <tag>target</tag> start with <tag>format</tag>, which must be one of html, pdf, latex, custom, epub, kindle, or braille (although the last three of these are still experimental, as of 8/10/2022).  If the format is <q>pdf</q>, you can specify the latex engine used to process the .tex file by using the <attr>pdf-method</attr> attribute on <tag>target</tag>.
+                The second required attribute of <tag>target</tag> is <attr>format</attr>, which must be one of html, pdf, latex, custom, epub, kindle, or braille (although the last three of these are still experimental, as of 9/1/2023).  
             </p>
 
             <p>
-                Next we have <tag>source</tag> which contains a (preferably) relative path to the main source file you will compile.  Different targets might have different main source files, in case you create a separate version of your project that includes only some chapters, for example.
+                With just these attributes, as with he manifest in <xref ref="cli-project-manifest-example"/>, the CLI assumes your project uses default values throughout.  In particular, 
+                <ul>
+                    <li><p>The source is <c>source/main.ptx</c>.</p></li>
+                    <li><p>The publication if is <c>publication/publication.ptx</c>.</p></li>
+                    <li><p>Output is stored in <c>output/</c> (with each target in a subfolder identical to the target's <c>name</c>).</p></li>
+                    <li><p>The staging directory to preview deploys is <c>output/stage</c>.</p></li>
+                </ul>
+                Each of these can be modified by adding the appropriate attribute of either the root <tag>project</tag> element or a particular <tag>target</tag> element.
             </p>
 
             <p>
-                <idx><h>publication file</h></idx>
-                <idx><h>CLI</h><h>publication file</h></idx>
-                The <tag>publication</tag> element specifies the path the the publication file for the target.  Different targets can have different publication files.
+                In <xref ref="table-cli-project-attributes"/> and <xref ref="table-cli-target-attributes"/> we give all the attributes you can have on the <tag>project</tag> and <tag>target</tag> elements, respectively.  Some attributes can be specified for both elements.  In such cases, the values will be paths, and the path given in the <tag>target</tag>'s attribute will be relative to the path given in the <tag>project</tag>'s attribute. This can be useful, for example, if all targets have publication files in the same folder, but the files for some targets are different.
             </p>
 
-            <p>
-                <idx><h>output-dir</h></idx>
-                <idx><h>CLI</h><h>output-dir</h></idx>
-                The <tag>output-dir</tag> element gives the path to the folder where the output of <c>pretext build</c> should go.  It is strongly recommended that this be a subfolder of <q>output</q>, which is ignored by git by default.  Again, different targets can, and probably should, have different output folders.
-            </p>
+            <p>All paths described below are given relative to the root of your project (i.e., the location of the <c>project.ptx</c> file).</p>
+
+            <table xml:id="table-cli-project-attributes">
+                <title>Attributes available for the <tag>project</tag> element.</title>
+                <tabular>
+                    <col/><col width="70%" valign="top"/>
+                    <row header="yes">
+                        <cell>Attribute</cell><cell>Description</cell>
+                    </row>
+                    <row>
+                        <cell><attr>ptx-version</attr></cell><cell><p>Required.  Must have value 2.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>source</attr></cell><cell><p>Optional, default: "source".  Path to folder holding main source file, relative to project root.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>publication</attr></cell><cell><p>Optional, default: "publication".  Path to folder holding publication file, relative to project root.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>output-dir</attr></cell><cell><p>Optional, default: "output".  Path to folder in which output files/folders for each target will be created.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>site</attr></cell><cell><p>Optional, default: "site".  Path to folder holding user-provided landing page for deploying multiple targets.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>stage</attr></cell><cell><p>Optional, default: "output/stage".  Path to folder where deployable targets will be collected before they are deployed.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>xsl</attr></cell><cell><p>Optional, default: "xsl".  Path to folder holding custom xsl files.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>asy-method</attr></cell><cell><p>Optional, default: "server".  Valid values: "server" or "local". Used to specify whether asymptote images should be generated using the "server" asymptote version or a "local" asymptote install.</p></cell>
+                    </row>
+                    
+                </tabular>
+            </table>
+
+            <table xml:id="table-cli-target-attributes">
+                <title>Attributes available for the <tag>target</tag> elements.</title>
+                <tabular halign="left" valign="top">
+                    <col/><col width="70%"/>
+                    <row header="yes">
+                        <cell>Attribute</cell><cell>Description</cell>
+                    </row>
+                    <row>
+                        <cell><attr>name</attr></cell><cell><p>Required.  The name you use when executing a CLI command.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>format</attr></cell><cell><p>Required.  Valid values: "html", "pdf", "latex", "epub", "kindle", "braille", "webwork", and "custom".  The format the target will be built into.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>source</attr></cell><cell><p>Optional, default: "main.ptx".  Path to the root source file of the project (relative to the value of the <attr>source</attr> of <tag>project</tag>).</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>publication</attr></cell><cell><p>Optional, default: "publication.ptx".  Path to publication file (relative to the value of <attr>publication</attr> attribute of <tag>project</tag>).</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>output-dir</attr></cell><cell><p>Optional, default: the value of <attr>name</attr>.  Path to folder in which output files/folders will be created (relative to the value of <attr>output-dir</attr> attribute of <tag>project</tag>).</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>output-filename</attr></cell><cell><p>Optional, default: generated by pretext. Only valid for formats that produce a single output file.  Path to output file to be built (relative to the value of <attr>output-dir</attr> of the same <tag>target</tag> element).</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>deploy-dir</attr></cell><cell><p>Optional, default: None.  Path to subdirectory of deployed site where this target will live.  If deploying multiple targets, then this attribute must have a value for it to be deployed.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>xsl</attr></cell><cell><p>Optional, default: None.  Path to custom <init>XSL</init> file (relative to the value of <attr>xsl</attr> attribute of <tag>project</tag>). Required when <attr>format</attr> is "custom".</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>latex-engine</attr></cell><cell><p>Optional, default: "xelatex".  Valid values: "xelatex", "pdflatex", or "latex". Only used on targets that build with latex, to specify what latex command to call in that step.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>braille-mode</attr></cell><cell><p>Optional, default: "emboss".  Valid values: "emboss" or "electronic". Only used when <attr>format</attr> is "braille", to specify the mode for braille.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>platform</attr></cell><cell><p>Optional, default: None.  Valid values: "runestone". Only valid when <attr>format</attr> is "html". Used to specify that the target will be hosted on Runestone.</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>compression</attr></cell><cell><p>Optional, default: None.  Valid values: "zip". Only valid when <attr>format</attr> is "html" (but <attr>platform</attr> is not "runestone") or "webwork". Results in output being compressed (as <c>.zip</c> file).</p></cell>
+                    </row>
+                    <row>
+                        <cell><attr>asy-method</attr></cell><cell><p>Optional, default: "server".  Valid values: "server" or "local". Overrides the <attr>asy-method</attr> attribute on <tag>project</tag>.</p></cell>
+                    </row>                    
+                </tabular>
+            </table>
+            
+            <example xml:id="example-manifest">
+                <title>Example Project Manifest</title>
+                
+                <p>
+                    To illustrate how the relative paths work, with attributes on both <tag>project</tag> and <tag>targets</tag> elements, consider the following manifest:
+                </p>
+            <program language="xml">
+                <input>
+                <![CDATA[
+                <?xml version="1.0" encoding="utf-8"?>
+                <project ptx-version="2" source="src" output-dir="out">
+                    <targets>
+                        <target 
+                            name="web" 
+                            format="html" 
+                            output-dir="web" />
+                        <target 
+                            name="print" 
+                            format="pdf" 
+                            source="main-print.ptx" 
+                            publication="pub/publication.ptx"/>
+                    </targets>
+                </project>
+                ]]>
+                </input>
+            </program>
+                <p>
+                    Here, the web target, with format html, will build from the root <pretext/> file "src/main.ptx", using the publication file "publication/publication.ptx", and will place the output in the folder "out/web".  
+                </p>
+                <p>
+                    The print target, with format pdf, will build from the file "src/main-print.ptx", using the publication file "publication/pub/publication.ptx", and will place the output in the folder "out/print".
+                </p>
+            </example>
 
             <p>
                 <idx><h>stringparam</h></idx>
                 <idx><h>CLI</h><h>stringparam</h></idx>
                 <idx><h>xmlid-root</h></idx>
                 <idx><h>CLI</h><h>xmlid-root</h></idx>
-                The above tags are required for each target.  There are also some optional tags that can further customize the behavior of a particular target.  The <tage>stringparam</tage> tag with attributes <attr>key</attr> and <attr>value</attr> can be used to specify string parameter options (<xref ref="publisher-string-parameters"/>.  The <tag>xmlid-root</tag> element is used to specify the xml:id of a division of a project for building only that subset of the project (useful for quickly testing just one chapter or section).
+                In addition to the attributes available for <tag>target</tag> elements, there is one optional child element, <tag>stringparams</tag>, which can be used to specify string parameter options (see <xref ref="publisher-string-parameters"/>).  These are specified using an attribute for the name of the string parameter, and the value of the attribute is the value of the string parameter.  Multiple string parameters are set using multiple attributes on the single <tag>stringparams</tag> element.
+            </p>
+        </subsection>
+
+        <subsection>
+            <title>Executables</title>
+            <idx><h>CLI</h><h>executables</h></idx>
+            <p>
+                <pretext/> uses several external tools to build and generate assets.  The CLI will automatically find these tools if they are installed in the default location for your operating system.  If you have installed them in a non-standard location, you can specify the path to the executable in a <c>executables.ptx</c> file, at the root of your project.  In <xref ref="listing-v2-executables"/> we give the defaults and formatting of such a file.
             </p>
 
-            <p>
-                <idx><h>custom xsl</h></idx>
-                <idx><h>CLI</h><h><c>custom xsl</c></h></idx>
-                The last optional element we will mention is the <tag>xsl</tag> element.  Here you would provide the path to a custom xsl file that itself calls the standard pretext-provided xsl.  To import the standard xsl file (say pretext-common.xsl) near the top of the custom xsl file, import it using<cd>
-                    <cline>&lt;xsl:import href="./core/pretext-common.xsl"/&gt;</cline>
-                </cd>To see an example of this used to build a revealjs slideshow, try <c>pretext new slideshow</c>.  Note that if you use the <q>custom</q> format, the <tag>xsl</tag> element is required, although it can be used on any format.  This is also how you would use the custom latex styles provided by pretext.
-            </p>
+            <listing xml:id="listing-v2-executables">
+                <caption>Example of version 2 executables file</caption>
+                <program language="xml">
+                  <input>
+                  <![CDATA[
+
+                  <?xml version="1.0" encoding="utf-8"?>
+                  <executables
+                        latex="latex"
+                        pdflatex="pdflatex"
+                        xelatex="xelatex"
+                        pdfsvg="pdf2svg"
+                        asy="asy"
+                        sage="sage"
+                        pdfpng="convert"
+                        pdfeps="pdftops"
+                        node="node"
+                        liblouis="file2brl" />
+
+                  ]]>
+                  </input>
+                </program>
+              </listing>
+
+              <warning>
+                <p>
+                    Prior to version 2 of the CLI, these executables were contained in the <c>project.ptx</c> file.  If you are using a version prior to 2.0, see <xref ref="cli-v1vsv2"/>.
+                </p>
+              </warning>
         </subsection>
 
         <subsection>
             <title>Getting help</title>
             <p>
                 <idx><h>CLI</h><h><c>-v debug</c></h></idx>
-                In addition to checking <c>pretext --help</c>, <c>pretext build --help</c>, <c>pretext generate --help</c>, etc, you have a few options when you run into trouble.  If you are getting errors that don't make sense, even after trying follow the suggestion of the error messages, look at the file <q>cli.log</q>, which includes even debug-level log messages.  You can also run the CLI using this higher level of verbosity using the <c>-v debug</c> option, which must go right after <c>pretext</c> command, before the subcommands (<c>build</c>, <c>generates</c>, etc.).  That is, enter the following for example,
+                In addition to checking <c>pretext --help</c>, <c>pretext build --help</c>, <c>pretext view --help</c>, etc, you have a few options when you run into trouble.  If you are getting errors that don't make sense, even after trying follow the suggestion of the error messages, look at the time-stamped log files inside the <c>logs</c> folder (or the <q>cli.log</q> file if you are using a CLI version prior to 2.0), which includes debug-level log messages.  You can also run the CLI using this higher level of verbosity using the <c>-v debug</c> option, which must go right after <c>pretext</c> command, before the subcommands (<c>build</c>, <c>deploy</c>, etc.).  That is, enter the following for example,
             </p>
 
             <console>
@@ -544,7 +645,7 @@
             <li><p>When you validate your source (see <xref ref="processing-dtd"/> and <xref ref="schema"/>) you will always point to the top-level source file (the one with the <tag>pretext</tag> tags).</p></li>
         </ul></p>
 
-        <p>The book generated by <c>pretext new book</c> has modular source, so is a nice starting point to see how this works.  Other examples are the sample book in <c>examples/sample-book</c> amply demonstrates different ways to modularize parts of a project (but in no way should be taken as best practice in this regard).  This guide, in <c>doc/author-guide</c> is a simple example of modular source files, and might be a good template to follow for your book.
+        <p>The book generated by <c>pretext new demo</c> has modular source, so is a nice starting point to see how this works.  Other examples are the sample book in <c>examples/sample-book</c> amply demonstrates different ways to modularize parts of a project (but in no way should be taken as best practice in this regard).  This guide, in <c>doc/author-guide</c> is a simple example of modular source files, and might be a good template to follow for your book.
         See <xref ref="topic-xinclude" /> for some of the finer points of this topic.</p>
     </section>
 
@@ -676,7 +777,7 @@
 
             <p>As you can tell from the above, different output formats have different expectations for additional files and when producing an output, there may be different expectations for where exactly where to find files.  A good example is the <init>EPUB</init> format, which despite being basically an HTML format, is still very rigorous about names, formats, and locations for image files.  With the above procedures you provide just enough information for <pretext/> to handle the remainder of the complexity for you, without you becoming an expert with the EPUB standard.  So the <c>pretext/pretext</c> script can automatically produce PDF, HTML, EPUB, Kindle, and braille, each in a single step.</p>
 
-            <p>We have skirted one finer point of all this.  How does an author know if a file is external or generated and what are the supported subdirectories of the generated directory?  A <pretext/> <attr>source</attr> attribute will almost always point to a file that belongs in the external directory.  An exception is the <attr>preview</attr> attribute which is used to specify static images to use in outputs like PDF or print to represent more dynamic objects employed in more-capable electronic formats (videos, audio, interactives).  (Please alert us to other exceptions!)  The list below describes the subdirectories of the generated directory.  The files that belong in these directories are all generated by the <c>pretex/pretext</c> script using aspects of your authored source.</p>
+            <p>We have skirted one finer point of all this.  How does an author know if a file is external or generated and what are the supported subdirectories of the generated directory?  A <pretext/> <attr>source</attr> attribute will almost always point to a file that belongs in the external directory.  An exception is the <attr>preview</attr> attribute which is used to specify static images to use in outputs like PDF or print to represent more dynamic objects employed in more-capable electronic formats (videos, audio, interactives).  (Please alert us to other exceptions!)  The list below describes the subdirectories of the generated directory.  The files that belong in these directories are all generated by the <c>pretext/pretext</c> script using aspects of your authored source.</p>
 
             <list xml:id="subdirectories-of-generated">
                 <title>Subdirectories of the Generated Directory</title>

--- a/doc/guide/backmatter.xml
+++ b/doc/guide/backmatter.xml
@@ -29,6 +29,7 @@
     <xi:include href="appendices/windows.xml"/>
     <xi:include href="appendices/windows-wsl.xml"/>
     <xi:include href="appendices/cli-transition.xml"/>
+    <xi:include href="appendices/cli-v1vsv2.xml"/>
     <appendix>
         <title>Example List of Notation</title>
         <notation-list />

--- a/doc/guide/developer/pretext-script.xml
+++ b/doc/guide/developer/pretext-script.xml
@@ -159,7 +159,7 @@ The script should be run on the entire document, even if all the images are in o
             <title>PreTeXt Script Methods</title>
 
             <tabular>
-                <row heade="yes" bottom="major">
+                <row header="yes" bottom="major">
                     <cell>Situation</cell>
                     <cell>Values</cell>
                 </row>

--- a/doc/guide/guideinfo.xml
+++ b/doc/guide/guideinfo.xml
@@ -10,7 +10,7 @@
 
 <docinfo>
     <rename element="note" xml:lang="en-US">Best Practice</rename>
-    <rename element="insight" xml:lang="en-US">Shortcut</rename>
+    <rename element="insight" xml:lang="en-US">Tip</rename>
     <!-- a demonstration in Basic Reference -->
     <rename element="algorithm" xml:lang="en-US">Porism</rename>
     <latex-image-preamble>
@@ -25,5 +25,3 @@
     \newcommand{\Hom}[2]{\homop\left(#1,\,#2\right)}
     </macros>
 </docinfo>
-
-

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- This file is part of the documentation of PreTeXt -->
-<!-- -->
-<!-- PreTeXt Author's Guide -->
-<!-- -->
-<!-- Copyright (C) 2013-2016 Robert A. Beezer -->
-<!-- See the file COPYING for copying conditions. -->
+<!-- This file is part of the documentation of PreTeXt              -->
+<!--                                                                -->
+<!--         The PreTeXt Guide                                      -->
+<!--                                                                -->
+<!-- Copyright (C) 2013-2019                                        -->
+<!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
+<!-- See the file COPYING for copying conditions.                   -->
 
 <chapter xml:id="start-here">
     <title>Why <pretext />? </title>

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--   This file is part of the documentation of PreTeXt      -->
-<!--                                                          -->
-<!--      PreTeXt Author's Guide                              -->
-<!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
-<!-- See the file COPYING for copying conditions.             -->
+<!-- This file is part of the documentation of PreTeXt -->
+<!-- -->
+<!-- PreTeXt Author's Guide -->
+<!-- -->
+<!-- Copyright (C) 2013-2016 Robert A. Beezer -->
+<!-- See the file COPYING for copying conditions. -->
 
 <chapter xml:id="start-here">
     <title>Why <pretext />? </title>
 
     <introduction>
-        <p>Welcome to <q>the Guide</q> for <pretext />.  You are likely eager to get started, but familiarizing yourself with this chapter should save you a lot of time in the long run.  We will try to keep it short and at the end of early chapters we will guide you on where to go next.  Not everything we say here will make sense on your first reading, so come back after your first few trial runs.  When you are ready to seek further help, or ask questions, please read the <xref ref="welcome" text="title"/> in <xref ref="welcome"/>.</p>
+        <p>Welcome to <q>the Guide</q> for <pretext />. You are likely eager to get started, but familiarizing yourself with this chapter should save you a lot of time in the long run. We will try to keep it short and at the end of early chapters we will guide you on where to go next. Not everything we say here will make sense on your first reading, so come back after your first few trial runs. When you are ready to seek further help, or ask questions, please read the <xref ref="welcome" text="title" /> in <xref ref="welcome" />.</p>
     </introduction>
 
     <section xml:id="philosophy">
@@ -19,19 +19,28 @@
 
         <p><pretext /> is a <term>markup language</term><idx>markup language</idx>, which means that you explicitly specify the logical parts of your document and not how these parts should be displayed.</p>
 
-        <p>This is very liberating for an author, since it frees you to concentrate on capturing your ideas to share with others, leaving the construction of the visual presentation to the software.  As an example, you might specify the content of the title of a chapter to be <c>Further Experiments</c>, but you will not be concerned if a 36 point sans-serif font in black will be used for this title in the print version of your book, or a CSS class specifying 18 pixel height in blue is used for a title in an online web version of your book.  You can just trust that a reasonable choice has been made for displaying a title of a chapter in a way that a reader will recognize it as a name for a chapter.  (And if all that talk of fonts was unfamiliar, all the more reason to trust the design to software.)</p>
+        <p>This is very liberating for an author, since it frees you to concentrate on capturing your ideas to share with others, leaving the construction of the visual presentation to the software. As an example, you might specify the content of the title of a chapter to be <c>Further Experiments</c>, but you will not be concerned if a 36 point sans-serif font in black will be used for this title in the print version of your book, or a CSS class specifying 18 pixel height in blue is used for a title in an online web version of your book. You can just trust that a reasonable choice has been made for displaying a title of a chapter in a way that a reader will recognize it as a name for a chapter. (And if all that talk of fonts was unfamiliar, all the more reason to trust the design to software.)</p>
 
-        <p>You are also freed from the technical details of presenting your ideas in the plethora of new formats available as a consequence of the advances in computers (including tablets and smartphones) and networks (global and wireless).  Your output <q>just works</q> and the software keeps up with technical advances and the introduction of new formats, while you concentrate on the content of your book (or article, or report, or proposal, or<nbsp /><ellipsis />).</p>
+        <p>You are also freed from the technical details of presenting your ideas in the plethora of new formats available as a consequence of the advances in computers (including tablets and smartphones) and networks (global and wireless). Your output <q>just works</q> and the software keeps up with technical advances and the introduction of new formats, while you concentrate on the content of your book (or article, or report, or proposal, or<nbsp /><ellipsis />).</p>
 
-        <p>If you have never used a markup language, it can be unfamiliar at first.  Even if you have used a markup language before (such as <init>HTML</init>, Markdown, or basic <latex />) you may need to make a few adjustments.  Most word-processors are WYSIWYG (<q>what you see is what you get</q>).  That approach is likely very helpful if you are designing the front page of a newspaper, but not if you are writing about the life-cycle of a salamander.  In the old days, programs like
-        <url href="https://en.wikipedia.org/wiki/Troff" visual="en.wikipedia.org/wiki/Troff"><c>troff</c></url> and its predecessor, <url href="https://en.wikipedia.org/wiki/TYPSET_and_RUNOFF" visual="en.wikipedia.org/wiki/TYPSET_and_RUNOFF"><c>RUNOFF</c></url> (1964), implemented simple markup languages to allow early computers to do limited text-formatting.  Sometimes the old ways are the best ways.</p>
+        <p>If you have never used a markup language, it can be unfamiliar at first. Even if you have used a markup language before (such as <init>HTML</init>, Markdown, or basic <latex />) you may need to make a few adjustments. Most word-processors are WYSIWYG (<q>what you see is what you get</q>). That approach is likely very helpful if you are designing the front page of a newspaper, but not if you are writing about the life-cycle of a salamander. In the old days, programs like <url href="https://en.wikipedia.org/wiki/Troff" visual="en.wikipedia.org/wiki/Troff">
+                <c>troff</c>
+            </url> and its predecessor, <url href="https://en.wikipedia.org/wiki/TYPSET_and_RUNOFF" visual="en.wikipedia.org/wiki/TYPSET_and_RUNOFF">
+                <c>RUNOFF</c>
+            </url> (1964), implemented simple markup languages to allow early computers to do limited text-formatting. Sometimes the old ways are the best ways.</p>
 
-        <p><pretext /> is what is called an <term>XML application</term><idx>XML application</idx><idx><h>XML application</h><seealso>XML vocabulary</seealso></idx> or an <term>XML vocabulary</term><idx>XML vocabulary</idx><idx><h>XML vocabulary</h><seealso>XML application</seealso></idx> (I prefer the latter). That is, the source you write is <q>marked up</q> as <init>XML</init>, with specific <term>tags</term> that describe the semantic structure of your document.  Authoring in <init>XML</init> might seem cumbersome at first, since some content will require more characters of markup than of content.  Much of this markup can be quickly produced with a modern text editor, but it can still be overwhelming.  We believe you will eventually appreciate the long-run economies, so keep an open mind.  And if you are already familiar with <init>XML</init>, realize we have been very careful to design this vocabulary with human authors foremost in our mind.</p>
+        <p><pretext /> is what is called an <term>XML application</term><idx>XML application</idx><idx>
+                <h>XML application</h>
+                <seealso>XML vocabulary</seealso>
+            </idx> or an <term>XML vocabulary</term><idx>XML vocabulary</idx><idx>
+                <h>XML vocabulary</h>
+                <seealso>XML application</seealso>
+            </idx> (I prefer the latter). That is, the source you write is <q>marked up</q> as <init>XML</init>, with specific <term>tags</term> that describe the semantic structure of your document. Authoring in <init>XML</init> might seem cumbersome at first, since some content will require more characters of markup than of content. Much of this markup can be quickly produced with a modern text editor, but it can still be overwhelming. We believe you will eventually appreciate the long-run economies, so keep an open mind. And if you are already familiar with <init>XML</init>, realize we have been very careful to design this vocabulary with human authors foremost in our mind.</p>
 
         <paragraphs>
             <title>Principles</title>
 
-            <p>The creation, design, development, and maintenance of <pretext /> is guided by the following list of principles.  These will become more understandable as you become more familiar with authoring texts with <pretext /> and should amplify some of the previous discussion.</p>
+            <p>The creation, design, development, and maintenance of <pretext /> is guided by the following list of principles. These will become more understandable as you become more familiar with authoring texts with <pretext /> and should amplify some of the previous discussion.</p>
 
             <list xml:id="list-principles">
                 <title><pretext /> Principles</title>
@@ -57,7 +66,7 @@
 
                     <li xml:id="principle-users"><pretext /> recognizes that scholarly documents involve the interaction of authors, publishers, scholars, curators, instructors, students, and readers, with each group having its own needs and goals.</li>
 
-                    <li xml:id="principle-accessibility"><pretext/> recognizes the inherent value in producing material that is accessible to everyone.</li>
+                    <li xml:id="principle-accessibility"><pretext /> recognizes the inherent value in producing material that is accessible to everyone.</li>
                 </ol>
             </list>
         </paragraphs>
@@ -66,33 +75,28 @@
     <section xml:id="introduction-to-source-formatting">
         <title>Understanding Your Source</title>
 
-        <p>Almost all of your time authoring in <pretext /> will be spent editing your <term>source</term><idx>source</idx> files.  We now briefly describe what these files will look like and how to edit them.</p>
+        <p>Almost all of your time authoring in <pretext /> will be spent editing your <term>source</term><idx>source</idx> files. We now briefly describe what these files will look like and how to edit them.</p>
 
         <paragraphs>
             <title>File Format and Text Editors</title>
 
-            <p>Your source will be plain text <term>ASCII files</term><idx>ASCII file</idx>, which you create and edit with any number of text editors. Files can be saved with the <c>.ptx</c> extension, which might tell your text editor what sort of file you are editing and will provide syntax highlighting and code completion, among other features.  If your editor does not recognize <c>.ptx</c>, then you can use the <c>.xml</c> extension which has wider editor support (but with fewer <pretext />-specific features).</p>
+            <p>Your source will be plain text <term>ASCII files</term><idx>ASCII file</idx>, which you create and edit with any number of text editors. Files can be saved with the <c>.ptx</c> extension, which might tell your text editor what sort of file you are editing and will provide syntax highlighting and code completion, among other features. If your editor does not recognize <c>.ptx</c>, then you can use the <c>.xml</c> extension which has wider editor support (but with fewer <pretext />-specific features).</p>
 
-            <p>Popular text editors include Visual Studio Code, Sublime Text, vi, emacs, Notepad, Notepad++, Atom, TextWrangler, and BBEdit.  But in particular, you should not use word processing programs like Word, LibreOffice, Google Docs, WordPerfect, AbiWord, Pages, or similar programs.  Sometimes these editors are known as a <term>programmer's editor</term><idx>programmer's editor</idx> (though we will be doing no programming).  Support for writing HTML sometimes translates directly to good support for XML.</p>
+            <p>Popular text editors include Visual Studio Code, Sublime Text, vi, emacs, Notepad, Notepad++, Atom, TextWrangler, and BBEdit. But in particular, you should not use word processing programs like Word, LibreOffice, Google Docs, WordPerfect, AbiWord, Pages, or similar programs. Sometimes these editors are known as a <term>programmer's editor</term><idx>programmer's editor</idx> (though we will be doing no programming). Support for writing HTML sometimes translates directly to good support for XML.</p>
 
-            <p>
-                Visual Studio Code has support for PreTeXt documents via a free extension, and the editor is open source and cross-platform (Windows, OS X, and Linux).  The developers of <pretext /> have also had a very good experience with Sublime Text, which is cross-platform, and can be used for free,
-                though it has a very liberal paid license if you want to avoid nagging.
-            </p>
+            <p> Visual Studio Code has support for PreTeXt documents via a free extension, and the editor is open source and cross-platform (Windows, OS X, and Linux). The developers of <pretext /> have also had a very good experience with Sublime Text, which is cross-platform, and can be used for free, though it has a very liberal paid license if you want to avoid nagging. </p>
 
-            <p>There are <term>XML editors</term><idx>XML editor</idx>, which might be too complex for authoring in <pretext />.  They do have some advantages and XML Copy Editor is one that you might find useful.</p>
+            <p>There are <term>XML editors</term><idx>XML editor</idx>, which might be too complex for authoring in <pretext />. They do have some advantages and XML Copy Editor is one that you might find useful.</p>
 
-            <p>Some text editors (like VS Code) have spell checking extensions.  More generally, recommendations for a spell checker can be found in <xref ref="aspell"/>.</p>
+            <p>Some text editors (like VS Code) have spell checking extensions. More generally, recommendations for a spell checker can be found in <xref ref="aspell" />.</p>
         </paragraphs>
 
 
         <paragraphs>
             <title>Structure of your Source</title>
-            <p>
-                If you start to think about the structure of a document (like an article or book) you will quickly realize that components are like blocks, stacked inside or next to other blocks.  From the <em>outside</em> to <em>inside</em>, a book will have a number of chapters (next to each other, but all inside the book), and each might have sections (adjacent but inside the chapter).  In the section, there will be a title, paragraphs, images, examples, theorems, and so on.  Examples will themselves contain paragraphs.  A theorem might contain a statement, which contains some paragraphs, which might contain some displayed math, and adjacent to the statement, there could be a proof, itself containing paragraphs, etc.
-            </p>
+            <p> If you start to think about the structure of a document (like an article or book) you will quickly realize that components are like blocks, stacked inside or next to other blocks. From the <em>outside</em> to <em>inside</em>, a book will have a number of chapters (next to each other, but all inside the book), and each might have sections (adjacent but inside the chapter). In the section, there will be a title, paragraphs, images, examples, theorems, and so on. Examples will themselves contain paragraphs. A theorem might contain a statement, which contains some paragraphs, which might contain some displayed math, and adjacent to the statement, there could be a proof, itself containing paragraphs, etc. </p>
 
-            <p>The hierarchical nature of <init>XML</init> is perfect to capture the hierarchical nature of a scholarly document.  Consider the start of a <pretext /> document shown in <xref ref="listing-simple"/>.</p>
+            <p>The hierarchical nature of <init>XML</init> is perfect to capture the hierarchical nature of a scholarly document. Consider the start of a <pretext /> document shown in <xref ref="listing-simple" />.</p>
 
             <listing xml:id="listing-simple">
                 <caption>Source of a simple <pretext /> book project.</caption>
@@ -115,33 +119,29 @@
                 </program>
             </listing>
 
-            <p>
-                The first line is boilerplate that lets various programs know the rest of the file is XML, and the line start <c>&lt;!--</c>  is an example of a comment that won't appear in the output.  Besides this, you can start to see how the structure of the book is layed out.
-            </p>
+            <p> The first line is boilerplate that lets various programs know the rest of the file is XML, and the line start <c>&lt;!--</c> is an example of a comment that won't appear in the output. Besides this, you can start to see how the structure of the book is layed out. </p>
         </paragraphs>
 
         <paragraphs>
             <title>Whitespace and Indentation</title>
 
-            <p>The term <term>whitespace</term><idx>whitespace</idx> refers to characters you type but typically do not see.  For us they are <term>space</term>, <term>non-breaking space</term>, <term>tab</term> and <term>newline</term> (also known as a <q>carriage return</q> and/or <q>line feed</q>).  Unlike some other markup languages, <pretext /> <em>does not ever use whitespace</em> to convey formatting information.</p>
+            <p>The term <term>whitespace</term><idx>whitespace</idx> refers to characters you type but typically do not see. For us they are <term>space</term>, <term>non-breaking space</term>, <term>tab</term> and <term>newline</term> (also known as a <q>carriage return</q> and/or <q>line feed</q>). Unlike some other markup languages, <pretext /> <em>does not ever use whitespace</em> to convey formatting information.</p>
 
-            <p>
-                However, it can be useful to use whitespace to indent the different levels of the <init>XML</init> (and document) hierarchy. Use two (or four) spaces for indentation; a good editor will visually respect this indentation, and help you with maintaining the right indentation with each new line.  Line up opening and closing tags at the same level of indentation, and your editor should let you <q>fold</q> the code to visually hide blocks.
-            </p>
+            <p> However, it can be useful to use whitespace to indent the different levels of the <init>XML</init> (and document) hierarchy. Use two (or four) spaces for indentation; a good editor will visually respect this indentation, and help you with maintaining the right indentation with each new line. Line up opening and closing tags at the same level of indentation, and your editor should let you <q>fold</q> the code to visually hide blocks. </p>
 
-            <p>Whatever you do, use a style and stick with it.  You could put titles on a new line (indented) after creating a new chapter or section; some people like them on the same line, immediately adjacent.  You could put a single blank line before each new paragraph, but not after the last.  And so on.  The choice is yours, but consistency will pay off when you inevitably come back to edit something.  You have put a lot of work and effort into your source.  You will be rewarded with fewer problems if you keep it neat and tidy.</p>
+            <p>Whatever you do, use a style and stick with it. You could put titles on a new line (indented) after creating a new chapter or section; some people like them on the same line, immediately adjacent. You could put a single blank line before each new paragraph, but not after the last. And so on. The choice is yours, but consistency will pay off when you inevitably come back to edit something. You have put a lot of work and effort into your source. You will be rewarded with fewer problems if you keep it neat and tidy.</p>
 
-            <p>In some parts of a <pretext /> document, every single whitespace character is important and will be transmitted to your output, such as in the <tag>input</tag> and <tag>output</tag> portions of a <tag>sage</tag> element.  Since Sage code mostly follows Python syntax, indentation is important and leading spaces must be preserved.  But you can indent all of your code to match your <init>XML</init> indentation and the entire <tag>input</tag> (or <tag>output</tag>) content will be uniformly shifted left to the margin in your final output.</p>
+            <p>In some parts of a <pretext /> document, every single whitespace character is important and will be transmitted to your output, such as in the <tag>input</tag> and <tag>output</tag> portions of a <tag>sage</tag> element. Since Sage code mostly follows Python syntax, indentation is important and leading spaces must be preserved. But you can indent all of your code to match your <init>XML</init> indentation and the entire <tag>input</tag> (or <tag>output</tag>) content will be uniformly shifted left to the margin in your final output.</p>
 
-            <p>Never use tabs, they can only cause problems.  You should be able to set your editor to translate the tab key to a certain number of spaces, or to translate tabs to spaces when you save a file (and these behaviors are useful).  Most editors have a setting that will show whitespace as a small faint dots or arrows, so you can be certain there is no stray whitespace <em>anywhere</em>.</p>
+            <p>Never use tabs, they can only cause problems. You should be able to set your editor to translate the tab key to a certain number of spaces, or to translate tabs to spaces when you save a file (and these behaviors are useful). Most editors have a setting that will show whitespace as a small faint dots or arrows, so you can be certain there is no stray whitespace <em>anywhere</em>.</p>
         </paragraphs>
 
         <paragraphs>
             <title>Learn to Use Your Editor</title>
 
-            <p>Because XML requires a closing tag for every opening tag, it feels like a lot of typing.  The VS Code <pretext /> extension comes with many <term>snippets</term> (code completions) that can fill out lots of the markup for you.  More generally, any editor should know what tag to close next and there should be a simple command to do that (for example, in Sublime Text on Linux, <c>Alt-Period</c> gives a closing tag).  Not only is this quick and easy, it can help spot errors when you forget to close an earlier tag.</p>
+            <p>Because XML requires a closing tag for every opening tag, it feels like a lot of typing. The VS Code <pretext /> extension comes with many <term>snippets</term> (code completions) that can fill out lots of the markup for you. More generally, any editor should know what tag to close next and there should be a simple command to do that (for example, in Sublime Text on Linux, <c>Alt-Period</c> gives a closing tag). Not only is this quick and easy, it can help spot errors when you forget to close an earlier tag.</p>
 
-            <p>If your editor can predict your opening tag, all the better.  VS Code can recognize what tags are allowed at a given position.    Sublime Text recognizes if you already have a <tag>section</tag> elsewhere, so when you start a second section, you very quickly (and automatically) get a short list of choices as you type, with the one you want at the top of the list, or close to it.</p>
+            <p>If your editor can predict your opening tag, all the better. VS Code can recognize what tags are allowed at a given position. Sublime Text recognizes if you already have a <tag>section</tag> elsewhere, so when you start a second section, you very quickly (and automatically) get a short list of choices as you type, with the one you want at the top of the list, or close to it.</p>
 
             <p>Invest a little time early on to learn, and configure, your editor and you can be even more efficient about capturing your ideas with a minimum of overhead and interference.</p>
         </paragraphs>
@@ -149,9 +149,9 @@
         <paragraphs>
             <title>Revision Control</title>
 
-            <p>If you are writing a book, or if you are collaborating with co-authors, then you owe it to yourself and your co-authors to learn how to use revision control<idx>revision control</idx>, which works well with <pretext /> since the source is just text files.  The hands-down favorite is <c>git</c>.  To fully understand it is beyond the scope of this guide but some information is provided in <xref ref="git-author" /> which has hints on how to best use <c>git</c> together with a <pretext /> project.</p>
+            <p>If you are writing a book, or if you are collaborating with co-authors, then you owe it to yourself and your co-authors to learn how to use revision control<idx>revision control</idx>, which works well with <pretext /> since the source is just text files. The hands-down favorite is <c>git</c>. To fully understand it is beyond the scope of this guide but some information is provided in <xref ref="git-author" /> which has hints on how to best use <c>git</c> together with a <pretext /> project.</p>
 
-            <p>If you use the workflow recommended in the <xref ref="tutorial"/> using GitHub's codespaces, you will get revision control via git automatically, and VS Code provides a graphical user interface for all the basic operations you need.</p>
+            <p>If you use the workflow recommended in the <xref ref="tutorial" /> using GitHub's codespaces, you will get revision control via git automatically, and VS Code provides a graphical user interface for all the basic operations you need.</p>
         </paragraphs>
 
     </section>
@@ -159,36 +159,26 @@
     <section xml:id="start-source-to-output">
         <title>Converting Your Source to Output</title>
 
-        <p>
-            Once you have content created in <pretext /> files (i.e., <init>XML</init> files), you will want to convert these files into a output format such as <init>HTML</init>, to be viewed in a web browser, or a <init>PDF</init>.  Instructions for doing this will be discussed in <xref ref="tutorial"/>, and in even more detail in <xref ref="processing"/>.  Here we provide an overview of how the conversion works to help you understand what is possible.
-        </p>
+        <p> Once you have content created in <pretext /> files (i.e., <init>XML</init> files), you will want to convert these files into a output format such as <init>HTML</init>, to be viewed in a web browser, or a <init>PDF</init>. Instructions for doing this will be discussed in <xref ref="tutorial" />, and in even more detail in <xref ref="processing" />. Here we provide an overview of how the conversion works to help you understand what is possible. </p>
 
-        <p>
-            With <pretext /> <q>installed</q> (on your computer or in the cloud), converting <pretext /> <init>XML</init> into a full <init>HTML</init> website can be as simple as typing <c>pretext build html</c> in a terminal, or hitting <c>Ctrl+Alt+B</c> in VS Code.  Behind-the-scenes, these commands read through your <init>XML</init> and use <term>XSL</term> 1.0 (<term>eXtensiible Stylesheet Language</term>) to <em>transform</em> the <init>XML</init> source, using a number of <init>XSL</init> stylesheets that come with <pretext />.
-        </p>
+        <p> With <pretext /> <q>installed</q> (on your computer or in the cloud), converting <pretext /> <init>XML</init> into a full <init>HTML</init> website can be as simple as typing <c>pretext build html</c> in a terminal, or hitting <c>Ctrl+Alt+B</c> in VS Code. Behind-the-scenes, these commands read through your <init>XML</init> and use <term>XSL</term> 1.0 (<term>eXtensiible Stylesheet Language</term>) to <em>transform</em> the <init>XML</init> source, using a number of <init>XSL</init> stylesheets that come with <pretext />. </p>
 
-        <p>
-            The recommended workflow for processing your source uses a python program we call the <em><pretext/>-CLI</em> (<init>CLI</init> is <term>command line interface</term>). There are also a number of other free tools that can processes <init>XML</init> with <init>XSL</init>.  For example, <c>xsltproc</c> is a command line program that is usually installed by default on Linux systems and MacOS.
-            This was the recommended method in the early days of <pretext />, and still works.  Documentation for how to use <c>xsltproc</c> with <pretext /> can be found in <xref ref="xsltproc"/>, but unless you are helping with the development of <pretext /> or are trying to do something fancy, you probably don't need it.
-        </p>
+        <p> The recommended workflow for processing your source uses a python program we call the <em><pretext />-CLI</em> (<init>CLI</init> is <term>command line interface</term>). There are also a number of other free tools that can processes <init>XML</init> with <init>XSL</init>. For example, <c>xsltproc</c> is a command line program that is usually installed by default on Linux systems and MacOS. This was the recommended method in the early days of <pretext />, and still works. Documentation for how to use <c>xsltproc</c> with <pretext /> can be found in <xref ref="xsltproc" />, but unless you are helping with the development of <pretext /> or are trying to do something fancy, you probably don't need it. </p>
 
-        <p>
-            Some features of <pretext />, such as the inclusion of images described in source, or including <webwork /> exercises, requires the use of an additional processing, done in python.  The <pretext />-CLI does this using the <c>pretext generate</c> command.
-            There is also a python script that can accesses these functions directly for use in development.  See <xref ref="pretext-script"/> if you are curious.
-        </p>
+        <p> Some features of <pretext />, such as the inclusion of images described in source, or including <webwork /> exercises, requires the use of an additional processing, done in python. Some of these also require additional software (such as <latex /> or Sage). The <pretext />-CLI does this automatically when building (and regenerates these assets if they have changed since the last build). There is also a python script that can accesses these functions directly for use in development. See <xref ref="pretext-script" /> if you are curious. </p>
 
     </section>
 
     <section xml:id="start-next">
         <title>Where Next?</title>
 
-        <p>To start playing with <pretext /> right away, work through the <xref ref="tutorial"/>.  It will guide you through a cloud-based setup (no software install required) and you will create, edit, convert, and deploy your first document.</p>
+        <p>To start playing with <pretext /> right away, work through the <xref ref="tutorial" />. It will guide you through a cloud-based setup (no software install required) and you will create, edit, convert, and deploy your first document.</p>
 
-        <p>If you would like a general, high-level overview of features skip ahead to <xref ref="overview"/>.</p>
+        <p>If you would like a general, high-level overview of features skip ahead to <xref ref="overview" />.</p>
 
-        <p>In-depth, comprehensive use of features is in <xref ref="topics"/>.</p>
+        <p>In-depth, comprehensive use of features is in <xref ref="topics" />.</p>
 
-        <p>If you have an existing project authored in <latex/> you may be interested in the conversion process described in <xref ref="latex-conversion"/>.</p>
+        <p>If you have an existing project authored in <latex /> you may be interested in the conversion process described in <xref ref="latex-conversion" />.</p>
     </section>
 
 </chapter>

--- a/doc/guide/introduction/tutorial.xml
+++ b/doc/guide/introduction/tutorial.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- This file is part of the documentation of PreTeXt -->
-<!-- -->
-<!-- PreTeXt Author's Guide -->
-<!-- -->
-<!-- Copyright (C) 2013-2023 Robert A. Beezer -->
-<!-- See the file COPYING for copying conditions. -->
+<!-- This file is part of the documentation of PreTeXt              -->
+<!--                                                                -->
+<!--         The PreTeXt Guide                                      -->
+<!--                                                                -->
+<!-- Copyright (C) 2013-2019                                        -->
+<!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
+<!-- See the file COPYING for copying conditions.                   -->
 
 <chapter xml:id="tutorial">
   <title>Getting Started Tutorial</title>

--- a/doc/guide/introduction/tutorial.xml
+++ b/doc/guide/introduction/tutorial.xml
@@ -1,475 +1,249 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--   This file is part of the documentation of PreTeXt      -->
-<!--                                                          -->
-<!--      PreTeXt Author's Guide                              -->
-<!--                                                          -->
-<!-- Copyright (C) 2013-2023  Robert A. Beezer                -->
-<!-- See the file COPYING for copying conditions.             -->
+<!-- This file is part of the documentation of PreTeXt -->
+<!-- -->
+<!-- PreTeXt Author's Guide -->
+<!-- -->
+<!-- Copyright (C) 2013-2023 Robert A. Beezer -->
+<!-- See the file COPYING for copying conditions. -->
 
 <chapter xml:id="tutorial">
-    <title>Getting Started Tutorial</title>
+  <title>Getting Started Tutorial</title>
 
-    <introduction>
-      <p>
-        This chapter serves as a tutorial for quickly getting started with <pretext /> in your web browser
-        using free services provided by <url href="https://github.com">GitHub</url>.
-        (Advanced users who'd prefer to install our free and open-source software
-        to their own machine may choose to skip ahead to <xref ref="quickstart-example"/>.)
-      </p>
-      <objectives>
-        <introduction><p>At the end of this tutorial you will have...</p></introduction>
-        <ul>
-          <li><p>Created a free GitHub account.</p></li>
-          <li><p>Created a GitHub Repository and Codespace for authoring <pretext/> in your web browser.</p></li>
-          <li><p>Learned the first steps to editing a <pretext/> document.</p></li>
-          <li><p>Converted your document to both <latex/> and accessible <init>HTML</init>.</p></li>
-          <li><p>Deployed your <init>HTML</init> to the web via GitHub Pages.</p></li>
-        </ul>
-      </objectives>
-      <p>
-        The community does its best to keep this guide updated, but for even more up-to-date advice,
-        join us at our regular Zoom drop-ins announced at
-        <url href="https://groups.google.com/g/pretext-announce/">our Google group</url> or
-        watch a recording posted in <xref ref="tutorial-videos"/>.
-      </p>
-    </introduction>
-
-    <section xml:id="tutorial-github">
-      <title>Using GitHub</title>
-      <subsection>
-        <title>What is GitHub?</title>
-        <p>
-          <term>GitHub</term> is a freely-available service for authoring, sharing, and deploying
-          documents and source code, owned by Microsoft. It uses the free and open-source <term>Git</term>
-          software for version management.
-        </p>
-        <p>
-          There are other services such as <url href="https://cocalc.com">CoCalc</url>
-          (see <xref ref="topic-build-in-cocalc"/>) and
-          <url href="https://about.gitlab.com/">GitLab</url> for managing <pretext/> documents
-          online, as well as other ways to write <pretext/> that don't require anything
-          besides installing the free and open-source <pretext/> software onto your own device
-          (see <xref ref="quickstart-example"/> to learn more).
-        </p>
-        <p>
-          We will use GitHub for this tutorial as it the most popular way to share and disseminate
-          <pretext/> documents, and provides the easiest pathway to getting started writing in the
-          <pretext/> language.
-        </p>
-        <p>
-          To create your free GitHub account,
-          <url href="https://github.com/signup">
-              follow the instructions on GitHub's
-              signup page
-          </url>. You can also log into an existing GitHub account if you already have one.
-          Be sure to note your GitHub username and password in your password manager
-          (or however you usually keep track of login credentials).
-        </p>
-        <paragraphs>
-          <title>Tip!</title>
-          <p>
-            Educators and non-profit researchers can get many of GitHub's paid features
-            for free. While this is not strictly required for the rest of the tutorial, it's a
-            useful way to increase GitHub's free Codespaces usage quotas.
-          </p>
-          <p>
-            Apply at
-            <url href="https://education.github.com/discount_requests/pack_application">Education.GitHub.com</url>
-            to unlock these features. In our experience, applications are usually processed quickly for <c>.edu</c>
-            email addresses, but you do not need to wait for approval to continue on with this tutorial.
-          </p>
-        </paragraphs>
-      </subsection>
-      <subsection>
-        <title>Three GitHub concepts</title>
-        <p>
-          This tutorial uses three GitHub services:
-          <dl>
-            <li>
-              <title>Codespaces (<c>github.dev</c>)</title>
-              <p>
-                The Codespace for your project is an application
-                run in your web browser that gives you access to a virtual
-                computer with all the software recommended to author <pretext/>
-                installed for you automatically. This Codespace is private to you,
-                and lives at an address like
-                <c>https://username-random-words-abc123.github.dev</c>.
-              </p>
-            </li>
-            <li>
-              <title>Repository hosting (<c>github.com</c>)</title>
-              <p>
-                The <term>repository</term> for your project represents
-                the history of its edits that have been <q>committed and synced</q>
-                from your Codespace to it. This repository can be public
-                or private (though we encourage public repositories as they help
-                the community provide support for each other),
-                and lives at an address like
-                <c>https://github.com/username/reponame/</c>.
-              </p>
-            </li>
-            <li>
-              <title>GitHub Pages (<c>github.io</c>)</title>
-              <p>
-                The <term>GitHub Pages</term> service provides free hosting
-                for websites such as the HTML generated from a <pretext/> project.
-                This website is public, and lives at an address like
-                <c>https://username.github.io/reponame/</c>.
-              </p>
-            </li>
-          </dl>
-        </p>
-        <p>
-          Broadly speaking, you <q>author</q> within your Codespace, which you periodically
-          <q>commit and sync</q> to your repository, and then occassionally <q>deploy</q>
-          to your public GitHub Pages website.
-        </p>
-      </subsection>
-      <subsection>
-        <title>Creating your repository and Codespace</title>
-        <p>
-          Follow the instructions at <url href="https://github.com/PreTeXtBook/pretext-codespace" />
-          to get started creating your repository and Codespace. You'll have the option to make your repository public
-          (recommended if you want support from the rest of the <pretext/> community) or private.
-          Either way, those instructions will also walk you through creating your private Codespace
-          for authoring.
-        </p>
-        <p>
-          This takes a few moments, but is a one-time process. Take note of the <c>github.com</c>
-          URL your new repository lives at so you can find it
-          the next time you want to work on your project.
-          (You can always access your <c>github.dev</c> Codespace link from there via the <c>Code</c>
-          menu.)
-          Then you'll be ready for <xref ref="tutorial-first-document"/>.
-        </p>
-      </subsection>
-    </section>
-
-    <section xml:id="tutorial-first-document">
-      <title>Your First PreTeXt Document</title>
+  <introduction>
+    <p> This chapter serves as a tutorial for quickly getting started with <pretext /> in your web browser using free services provided by <url href="https://github.com">GitHub</url>. (Advanced users who'd prefer to install our free and open-source software to their own machine may choose to skip ahead to <xref ref="quickstart-example" />.) </p>
+    <objectives>
       <introduction>
-        <p>
-          At this point, you should have a <pretext /> project set up as a
-          <c>github.com</c> repository with a <c>github.dev</c> Codespace. You can use the
-          <c>Code</c> menu on the repository webpage to pull up the Codespace environment in
-          your web browser if you haven't already.
-        </p>
-        <p>
-          The left-hand menu should display a file tree, containing a folder called <c>source</c>
-          with a file called <c>main.ptx</c>.  These files were created when you set up your Codespace,
-          and form a complete, albeit very short, <pretext /> document.
-        </p>
-
-        <p>
-          Now you are ready to build it!
-        </p>
+        <p>At the end of this tutorial you will have...</p>
       </introduction>
-      <subsection>
-        <title>Building for web</title>
-        <p>
-          You can build your entire project in a few different ways.
-          <ul>
-            <li>
-              <p>
-                Click the <q>PreTeXt</q> button in the center left of the bottom toolbar of the VS Code window (see <xref ref="tutorial-figure-codespaces-pretext"/>). A dialog will pop up asking which <pretext /> command you want to run.  Select <c>Build</c> to get a menu of options to select a <term>target</term> to build: choose <c>web</c>.
-              </p>
-            </li>
-            <li>
-              <p>
-                You can use the keyboard shortcut <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>p</kbd>
-                (replacing <kbd>CTRL</kbd> with <kbd>CMD</kbd> if you have a Mac) to get the same dialogs.  Or to build in one step, use <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>b</kbd>.
-              </p>
-            </li>
-            <li>
-              <p>
-                Select a <pretext /> command from the VS Code command pallette, which you can access by clicking the icon in the bottom left of the VS Code window. You can also access this by typing <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>p</kbd> (again, replacing <kbd>CTRL</kbd> with <kbd>CMD</kbd> if you have a Mac).  Start typing <q>pretext</q> to get a list of commands available.
-              </p>  
-            </li>
-            <li>
-              <p>
-                If you are comfortable entering commands in a terminal/command prompt, you can access one in your Codespace using <kbd>CTRL</kbd>+<kbd>`</kbd>.  Then you can run <c>pretext build web</c> to build your project.
-              </p>
-            </li>
-          </ul>
-          The resulting HTML files will be available in the <c>output/web</c> directory of your project.  However, to view it, you should NOT navigate there and open the files. Instead, read on.
-        </p>
+      <ul>
+        <li>
+          <p>Created a free GitHub account.</p>
+        </li>
+        <li>
+          <p>Created a GitHub Repository and Codespace for authoring <pretext /> in your web browser.</p>
+        </li>
+        <li>
+          <p>Learned the first steps to editing a <pretext /> document.</p>
+        </li>
+        <li>
+          <p>Converted your document to both <latex /> and accessible <init>HTML</init>.</p>
+        </li>
+        <li>
+          <p>Deployed your <init>HTML</init> to the web via GitHub Pages.</p>
+        </li>
+      </ul>
+    </objectives>
+    <p> The community does its best to keep this guide updated, but for even more up-to-date advice, join us at our regular Zoom drop-ins announced at <url href="https://groups.google.com/g/pretext-announce/">our Google group</url> or watch a recording posted in <xref ref="tutorial-videos" />. </p>
+  </introduction>
 
-        <figure xml:id="tutorial-figure-codespaces-pretext">
-          <caption>PreTeXt commands in Codespaces</caption>
-          <image width="50%" source="codespaces-pretext.png">
-            <description>Screenshot of VS Code PreTeXt button in Codespaces</description>
-          </image>
-        </figure>
-      </subsection>
+  <section xml:id="tutorial-github">
+    <title>Using GitHub</title>
+    <subsection>
+      <title>What is GitHub?</title>
+      <p>
+        <term>GitHub</term> is a freely-available service for authoring, sharing, and deploying documents and source code, owned by Microsoft. It uses the free and open-source <term>Git</term> software for version management. </p>
+      <p> There are other services such as <url href="https://cocalc.com">CoCalc</url> (see <xref ref="topic-build-in-cocalc" />) and <url href="https://about.gitlab.com/">GitLab</url> for managing <pretext /> documents online, as well as other ways to write <pretext /> that don't require anything besides installing the free and open-source <pretext /> software onto your own device (see <xref ref="quickstart-example" /> to learn more). </p>
+      <p> We will use GitHub for this tutorial as it the most popular way to share and disseminate <pretext /> documents, and provides the easiest pathway to getting started writing in the <pretext /> language. </p>
+      <p> To create your free GitHub account, <url href="https://github.com/signup"> follow the instructions on GitHub's signup page </url>. You can also log into an existing GitHub account if you already have one. Be sure to note your GitHub username and password in your password manager (or however you usually keep track of login credentials). </p>
+      <paragraphs>
+        <title>Tip!</title>
+        <p> Educators and non-profit researchers can get many of GitHub's paid features for free. While this is not strictly required for the rest of the tutorial, it's a useful way to increase GitHub's free Codespaces usage quotas. </p>
+        <p> Apply at <url href="https://education.github.com/discount_requests/pack_application">Education.GitHub.com</url> to unlock these features. In our experience, applications are usually processed quickly for <c>.edu</c> email addresses, but you do not need to wait for approval to continue on with this tutorial. </p>
+      </paragraphs>
+    </subsection>
+    <subsection>
+      <title>Three GitHub concepts</title>
+      <p> This tutorial uses three GitHub services: <dl>
+          <li>
+            <title>Codespaces (<c>github.dev</c>)</title>
+            <p> The Codespace for your project is an application run in your web browser that gives you access to a virtual computer with all the software recommended to author <pretext /> installed for you automatically. This Codespace is private to you, and lives at an address like <c>https://username-random-words-abc123.github.dev</c>. </p>
+          </li>
+          <li>
+            <title>Repository hosting (<c>github.com</c>)</title>
+            <p> The <term>repository</term> for your project represents the history of its edits that have been <q>committed and synced</q> from your Codespace to it. This repository can be public or private (though we encourage public repositories as they help the community provide support for each other), and lives at an address like <c>https://github.com/username/reponame/</c>. </p>
+          </li>
+          <li>
+            <title>GitHub Pages (<c>github.io</c>)</title>
+            <p> The <term>GitHub Pages</term> service provides free hosting for websites such as the HTML generated from a <pretext /> project. This website is public, and lives at an address like <c>https://username.github.io/reponame/</c>. </p>
+          </li>
+        </dl>
+      </p>
+      <p> Broadly speaking, you <q>author</q> within your Codespace, which you periodically <q>commit and sync</q> to your repository, and then occassionally <q>deploy</q> to your public GitHub Pages website. </p>
+    </subsection>
+    <subsection>
+      <title>Creating your repository and Codespace</title>
+      <p> Follow the instructions at <url href="https://github.com/PreTeXtBook/pretext-codespace" /> to get started creating your repository and Codespace. You'll have the option to make your repository public (recommended if you want support from the rest of the <pretext /> community) or private. Either way, those instructions will also walk you through creating your private Codespace for authoring. </p>
+      <p> This takes a few moments, but is a one-time process. Take note of the <c>github.com</c> URL your new repository lives at so you can find it the next time you want to work on your project. (You can always access your <c>github.dev</c> Codespace link from there via the <c>Code</c> menu.) Then you'll be ready for <xref ref="tutorial-first-document" />. </p>
+    </subsection>
+  </section>
 
-      <subsection xml:id="tutorial-previewing">
-        <title>Viewing</title>
-        <p>
-          You can preview these HTML files you just built using the <term>View</term> command.
-          Again, you can access this in multiple ways: <pretext /> buttom in the toolbar, <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>p</kbd>, etc.
-          Select <c>View</c> from the dialog.  You may be given options on how to view the document,
-          depending on what VS Code plugins you have available to you. Try one or another until
-          you're able to view your web build in either a new tab of your browser or a tab within VS Code.
-        </p>
+  <section xml:id="tutorial-first-document">
+    <title>Your First PreTeXt Document</title>
+    <introduction>
+      <p> At this point, you should have a <pretext /> project set up as a <c>github.com</c> repository with a <c>github.dev</c> Codespace. You can use the <c>Code</c> menu on the repository webpage to pull up the Codespace environment in your web browser if you haven't already. </p>
+      <p> The left-hand menu should display a file tree, containing a folder called <c>source</c> with a file called <c>main.ptx</c>. These files were created when you set up your Codespace, and form a complete, albeit very short, <pretext /> document. </p>
 
-        <p>
-          The VS Code Live Preview is a good option, but it is buggy when used inside Codespaces.  It seems to help to use the VS Code command pallette to run <c>Live Preview: Show Preview (External Browser)</c>, then close the tab that opens, and start the process over.  You may need to do this a few times before it works. 
-        </p>
+      <p> Now you are ready to build it! </p>
+    </introduction>
+    <subsection>
+      <title>Building for web</title>
+      <p> You can build your entire project in a few different ways. <ul>
+          <li>
+            <p> Click the <q>PreTeXt</q> button in the center left of the bottom toolbar of the VS Code window (see <xref ref="tutorial-figure-codespaces-pretext" />). A dialog will pop up asking which <pretext /> command you want to run. Select <c>Build</c> to get a menu of options to select a <term>target</term> to build: choose <c>web</c>. </p>
+          </li>
+          <li>
+            <p> You can use the keyboard shortcut <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>p</kbd> (replacing <kbd>CTRL</kbd> with <kbd>CMD</kbd> if you have a Mac) to get the same dialogs. Or to build in one step, use <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>b</kbd>. </p>
+          </li>
+          <li>
+            <p> Select a <pretext /> command from the VS Code command pallette, which you can access by clicking the icon in the bottom left of the VS Code window. You can also access this by typing <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>p</kbd> (again, replacing <kbd>CTRL</kbd> with <kbd>CMD</kbd> if you have a Mac). Start typing <q>pretext</q> to get a list of commands available. </p>
+          </li>
+          <li>
+            <p> If you are comfortable entering commands in a terminal/command prompt, you can access one in your Codespace using <kbd>CTRL</kbd>+<kbd>`</kbd>. Then you can run <c>pretext build web</c> to build your project. </p>
+          </li>
+        </ul> The resulting HTML files will be available in the <c>output/web</c> directory of your project. However, to view it, you should NOT navigate there and open the files. Instead, read on. </p>
 
-        <p>
-          Now is a great time to try to make edits to your source files (maybe change the title).
-          Note that these changes aren't updated live in your preview:
-          you will need to build again, and then refresh the preview window to see them.  Note, you do not need to run the <c>View</c> command again unless you stop the preview server.
-        </p>
-      </subsection>
-
-      <subsection xml:id="tutorial-pdf">
-        <title>Building for print</title>
-        <p>
-          The instructions above can be repeated to produce <latex /> code:
-          just choose <c>print-latex</c> instead of <c>web</c> as your target.
-          The resulting files are available in <c>output/print-latex</c>.
-        </p>
-        <p>
-          Of course, it'd be even more convenient to produce a PDF directly.
-          This requires software that can process <latex />, which should be installed in the <pretext/> Codespace by default. Repeat the above instructions
-          with the <c>print</c> target to produce a PDF. It can be downloaded by right-clicking
-          <c>output/print/main.pdf</c> in the VS Code file explorer, or previewed using
-          a View command.
-        </p>
-
-      </subsection>
-
-
-      <subsection xml:id="tutorial-saving">
-        <title>Saving your work</title>
-        <p>
-          Using Codespaces will keep all your files <q>in the cloud</q>,
-          saved automatically as you edit.
-          As long as your Codespace is active, your files will be saved there
-          for your private use. However, inactive Codespaces are periodically
-          cleaned up by GitHub (as of writing, this happens after one month of
-          inactivity), so you'll need to periodally
-          <term>commit &amp; sync</term> your work to your repository
-          where it will never be deleted.
-        </p>
-
-        <p>
-          Recall that your Codespace lives at <c>github.dev</c>, while your
-          repository has a <c>github.com</c> address like
-          <c>https://github.com/username/reponame</c>).
-          This repository serves as a backup of your work in the Codespace, and has the added benefit of
-          allowing collaborators to access your files as well. As a bonus, if you made your repository
-          public, members of the PreTeXt community who watch
-          the <url href="https://groups.google.com/g/pretext-support">PreTeXt-support</url>
-          Google group can create their own Codespace based on your public repository and easily answer any
-          questions you have.
-        </p>
-
-        <p>
-          While Git and GitHub have a lot of features, there's a very simple way to use them
-          via Codespaces. As you edit files, you'll notice that their filenames will turn orange, and new
-          files will appear green. Likewise, a blue number will appear in the left sidebar.
-        </p>
-
-        <figure xml-id="tutorial-figure-codespaces-sidebar">
-          <caption>Filenames changing color as they are edited in Codespaces</caption>
-          <image width="50%" source="codespaces-sidebar.png">
-            <description>Screenshot of VS Code sidebar in Codespaces</description>
-          </image>
-        </figure>
-
-        <p>
-          This blue badge is next to the Source Control view.
-          You will notice a list of files that were changed;
-          you can click on any of these to see what the changes are.
-        </p>
-
-        <figure xml-id="tutorial-figure-codespaces-diff">
-          <caption>A <q>Git diff</q> showing changes in a file</caption>
-          <image width="100%" source="codespaces-diff.png">
-            <description>Screenshot of VS Code Git diff in Codespaces</description>
-          </image>
-        </figure>
-
-        <p>
-          <em>Type a message describing the changes you've made</em> then
-          click the green <q>Commit and Sync</q> button. If it just says <q>Commit</q>,
-          use the drop-down menu to choose <q>Commit and Sync</q>. (If you forget to type a message describing the changes you've made, then a new tab will open: <q>COMMIT_EDITMSG</q> where you can type the message.  When you are done, close the tab.)
-        </p>
-
-        <figure xml-id="tutorial-figure-codespaces-sync">
-          <caption>Commiting and syncing changes</caption>
-          <image width="50%" source="codespaces-sync.png">
-            <description>Screenshot of VS Code source control in Codespaces</description>
-          </image>
-        </figure>
-
-        <p>
-          To see that this is successful, return to your <c>github.com</c> repository webpage.
-          You should see your files with all your
-          committed/synced changes. (That is, most of them: many files, such as log files and
-          temporary build files that appear in gray within your Codespace, will not
-          be synced.
-          This is no problem: they are created during a build automatically and don't need to be,
-          and really shouldn't be, saved or shared with others.)
-        </p>
-      </subsection>
-
-      <subsection xml:id="tutorial-generate">
-        <title>Generating assets</title>
-
-        <p>
-          If your document contains certain elements, you might need to <term>generate</term> their assets
-          for use in certain output formats. Depending on your build target, these include:
-          <ul>
-            <li><tag>latex-image</tag></li>
-            <li><tag>sagemath</tag></li>
-            <li><tag>asymptote</tag></li>
-            <li><tag>youtube</tag></li>
-            <li><tag>webwork</tag></li>
-            <li><tag>codelens</tag></li>
-          </ul>
-        </p>
-
-        <p>
-          You can generate assets in much the same way you run a build,
-          though you may need to first install some extra software.
-          You will see a <c>Generate</c> option in the <pretext /> command dialog, just below <c>Build</c>.
-          Select your target and wait for the process to complete, then <c>Build</c> once more to
-          incorporate your generated assets.
-        </p>
-
-      </subsection>
-
-      <subsection xml:id="tutorial-deploy">
-        <title>Deploy</title>
-        <p>
-          So you have worked tirelessly to prepare course notes or a book, built and previewed,
-          synced changes to your git repository, and now you are ready to share the results of
-          your efforts with the world.  It's time to <term>deploy</term> your project!
-        </p>
-
-        <p>
-          From the <q>PreTeXt Commands</q> dialog, select
-          <q>Deploy</q>.  This will automatically take the most recent build of your web target
-          and host it through <url href="https://pages.github.com/">GitHub Pages</url>.  Watch the output
-          pane for a link to your published site; unlike the preview link you've been using on <c>github.dev</c>
-          which is private to only you, this <c>github.io</c> link is ready to share with the world.
-          (It can take a few minutes for the site to get set up
-          or updated; there should be another link to view the progress of the GitHub <q>action</q> that
-          reports the progress.)
-        </p>
-      </subsection>
-
-      <subsection xml:id="tutorial-advanced">
-        <title>Using this guide and advanced features</title>
-        <p>
-          The rest of this guide will help you on your way.
-          However, keep in mind that this guide is the work of many volunteers
-          over many years, and certain sections may assume the reader is using mechanisms for writing <pretext/>
-          that have been around for much longer than the Codespaces environment
-          recommended for this tutorial.
-        </p>
-        <p>
-          In particular, there are two advanced mechanisms used by many <pretext/> authors: the
-          <term>PreTeXt developer script</term>
-          <xref ref="pretext-script"/> (i.e. the <c>pretext/pretext</c> script) and the
-          <term>PreTeXt CLI</term> <xref ref="processing-CLI"/>.
-        </p>
-        <p>
-          Under the hood, the PreTeXt CLI is what you're using in Codespaces, and it also has the ability to
-          call the PreTeXt developer script as well. If you ever want to use a PreTeXt CLI command, you can open
-          a <term>Terminal</term> in your Codespace using the menus, or by pressing <kbd>Ctrl</kbd>+<kbd>`</kbd>
-          (the backtick key, found in upper left of many keyboards).
-        </p>
-        <p>
-          From the terminal, you can type in any PreTeXt CLI commands directly. For example,
-          typing in the CLI command <c>pretext build web</c> and running it by pressing <kbd>Enter</kbd> builds the
-          web target.
-        </p>
-        <figure xml:id="tutorial-figure-codespaces-pretext-cli">
-          <caption>Using the PreTeXt CLI with a Codespaces terminal</caption>
-          <image width="80%" source="codespaces-pretext-cli.png">
-            <description>Screenshot of using the PreTeXt CLI within Codespaces</description>
-          </image>
-        </figure>
-        <p>
-          The CLI should be sufficient to do nearly everything you want to do for your project, and using
-          the developer script should be exercised with caution. Nonetheless,
-          to access a <c>pretext/pretext</c> developer script feature, you can use <c>pretext devscript</c>.
-          For example, if the
-          documentation suggests a command like <c>pretext/pretext -foo bar</c>, you could try running
-          <c>pretext devscript -foo bar</c>.
-        </p>
-      </subsection>
-    </section>
-    <section xml:id="tutorial-videos">
-      <title>Videos</title>
-
-      <p>Regularly produced videos showcasing how to get started with PreTeXt
-      as the ecosystem evolves over time is curated by
-      <url href="https://clontz.org">Steven Clontz</url>. Roughly once
-      a month, a <q>Getting Started with PreTeXt</q> presentation is offered
-      to new or prospective community members, showcasing the latest recommendations
-      for writing modern PreTeXt.</p>
-
-      <p>The most recent recording of this series is provided here for
-      your reference.</p>
-
-      <figure xml:id="tutorial-videos-figure">
-          <caption>Getting Started in 2023 March</caption>
-          <video xml:id="tutorial-videos-video" youtube="Z-BfcnZ8Sm8" preview="getting-started-preview.png"/>
+      <figure xml:id="tutorial-figure-codespaces-pretext">
+        <caption>PreTeXt commands in Codespaces</caption>
+        <image width="50%" source="codespaces-pretext.png">
+          <description>Screenshot of VS Code PreTeXt button in Codespaces</description>
+        </image>
       </figure>
-    </section>
+    </subsection>
+
+    <subsection xml:id="tutorial-previewing">
+      <title>Viewing</title>
+      <p> You can preview these HTML files you just built using the <term>View</term> command. Again, you can access this in multiple ways: <pretext /> buttom in the toolbar, <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>p</kbd>, etc. Select <c>View</c> from the dialog. You may be given options on how to view the document, depending on what VS Code plugins you have available to you. Try one or another until you're able to view your web build in either a new tab of your browser or a tab within VS Code. </p>
+
+      <p> The VS Code Live Preview is a good option, but it is buggy when used inside Codespaces. It seems to help to use the VS Code command pallette to run <c>Live Preview: Show Preview (External Browser)</c>, then close the tab that opens, and start the process over. You may need to do this a few times before it works. </p>
+
+      <p> Now is a great time to try to make edits to your source files (maybe change the title). Note that these changes aren't updated live in your preview: you will need to build again, and then refresh the preview window to see them. Note, you do not need to run the <c>View</c> command again unless you stop the preview server. </p>
+    </subsection>
+
+    <subsection xml:id="tutorial-pdf">
+      <title>Building for print</title>
+      <p> The instructions above can be repeated to produce <latex /> code: just choose <c>print-latex</c> instead of <c>web</c> as your target. The resulting files are available in <c>output/print-latex</c>. </p>
+      <p> Of course, it'd be even more convenient to produce a PDF directly. This requires software that can process <latex />, which should be installed in the <pretext /> Codespace by default. Repeat the above instructions with the <c>print</c> target to produce a PDF. It can be downloaded by right-clicking <c>output/print/main.pdf</c> in the VS Code file explorer, or previewed using a View command. </p>
+
+    </subsection>
+
+
+    <subsection xml:id="tutorial-saving">
+      <title>Saving your work</title>
+      <p> Using Codespaces will keep all your files <q>in the cloud</q>, saved automatically as you edit. As long as your Codespace is active, your files will be saved there for your private use. However, inactive Codespaces are periodically cleaned up by GitHub (as of writing, this happens after one month of inactivity), so you'll need to periodally <term>commit &amp; sync</term> your work to your repository where it will never be deleted. </p>
+
+      <p> Recall that your Codespace lives at <c>github.dev</c>, while your repository has a <c>github.com</c> address like <c>https://github.com/username/reponame</c>). This repository serves as a backup of your work in the Codespace, and has the added benefit of allowing collaborators to access your files as well. As a bonus, if you made your repository public, members of the PreTeXt community who watch the <url href="https://groups.google.com/g/pretext-support">PreTeXt-support</url> Google group can create their own Codespace based on your public repository and easily answer any questions you have. </p>
+
+      <p> While Git and GitHub have a lot of features, there's a very simple way to use them via Codespaces. As you edit files, you'll notice that their filenames will turn orange, and new files will appear green. Likewise, a blue number will appear in the left sidebar. </p>
+
+      <figure xml-id="tutorial-figure-codespaces-sidebar">
+        <caption>Filenames changing color as they are edited in Codespaces</caption>
+        <image width="50%" source="codespaces-sidebar.png">
+          <description>Screenshot of VS Code sidebar in Codespaces</description>
+        </image>
+      </figure>
+
+      <p> This blue badge is next to the Source Control view. You will notice a list of files that were changed; you can click on any of these to see what the changes are. </p>
+
+      <figure xml-id="tutorial-figure-codespaces-diff">
+        <caption>A <q>Git diff</q> showing changes in a file</caption>
+        <image width="100%" source="codespaces-diff.png">
+          <description>Screenshot of VS Code Git diff in Codespaces</description>
+        </image>
+      </figure>
+
+      <p>
+        <em>Type a message describing the changes you've made</em> then click the green <q>Commit and Sync</q> button. If it just says <q>Commit</q>, use the drop-down menu to choose <q>Commit and Sync</q>. (If you forget to type a message describing the changes you've made, then a new tab will open: <q>COMMIT_EDITMSG</q> where you can type the message. When you are done, close the tab.) </p>
+
+      <figure xml-id="tutorial-figure-codespaces-sync">
+        <caption>Commiting and syncing changes</caption>
+        <image width="50%" source="codespaces-sync.png">
+          <description>Screenshot of VS Code source control in Codespaces</description>
+        </image>
+      </figure>
+
+      <p> To see that this is successful, return to your <c>github.com</c> repository webpage. You should see your files with all your committed/synced changes. (That is, most of them: many files, such as log files and temporary build files that appear in gray within your Codespace, will not be synced. This is no problem: they are created during a build automatically and don't need to be, and really shouldn't be, saved or shared with others.) </p>
+    </subsection>
+
+    <subsection xml:id="tutorial-generate">
+      <title>Generating assets</title>
+
+      <p> If your document contains certain elements, you might need to <term>generate</term> their assets for use in certain output formats. Depending on your build target, these include: <ul>
+          <li>
+            <tag>latex-image</tag>
+          </li>
+          <li>
+            <tag>sagemath</tag>
+          </li>
+          <li>
+            <tag>asymptote</tag>
+          </li>
+          <li>
+            <tag>youtube</tag>
+          </li>
+          <li>
+            <tag>webwork</tag>
+          </li>
+          <li>
+            <tag>codelens</tag>
+          </li>
+        </ul>
+      </p>
+
+      <p> Starting in CLI version 1.7, these assets will be automatically generated whenever you build your output. If you change the source of these assets, they will be regenerated when you build. </p>
+      <p> Regardless of which version of the CLI you are using, you can generate assets as a separate step in much the same way you run a build. You will see a <c>Generate</c> option in the <pretext /> command dialog, just below <c>Build</c>. Select your target and wait for the process to complete, then <c>Build</c> once more to incorporate your generated assets. </p>
+
+    </subsection>
+
+    <subsection xml:id="tutorial-deploy">
+      <title>Deploy</title>
+      <p> So you have worked tirelessly to prepare course notes or a book, built and previewed, synced changes to your git repository, and now you are ready to share the results of your efforts with the world. It's time to <term>deploy</term> your project! </p>
+
+      <p> From the <q>PreTeXt Commands</q> dialog, select <q>Deploy</q>. This will automatically take the most recent build of your web target and host it through <url href="https://pages.github.com/">GitHub Pages</url>. Watch the output pane for a link to your published site; unlike the preview link you've been using on <c>github.dev</c> which is private to only you, this <c>github.io</c> link is ready to share with the world. (It can take a few minutes for the site to get set up or updated; there should be another link to view the progress of the GitHub <q>action</q> that reports the progress.) </p>
+
+      <p> By default, doing a deploy will just publish your <c>web</c> target. It is also possible to deploy multiple targets along with a <q>landing</q> page directing a visitor of your site to the different versions of your project. See <xref ref="processing-CLI" /> for more information. </p>
+    </subsection>
+
+    <subsection xml:id="tutorial-advanced">
+      <title>Using this guide and advanced features</title>
+      <p> The rest of this guide will help you on your way. However, keep in mind that this guide is the work of many volunteers over many years, and certain sections may assume the reader is using mechanisms for writing <pretext /> that have been around for much longer than the Codespaces environment recommended for this tutorial. </p>
+      <p> In particular, there are two advanced mechanisms used by many <pretext /> authors: the <term>PreTeXt developer script</term>
+          <xref ref="pretext-script" /> (i.e. the <c>pretext/pretext</c> script) and the <term>PreTeXt CLI</term> <xref ref="processing-CLI" />. </p>
+      <p> Under the hood, the PreTeXt CLI is what you're using in Codespaces, and it also has the ability to call the PreTeXt developer script as well. If you ever want to use a PreTeXt CLI command, you can open a <term>Terminal</term> in your Codespace using the menus, or by pressing <kbd>Ctrl</kbd>+<kbd>`</kbd> (the backtick key, found in upper left of many keyboards). </p>
+      <p> From the terminal, you can type in any PreTeXt CLI commands directly. For example, typing in the CLI command <c>pretext build web</c> and running it by pressing <kbd>Enter</kbd> builds the web target. </p>
+      <figure xml:id="tutorial-figure-codespaces-pretext-cli">
+        <caption>Using the PreTeXt CLI with a Codespaces terminal</caption>
+        <image width="80%" source="codespaces-pretext-cli.png">
+          <description>Screenshot of using the PreTeXt CLI within Codespaces</description>
+        </image>
+      </figure>
+      <p> The CLI should be sufficient to do nearly everything you want to do for your project, and using the developer script should be exercised with caution. Nonetheless, to access a <c>pretext/pretext</c> developer script feature, you can use <c>pretext devscript</c>. For example, if the documentation suggests a command like <c>pretext/pretext -foo bar</c>, you could try running <c>pretext devscript -foo bar</c>. </p>
+    </subsection>
+  </section>
+  <section xml:id="tutorial-videos">
+    <title>Videos</title>
+
+    <p>Regularly produced videos showcasing how to get started with PreTeXt as the ecosystem evolves over time is curated by <url href="https://clontz.org">Steven Clontz</url>. Roughly once a month, a <q>Getting Started with PreTeXt</q> presentation is offered to new or prospective community members, showcasing the latest recommendations for writing modern PreTeXt.</p>
+
+    <p>The most recent recording of this series is provided here for your reference.</p>
+
+    <figure xml:id="tutorial-videos-figure">
+      <caption>Getting Started in 2023 March</caption>
+      <video xml:id="tutorial-videos-video" youtube="Z-BfcnZ8Sm8" preview="getting-started-preview.png" />
+    </figure>
+  </section>
 
   <section xml:id="quickstart-example">
     <title>For Advanced Users New to PreTeXt</title>
 
-    <p>
-      This section is intended for users who have read
-      <xref ref="start-here"/>
-      and are already experienced
-      with other open-source software projects
-      or command-line tools. If you're more
-      interested in a browser-based workflow to getting started with
-      PreTeXt, check out <xref ref="tutorial-github"/>.
-    </p>
+    <p> This section is intended for users who have read <xref ref="start-here" /> and are already experienced with other open-source software projects or command-line tools. If you're more interested in a browser-based workflow to getting started with PreTeXt, check out <xref ref="tutorial-github" />. </p>
 
-    <p>
-      PreTeXt is an open-source
-      <url href="https://en.wikipedia.org/wiki/XML">XML</url> language
-      primarily powered by
-      <url href="https://en.wikipedia.org/wiki/XSLT">XSLT</url> and
-      <url href="https://en.wikipedia.org/wiki/Python_(programming_language)">Python</url>
-      tools.
-    </p>
+    <p> PreTeXt is an open-source <url href="https://en.wikipedia.org/wiki/XML">XML</url> language primarily powered by <url href="https://en.wikipedia.org/wiki/XSLT">XSLT</url> and <url href="https://en.wikipedia.org/wiki/Python_(programming_language)">Python</url> tools. </p>
 
-    <p>
-      For new authors comfortable working on the command line who want to use their
-      favorite text editor or IDE, we recommend <c>pip install</c>ing the PreTeXt-CLI
-      from the Python Package Index. <xref ref="processing-CLI"/> has these details,
-      and <c>pretext -h</c> and <c>pretext CMD -h</c> are at your disposal as well
-      after installation.
-    </p>
+    <p> For new authors comfortable working on the command line who want to use their favorite text editor or IDE, we recommend <c>pip install</c>ing the PreTeXt-CLI from the Python Package Index. <xref ref="processing-CLI" /> has these details, and <c>pretext -h</c> and <c>pretext CMD -h</c> are at your disposal as well after installation. </p>
 
-    <p>
-      Some context for experienced Python developers: PreTeXt development is primarily
-      split over two GitHub repositories:
-      <url href="https://github.com/PreTeXtBook/pretext">PreTeXtBook/pretext</url>
-      for the <q>core</q> functionality of PreTeXt, and the more recent
-      <url href="https://github.com/PreTeXtBook/pretext-cli">PreTeXtBook/pretext-cli</url>
-      that packages up these resources into a Python package with several UX enhancements
-      such as a simplified command line interface and project management that does not require
-      the use of custom makefiles.
-    </p>
+    <p> Some context for experienced Python developers: PreTeXt development is primarily split over two GitHub repositories: <url href="https://github.com/PreTeXtBook/pretext">PreTeXtBook/pretext</url> for the <q>core</q> functionality of PreTeXt, and the more recent <url href="https://github.com/PreTeXtBook/pretext-cli">PreTeXtBook/pretext-cli</url> that packages up these resources into a Python package with several UX enhancements such as a simplified command line interface and project management that does not require the use of custom makefiles. </p>
 
-    <p>
-      If you're interested in potentially contributing back to PreTeXt someday, please
-      feel free to request to join
-      <url href="https://groups.google.com/g/pretext-dev">our developer Google Group</url>
-      and say hello!
-    </p>
+    <p> If you're interested in potentially contributing back to PreTeXt someday, please feel free to request to join <url href="https://groups.google.com/g/pretext-dev">our developer Google Group</url> and say hello! </p>
   </section>
 </chapter>

--- a/doc/guide/project.ptx
+++ b/doc/guide/project.ptx
@@ -34,8 +34,6 @@
     <sage>sage</sage>
     <pdfpng>convert</pdfpng>
     <pdfeps>pdftops</pdfeps>
-    <pdfcrop>pdf-crop-margins</pdfcrop>
-    <pageres>pageres</pageres>
     <node>node</node>
     <liblouis>file2brl</liblouis>
   </executables>

--- a/doc/quickref/quickref-cli.tex
+++ b/doc/quickref/quickref-cli.tex
@@ -9,7 +9,7 @@
 %
 %
 \documentclass{article}
-\usepackage{graphicx}  
+\usepackage{graphicx}
 \usepackage[landscape]{geometry}
 \usepackage[xetex]{color}
 \usepackage{url}
@@ -128,7 +128,7 @@ If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc
 
 %*********************************************
 \hr\textbf{Project Manifest}
-The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. "print-latex") that you build or view with, e.g. {\verb|pretext build print-latex|}.  
+The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. "print-latex") that you build or view with, e.g. {\verb|pretext build print-latex|}.
 
 Structure of a target:
 \begin{verbatim}

--- a/doc/quickref/quickref-cli.tex
+++ b/doc/quickref/quickref-cli.tex
@@ -95,14 +95,14 @@ If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc
 
 {\ex \verb| pretext generate|}: Generate all assets for first target in {\verb|project.ptx|}.\\
 {\ex \verb| pretext generate webwork|}: Generate webwork for first target in {\verb|publication.ptx|}\\
-{\ex \verb| pretext generate sageplot -t print|}: Generate sageplot for target "print".\\
-{\ex \verb| pretext generate latex-image -x img-graph1|}: Generate latex-image with xml:id "img-graph1" (for first target).\\
+{\ex \verb| pretext generate sageplot -t print|}: Generate sageplot for target ``print''.\\
+{\ex \verb| pretext generate latex-image -x img-graph1|}: Generate latex-image with xml:id ``img-graph1'' (for first target).\\
 %*********************************************
 
  \hr\textbf{View a PreTeXt document (local)}
 
 {\ex \verb| pretext view|}: Creates a local server to preview the first target in {\verb|project.ptx|}\\
-{\ex \verb| pretext view print|}: Views the "print" target\\
+{\ex \verb| pretext view print|}: Views the ``print'' target\\
 % {\ex \verb| CTRL+C|} to close the server\\
 %*********************************************
 
@@ -128,7 +128,7 @@ If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc
 
 %*********************************************
 \hr\textbf{Project Manifest}
-The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. "print-latex") that you build or view with, e.g. {\verb|pretext build print-latex|}.
+The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. ``print-latex'') that you build or view with, e.g. {\verb|pretext build print-latex|}.
 
 Structure of a target:
 \begin{verbatim}

--- a/doc/quickref/quickref-cli.tex
+++ b/doc/quickref/quickref-cli.tex
@@ -41,7 +41,7 @@
 \begin{center}
 \textbf{PreTeXt Quick Reference:\\ Command Line Interface (CLI)}\\
 % Steve Clontz, T.\ W.\ Judson, and Oscar Levin \\
-CLI version 1.0.0, 2022-08-05  \\
+CLI version 2.0.0, 2023-09-12  \\
 Full documentation: \url{pretextbook.org}\\
 % Switch to CC?
 GNU Free Document License, extend for your own use
@@ -91,7 +91,7 @@ GNU Free Document License, extend for your own use
 
 
 \hr\textbf{Generate source images and WeBWorK}\\
-If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc. you need to generate these from source.
+If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc. assets will be generated on each build. You can generate separately with:\\
 
 {\ex \verb| pretext generate|}: Generate all assets for first target in {\verb|project.ptx|}.\\
 {\ex \verb| pretext generate webwork|}: Generate webwork for first target in {\verb|publication.ptx|}\\
@@ -103,7 +103,6 @@ If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc
 
 {\ex \verb| pretext view|}: Creates a local server to preview the first target in {\verb|project.ptx|}\\
 {\ex \verb| pretext view print|}: Views the "print" target\\
-{\ex \verb| pretext view -w|}: Builds, starts server, and rebuilds every time the source is saved\\
 % {\ex \verb| CTRL+C|} to close the server\\
 %*********************************************
 
@@ -117,37 +116,29 @@ If your book has any WeBWorK, latex-image, asymptote, sageplot, interactive, etc
 
 %*********************************************
 
-\hr\textbf{Useful Shortcuts}
+% \hr\textbf{Useful Shortcuts}
 
-{\ex \verb| pretext build -g|}: build and generate in one step\\
-{\ex \verb| pretext build web -g latex-image|}: build web target and generate latex-images\\
-{\ex \verb| pretext view -b|}: build before you preview\\
-{\ex \verb| pretext view -g|}: generate assets before you view\\
-{\ex \verb| pretext view -bg|}: generate assets, build, and view\\
+% {\ex \verb| pretext build -g|}: build and generate in one step\\
+% {\ex \verb| pretext build web -g latex-image|}: build web target and generate latex-images\\
+% {\ex \verb| pretext view -b|}: build before you preview\\
+% {\ex \verb| pretext view -g|}: generate assets before you view\\
+% {\ex \verb| pretext view -bg|}: generate assets, build, and view\\
 
 \columnbreak
 
 %*********************************************
 \hr\textbf{Project Manifest}
-The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. "print-latex") that you build or view with, e.g. {\verb|pretext build print-latex|} or generate assets for with, e.g. {\verb|pretext generate webwork -t print-latex|}.  
+The file {\verb|project.ptx|} describes your build targets.  Each target has a \emph{name} (e.g. "print-latex") that you build or view with, e.g. {\verb|pretext build print-latex|}.  
 
 Structure of a target:
 \begin{verbatim}
-  <target name="web">
-    <format>html</format>
-    <source>...</source>
-    <publication>...</publication>
-    <output-dir>...</output-dir>
-  </target>
+  <target name="web" format="html"\>
 \end{verbatim}
-{\ex \verb|<format>|} can be html, latex, pdf, custom, epub, or kindle\\
-{\ex \verb|<source>|} is the path to the root ptx document.  Usually \texttt{source/main.ptx}\\
-{\ex \verb|<publication>|} is the path to the publication file.  Usually \texttt{publication/publication.ptx}\\
-{\ex \verb|<output-dir>|} is the path the the folder that will hold output.  Usually something like \texttt{output/web}\\
-Other optional elements:\\
-{\ex \verb|<stringparam key="..." value="..."/>|}: allows for setting the value of string parameters\\
-{\ex \verb|<xmlid-root>ch-first</xmlid-root>|}: used to restrict build to a subset of the source, starting with the element with xml:id "ch-first"\\ 
-{\ex \verb|<xsl>xsl/custom.xsl</xsl>|}: used to build with a custom xsl file.  Import standard xsl from that file using, e.g.\\ {\verb|<xsl:import href=".core/pretext-common.xsl"/>|}
+{\ex \verb|format|} can be html, latex, pdf, custom, epub, kindle, or braille\\
+Additional attributes:\\
+{\ex \verb|source|} is the path to the root ptx document.  Default: \texttt{source/main.ptx}\\
+{\ex \verb|publication|} is the path to the publication file.  Default \texttt{publication/publication.ptx}\\
+{\ex \verb|output-dir|} is the path the the folder that will hold output.  Default is \texttt{output/[target name]}\\
 
 
 


### PR DESCRIPTION
A large update to the CLI sections of the guide to coincide with CLI version 2.0.  Quickref has also been updated.

Also a couple typo fixes that I came across.