### PR TITLE
WeBWorK: use 'latest' js folder

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10256,7 +10256,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <script src="{$webwork-domain}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
             </xsl:when>
             <xsl:when test="$webwork-reps-version = 2">
-                <script src="{$html.js.server}/js/{$html.js.version}/pretext-webwork/2.{$webwork-minor-version}/pretext-webwork.js"></script>
+                <script src="{$html.js.server}/js/latest/pretext-webwork/2.{$webwork-minor-version}/pretext-webwork.js"></script>
                 <script src="{$webwork-domain}/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.min.js"></script>
             </xsl:when>
         </xsl:choose>


### PR DESCRIPTION
This makes HTML look for `pretext-webwork.js` in the new "latest" folder instead of a versioned folder. Less upkeep for Brad in the assignments page. 