### PR TITLE
WeBWorK: clear solution label regardless of div or span

### DIFF
--- a/js/pretext-webwork/2.19/pretext-webwork.js
+++ b/js/pretext-webwork/2.19/pretext-webwork.js
@@ -616,7 +616,7 @@ function translateHintSol(ww_id, body_div, ww_domain, b_ptx_has_hint, b_ptx_has_
         knowlSummary.className = '';
         knowlSummary.classList.add('knowl__link');
 
-        const summaryLabel = knowlSummary.getElementsByTagName('div')[0];
+        const summaryLabel = knowlSummary.children[0];
         summaryLabel.remove();
 
         const newLabelSpan = document.createElement('span');


### PR DESCRIPTION
This area of the pretext-webwork.js code clears the label like "Solution" that WW puts as the solution clickable (so that PTX can replace it with a localized version). Previously it was a `div`, but now it's a `span`. This change in code will clear it regardless of what HTML element it is.