### PR TITLE
Add born-hidden-knowl class

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2811,6 +2811,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- put relevant class names on "details" to help with styling -->
         <xsl:attribute name="class">
             <xsl:apply-templates select="." mode="body-css-class"/>
+            <xsl:text> born-hidden-knowl</xsl:text>
         </xsl:attribute>
         <!-- the clickable that is visible on the page -->
         <summary>


### PR DESCRIPTION
Current details implementation for born hidden knowls lacks identifying class for CSS targeting. This adds `born-hidden-knowl` to them.