### PR TITLE
Add a valid href to knowled xref's

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7967,8 +7967,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- build a modern knowl -->
                     <xsl:when test="$knowl='true'">
-                        <!-- provide href for a fallback beavior if JS is disabled -->
-                        <!-- or knowl loading fails  -->
+                        <!-- provide href for a fallback behavior if knowl is -->
+                        <!-- disabled intentionally or not                    -->
                         <xsl:attribute name="href">
                             <xsl:apply-templates select="$target" mode="url" />
                         </xsl:attribute>
@@ -7980,6 +7980,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:apply-templates select="$target" mode="knowl-filename">
                                 <xsl:with-param name="origin" select="$origin"/>
                             </xsl:apply-templates>
+                        </xsl:attribute>
+                        <!-- text to use for tooltip/aria  -->
+                        <xsl:attribute name="data-reveal-label">
+                            <xsl:apply-templates select="." mode="type-name">
+                                <xsl:with-param name="string-id" select="'reveal'"/>
+                            </xsl:apply-templates>
+                            <xsl:text> </xsl:text>
+                            <xsl:copy-of select="$content"/>
                         </xsl:attribute>
                     </xsl:when>
                     <!-- build traditional hyperlink -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7967,11 +7967,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- build a modern knowl -->
                     <xsl:when test="$knowl='true'">
-                        <!-- empty, but presence needed for accessibility -->
-                        <!-- An HTML "a" without an href attribute does   -->
-                        <!-- not default to role "link" and does not read -->
-                        <!-- as clickable by a screen reader.             -->
-                        <xsl:attribute name="href"/>
+                        <!-- provide href for a fallback beavior if JS is disabled -->
+                        <!-- or knowl loading fails  -->
+                        <xsl:attribute name="href">
+                            <xsl:apply-templates select="$target" mode="url" />
+                        </xsl:attribute>
                         <!-- mark as duplicated content via an xref -->
                         <xsl:attribute name="class">
                             <xsl:text>xref</xsl:text>


### PR DESCRIPTION
Make sure a valid href is available for xref links in case knowl.js is not loaded.

`<a href="./some-page.html" class="xref" data-knowl...`

Instead of

`<a href class="xref" data-knowl...`

@davidfarmer - Question for David: The knowl code strips out the href of all xref knowls and ignores the default behavior of clicking on them. Thus I can't find any harm from having the href value there. Can you think of any weird situation where it might cause issues?