### PR TITLE
Webwork bad xml

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1382,7 +1382,7 @@ def webwork_to_xml(
         file_empty = "ERROR:  This problem file was empty!" in response.text
 
         no_compile = (
-            "ERROR caught by Translator while processing problem file:" in response.text
+            "ERROR caught by Translator while processing" in response.text
         )
 
         bad_xml = False
@@ -1407,6 +1407,9 @@ def webwork_to_xml(
         badness_tip = ""
         badness_type = ""
         badness_base64 = ""
+        # NB: in WeBWorK 2.17+, the response from a nonexistent problem is not distinguishable from
+        # the response from a problem that has broken code. So even when a file is empty, file_empty
+        # will be false and instead no_compile will be true.
         if file_empty:
             badness_msg = "PTX:ERROR: WeBWorK problem {} was empty\n"
             badness_tip = ""
@@ -1414,7 +1417,7 @@ def webwork_to_xml(
             badness_base64 = "RE9DVU1FTlQoKTsKbG9hZE1hY3JvcygiUEdzdGFuZGFyZC5wbCIsIlBHTUwucGwiLCJQR2NvdXJzZS5wbCIsKTtURVhUKGJlZ2lucHJvYmxlbSgpKTtDb250ZXh0KCdOdW1lcmljJyk7CgpCRUdJTl9QR01MCldlQldvcksgUHJvYmxlbSBGaWxlIFdhcyBFbXB0eQoKRU5EX1BHTUwKCkVORERPQ1VNRU5UKCk7"
         elif no_compile:
             badness_msg = (
-                "PTX:ERROR: WeBWorK problem {} with seed {} did not compile  \n{}\n"
+                "PTX:ERROR: WeBWorK problem {} with seed {} is either empty or failed to compile  \n{}\n"
             )
             badness_tip = (
                 "  Use -a to halt with full PG and returned content"
@@ -1422,7 +1425,7 @@ def webwork_to_xml(
                 else "  Use -a to halt with returned content"
             )
             badness_type = "compile"
-            badness_base64 = "RE9DVU1FTlQoKTsKbG9hZE1hY3JvcygiUEdzdGFuZGFyZC5wbCIsIlBHTUwucGwiLCJQR2NvdXJzZS5wbCIsKTtURVhUKGJlZ2lucHJvYmxlbSgpKTtDb250ZXh0KCdOdW1lcmljJyk7CgpCRUdJTl9QR01MCldlQldvcksgUHJvYmxlbSBEaWQgTm90IENvbXBpbGUKCkVORF9QR01MCgpFTkRET0NVTUVOVCgpOw=="
+            badness_base64 = "RE9DVU1FTlQoKTsKbG9hZE1hY3JvcygiUEdzdGFuZGFyZC5wbCIsIlBHTUwucGwiLCJQR2NvdXJzZS5wbCIsKTtURVhUKGJlZ2lucHJvYmxlbSgpKTtDb250ZXh0KCdOdW1lcmljJyk7CgpCRUdJTl9QR01MCldlQldvcksgUHJvYmxlbSBEb2VzIE5vdCBFeGlzdCBPciBEaWQgTm90IENvbXBpbGUKCkVORF9QR01MCgpFTkRET0NVTUVOVCgpOw=="
         elif bad_xml:
             badness_msg = "PTX:ERROR: WeBWorK problem {} with seed {} does not return valid XML  \n  It may not be PTX compatible  \n{}\n"
             badness_tip = "  Use -a to halt with returned content"

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -1607,8 +1607,6 @@ def webwork_to_xml(
                         log.warning(msg.format(destination_image_file, ext))
                 os.remove(os.path.join(ww_images_dir, ptx_image_filename))
 
-        # Start appending XML children
-        response_root = ET.fromstring(bytes(response_text, encoding='utf-8'))
         # Use "webwork-reps" as parent tag for the various representations of a problem
         webwork_reps = ET.SubElement(webwork_representations, "webwork-reps")
         webwork_reps.set("version", ww_reps_version)
@@ -1630,6 +1628,9 @@ def webwork_to_xml(
             p = ET.SubElement(statement, "p")
             p.text = badness_msg.format(problem_identifier, seed[problem], badness_tip)
             continue
+
+        # Start appending XML children
+        response_root = ET.fromstring(bytes(response_text, encoding='utf-8'))
 
         # This recursive function is needed in the case of nested tasks.
         # It is written in such a way to handle task with no nesting, and even an exercise without any task.


### PR DESCRIPTION
This fixes a few things. The first commit just moves a certain variable declaration further down. That declaration wants to parse the server's response as XML, but what if we've already established the response is not valid XML? So that line is harmlessly pushed down later past the final place where recognition of bad XML will have already caused the loop to iterate on to the next exercise. Nothing relies on that declaration until further down.

The second commit is that it seems some things changed from 2.16 to 2.17 about what the response looks like when a problem file does not exist, and when the problem failed to compile. Formerly, there was a bit of detail in the response so you could distinguish these situations. But I guess with 2.17, the response is all the same. Not sure why, maybe it is a security reason trying to minimize sending internal details info to the outside world. But I changed how we recognize the failure to compile accordingly.

To test, build the sample chapter (with `pretext/pretext/pretext -v`, not with the CLI) doing each of the following before and after these commits:

1. Change the OPL problem to a nonexistent problem (just attach 'foo' to end of problem file name before the `.pg`).
2. Break the syntax on a PTX-coded problem, say by removing a semicolon. If you do this on the first exercise from the sample chapter, you will actually break three problems since two later on are copies of the first.

Prior to these commits, either of these things will halt the representations build because of an lxml error. After these commits, you will get messages like `PTX:ERROR: WeBWorK problem webwork-add-numbers with seed 6 is either empty or failed to compile`.

After this is resolved, I would like to try to modularize the enormous `webwork_to_xml` def to make this kind of thing easier to prevent in the future.