### PR TITLE
Ensure Asymptote generation runs in background using local method

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -326,7 +326,7 @@ def asymptote_conversion(
                 # 2021-12-10, Michael Doob: "-noprc" is default for the server,
                 # and newer CLI versions.  Retain for explicit use locally when
                 # perhaps an older version is being employed
-                asy_cli = asy_executable_cmd + ["-f", outform]
+                asy_cli = asy_executable_cmd + ["-noV", "-f", outform]
                 if outform in ["pdf", "eps"]:
                     asy_cli += ["-noprc", "-iconify", "-tex", "xelatex", "-batchMask"]
                 elif outform in ["svg", "png"]:


### PR DESCRIPTION
In some environments (in particular, Windows), Asymptote defaults to the `-V` option when generating images. The assumption is that the user will want to see their output when it is created.

This isn't ideal when you are building a textbook with 300 Asymptote diagrams. Every single image will open in your web browser, so you can forget about using it until Asymptote generation is done. I suspect this is also not ideal on systems with limited memory.

This adds the `-noV` option to the Asymptote command to ensure that every format, on every OS, is generated silently.

I've tested it on Windows against APEX and it ran as expected. However, someone should check to see if I have chosen the best spot to place the `-noV` option.