### PR TITLE
slideshow: update image template for managed directories

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13227,4 +13227,5 @@ TODO:
     </xsl:if>
 </xsl:template>
 
+
 </xsl:stylesheet>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5969,7 +5969,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
     <!-- div is constraint/positioning for contained image -->
-    <div>
+    <div class="image-box">
         <xsl:attribute name="style">
             <xsl:text>width: </xsl:text>
             <xsl:value-of select="$layout/width"/>
@@ -5981,8 +5981,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$layout/right-margin"/>
             <xsl:text>%;</xsl:text>
         </xsl:attribute>
-        <!-- fragment for reveal.js pauses -->
-        <xsl:apply-templates select="." mode="class"/>
         <xsl:apply-templates select="." mode="image-inclusion"/>
     </div>
 </xsl:template>
@@ -13227,13 +13225,6 @@ TODO:
             <xsl:value-of select="$warning" />
         </xsl:element>
     </xsl:if>
-</xsl:template>
-
-<!-- the class for image, to be overridden by reveal.js stylesheet -->
-<xsl:template match="image" mode="class">
-  <xsl:attribute name="class">
-    <xsl:text>image-box</xsl:text>
-  </xsl:attribute>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5969,7 +5969,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
     <!-- div is constraint/positioning for contained image -->
-    <div class="image-box">
+    <div>
         <xsl:attribute name="style">
             <xsl:text>width: </xsl:text>
             <xsl:value-of select="$layout/width"/>
@@ -5981,6 +5981,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$layout/right-margin"/>
             <xsl:text>%;</xsl:text>
         </xsl:attribute>
+        <!-- fragment for reveal.js pauses -->
+        <xsl:apply-templates select="." mode="class"/>
         <xsl:apply-templates select="." mode="image-inclusion"/>
     </div>
 </xsl:template>
@@ -13227,5 +13229,11 @@ TODO:
     </xsl:if>
 </xsl:template>
 
+<!-- the class for image, to be overridden by reveal.js stylesheet -->
+<xsl:template match="image" mode="class">
+  <xsl:attribute name="class">
+    <xsl:text>image-box</xsl:text>
+  </xsl:attribute>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -427,17 +427,12 @@ dfn {
   </p>
 </xsl:template>
 
-<!-- Images get wrapped in a span with @class="fragment" if they are -->
+<!-- Images get wrapped in a div with @class="fragment" if they are  -->
 <!-- paused                                                          -->
-<xsl:template match="image[not(ancestor::sidebyside)]">
-  <xsl:if test="@pause = 'yes'">
-    <span class="fragment">
-      <xsl:apply-imports />
-    </span>
-  </xsl:if>
-  <xsl:if test="not(@pause = 'yes')">
-    <xsl:apply-imports />
-  </xsl:if>
+<xsl:template match="image[not(ancestor::sidebyside) and (@pause='yes')]">
+    <div class="fragment">
+      <xsl:apply-imports/>
+    </div>
 </xsl:template>
 
 

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -428,18 +428,32 @@ dfn {
 </xsl:template>
 
 
-<xsl:template match="image">
-  <img>
-    <xsl:attribute name="src">
-        <xsl:value-of select="@source" />
+<!-- Override bare image container template to insert @pause -->
+<xsl:template match="image[not(ancestor::sidebyside)]">
+  <xsl:variable name="rtf-layout">
+    <xsl:apply-templates select="." mode="layout-parameters" />
+  </xsl:variable>
+  <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
+  <!-- div is constraint/positioning for contained image -->
+  <div class="image-box">
+    <xsl:attribute name="style">
+        <xsl:text>width: </xsl:text>
+        <xsl:value-of select="$layout/width"/>
+        <xsl:text>%;</xsl:text>
+        <xsl:text> margin-left: </xsl:text>
+        <xsl:value-of select="$layout/left-margin"/>
+        <xsl:text>%;</xsl:text>
+        <xsl:text> margin-right: </xsl:text>
+        <xsl:value-of select="$layout/right-margin"/>
+        <xsl:text>%;</xsl:text>
     </xsl:attribute>
     <xsl:if test="@pause = 'yes'">
       <xsl:attribute name="class">
         <xsl:text>fragment</xsl:text>
       </xsl:attribute>
     </xsl:if>
-    <xsl:apply-templates/>
-  </img>
+    <xsl:apply-templates select="." mode="image-inclusion"/>
+</div>
 </xsl:template>
 
 <!-- A "url" with content gets an automatic footnote with the @visual -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -418,42 +418,18 @@ dfn {
 
 <xsl:template match="p">
   <p>
-    <xsl:if test="@pause = 'yes'">
-      <xsl:attribute name="class">
-        <xsl:text>fragment</xsl:text>
-      </xsl:attribute>
-    </xsl:if>
+    <xsl:apply-templates select="." mode="class"/>
     <xsl:apply-templates/>
   </p>
 </xsl:template>
 
-
-<!-- Override bare image container template to insert @pause -->
-<xsl:template match="image[not(ancestor::sidebyside)]">
-  <xsl:variable name="rtf-layout">
-    <xsl:apply-templates select="." mode="layout-parameters" />
-  </xsl:variable>
-  <xsl:variable name="layout" select="exsl:node-set($rtf-layout)" />
-  <!-- div is constraint/positioning for contained image -->
-  <div class="image-box">
-    <xsl:attribute name="style">
-        <xsl:text>width: </xsl:text>
-        <xsl:value-of select="$layout/width"/>
-        <xsl:text>%;</xsl:text>
-        <xsl:text> margin-left: </xsl:text>
-        <xsl:value-of select="$layout/left-margin"/>
-        <xsl:text>%;</xsl:text>
-        <xsl:text> margin-right: </xsl:text>
-        <xsl:value-of select="$layout/right-margin"/>
-        <xsl:text>%;</xsl:text>
+<!-- for pauses, overriding class-mode for images in pretext-html -->
+<xsl:template match="p|image" mode="class">
+  <xsl:if test="@pause = 'yes'">
+    <xsl:attribute name="class">
+      <xsl:text>fragment</xsl:text>
     </xsl:attribute>
-    <xsl:if test="@pause = 'yes'">
-      <xsl:attribute name="class">
-        <xsl:text>fragment</xsl:text>
-      </xsl:attribute>
-    </xsl:if>
-    <xsl:apply-templates select="." mode="image-inclusion"/>
-</div>
+  </xsl:if>
 </xsl:template>
 
 <!-- A "url" with content gets an automatic footnote with the @visual -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -418,19 +418,28 @@ dfn {
 
 <xsl:template match="p">
   <p>
-    <xsl:apply-templates select="." mode="class"/>
+    <xsl:if test="@pause = 'yes'">
+      <xsl:attribute name="class">
+        <xsl:text>fragment</xsl:text>
+      </xsl:attribute>
+    </xsl:if>
     <xsl:apply-templates/>
   </p>
 </xsl:template>
 
-<!-- for pauses, overriding class-mode for images in pretext-html -->
-<xsl:template match="p|image" mode="class">
+<!-- Images get wrapped in a span with @class="fragment" if they are -->
+<!-- paused                                                          -->
+<xsl:template match="image[not(ancestor::sidebyside)]">
   <xsl:if test="@pause = 'yes'">
-    <xsl:attribute name="class">
-      <xsl:text>fragment</xsl:text>
-    </xsl:attribute>
+    <span class="fragment">
+      <xsl:apply-imports />
+    </span>
+  </xsl:if>
+  <xsl:if test="not(@pause = 'yes')">
+    <xsl:apply-imports />
   </xsl:if>
 </xsl:template>
+
 
 <!-- A "url" with content gets an automatic footnote with the @visual -->
 <!-- attribute value (if non-empty) or a mildly-sanitized version of  -->


### PR DESCRIPTION
Replaced the simple `image` template with a tweaked override of the html non-sidebyside image container.  Now images in reveal.js slideshows will behave just like html images, except if they are bare images they can have a `@pause`.

In particular, this will respect managed directories.  Closes #2155 .