### PR TITLE
Modify ToC scroll so it doesn't change tab location

### DIFF
--- a/js/pretext.js
+++ b/js/pretext.js
@@ -12,11 +12,13 @@
  */
 
 function scrollTocToActive() {
+    //Try to figure out current TocItem from URL
     pagefilename  = window.location.href;
     pagefilename  = pagefilename.match(/[^\/]*$/)[0];
+    pagefilename = pagefilename.split("#")[0];
     possibletocentries = document.querySelectorAll('#ptx-toc a[href="' + pagefilename + '"]');
     if (possibletocentries.length == 0) {
-        console.log("linked below a subsection");
+        //linked below a subsection
         pagefilename  = pagefilename.match(/^[^\#]*/)[0];
         possibletocentries = document.querySelectorAll('#ptx-toc a[href="' + pagefilename + '"]');
     }
@@ -24,8 +26,14 @@ function scrollTocToActive() {
         console.log("error, cannot find", pagefilename, "in TOC");
         return
     }
-    possibletocentries[0].scrollIntoView({block: "center"});
-    possibletocentries[0].classList.add("active");}
+
+    //scroll to the active entry... don't use scrollIntoView because it
+    //sets the user'stab position to that item
+    let targetY = possibletocentries[0].offsetTop;
+    document.querySelector("#ptx-toc").scrollTop = targetY;
+
+    possibletocentries[0].classList.add("active");
+}
 
 function toggletoc() {
    thesidebar = document.getElementById("ptx-sidebar");

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -13,26 +13,29 @@
 
 function scrollTocToActive() {
     //Try to figure out current TocItem from URL
-    pagefilename  = window.location.href;
-    pagefilename  = pagefilename.match(/[^\/]*$/)[0];
-    pagefilename = pagefilename.split("#")[0];
-    possibletocentries = document.querySelectorAll('#ptx-toc a[href="' + pagefilename + '"]');
-    if (possibletocentries.length == 0) {
-        //linked below a subsection
-        pagefilename  = pagefilename.match(/^[^\#]*/)[0];
-        possibletocentries = document.querySelectorAll('#ptx-toc a[href="' + pagefilename + '"]');
-    }
-    if (possibletocentries.length == 0) {
-        console.log("error, cannot find", pagefilename, "in TOC");
-        return
+    let fileNameWHash = window.location.href.split("/").pop();
+    let fileName = fileNameWHash.split("#")[0];
+
+    //Find just the filename in ToC
+    let tocEntry = document.querySelector('#ptx-toc a[href="' + fileName + '"]');
+    if (!tocEntry) {
+        return; //complete failure, get out
     }
 
-    //scroll to the active entry... don't use scrollIntoView because it
-    //sets the user'stab position to that item
-    let targetY = possibletocentries[0].offsetTop;
-    document.querySelector("#ptx-toc").scrollTop = targetY;
+    //See if we can also match fileName#hash
+    let tocEntryWHash = document.querySelector(
+        '#ptx-toc a[href="' + fileNameWHash + '"]'
+    );
+    if (tocEntryWHash) {
+        //Matched something below a subsection - activate the list item that contains it
+        tocEntryWHash.closest("li").classList.add("active");
+    }
 
-    possibletocentries[0].classList.add("active");
+    //Now activate ToC item for fileName and scroll to it
+    //  Don't use scrollIntoView because it changes users tab position in Chrome
+    //  and messes up keyboard navigation
+    tocEntry.closest("li").classList.add("active");
+    document.querySelector("#ptx-toc").scrollTop = tocEntry.offsetTop;
 }
 
 function toggletoc() {


### PR DESCRIPTION
While playing with a screen reader, I figured out that the js library function `scrollIntoView` sets the target item as the current location for tab purposes. Thus when the ToC has to scroll to reveal an item, that item becomes the current tab stop. If the user hits tab they are already deep in the menu instead of starting from the top of the page and immediately hitting the skip link.

This modifies the ToC scroll code to not rely on that library function