### PR TITLE
Pretext: escape backslashes in regex

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -2521,9 +2521,9 @@ def _split_brf(filename):
             if len(re.findall("^[ ]{2}#([a-j]+?) ", line)) > 0:
                 numbered_chapter = True
                 chapter_number = brf_to_num(re.findall("^[ ]{2}#([a-j]+?) ", line)[0])
-            elif len(re.findall("^[ ]{2},\*apt} #([a-j]+?) ", line)) > 0:
+            elif len(re.findall("^[ ]{2},\\*apt} #([a-j]+?) ", line)) > 0:
                 numbered_chapter = True
-                chapter_number = brf_to_num(re.findall("^[ ]{2},\*apt} #([a-j]+?) ", line)[0])
+                chapter_number = brf_to_num(re.findall("^[ ]{2},\\*apt} #([a-j]+?) ", line)[0])
             else:
                 numbered_chapter = False
                 chapter_number = -1


### PR DESCRIPTION
With Python 3.12.2, running `pretext` produces these warnings:
```
/Users/alex.jordan/pretext/pretext/pretext.py:2524: SyntaxWarning: invalid escape sequence '\*'
  elif len(re.findall('^[ ]{2},\*apt} #([a-j]+?) ', line)) > 0:
/Users/alex.jordan/pretext/pretext/pretext.py:2526: SyntaxWarning: invalid escape sequence '\*'
  chapter_number = brf_to_num(re.findall("^[ ]{2},\*apt} #([a-j]+?) ", line)[0])
```

The intent here is to escape the asterisk in the regex context. But first the backslash must be escaped or python will produce that warning. I'm guessing might `\*` become `*`, and this regex was not working as intended. Or maybe `\*` becomes `\*`. But this change should have things working as intended and make those warnings go away.