### PR TITLE
Latexmode

### DIFF
--- a/examples/humanities/project.ptx
+++ b/examples/humanities/project.ptx
@@ -26,7 +26,9 @@
     </target>
   </targets>
   <executables>
-      <tex>xelatex</tex>
+      <latex>latex</latex>
+      <pdflatex>pdflatex</pdflatex>
+      <xelatex>xelatex</xelatex>
       <pdfsvg>pdf2svg</pdfsvg>
       <asy>asy</asy>
       <sage>sage</sage>

--- a/examples/minimal/project.ptx
+++ b/examples/minimal/project.ptx
@@ -26,7 +26,9 @@
     </target>
   </targets>
   <executables>
-      <tex>xelatex</tex>
+      <latex>latex</latex>
+      <pdflatex>pdflatex</pdflatex>
+      <xelatex>xelatex</xelatex>
       <pdfsvg>pdf2svg</pdfsvg>
       <asy>asy</asy>
       <sage>sage</sage>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -493,7 +493,7 @@ def latex_image_conversion(
                 tex_executable_cmd = get_executable_cmd(latex_key)
                 # TODO why this debug line? get_executable_cmd() outputs the same debug info
                 log.debug("tex executable: {}".format(tex_executable_cmd[0]))
-                latex_cmd = tex_executable_cmd + ["-halt-on-error", latex_image]
+                latex_cmd = tex_executable_cmd + ["-interaction=nonstopmode", "-halt-on-error", latex_image]
                 log.info("converting {} to {}".format(latex_image, latex_image_pdf))
                 # Run LaTeX on the image file, usual console transcript is stdout.
                 # "result" is a "CompletedProcess" object.  Specifying an encoding


### PR DESCRIPTION
Two commits here. The first just updates a couple of project.ptx files. Without these changes, the CLI croaks when trying to build these two projects. Discovered while trying to use minimal example in testing the following.

Today a user asked about something which led me to realize: if your system does not have a certain latex package, and if that package is loaded in your latex-image-preamble, then when pretext tries to make images, of course it fails to find that package. This is not considered a latex compilation error that would make latex compilation stop (since we use `-halt-on-error`). Rather, this causes a prompt asking for the user to try entering a path for the missing package. I don't know where that prompt goes, but it does not go to the pretext user's terminal. So in the end, it just seems like pretext is stalling out. Really, it's waiting for input that will never come.

So I added `nonstopmode`. Shouldn't change anything when an actual error is hit, because `-halt-on-error` will halt the compilation. But `nonstopmode` also causes the job to abort when a package file is missing. So now it's clear to the user something went bad. A user can run in a verbose debugging mode to get more information about exactly what.