### PR TITLE
Geogebra material customization of presentation

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -7955,12 +7955,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <p>Once you find a material that looks instructive, it will be at a <init>URL</init> such as<cd>https://www.geogebra.org/m/KGn2d4Qd</cd> and you want to pick off the identifier on the end, in this case <c>KGn2d4Qd</c>.  Then author<cd>&lt;interactive geogebra="KGn2d4Qd" /&gt;</cd>  At this writing (2018-02-04) you will want to place this inside a <c>figure</c>, with a caption, as we do right now with material <c>KGn2d4Qd</c>.</p>
 
-                <p>The shape of the material will be fixed, so guess (or measure with an on-screen ruler), the aspect ratio and use that in the <tag>interactive</tag> element.</p>
+                <p>The shape of the material will be fixed, so guess (or measure with an on-screen ruler), the aspect ratio and use that in the <tag>interactive</tag> element. If the width of the original material is anything other than 800 pixels, you should add <c>@srcWidth</c> with the actual material width.</p>
 
                 <figure>
                     <caption>Right Triangle Paradox</caption>
-                    <interactive xml:id="geogebra-right-triangle" geogebra="KGn2d4Qd" width="70%" aspect="9:5"/>
+                    <interactive xml:id="geogebra-right-triangle" geogebra="KGn2d4Qd" width="70%" aspect="9:5" resetIcon="yes"/>
                 </figure>
+
+                <p>There are some optional control elements that Geogebra provides, such as the presence of the toolbar and the reset button. These can be controlled by adding the following additional attributes to the <c>interactive</c>.
+                <ul>
+                    <li><p><c>toolbar="yes"</c>: add the Geogebra toolbar above the material</p></li>
+                    <li><p><c>algebraInput="yes"</c>: add an entry box below the material to add graphical objects using algebra formulas or Geogebra graphical commands</p></li>
+                    <li><p><c>resetIcon="yes"</c>: enable the reset icon</p></li>
+                    <li><p><c>shiftDragZoom="yes"</c>: enable ability to drag and zoom the viewing context</p></li>
+                </ul>
+                </p>
 
                 <p>Note that materials hosted at <c>geogebra.org</c> have a non-standard, non-commercial license you must agree to before you can download them as source code.  Perhaps you must forfeit your copyright when you upload a material?  We have not investigated this thoroughly.</p>
             </subsection>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9894,7 +9894,52 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Geogebra -->
 <!-- Similar again, but with options fixed -->
 <xsl:template match="interactive[@geogebra]" mode="iframe-interactive">
-    <iframe src="https://www.geogebra.org/material/iframe/id/{@geogebra}/width/800/height/450/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false">
+    <xsl:param name="default-aspect" select="'1:1'" />
+    <xsl:variable name="ggbToolBar">
+        <xsl:choose>
+            <xsl:when test="@toolbar='yes'"><xsl:text>true</xsl:text></xsl:when>
+            <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="ggbAlgebraInput">
+        <xsl:choose>
+            <xsl:when test="@algebraInput='yes'"><xsl:text>true</xsl:text></xsl:when>
+            <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="ggbResetIcon">
+        <xsl:choose>
+            <xsl:when test="@resetIcon='yes'"><xsl:text>true</xsl:text></xsl:when>
+            <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="ggbShiftDragZoom">
+        <xsl:choose>
+            <xsl:when test="@shiftDragZoom='yes'"><xsl:text>true</xsl:text></xsl:when>
+            <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="ggbMaterialWidth">
+        <xsl:choose>
+            <xsl:when test="@srcWidth"><xsl:value-of select="@srcWidth"/></xsl:when>
+            <xsl:otherwise>800</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="aspect-ratio">
+        <xsl:apply-templates select="." mode="get-aspect-ratio">
+            <xsl:with-param name="default-aspect" select="$default-aspect" />
+        </xsl:apply-templates>
+    </xsl:variable>
+    <xsl:variable name="ggbMaterialHeight">
+        <xsl:value-of select="round($ggbMaterialWidth div $aspect-ratio)" />
+    </xsl:variable>
+    <!-- iframe options not implemented: -->
+    <!-- smb = show menu bar                   -->
+    <!-- asb = allow style bar                 -->
+    <!-- rc = enable right click options       -->
+    <!-- ld = enable label drag                -->
+    <!-- ctl = click to launch                 -->
+    <iframe src="https://www.geogebra.org/material/iframe/id/{@geogebra}/width/{$ggbMaterialWidth}/height/{$ggbMaterialHeight}/border/888888/smb/false/stb/{$ggbToolBar}/stbh/{$ggbToolBar}/ai/{$ggbAlgebraInput}/asb/false/sri/{$ggbResetIcon}/rc/false/ld/false/sdz/{$ggbShiftDragZoom}/ctl/false">
         <xsl:apply-templates select="." mode="iframe-id"/>
         <xsl:apply-templates select="." mode="size-pixels-attributes" />
     </iframe>


### PR DESCRIPTION
This PR addresses the implementation of additional attributes to interactive[geogebra] so that it is possible to add the toolbar, algebra input, and reset icon, as well as to specify the source material's pixel width for cases where it is different than the default 800. It also changed from a fixed iframe size (that was based on a particular 9:5 aspect ratio) to one that uses the provided aspect ratio. The sample article was also updated in Chapter 14 to describe these options, and the provided example had the reset icon added.

Initiated based on pretext-dev thread https://groups.google.com/g/pretext-dev/c/l8zMPV0WYiA