### PR TITLE
WeBWorK: don't put all solutions and hints in the first task

### DIFF
--- a/js/pretext-webwork/2.19/pretext-webwork.js
+++ b/js/pretext-webwork/2.19/pretext-webwork.js
@@ -595,13 +595,12 @@ function translateHintSol(ww_id, body_div, ww_domain, b_ptx_has_hint, b_ptx_has_
     const hintSols = body_div.querySelectorAll('.accordion.hint,.accordion.solution');
     if (hintSols.length == 0) {return};
 
-    const parent = hintSols[0].parentNode;
-
-    solutionlikewrapper = document.createElement('div');
-    solutionlikewrapper.classList.add('solutions');
-    parent.insertBefore(solutionlikewrapper, hintSols[0]);
-
     for (const hintSol of hintSols) {
+        const parent = hintSol.parentNode;
+        solutionlikewrapper = document.createElement('div');
+        solutionlikewrapper.classList.add('solutions');
+        parent.insertBefore(solutionlikewrapper, hintSol);
+
         const hintSolType = hintSol.classList.contains('hint') ? 'hint' : 'solution';
 
         if ((hintSolType == 'solution' && !b_ptx_has_solution) ||


### PR DESCRIPTION
This was a mistake in the 2.19 WW js I recently added. I thought I was being clever and efficient by doing a certain thing outside of a loop. But it turns out that caused all hints and solutions for a multi-task exercise to be placed wherever the first hint/solution was. So for example, causing the second task's solution to appear within the first task, after the first task's solution.

This fixes that.