### PR TITLE
Make datafile "questions" be marked as optional in runestone-manifest

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -859,6 +859,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- In database with the same structure as an exercise/question. -->
 <xsl:template match="datafile" mode="runestone-manifest">
     <question>
+    <xsl:attribute name="optional">
+        <xsl:text>yes</xsl:text>
+    </xsl:attribute>
         <!-- label is from the "program", or enclosing "listing" -->
         <xsl:apply-templates select="." mode="runestone-manifest-label"/>
         <htmlsrc>


### PR DESCRIPTION
Datafiles are manifested as questions. Those are counted as "activities" that must be completed in Runestone, but there is no way to complete them.

This sets @optional to True on them, which will cause Runestone to mark them as optional and not count them against students: https://github.com/RunestoneInteractive/rs/blob/10bfd6eb5a3cbb6d6b5e1e5880f004f8691bcf29/components/rsptx/build_tools/core.py#L570

@bnmnetp Should sign off on this before it is merged.