### PR TITLE
WeBWorK: remove MathView css

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10247,14 +10247,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ########################## -->
 
 <!-- WeBWorK HTML CSS header -->
-<!-- MathView is a math entry palette tool that could be enabled  -->
-<!-- in the host anonymous course.   It is incorporated only if   -->
-<!-- "webwork-reps" element is present                            -->
-<!-- TODO: should also depend on whether all are presented as static -->
-<!-- TODO: it is unclear if MathView should be loaded here at all; -->
 <xsl:template name="webwork">
     <xsl:if test="$b-has-webwork-reps">
-        <link href="{$webwork-domain}/webwork2_files/js/apps/MathView/mathview.css" rel="stylesheet" />
         <xsl:choose>
             <xsl:when test="$webwork-reps-version = 1">
                 <script src="{$webwork-domain}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>


### PR DESCRIPTION
As a comment suggests (a comment now being deleted) it is unclear why this CSS file was loaded this way. Maybe there was a temporary, experimental period where we loaded live WW problems by inserting them into the DOM without using an iframe. Then I could see this being used. But the old 2.16- style of live rendering, and also the settled 2.17+ style of a static version that transitions to the live problem both use iframes, and the proper CSS for that tool should be handled correctly now by pretext-webwork.js.

So these lines can go. Note that on a 2.18 WW server, the file here exists but is in a different location. So this is actually  causing console errors (404) at sites using a 2.18 server.