### PR TITLE
WeBWorK: store localizations for 'Hint' and 'Solution'

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10404,6 +10404,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="string-id" select="'reset'"/>
             </xsl:apply-templates>
         </xsl:attribute>
+        <xsl:attribute name="data-localize-hint">
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'hint'"/>
+            </xsl:apply-templates>
+        </xsl:attribute>
+        <xsl:attribute name="data-localize-solution">
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'solution'"/>
+            </xsl:apply-templates>
+        </xsl:attribute>
         <xsl:choose>
             <xsl:when test="server-data/@problemSource">
                 <xsl:attribute name="data-problemSource">


### PR DESCRIPTION
The change here puts localized versions of 'Hint' and 'Solution' into `data-` attributes so that later, I can change `pretext-webwork.js` to use those words instead of trying to reverse engineer them from the HTML, which was fragile and recently broke.