### PR TITLE
Include eg/intro ahead of each eg/exercise in manifest

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.xml
+++ b/examples/webwork/sample-chapter/sample-chapter.xml
@@ -2527,6 +2527,57 @@
                 </exercises>
             </section>
 
+            <section xml:id="section-runestone-testing">
+                <title>Runestone Assignment Testing</title>
+                <p>
+                    This section is specifically for testing when exercises are migrated to a
+                    Runestone Assignment page.
+                </p>
+                <exercises>
+                    <exercisegroup>
+                        <introduction>
+                            <p>
+                                This introduction should appear ahead of the exercise when it shows
+                                up in the Assignment page.
+                            </p>
+                            <tabular>
+                                <row>
+                                    <cell><m>(0,0)</m></cell>
+                                    <cell><m>(0,1)</m></cell>
+                                </row>
+                                <row>
+                                    <cell><m>(1,0)</m></cell>
+                                    <cell><m>(1,1)</m></cell>
+                                </row>
+                            </tabular>
+                            <image>
+                                <latex-image>
+                                    \begin{tikzpicture}
+                                        \draw[fill=blue!20] (0,0) -| (1,1) -| cycle;
+                                    \end{tikzpicture}
+                                </latex-image>
+                                <shortdescription>a blue square</shortdescription>
+                            </image>
+                            <p>
+                                It has a table and an image too to check it all comes through.
+                            </p>
+                        </introduction>
+                        <exercise label="an-exercisegroup-exercise">
+                            <webwork>
+                                <statement>
+                                    <p>
+                                        What is <m>1+1</m>?
+                                    </p>
+                                    <p>
+                                        <var name="'2'" width="5"/>>
+                                    </p>
+                                </statement>
+                            </webwork>
+                        </exercise>
+                    </exercisegroup>
+                </exercises>
+            </section>
+
             <section xml:id="section-deprecations">
                 <title>Deprecations</title>
 

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -800,6 +800,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- not knowled. Solutions are available in the originals, via  -->
         <!-- an "in context" link off the Assignment page                -->
         <htmlsrc>
+            <xsl:apply-templates select="." mode="introduction"/>
             <xsl:choose>
                 <!-- with "webwork" guts, the HTML is exceptional -->
                 <xsl:when test="@exercise-interactive = 'webwork-reps'">
@@ -820,6 +821,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:choose>
         </htmlsrc>
     </question>
+</xsl:template>
+
+<xsl:template match="*" mode="introduction"/>
+
+<xsl:template match="exercisegroup/exercise" mode="introduction">
+    <xsl:apply-templates select="parent::exercisegroup/introduction"/>
 </xsl:template>
 
 <!-- TODO: by renaming/refactoring the templates inside of   -->


### PR DESCRIPTION
This is just to sit here until confirmed by @bnmnetp that this does not run contrary to Runestone philosophy.

When an interactive exercise is within an exercisegroup, this adds the exercisegroup's introduction to the htmlsrc version of the exercise in the manifest. For example, suppose a book has this exercisegroup:

```
Convert the given Celsius temperature to Fahrenheit using the formula F = 9/5 C + 32.
  1. 0 degC
  2. 100 degC
```

Prior to this PR, suppose you put the first exercise into a RS Assignment. Then on the assignments page you just get:
```
   0 degC
```
(Of course you can use the in-context link to see the introduction.)

With this PR, you will see:
```
   Convert the given Celsius temperature to Fahrenheit using the formula F = 9/5 C + 32.
   0 degC
```

I started a section in the Sample Chapter (newly reborn as a book thanks to Brad and Rob) that is for testing specific things about when a WW exercise is used in a RS assignment. I'm not sure that I can actually test what the end result of this will look like in a RS Assignment. But I can see the added content in the manifest htmlsrc, and it looks like I would expect it to look, as far as raw HTML.
