### PR TITLE
Knowl rewrite

### DIFF
--- a/css/knowls_default.css
+++ b/css/knowls_default.css
@@ -82,6 +82,7 @@ article > [data-knowl]::after, article > [data-knowl]:hover::after, article > [d
     border-radius: 10px;
     padding: 0;
     margin-top: 10px;
+    scroll-margin-top: 60px; /* height of header */
 }
 
 .knowl-output.original {
@@ -109,7 +110,17 @@ article > [data-knowl]::after, article > [data-knowl]:hover::after, article > [d
     background: inherit;
 }
 
+.knowl-output--hide {
+    display: none;
+}
 
+.knowl-output__error .para:first-child {
+    margin-top: 0;
+}
+
+.knowl-output__error a {
+    text-decoration: underline;
+}
 
 .knowl-output .knowl-output {
     border-width: 6px;

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -9032,6 +9032,37 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <p>Foo <dataurl source="data/runningstatisticstemplate.ots" visual="http://example.com">Runners Template</dataurl> Bar</p>
             <p>Foo <dataurl href="http://go.microsoft.com/fwlink/?LinkID=521962">Sample Excel Spreadsheet</dataurl> Bar</p>
             <p>Foo <dataurl source="data/runningstatisticstemplate.ots">Runners Template</dataurl> Bar</p>
+            <p>Testing of output positioning for xref's that are inside containers:</p>
+            <table xml:id="self-referential-tabular-xref">
+                <title>Self-referential Xref In a table</title>
+                <tabular>
+                    <row bottom="medium">
+                        <cell>A</cell>
+                        <cell>B</cell>
+                        <cell>C</cell>
+                        <cell>D</cell>
+                    </row>
+                    <row>
+                        <cell><xref ref="self-referential-tabular-xref" text="type-global" /></cell>
+                        <cell>B</cell>
+                        <cell>C</cell>
+                        <cell>D</cell>
+                    </row>
+                </tabular>
+            </table>
+            
+            <figure>
+                <caption>Xref Inside MathJAX</caption>
+                <p>
+                    <md>
+                        <mrow>{\mathbb Z}_2 \times {\mathbb Z}_2</mrow>
+                        <mrow><xref ref="theorem-FTC" text="type-global"/></mrow>
+                        <mrow>{\mathbb Z}_2 \times {\mathbb Z}_2</mrow>
+                    </md>
+                </p>
+            </figure>
+
+            <p>Now we have two xref's to that same target that has a runestone component. Only the first one clicked should try to render the runestone.<xref ref="program-activecode-python"/><xref ref="program-activecode-python"/></p>
         </section>
 
         <section xml:id="section-internationalization" label="section-internationalization">

--- a/js_lib/knowl.js
+++ b/js_lib/knowl.js
@@ -82,7 +82,7 @@ class LinkKnowl {
 
   // Returns element the knowl output should be inserted after
   findOutputLocation() {
-    const invalidParents = "table, mjx-container, div.tabular-box";
+    const invalidParents = "table, mjx-container, div.tabular-box, .runestone > .parsons";
     // Start with the link's parent, move up as long as there are invalid parents
     let el = this.linkElement.parentElement;
     let problemAncestor = el.closest(invalidParents);

--- a/js_lib/knowl.js
+++ b/js_lib/knowl.js
@@ -1,344 +1,216 @@
-/* 
- * Knowl - Feature Demo for Knowls
- * Copyright (C) 2011  Harald Schilly
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * 4/11/2012 Modified by David Guichard to allow inline knowl code.
- * Sample use:
- *      This is an <a data-knowl="" class="internal" 
- *      value="Hello World!">inline knowl.</a>
- */
+// Code for link based knowls
 
-/*  8/14/14  Modified by David Farmer to allow knowl content to be
- *  taken from the element with a given id.
- *
- * The syntax is <a data-knowl="" class="id-ref" data-refid="proofSS">Proof</a>
- */
- 
-/* javascript code for the knowl features 
- * global counter, used to uniquely identify each knowl-output element
- * that's necessary because the same knowl could be referenced several times
- * on the same page */
-var knowl_id_counter = 0;
+// Assumes this file is loaded as part of initial page
+window.addEventListener("load", (event) => {
+  addLinkKnowls(document);
+});
 
-var knowl_focus_stack_uid = [];
-var knowl_focus_stack = [];
-
-var sagecellEvalName = "Evaluate";
-
-var mjvers = 0;
-if (window.MathJax !== undefined) {
-  mjvers = MathJax.version;
-  console.log("mjvers", mjvers);
-  if (typeof mjvers == 'undefined') {
-    mjvers = "2.14159";
+function addLinkKnowls(target) {
+  const xrefs = target.querySelectorAll("[data-knowl]");
+  for (const xref of xrefs) {
+    LinkKnowl.initializeXrefKnowl(xref);
   }
-  mjvers = parseFloat(mjvers.substring(0,3));
 }
-console.log("               mjvers", mjvers);
 
- 
-function knowl_click_handler($el) {
-  // the knowl attribute holds the id of the knowl
-  var knowl_id = $el.attr("data-knowl");
-  // the uid is necessary if we want to reference the same content several times
-  var uid = $el.attr("data-knowl-uid");
-  var output_id = '#knowl-output-' + uid; 
-  var $output_id = $(output_id);
-  // create the element for the content, insert it after the one where the 
-  // knowl element is included (e.g. inside a <h1> tag) (sibling in DOM)
-  var idtag = "id='"+output_id.substring(1) + "'";
-  var kid   = "id='kuid-"+ uid + "'";
-  // if we already have the content, toggle visibility
+// A LinkKnowl managages a single link based knowl
+class LinkKnowl {
+  // Used to uniquely identify XrefKnowls
+  static xrefCount = 0;
 
-  // Note that for tracking knowls, this setup is not optimal
-  // because it applies to open knowls and also knowls which
-  // were opened and then closed.
-  if ($output_id.length > 0) {
-     thisknowlid = "kuid-"+uid
-// when this is an entry in a table, then it is the parents parent we need to toggle
-// also need to clean this up
-     if($("#kuid-"+uid).parent().is("td.knowl-td")) {
-         $("#kuid-"+uid).parent().parent().slideToggle("fast");
-     }
-     else {
-         $("#kuid-"+uid).slideToggle("fast");
-     }
-
-     if($el.attr("replace")) {
-       $($el.attr("replace")).slideToggle("fast");
-     }
-
-     this_knowl_focus_stack_uidindex = knowl_focus_stack_uid.indexOf(uid);
-     
-     if($el.hasClass("active")) {
-       if(this_knowl_focus_stack_uidindex != -1) {
-         knowl_focus_stack_uid.splice(this_knowl_focus_stack_uidindex, 1);
-         knowl_focus_stack.splice(this_knowl_focus_stack_uidindex, 1);
-       }
-     }
-     else {
-         knowl_focus_stack_uid.push(uid);
-         knowl_focus_stack.push($el);
-         document.getElementById(thisknowlid).focus();
-     }
-
-     $el.toggleClass("active");
- 
-  // otherwise download it or get it from the cache
-  } else { 
-    // where_it_goes is the location the knowl will appear *after*
-    // knowl is the variable that will hold the content of the output knowl
-    var where_it_goes = $el;
-    var knowl = "";
-    if ($el.hasClass('original')) {  // knowls with original content can be styled differently from xref knowls
-        knowl = "<div class='knowl-output original' "+kid+"><div class='knowl'><div class='knowl-content' " +idtag+ ">loading '"+knowl_id+"'</div><div class='knowl-footer'>"+knowl_id+"</div></div></div>";
-    } else {
-        knowl = "<div class='knowl-output' "+kid+"><div class='knowl'><div class='knowl-content' " +idtag+ ">loading '"+knowl_id+"'</div><div class='knowl-footer'>"+knowl_id+"</div></div></div>";
-    }
-
-    // addafter="#id" means to put the knowl after the element with that id
-    if($el.attr("addafter")) {
-        where_it_goes = $($el.attr("addafter"));
-    } else if($el.attr("replace")) {
-        where_it_goes = $($el.attr("replace"));
-    } else if($el.hasClass("kohere")) {
-        where_it_goes = $el;
-    } else if($el.hasClass("original") && $el.parent().is("article")) {
-        where_it_goes = $el.after();
-    } else {
-       // otherwise, typically put it after the nearest enclosing block element
-
-      // check, if the knowl is inside a td or th in a table
-      if($el.parent().is("td") || $el.parent().is("th") ) {
-        // assume we are in a td or th tag, go 2 levels up
-        where_it_goes = $el.parent().parent();
-        var cols = $el.parent().parent().children().length;
-        knowl = "<tr><td colspan='"+cols+"' class='knowl-td'>"+knowl+"</td></tr>";
-      } else if ($el.parent().is("p") && $el.parent().parent().is("td")) {
-        where_it_goes = $el.parent().parent().parent();
-        var cols = $el.parent().parent().parent().children().length;
-        knowl = "<tr><td colspan='"+cols+"' class='knowl-td'>"+knowl+"</td></tr>";
-      } else if ($el.parent().is("li")) {
-        where_it_goes = $el.parent();
-      } 
-      // not sure it is is worth making the following more elegant
-      else if ($el.parent().parent().is("li")) {
-        where_it_goes = $el.parent().parent();
-        // the '.is("p")' is for the first paragraph of a theorem or proof
-      } else if ($el.parent().prop("tagName").startsWith("MJX")) {
-          where_it_goes = $el.closest("mjx-container")
-      } else if ($el.parent().css('display') == "block" || $el.parent().is("p") || $el.parent().hasClass("para") || $el.parent().hasClass("hidden-knowl-wrapper") || $el.parent().hasClass("kohere")) {
-        where_it_goes = $el.parent();
-      } else if ($el.parent().parent().css('display') == "block" || $el.parent().parent().is("p") || $el.parent().parent().hasClass("hidden-knowl-wrapper") || $el.parent().parent().hasClass("kohere")) {
-        where_it_goes = $el.parent().parent();
-      } else {
-        //  is this a reasonable last case?
-        //  if we omit the else, then if goes after $el
-        where_it_goes = $el.parent().parent().parent();
-      }
-
-    }
-
-    // now that we know where the knowl goes, insert the knowl content
-    if($el.attr("replace")) {
-        where_it_goes.before(knowl);
-    }
-    else {
-        where_it_goes.after(knowl);
-    }
- 
-    // "select" where the output is and get a hold of it 
-    var $output = $(output_id);
-    var $knowl = $("#kuid-"+uid);
-    $output.addClass("loading");
-    $knowl.hide();
-
-    // DRG: inline code
-    if ($el.hasClass('internal')) {
-      $output.html($el.attr("value"));
-//    } else if ($el.attr("class") == 'id-ref') {
-    } else if ($el.hasClass('id-ref')) {
-     //get content from element with the given id
-      $output.html($("#".concat($el.attr("data-refid"))).html());
-    } else {
-    // Get code from server.
-    $output.load(knowl_id,
-     function(response, status, xhr) { 
-       $knowl.removeClass("loading");
-       if (status == "error") {
-         $el.removeClass("active");
-         $output.html("<div class='knowl-output error'>ERROR: " + xhr.status + " " + xhr.statusText + '</div>');
-         $output.show();
-       } else if (status == "timeout") {
-         $el.removeClass("active");
-         $output.html("<div class='knowl-output error'>ERROR: timeout. " + xhr.status + " " + xhr.statusText + '</div>');
-         $output.show();
-       }
-       else {
-           // this is sloppy, because this is called again later.
-         if (mjvers && mjvers < 3) {
-              MathJax.Hub.Queue(['Typeset', MathJax.Hub, $output.get(0)]);
-         } else if (mjvers > 3) {
-              MathJax.typesetPromise([$output.get(0)]);
-         }
-// not sure of the use case for this,
-// since the same code appears later:
- $(".knowl-output .hidden-content .hidden-sagecell-sage").attr("class", "doubly-hidden-sagecell-sage");
- $(".knowl-output .hidden-sagecell-sage").attr("class", "sagecell-sage");
- sagecell.makeSagecell({inputLocation: ".sagecell-sage",  linked: true, evalButtonText: sagecellEvalName });
- $(".knowl-output .hidden-content .doubly-hidden-sagecell-sage").attr("class", "hidden-sagecell-sage");
-    }
-     });
-    };
-
-   // we have the knowl content, and put it hidden in the right place,
-   // so now we show it
-
-   $knowl.hide();
-
-   $el.addClass("active");
- // if we are using MathJax, then we reveal the knowl after it has finished rendering the contents
-   if(window.MathJax == undefined) {
-            $knowl.slideDown("slow");
-   } else {
-     if (mjvers < 3) {
-       $knowl.addClass("processing");
-       MathJax.Hub.Queue(['Typeset', MathJax.Hub, $output.get(0)]);
-       MathJax.Hub.Queue([ function() {
-       $knowl.removeClass("processing");
-       $knowl.slideDown("slow");
-
-       // if replacing, then need to hide what was there
-       // (and also do some other things so that toggling works -- not implemented yet)
-       if($el.attr("replace")) {
-          var the_replaced_thing = $($el.attr("replace"));
-          the_replaced_thing.hide("slow");
-        }
-
-        var thisknowlid = 'kuid-'.concat(uid)
-        document.getElementById(thisknowlid).tabIndex=0;
-        document.getElementById(thisknowlid).focus();
-        knowl_focus_stack_uid.push(uid);
-        knowl_focus_stack.push($el);
-        $("a[data-knowl]").attr("href", "");
-        }]);
-     } else if (mjvers > 3) {
-       console.log("processing for MJ3");
-       $knowl.addClass("processing");
-  //      MathJax.typesetPromise([$output.get(0)]);
-  //      MathJax.typesetPromise([ function() {
-        MathJax.typesetPromise([$output.get(0)]);
-       $knowl.removeClass("processing");
-       $knowl.slideDown("slow");
-
-       console.log("just did slideDown");
-       // if replacing, then need to hide what was there
-       // (and also do some other things so that toggling works -- not implemented yet)
-       if($el.attr("replace")) {
-          var the_replaced_thing = $($el.attr("replace"));
-          the_replaced_thing.hide("slow");
-        }
-
-        var thisknowlid = 'kuid-'.concat(uid)
-        document.getElementById(thisknowlid).tabIndex=0;
-        document.getElementById(thisknowlid).focus();
-        knowl_focus_stack_uid.push(uid);
-        knowl_focus_stack.push($el);
-        $("a[data-knowl]").attr("href", "");
-//        }]);
-     } else {
-        $knowl.slideDown("slow");
-     }
-// if this is before the MathJax, big problems
-        $(".knowl-output .hidden-content .hidden-sagecell-sage").attr("class", "doubly-hidden-sagecell-sage");
-        $(".knowl-output .hidden-sagecell-sage").attr("class", "sagecell-sage");
-        try {
-          sagecell.makeSagecell({inputLocation: ".sagecell-sage",  linked: true, evalButtonText: sagecellEvalName});
-        } catch {
-          console.log("sagecell is missing")
-        }
-        $(".knowl-output .hidden-content .doubly-hidden-sagecell-sage").attr("class", "hidden-sagecell-sage");
+  // Factory to create an XrefKnowl from a knowl link
+  // Will avoid duplicate initialization
+  // This should be used by outside code to create XrefKnowls
+  static initializeXrefKnowl(knowlLinkElement) {
+    if (knowlLinkElement.getAttribute("data-knowl-uid") === null) {
+      return new LinkKnowl(knowlLinkElement);
     }
   }
-  return($knowl)
-} //~~ end click handler for *[data-knowl] elements
 
-/** register a click handler for each element with the knowl attribute 
- * @see jquery's doc about 'live'! the handler function does the 
- *  download/show/hide magic. also add a unique ID, 
- *  necessary when the same reference is used several times. */
-$(function() {
-    $("body").on("click", "*[data-knowl]", function(evt) {
-      evt.preventDefault();
-      var $knowl = $(this);
-      if(!$knowl.attr("data-knowl-uid")) {
-        $knowl.attr("data-knowl-uid", knowl_id_counter);
-        knowl_id_counter++;
+  // "Private" constructor - should only be called by initializeXrefKnowl
+  constructor(knowlLinkElement) {
+    this.linkElement = knowlLinkElement;
+    this.outputElement = null;
+    this.uid = LinkKnowl.xrefCount++;
+    knowlLinkElement.setAttribute("data-knowl-uid", this.uid);
+
+    // Xref's behavior is that of a button
+    knowlLinkElement.setAttribute("role", "button");
+
+    // Stash a copy of the original title for use in aria-label
+    // If no title, use textContent
+    knowlLinkElement.setAttribute("data-base-title", knowlLinkElement.getAttribute("title") || this.linkElement.textContent);
+
+    this.updateLabels(false);
+
+    // Bind required to force "this" of event handler to be this object
+    knowlLinkElement.addEventListener("click", this.handleLinkClick.bind(this));
+  }
+
+  // Set aria-label and title based on visibility of knowl
+  updateLabels(isVisible) {
+    const verb = isVisible
+      ? this.linkElement.getAttribute("data-close-label") || "Close"
+      : this.linkElement.getAttribute("data-reveal-label") || "Reveal";
+    const targetDescript = this.linkElement.getAttribute("data-base-title");
+    const helpText = verb + " " + targetDescript;
+
+    this.linkElement.setAttribute("aria-label", helpText);
+    this.linkElement.setAttribute("title", helpText);
+  }
+
+  // Toggle the state of the knowl link and output elements
+  // Assumes output is already created
+  toggle() {
+    this.linkElement.classList.toggle("active");
+    this.updateLabels(this.linkElement.classList.contains("active"));
+
+    this.outputElement.classList.toggle("knowl-output--hide");
+
+    // Scroll to reveal if needed
+    if (!this.outputElement.classList.contains("knowl-output--hide")) {
+      const h = this.outputElement.getBoundingClientRect().height;
+      if (h > window.innerHeight) {
+        // knowl is taller than window, scroll to top of knowl
+        this.outputElement.scrollIntoView(true);
+      } else {
+        // reveal full knowl
+        if (this.outputElement.getBoundingClientRect().bottom > window.innerHeight)
+          this.outputElement.scrollIntoView(false);
       }
-      var knowlc = knowl_click_handler($knowl, evt);
-      console.log("after click handler", knowlc);
-      if (typeof knowlc !== "undefined") {
-        setTimeout(function () {
-          if (knowlc[0]["innerHTML"].includes("knowl-output error")) {
-            console.log("seem to have a bad knowl")
-            var missing_knowl_message = "<div style='padding: 0.5rem 1rem'>";
-            missing_knowl_message += "<h2>This is not the knowl you are looking for!</h2>";
-            missing_knowl_message += "<h3>Why is that?</h3>";
-            missing_knowl_message += "<p>The knowl you wanted was empty, so this message was put in its place.</p>";
-            missing_knowl_message += "<p>If you are viewing this file on your laptop, ";
-            missing_knowl_message += "a security setting on your browser prevents ";
-            missing_knowl_message += "the knowl file from opening, resulting in an empty knowl.  See the <a href='https://pretextbook.org/doc/guide/html/author-faq.html' style='text-decoration: underline; color:#00f'>PreTeXt FAQ</a>.</p>";
-            missing_knowl_message += "<p>If you are viewing this page from a server, ";
-            missing_knowl_message += "then something else went wrong.</p>";
-            missing_knowl_message += "</div>";
-            knowlc[0]["innerHTML"] = missing_knowl_message
+    }
+  }
+
+  // Returns element the knowl output should be inserted after
+  findOutputLocation() {
+    const invalidParents = "table, mjx-container, div.tabular-box";
+    // Start with the link's parent, move up as long as there are invalid parents
+    let el = this.linkElement.parentElement;
+    let problemAncestor = el.closest(invalidParents);
+    while (problemAncestor && problemAncestor !== el) {
+      el = problemAncestor;
+      problemAncestor = el.closest(invalidParents);
+    }
+    return el;
+  }
+
+  // Create the knowl output element
+  createOutputElement() {
+    const outputId = "knowl-uid-" + this.uid;
+    const outputContentsId = "knowl-output-" + this.uid;
+    const linkTarget = this.linkElement.getAttribute("data-knowl");
+
+    const placeholderText = `<div class='knowl-output knowl-output--hide' id='${outputId}' aria-live='polite'>`
+      + `<div class='knowl'>`
+      + `<div class='knowl-content' id='${outputContentsId}'>`
+      + `Loading '${linkTarget}'`
+      + `</div>`
+      + `<div class='knowl-footer'>${linkTarget}</div>`
+      + `</div></div></div>`;
+
+    const temp = document.createElement("template");
+    temp.innerHTML = placeholderText;
+    this.outputElement = temp.content.children[0];
+
+    const insertLoc = this.findOutputLocation(this.linkElement);
+    insertLoc.after(this.outputElement);
+  }
+
+  // Get content for knowl as dom element. Returns promise that resolves to knowl content
+  async getContent() {
+    const contentURL = this.linkElement.getAttribute("data-knowl");
+    const knowlContent = await fetch(contentURL)
+      .then((response) => response.text())
+      .then((data) => {
+        // knowls are full HTML pages, need to just extract body
+        let knowlDoc = (new DOMParser()).parseFromString(data, "text/html");
+        let tempContainer = knowlDoc.body;
+        // grab any scripts from head of knowl doc and add them to the output
+        let scripts = knowlDoc.querySelectorAll("head script");
+        tempContainer.append(...scripts);
+        return tempContainer;
+      })
+      .catch((error) => {
+        const destination = this.linkElement.getAttribute("href");
+        const text = this.linkElement.textContent;
+        const err_message = `<div class='knowl-output__error'>`
+          + `<div class='para'>Error fetching content. (<em>${error}</em>)</div>`
+          + `<div class='para'><a href='${destination}'>Navigate to ${text}</a> instead.</div>`
+          + `<div class='para'>If you are viewing this book from your local filesystem, this is expected behavior. To view the book with all features, you must serve the book from a web server. See the <a href="https://pretextbook.org/doc/guide/html/author-faq.html#how-do-i-view-my-book-locally">PreTeXt FAQ</a> for more information.</div>`
+          + `</div>`;
+        return err_message;
+      });
+    return knowlContent;
+  }
+
+  // Handle a click on the knowl link
+  handleLinkClick(event) {
+    // prevent navigation
+    event.preventDefault();
+
+    if (this.outputElement !== null) {
+      // output already created, toggle visibility
+      this.toggle();
+    } else {
+      this.createOutputElement();
+
+      // Wait up to a half second in hopes of avoiding double content change
+      // then render to show loading message
+      let loadingTimeout = setTimeout(() => {
+        loadingTimeout = null;
+        this.toggle();
+      }, 500);
+
+      const content = this.getContent();
+
+      // Content is a promise at this point, insert when resolved
+      content
+        .then((tempContainer) => {
+          // if timeout still active, cancel it and render
+          if (loadingTimeout !== null) {
+            clearTimeout(loadingTimeout);
           }
-         }, 1000
-        )
-      }
-  });
-});
+          // Now give code that follows .1 seconds to render before making visible
+          setTimeout(() => {
+            this.toggle();
+          }, 100);
 
+          // check embeded runestone interactives by loading content into a temp container
+          // we want to not render any that already are on page. Dupe IDs probably bad
+          const runestoneElements = tempContainer.querySelectorAll(".ptx-runestone-container");
+          [...runestoneElements].forEach((e) => {
+            const rsId = e.querySelector("[data-component]")?.id;
+            const onPage = document.getElementById(rsId);
+            if (onPage) {
+              e.innerHTML = `<div class="para">The interactive that belongs here is already on the page and cannot appear multiple times. <a href="#${rsId}">Scroll to interactive.</a>`;
+            } else {
+              // let runestone start rendering it
+              window.runestoneComponents.renderOneComponent(e);
+            }
+          });
 
-// change from jQuery 3
-// $(window).load(function() {
-$(window).on("load", function() {
-   $("a[data-knowl]").attr("href", "");
-});
+          // now move all contents to the real output element
+          const target = document.getElementById("knowl-output-" + this.uid);
+          const children = [...tempContainer.children];
+          target.innerHTML = "";
+          target.append(...children);
 
-//window.onload = function() {
-/*
-window.addEventListener("load",function(event) {
-    document.onkeyup = function(event)
-    {
-        var e = (!event) ? window.event : event;
-        switch(e.keyCode)
-        {
-            case 27: //esc
-                if(knowl_focus_stack.length > 0 ) {
-                   most_recently_opened = knowl_focus_stack.pop();
-                   knowl_focus_stack_uid.pop();
-                   most_recently_opened.focus();
-                } else {
-                   console.log("no open knowls being tracked");
-                   break;
-                }
-        };
-    };
-},
-false);
+          // render any knowls and mathjax in the knowl
+          MathJax.typesetPromise([target]);
+          addLinkKnowls(target);
 
-*/
+          // force any scripts (e.g. sagecell) to execute by evaling them
+          [...target.getElementsByTagName("script")].forEach((s) => {
+            if (
+              s.getAttribute("type") === null ||
+              s.getAttribute("type") === "text/javascript"
+            ) {
+              eval(s.innerHTML);
+            }
+          });
+        })
+        .catch((data) => {
+          console.log("Error fetching knowl content: " + data);
+        });
+    }
+  }
+}

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -264,4 +264,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -288,4 +288,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -267,4 +267,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -262,4 +262,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Reset</localization>
     <localization string-id='array'>pole</localization>
     <localization string-id='print'>Tisk</localization>
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -273,4 +273,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -311,5 +311,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='array'>array</localization>
     <!-- Print page button text -->
     <localization string-id='print'>Print</localization>
+    <!-- Close something interactive                              -->
+    <localization string-id='close'>Close</localization>
 
 </locale>

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -268,4 +268,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -274,4 +274,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -258,4 +258,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -260,4 +260,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -262,4 +262,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -263,4 +263,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Azzera</localization>
     <localization string-id='array'>tabella</localization>
     <localization string-id='print'>Stampa</localization>
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/ku-CKB.xml
+++ b/xsl/localizations/ku-CKB.xml
@@ -307,5 +307,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='array'>ڕیزکراو</localization>
     <!-- Print page button text -->
     <localization string-id='print'>پرنت</localization>
-
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/nl-NL.xml
+++ b/xsl/localizations/nl-NL.xml
@@ -315,4 +315,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Reset an interactive to its original state               -->
     <localization string-id='reset'>Resetten</localization>
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -271,4 +271,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Redefinir</localization>
     <localization string-id='array'>lista</localization>
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -274,4 +274,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/zh-HANS.xml
+++ b/xsl/localizations/zh-HANS.xml
@@ -311,5 +311,5 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='array'>数组</localization>
     <!-- Print page button text -->
     <localization string-id='print'>打印</localization>
-
+    <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7959,11 +7959,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- build a modern knowl -->
                     <xsl:when test="$knowl='true'">
-                        <!-- empty, but presence needed for accessibility -->
-                        <!-- An HTML "a" without an href attribute does   -->
-                        <!-- not default to role "link" and does not read -->
-                        <!-- as clickable by a screen reader.             -->
-                        <xsl:attribute name="href"/>
+                        <!-- provide href for a fallback behavior if knowl is -->
+                        <!-- disabled intentionally or not                    -->
+                        <xsl:attribute name="href">
+                            <xsl:apply-templates select="$target" mode="url" />
+                        </xsl:attribute>
                         <!-- mark as duplicated content via an xref -->
                         <xsl:attribute name="class">
                             <xsl:text>xref</xsl:text>
@@ -7972,6 +7972,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:apply-templates select="$target" mode="knowl-filename">
                                 <xsl:with-param name="origin" select="$origin"/>
                             </xsl:apply-templates>
+                        </xsl:attribute>
+                        <!-- text to use for tooltip/aria  -->
+                        <xsl:attribute name="data-reveal-label">
+                            <xsl:apply-templates select="." mode="type-name">
+                                <xsl:with-param name="string-id" select="'reveal'"/>
+                            </xsl:apply-templates>
+                            <xsl:text> </xsl:text>
+                            <xsl:copy-of select="$content"/>
                         </xsl:attribute>
                     </xsl:when>
                     <!-- build traditional hyperlink -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7978,8 +7978,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:apply-templates select="." mode="type-name">
                                 <xsl:with-param name="string-id" select="'reveal'"/>
                             </xsl:apply-templates>
-                            <xsl:text> </xsl:text>
-                            <xsl:copy-of select="$content"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="data-close-label">
+                            <xsl:apply-templates select="." mode="type-name">
+                                <xsl:with-param name="string-id" select="'close'"/>
+                            </xsl:apply-templates>
                         </xsl:attribute>
                     </xsl:when>
                     <!-- build traditional hyperlink -->


### PR DESCRIPTION
Rewrite of knowl.js to remove JQuery dependency
Incorporates knowl accessibility improvements discussed in this closed PR: https://github.com/PreTeXtBook/pretext/pull/2107

Opened as draft. Others won't easily be able to test this until pretext points at `_static` for js/css.

Tested and working:
- Sage cells
- Basic tricky xref locations: inside tables or mathjax

Needed testing:
- Interactions with Webwork
- Other tricky xref locations