### PR TITLE
Strip newlines from permalink descriptions

### DIFF
--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -137,7 +137,7 @@ function permalinkDescription(elem) {
     if ((lastChr == '.') || (lastChr == ':'))  {
         retStr = retStr.slice(0,retStr.length - 1);
     }
-    return retStr;
+    return retStr.replace(/[\n\r]/g, "");
 }
 
 /*


### PR DESCRIPTION
I noticed that the non-rich-text version of permalinks to items whose title contains math have recently started to have extra newlines in the math part for some reason. This patch strips them.

I haven't tested this extensively, but I can't think of any reason why `@data-description` on a `div.autopermalink` element might need to contain a newline. 