### PR TITLE
HTML: adjust spacing of icons in footer

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12528,7 +12528,7 @@ TODO:
 <xsl:template name="pretext-link">
     <a class="pretext-link" href="https://pretextbook.org" title="PreTeXt">
         <div class="logo">
-            <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="338 3000 8772 6866">
+            <svg xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="338 3000 8772 6866">
                 <g style="stroke-width:.025in; stroke:black; fill:none">
                     <polyline points="472,3590 472,9732 " style="stroke:#000000;stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; "/>
                     <path style="stroke:#000000;stroke-width:126;stroke-linecap:butt;"  d="M 4724,9448 A 4660 4660  0  0  1  8598  9259"/>


### PR DESCRIPTION
This pull request removes the width attribute on the PreTeXt logo in the page footer.  

This width is preventing the footer's flexbox from distributing the PreTeXt, Runestone, and MathJax icons evenly.