### PR TITLE
Add `requirements.txt` for easy pip install of external libraries

### DIFF
--- a/doc/guide/appendices/python.xml
+++ b/doc/guide/appendices/python.xml
@@ -74,9 +74,18 @@
           If you have installed the <pretext/>-CLI already using pip, then all the programs below are already installed.  Otherwise (for example, if you are using <c>xsltproc</c>) you will need to install the following manually.
         </p>
 
-        <p>In your virtual environment, go<cd>
+        <p>
+          To install all required additional python libraries, in your virtual enviroment, navigate to the <c>pretext</c> directory and run
+          <cd>
+            <cline>(ptx) $ pip install<cline>
+          </cd>
+          You can also install individual libraries, as in
+          <cd>
             <cline>(ptx) $ pip install lxml</cline>
-        </cd>Now you have a collection of Python routines that interface with the same base libraries for <init>XSL</init> processing as the <c>xsltproc</c> executable.  A second library is <c>requests</c> which moderates communications with online servers and is necessary to communicate with WeBWorK servers and with a YouTube server that provides thumbnail images for static versions of videos. The <c>pdfCropMargins</c> package provides a tool that will crop images during their production with the <c>pretext</c> script.  Finally, <c>playwright</c> uses a Chromium headless browser to take static screenshots of interactive elements of your project.</p>
+          </cd>
+        </p>
+
+        <p>With <c>lxml</c>, you have a collection of Python routines that interface with the same base libraries for <init>XSL</init> processing as the <c>xsltproc</c> executable.  A second library is <c>requests</c> which moderates communications with online servers and is necessary to communicate with WeBWorK servers and with a YouTube server that provides thumbnail images for static versions of videos. The <c>pdfCropMargins</c> package provides a tool that will crop images during their production with the <c>pretext</c> script.  Finally, <c>playwright</c> uses a Chromium headless browser to take static screenshots of interactive elements of your project.</p>
 
         <p>Note that right after you install <c>playwright</c> then you want to run<cd>
             <cline> playwright install</cline>

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -200,11 +200,11 @@
         </cd>
         And if it isn't, you can install it with <c>pip</c>, specifically with:
         <cd>
-          sudo pip install requests
+          pip install requests
         </cd>
         (If you don't have <c>pip</c> installed, you could use:
         <cd>
-          sudo easy_install pip
+          easy_install pip
         </cd>
         to install it.)
       </p>

--- a/pretext/requirements.txt
+++ b/pretext/requirements.txt
@@ -1,0 +1,10 @@
+# Python packages to be installed by pip.  
+# From this folder, run `pip install` to ensure all the following are installed.
+
+lxml
+pdfCropMargins >= 1.0.9, < 1.1 
+playwright 
+PyPDF2 >= 2.5, <2.6
+pyMuPDF
+qrcode
+requests


### PR DESCRIPTION
Two commits, the second add documentation.  Now users can run `pip install` from the `pretext` directory to get all external libraries.