### PR TITLE
Recompile a LaTeX image if neccessary

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -488,6 +488,7 @@ def latex_image_conversion(
                 latex_image_svg = "{}.svg".format(filebase)
                 latex_image_png = "{}.png".format(filebase)
                 latex_image_eps = "{}.eps".format(filebase)
+                latex_image_log = "{}.log".format(filebase)
                 # process with a  latex  engine
                 latex_key = get_deprecated_tex_fallback(method)
                 tex_executable_cmd = get_executable_cmd(latex_key)
@@ -499,6 +500,23 @@ def latex_image_conversion(
                 # "result" is a "CompletedProcess" object.  Specifying an encoding
                 # causes captured output to be a string, which is convenient.
                 result = subprocess.run(latex_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+
+                # It may be that the image needs to be compiled twice. If the .log file contains
+                # the string `Rerun to get`, then the document should be compiled again.
+
+                # We keep track of how many times we've tried to compile the document and
+                # bail if it looks like we're stuck in a loop.
+                loop_count = 0
+                MAX_LOOPS = 10
+                while result.returncode == 0 and "Rerun to get" in open(latex_image_log).read() and loop_count < MAX_LOOPS:
+                    log.info("File {} needs to be processed with LaTeX again. Rerunning LaTeX.".format(latex_image))
+                    result = subprocess.run(latex_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+                    loop_count += 1
+
+                if loop_count == MAX_LOOPS:
+                    log.error("Detected infinite loop while compiling {}. Aborting.".format(latex_image))
+                    result.returncode = 1
+
                 if result.returncode != 0:
                     # failed
                     failed_images.append(latex_image)
@@ -563,7 +581,7 @@ def latex_image_conversion(
                             with open(latex_image_svg, "w") as f:
                                 f.write(svg)
                             shutil.copy2(latex_image_svg, dest_dir)
-                            # clasic way to produce svg, using pdf2svg:
+                            # classic way to produce svg, using pdf2svg:
                             latex_image_svg = "classic-" + latex_image_svg
                         pdfsvg_executable_cmd = get_executable_cmd("pdfsvg")
                         # TODO why this debug line? get_executable_cmd() outputs the same debug info


### PR DESCRIPTION
If `Rerun to get` is present in a `.log` file left over form a LaTeX compile, then the file needs to be recompiled to reach its final state. This can happen, e.g., for tikz images where it has saved position information to the `.aux` file.

This commit adds a check of the log file to see if an image needs recompilation and recompiles if necessary.

Fixes #2140 


This code can be tested by running `./pretext/pretext -c latex-image -f svg -v [file location]` on the example:
```xml
<pretext>

    <docinfo>
        <macros>
        \newcommand{\doubler}[1]{2#1}
        </macros>
        <latex-image-preamble>
            \usepackage[dvipsnames]{xcolor}
            \usepackage{tikz}
            \usepackage{nicematrix}
        </latex-image-preamble>
    </docinfo>

    <article xml:id="minimal">
        <title>A Minimal Article</title>

        <section xml:id="section-textual">
            <title>Just Some Text</title>

            <image width="50%">
                <latex-image>
                    \begin{tikzpicture}
                    \node{
                        $\begin{bNiceArray}{ccc|cc}[
                        code-before={\cellcolor{LimeGreen!72}{1-1,2-2,3-3}\cellcolor{NavyBlue!72}{1-2,2-3,3-4}\cellcolor{CornflowerBlue!72}{1-3,2-4,3-5}}
                        ]
                        3 \amp 4 \amp 0 \amp 1 \amp 4 \\
                        -2 \amp 3 \amp 1 \amp -2 \amp 3 \\
                        0 \amp 2 \amp 1 \amp 0 \amp 2
                        \end{bNiceArray}$
                    };
                \end{tikzpicture}
                </latex-image>
            </image>
        </section>

    </article>

</pretext>
```

If compiled correctly, you should see colored boxes along the diagonal of the matrix.