### PR TITLE
Schema improvements

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -685,6 +685,7 @@
                     UniqueID?,
                     LabelID?,
                     PermanentID?,
+                    Component?,
                     TextParagraph
                 }
             ParagraphLined =
@@ -692,6 +693,7 @@
                     UniqueID?,
                     LabelID?,
                     PermanentID?,
+                    Component?,
                     element line {TextShort}+
                 }
             </code>
@@ -1417,6 +1419,7 @@
             Console =
                 element console {
                     PermanentID?,
+                    Component?,
                     attribute prompt {text}?,
                     attribute width {text}?,
                     attribute margins {text}?,
@@ -1431,6 +1434,7 @@
             Program =
                 element program {
                     PermanentID?,
+                    Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute language {text}?,
@@ -1456,6 +1460,7 @@
             List =
                 element ol {
                     PermanentID?,
+                    Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
                     element li {
@@ -1468,6 +1473,7 @@
                 } |
                 element ul {
                     PermanentID?,
+                    Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {"disc" | "circle" | "square" | ""}?,
                     element li {
@@ -1480,6 +1486,7 @@
                 } |
                 element dl {
                     PermanentID?,
+                    Component?,
                     attribute width {"narrow" | "medium" | "wide"}?,
                     element li {
                         MetaDataTitle,
@@ -1803,6 +1810,7 @@
             Tabular =
                 element tabular {
                     PermanentID?,
+                    Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute row-headers {"yes" | "no"}?,
@@ -1870,6 +1878,7 @@
                 }
             SidebySideAttributes =
                 PermanentID?,
+                Component?,
                 attribute margins {text}?,
                 (attribute width {text} | attribute widths {text})?,
                 (AlignmentVertical | attribute valigns {text})?
@@ -1935,6 +1944,7 @@
                 element image {
                     UniqueID?,
                     PermanentID?,
+                    Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute rotate {text}?,
@@ -1955,6 +1965,7 @@
                 element image {
                     UniqueID?,
                     PermanentID?,
+                    Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute archive {text}?,
@@ -1968,14 +1979,17 @@
                           (
                             element latex-image {
                               LabelID?,
+                              Component?,
                               text
                             } |
                             element asymptote {
                               LabelID?,
+                              Component?,
                               text
                             } |
                             element sageplot {
                                 LabelID?,  
+                                Component?,
                                 attribute variant {'2d'|'3d'}?,
                                 attribute aspect {text}?,
                                 text
@@ -2017,6 +2031,7 @@
             <code>
             Sage = element sage {
                 PermanentID?,
+                Component?,
                 attribute doctest {text}?,
                 attribute tolerance {text}?,
                 attribute auto-evaluate {'no'|'yes'}?,
@@ -2058,6 +2073,7 @@
                     UniqueID?,
                     LabelID?,
                     PermanentID?,
+                    Component?,
                     attribute aspect { text }?,
                     attribute width { text }?,
                     attribute platform { text }?,
@@ -2096,6 +2112,7 @@
                 element slate {
                     UniqueID?,
                     LabelID?,
+                    Component?,
                     (
                       JessieCodeAtt |
                       (
@@ -2190,6 +2207,7 @@
                     UniqueID?,
                     LabelID?,
                     PermanentID?,
+                    Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
                     attribute aspect {text}?,
@@ -2423,6 +2441,7 @@
                     UniqueID?,
                     LabelID?,
                     PermanentID?,
+                    Component?,
                     TextParagraphAreas
                 }
             Areas = 
@@ -2590,6 +2609,7 @@
                 element webwork {
                     UniqueID?,
                     LabelID?,
+                    Component?,
                     attribute seed {xsd:integer}?,
                     attribute copy {text}?,
                     element description {
@@ -2720,6 +2740,7 @@
             <li><attr>permid</attr> is part of managing editions, and is supplied by a script.  You should not be adding these manually as an author.  (You do want to manually author <attr>xml:id</attr>.)</li>
             <li>The <c>xinlude</c> mechanism may pass language tags down through the root element of included files to make them universally available.</li>
             <li>The <c>xinclude</c> mechanism inserts a <c>@xml:base</c> attribute on the root element of an included file.  So we allow this attribute on any element that allows a title.</li>
+            <li>The <c>component</c> attribute allows versions to be controlled by a publisher file.</li>
             <li>These are not unordered specifications since they contain several attributes, and we enforce a <c>title</c>, <c>subtitle</c>, <tag>shorttitle</tag>, <tag>plaintitle</tag>, <c>creator</c>, <c>caption</c>, <c>idx</c> order.</li>
             <li><c>MetaDataTarget</c> is for items that are targets of cross-references, but without even optional titles.  Since they will be knowled, they can appear in an index.  But without the potential to be titled, we do not set them up as possible root elements of a file to <c>xinclude</c>.</li>
             <li><c>MetaDataTitle</c> has a required <tag>title</tag>.</li>
@@ -2740,6 +2761,8 @@
                 attribute label {text}
             PermanentID =
                 attribute permid {text}
+            Component = 
+                attribute component {text}
             Title =
                 element title {TextLong}
             LinedTitle =
@@ -2760,11 +2783,13 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 Index*
             MetaDataTitle =
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title,
@@ -2773,6 +2798,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title,
@@ -2783,6 +2809,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
@@ -2793,6 +2820,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title,
@@ -2804,6 +2832,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
@@ -2815,6 +2844,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title?,
@@ -2823,6 +2853,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 (Title, ShortTitle?, PlainTitle?)?,
@@ -2831,6 +2862,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title?,
@@ -2840,6 +2872,7 @@
                 UniqueID?,
                 LabelID?,
                 PermanentID?,
+                Component?,
                 XMLBase?,
                 XMLLang?,
                 Title?,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -683,12 +683,14 @@
             Paragraph =
                 element p {
                     UniqueID?,
+                    LabelID?,
                     PermanentID?,
                     TextParagraph
                 }
             ParagraphLined =
                 element p {
                     UniqueID?,
+                    LabelID?,
                     PermanentID?,
                     element line {TextShort}+
                 }
@@ -1784,7 +1786,7 @@
                 }
             TableRow =
                 element row {
-                    attribute header {"yes" | "no"}?,
+                    attribute header {"yes" | "no" | "vertical"}?,
                     AlignmentHorizontal?,
                     AlignmentVertical?,
                     BorderBottom?,
@@ -1939,12 +1941,15 @@
                     attribute archive {text}?,
                     attribute source {text},
                     (
-                        attribute decorative {"yes" | "no"}? |
+                      attribute decorative {"yes"} |
+                      (
+                        attribute decorative {"no"}?,
                         (
-                            element shortdescription {text},
-                            element description {(Paragraph | Tabular)+}?
+                          element shortdescription {text}? &amp;
+                          element description {(Paragraph | Tabular)+}?
                         )
-                    )?
+                      )
+                    )
                 }
             ImageCode =
                 element image {
@@ -1954,20 +1959,30 @@
                     attribute margins {text}?,
                     attribute archive {text}?,
                     (
-                        attribute decorative {"yes" | "no"}? |
+                      attribute decorative {"yes"} |
+                      (
+                        attribute decorative {"no"}?,
                         (
-                            element shortdescription {(text | WWVariable)+},
-                            element description {(Paragraph | Tabular)+}?
+                          element shortdescription {(text | WWVariable)+}? &amp;
+                          element description {(Paragraph | Tabular)+}? &amp;
+                          (
+                            element latex-image {
+                              LabelID?,
+                              text
+                            } |
+                            element asymptote {
+                              LabelID?,
+                              text
+                            } |
+                            element sageplot {
+                                LabelID?,  
+                                attribute variant {'2d'|'3d'}?,
+                                attribute aspect {text}?,
+                                text
+                            }
+                          )
                         )
-                    )?,
-                    (
-                        element latex-image {text} |
-                        element asymptote {text} |
-                        element sageplot {
-                            attribute variant {'2d'|'3d'}?,
-                            attribute aspect {text}?,
-                            text
-                        }
+                      )
                     )
                 }
             ImageWW =
@@ -1975,15 +1990,18 @@
                     attribute pg-name {text}?,
                     attribute width {text}?,
                     (
-                        attribute decorative {"yes" | "no"}? |
+                      attribute decorative {"yes"} |
+                      (
+                        attribute decorative {"no"}?,
                         (
-                            element shortdescription {(text | WWVariable)+},
-                            element description {(Paragraph | Tabular)+}?
+                          element shortdescription {(text | WWVariable)+}? &amp;
+                          element description {(Paragraph | Tabular)+}? &amp;
+                          element latex-image {
+                            text
+                          }?
                         )
-                    )?,
-                    element latex-image {
-                        text
-                    }?
+                      )
+                    )
                 }
             </code>
         </fragment>
@@ -2038,6 +2056,7 @@
             Interactive =
                 element interactive {
                     UniqueID?,
+                    LabelID?,
                     PermanentID?,
                     attribute aspect { text }?,
                     attribute width { text }?,
@@ -2076,6 +2095,7 @@
             Slate =
                 element slate {
                     UniqueID?,
+                    LabelID?,
                     (
                       JessieCodeAtt |
                       (
@@ -2168,6 +2188,7 @@
             Video =
                 element video {
                     UniqueID?,
+                    LabelID?,
                     PermanentID?,
                     attribute width {text}?,
                     attribute margins {text}?,
@@ -2400,6 +2421,7 @@
             ParagraphAreas =
                 element p {
                     UniqueID?,
+                    LabelID?,
                     PermanentID?,
                     TextParagraphAreas
                 }
@@ -2567,6 +2589,7 @@
             WebWorkAuthored =
                 element webwork {
                     UniqueID?,
+                    LabelID?,
                     attribute seed {xsd:integer}?,
                     attribute copy {text}?,
                     element description {
@@ -2713,6 +2736,8 @@
             <code>
             UniqueID =
                 attribute xml:id {text}
+            LabelID =
+                attribute label {text}
             PermanentID =
                 attribute permid {text}
             Title =
@@ -2733,10 +2758,12 @@
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 Index*
             MetaDataTitle =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2744,6 +2771,7 @@
                 Index*
             MetaDataAltTitle =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2753,6 +2781,7 @@
                 Index*
             MetaDataLinedTitle =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2762,6 +2791,7 @@
                 Index*
             MetaDataSubtitle =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2772,6 +2802,7 @@
                 Index*
             MetaDataLinedSubtitle =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2782,6 +2813,7 @@
                 Index*
             MetaDataTitleOptional =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2789,6 +2821,7 @@
                 Index*
             MetaDataAltTitleOptional =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2796,6 +2829,7 @@
                 Index*
             MetaDataTitleCreatorOptional =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2804,6 +2838,7 @@
                 Index*
             MetaDataCaption =
                 UniqueID?,
+                LabelID?,
                 PermanentID?,
                 XMLBase?,
                 XMLLang?,
@@ -2815,18 +2850,6 @@
 
     </section>
 
-    <section>
-        <title>Labels as Unique IDs (experimental)</title>
-        <p>We assume that everywhere an xml:id can go, we can also now put a label.</p>
-        <fragment xml:id="label">
-            <title>Labels as Unique IDs</title>
-            <code>
-            UniqueID |=
-                attribute xml:id {text}?,
-                attribute label {text}?
-            </code>
-        </fragment>
-    </section>
     <section>
         <title>Miscellaneous</title>
 
@@ -3367,7 +3390,6 @@
             <fragref ref="solutions-dev"/>
             <fragref ref="reference-dev"/>
             <fragref ref="mathematics-dev"/>
-            <fragref ref="label"/>
             <fragref ref="exercise-dev"/>
             <code>
                 }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2046,18 +2046,85 @@
                     attribute iframe { text }?,
                     attribute source { text }?,
                     attribute version { text }?,
-                    (Slate | SideBySideNoCaption | SideBySideGroupNoCaption)*,
-                    element instructions { BlockText* | text }?
+                    (
+                      (
+                        Slate |
+                        SideBySideNoCaption |
+                        SideBySideGroupNoCaption
+                      )* &amp;
+                      element instructions { mixed { MetaDataTitleOptional, BlockText } }? &amp;
+                      element static { Image }?
+                    )
+
+                }
+            
+            Stack |=
+                element stack {
+                    (
+                        Tabular |
+                        Image |
+                        Video |
+                        Program |
+                        Console |
+                        Paragraph |
+                        Preformatted |
+                        List |
+                        Slate
+                    )+
                 }
 
             Slate =
                 element slate {
                     UniqueID?,
-                    attribute surface { text },
-                    (attribute source { text } | attribute material { text })?,
-                    attribute aspect { text }?,
-                    (Paragraph | Tabular | SideBySideNoCaption)*
+                    (
+                      JessieCodeAtt |
+                      (
+                        attribute surface { text },
+                        (
+                          attribute source { text } |
+                          attribute material { text }
+                        )?,
+                        attribute aspect { text }?,
+                        (
+                          Paragraph |
+                          Tabular |
+                          SideBySideNoCaption |
+                          SlateInput |
+                          element xhtml:button {
+                            attribute type { text },
+                            attribute id { text },
+                            text*
+                          }? |
+                          text*
+                        )*
+                      )
+                    )
                 }
+
+              JessieCodeAtt =
+                attribute surface {"jessiecode"},
+                attribute axis {"true" | "false"}?,
+                attribute grid {"true" | "false"}?,
+                (
+                  attribute source {text} | 
+                  text*
+                )
+
+              SlateInput = 
+                element xhtml:input {
+                  attribute type {text}?, 
+                  attribute value {text}?,
+                  attribute onkeypress {text}?,
+                  attribute onclick {text}?,
+                  attribute style {text}?
+                } |
+                element input {
+                  attribute type {text}?, 
+                  attribute value {text}?,
+                  attribute onkeypress {text}?,
+                  attribute onclick {text}?,
+                  attribute style {text}?
+                } 
 
             # add Interactives where used
             BlockStatement |= Interactive
@@ -2254,12 +2321,12 @@
                     attribute order {xsd:integer}?,
                     ((
                         attribute correct {"yes"|"no"}?,
-                        mixed {BlockText?}
+                        mixed {BlockText?, CodeLine?}+
                     ) |
                     (
                         element choice {
                             attribute correct {"yes"|"no"}?,
-                            mixed {BlockText?}
+                            mixed {BlockText?, CodeLine?}+
                         }+
                     ))
                 }
@@ -2292,6 +2359,60 @@
                 )
             Response =
                 element response {empty}
+            
+            
+            # Selectable areas
+            Area = 
+                element area {
+                    attribute correct {"yes"|"no"}?,
+                    TextLong
+                }
+            TextLongAreas =  mixed { (
+                  Area |
+                  Character |
+                  Generator |
+                  Verbatim |
+                  GroupAreas |
+                  MathInline |
+                  Music |
+                  Reference |
+                  WWVariable)* }
+            GroupAreas |=
+                element q {TextLongAreas} |
+                element sq {TextLongAreas}
+            TextParagraphAreas = mixed { (
+              Character |
+              Generator |
+              Verbatim |
+              Group |
+              WWVariable |
+              MathInline |
+              Music |
+              Reference |
+              CodeDisplay |
+              MathDisplay |
+              List |
+              Footnote |
+              Notation |
+              Index |
+              Area |
+              GroupAreas)* }
+            ParagraphAreas =
+                element p {
+                    UniqueID?,
+                    PermanentID?,
+                    TextParagraphAreas
+                }
+            Areas = 
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                Feedback?,
+                element areas {
+                  ParagraphAreas+
+                },
+                Hint*, Answer*, Solution*
+
             # General feedback element
             Feedback =
                 element feedback {
@@ -2305,14 +2426,16 @@
                     MultipleChoice |
                     Parsons |
                     Matching |
-                    FreeResponse
+                    FreeResponse |
+                    Areas
                 }
             ProjectLike |=
                 TrueFalse |
                 MultipleChoice |
                 Parsons |
                 Matching |
-                FreeResponse
+                FreeResponse |
+                Areas
             </code>
         </fragment>
     </section>
@@ -3230,6 +3353,7 @@
         <fragment filename="pretext-dev.rnc">
             <title>Development Schema</title>
             <code>
+              namespace xhtml = "http://www.w3.org/1999/xhtml"
                 grammar {
 
                 include "pretext.rnc"


### PR DESCRIPTION
This is the start of a bunch of schema and experimental schema improvements.  Leaving as draft for now, but would love feedback as I continue to work on this.

One major change to the non-development schema is the tweak the description/shortdescription for images.  Previously, if you had `@decorative` with either "yes" or "no", then it was a violation to have a description or shortdescription.  So I remove that rule.  I also allow shortdescription and description to come in any order, with the possible other elements of an image.  And for now, both are optional.  
