### PR TITLE
Schema: correct "website" contents

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2793,10 +2793,7 @@
                         element entity {TextLong}
                     }*,
                     element edition {text}?,
-                    element website {
-                        element name {TextShort},
-                        element address {text}
-                    }?,
+                    element website {Url}?,
                     element copyright {
                         element year {TextShort},
                         element holder {text},


### PR DESCRIPTION
Assuming the deprecation warning about `<website>` is correct, this should fix the schema for that.