### PR TITLE
Fix typo in schema/pretext.xml

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -498,7 +498,7 @@
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute language {text}?,
-                    attribute line-numberss {"yes"|"no"}?,
+                    attribute line-numbers {"yes"|"no"}?,
                     attribute highlight-lines {text}?,
                     attribute interactive {"codelens"}?,
                     element input {text}

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1432,7 +1432,7 @@
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute language {text}?,
-                    attribute line-numberss {"yes"|"no"}?,
+                    attribute line-numbers {"yes"|"no"}?,
                     attribute highlight-lines {text}?,
                     attribute interactive {"codelens"}?,
                     element input {text}


### PR DESCRIPTION
Sorry for the mess. I blindly followed the GFA cheat sheet. My bad choice not helped by my ignorance on
how to fix things.
I don't know how often the pretext.rnc file gets regenerated so I fixed that file by hand.
Also, there is a PR on pretext/projects. 

Apologies again; I know you're really busy.
 
