### PR TITLE
WeBWorK: check select option exists before setting as selected

### DIFF
--- a/js/pretext-webwork/2.17/pretext-webwork.js
+++ b/js/pretext-webwork/2.17/pretext-webwork.js
@@ -182,7 +182,7 @@ function handleWW(ww_id, action) {
 					if (/^\\text\{.*\}$/.test(this_answer)) {this_answer = this_answer.match(/^\\text\{(.*)\}$/)[1]};
 					let quote_escaped_answer = this_answer.replace(/"/g, '\\"');
 					const option = body_div.querySelector(`select[id="${answer}"] option[value="${quote_escaped_answer}"]`);
-					option.setAttribute('selected', 'selected');
+					if (option) {option.setAttribute('selected', 'selected')};
 				}
 			}
 		}


### PR DESCRIPTION
This should fix something mentioned today on -dev.

@davidfarmer Do you know what is the procedure now? Should I merge this? Is it better if I ask you to merge it? And then should I go somewhere on the utmost server and pull?