### PR TITLE
Schema: Fix incorrect start elements

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -70,7 +70,7 @@
         <fragment xml:id="start-elements">
             <title>Start elements</title>
             <code>
-            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Worksheet | Figure | Webwork
+            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
             </code>
         </fragment>
     </section>


### PR DESCRIPTION
This is totally my fault, in 74b0796b9c1ccbdbe2f952b0c283807a526943e3.  I added a few new start elements so editors wouldn't complain about modular files.  Forgot that `Worksheet` is only in the experimental schema, and mis-capitalized `WebWork`.  The result is that the nightly build of the CLI quits before building since it tries to validate the schema.