### PR TITLE
Add docs for codelens="no" on activecodes

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -3236,7 +3236,7 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
 
             <p>Place the <attr>interactive</attr> attribute on a <tag>program</tag> element with the value <c>activecode</c> to elect this behavior (<c>no</c> is the default value).  Also, be sure to specify a language from the supported languages.  Consult <xref ref="table-program-interactive"/> below for a summary of various combinations.  When an output format does not support an interactive ActiveCode instance, the fallback is a static program listing.</p>
 
-            <p>Note that a Python ActiveCode automatically is enabled with a CodeLens button and requires no preparation of any trace data.  So a reader can form any type of Python program and closely examine its behavior.</p>
+            <p>For languages that support CodeLens, a button will be created that allows the reader to step through the program. For some programs, especially ones using libraries like turtle graphics or image, CodeLens will not function. To prevent showing the CodeLens button on programs for it will not work, authors can set the <attr>codelens</attr> attribute to <c>no</c>.</p>
 
             <p>Note also that a data file may be provided independently for consumption by an ActiveCode program.  See <xref ref="topic-datafile"/>.</p>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8557,6 +8557,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </input>
                     </program>
                 </listing>
+
+                <listing xml:id="program-activecode-python-no-codelens">
+                    <caption>An interactive Python program without codelens.</caption>
+                    <program xml:id="python-hello-world-no-codelens" label="python-hello-world-no-codelens" interactive='activecode' language="python" codelens="no">
+                        <input>
+                        print("Hello, World!")
+                        </input>
+                    </program>
+                </listing>
             </exercises>
 
             <exercises>


### PR DESCRIPTION
This adds minimal documentation for the `codelens="no"` option on activecodes that was added in #2138.