### PR TITLE
Refactor handling of ol marker attribute to allow custom markers in html

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -4539,7 +4539,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <li><p>Purple</p></li>
                 </ul></p>
 
-                <p>Next, we have a list with no customization and multiple levels to test the defaults.  <latex /> allows a maximum of four levels of ordered/numbered lists, and a total of six levels if some unordered lists are mixed in.  The second-level defaults (lower-case Latin) are formatted slightly different in <latex /> versus HTML.  The HTML style is not easy to adjust, but you can specify the <latex /> version to match if it is important.  Note that to have nested lists you <em>must</em> structure your list items as paragraphs, since a list may only appear within a <tag>p</tag> element.<ol>
+                <p>Next, we have a list with no customization and multiple levels to test the defaults.  <latex /> allows a maximum of four levels of ordered/numbered lists, and a total of six levels if some unordered lists are mixed in.  Note that to have nested lists you <em>must</em> structure your list items as paragraphs, since a list may only appear within a <tag>p</tag> element.<ol>
                     <li>
                         <title>A title on a top-level item</title>
                         <p>Level 1, first.</p>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -232,11 +232,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="node()|@*" mode="augment">
     <xsl:param name="parent-struct" select="''"/>
     <xsl:param name="level" select="0"/>
+    <xsl:param name="ordered-list-level" select="0"/>
 
     <xsl:copy>
         <xsl:apply-templates select="node()|@*" mode="augment">
             <xsl:with-param name="parent-struct" select="$parent-struct"/>
             <xsl:with-param name="level" select="$level"/>
+            <xsl:with-param name="ordered-list-level" select="$ordered-list-level"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -1574,6 +1576,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="part|chapter|appendix|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet" mode="augment">
     <xsl:param name="parent-struct"/>
     <xsl:param name="level"/>
+    <xsl:param name="ordered-list-level" />
 
     <xsl:variable name="the-serial">
         <xsl:apply-templates select="." mode="division-serial-number"/>
@@ -1600,6 +1603,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="next-level" select="$level + 1"/>
+    <xsl:variable name="next-ordered-list-level">
+        <xsl:choose>
+            <xsl:when test="self::exercises or self::worksheet or self::reading-questions or self::references">
+                <xsl:number value="1" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:number value="0" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:copy>
         <xsl:attribute name="struct">
             <xsl:value-of select="$parent-struct"/>
@@ -1613,6 +1626,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="node()|@*" mode="augment">
             <xsl:with-param name="parent-struct" select="$new-struct"/>
             <xsl:with-param name="level" select="$next-level"/>
+            <xsl:with-param name="ordered-list-level" select="$next-ordered-list-level"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -1648,6 +1662,114 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
+
+<!-- Labels of ordered lists have formatting codes, which  -->
+<!-- we detect here and pass on to other more specialized  -->
+<!-- templates for implementation specifics                -->
+<!-- In order: Arabic (0-based), Arabic (1-based)          -->
+<!-- lower-case Latin, upper-case Latin,                   -->
+<!-- lower-case Roman numeral, upper-case Roman numeral    -->
+<!-- Absent a label attribute, defaults go 4 levels deep   -->
+<!-- (max for Latex) as: Arabic, lower-case Latin,         -->
+<!-- lower-case Roman numeral, upper-case Latin            -->
+<xsl:template match="ol" mode="format-code">
+    <xsl:param name="level"/>
+    <xsl:choose>
+        <xsl:when test="@marker">
+            <xsl:choose>
+                <xsl:when test="contains(@marker,'0')">0</xsl:when>
+                <xsl:when test="contains(@marker,'1')">1</xsl:when>
+                <xsl:when test="contains(@marker,'a')">a</xsl:when>
+                <xsl:when test="contains(@marker,'A')">A</xsl:when>
+                <xsl:when test="contains(@marker,'i')">i</xsl:when>
+                <xsl:when test="contains(@marker,'I')">I</xsl:when>
+                <!-- DEPRECATED 2015-12-12 -->
+                <xsl:when test="@marker=''" />
+                <xsl:otherwise>
+                    <xsl:message>MBX:ERROR: ordered list label (<xsl:value-of select="@marker" />) not recognized</xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:choose>
+                <xsl:when test="$level='0'">1</xsl:when>
+                <xsl:when test="$level='1'">a</xsl:when>
+                <xsl:when test="$level='2'">i</xsl:when>
+                <xsl:when test="$level='3'">A</xsl:when>
+                <xsl:otherwise>
+                    <xsl:message>PTX:ERROR: ordered list is more than 4 levels deep (at level <xsl:value-of select="$level" />) or is inside an "exercise" and is more than 3 levels deep  (at level <xsl:value-of select="$level - 1" />)</xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="ol" mode="augment">
+    <xsl:param name="ordered-list-level"/>
+    <xsl:variable name="this-level">
+        <xsl:choose>
+            <xsl:when test="self::ol">
+                <xsl:value-of select="$ordered-list-level" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="0" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="next-level" select="$this-level + 1" />
+    <xsl:variable name="format-code">
+        <xsl:apply-templates select="." mode="format-code">
+            <xsl:with-param name="level" select="$this-level"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+    <!-- deconstruct the left and right adornments of the label   -->
+    <!-- or provide default adornments, consistent with LaTeX     -->
+    <!-- then store them                                          -->
+    <xsl:variable name="marker-prefix">
+        <xsl:choose>
+            <xsl:when test="@marker">
+                <xsl:value-of select="substring-before(@marker, $format-code)" />
+            </xsl:when>
+            <xsl:when test="$format-code='a'">
+                <xsl:text>(</xsl:text>
+            </xsl:when>
+            <xsl:otherwise />
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="marker-suffix">
+        <xsl:choose>
+            <xsl:when test="@marker">
+                <xsl:value-of select="substring-after(@marker, $format-code)" />
+            </xsl:when>
+            <xsl:when test="$format-code='a'">
+                <xsl:text>)</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>.</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:copy>
+        <xsl:attribute name="ordered-list-level">
+            <xsl:value-of select="$this-level"/>
+        </xsl:attribute>
+        <xsl:if test="self::ol">
+            <xsl:attribute name="format-code">
+                <xsl:value-of select="$format-code"/>
+            </xsl:attribute>
+            <xsl:attribute name="marker-prefix">
+                <xsl:value-of select="$marker-prefix"/>
+            </xsl:attribute>
+            <xsl:attribute name="marker-suffix">
+                <xsl:value-of select="$marker-suffix"/>
+            </xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates select="node()|@*" mode="augment">
+            <xsl:with-param name="ordered-list-level" select="$next-level"/>
+        </xsl:apply-templates>
+    </xsl:copy>
+</xsl:template>
+
 
 <!-- ######### -->
 <!-- Exercises -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4349,9 +4349,7 @@ Book (with parts), "section" at level 3
 <!-- First, the number of a list item within its own ordered list.  This -->
 <!-- trades on the PTX format codes being identical to the XSLT codes.   -->
 <xsl:template match="ol/li" mode="item-number">
-    <xsl:variable name="code">
-        <xsl:apply-templates select=".." mode="format-code" />
-    </xsl:variable>
+    <xsl:variable name="code" select="../@format-code" />
     <xsl:number format="{$code}" />
 </xsl:template>
 
@@ -5902,50 +5900,6 @@ Book (with parts), "section" at level 3
         <!-- now done, report level -->
         <xsl:otherwise>
             <xsl:value-of select="$level" />
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-
-<!-- Labels of ordered lists have formatting codes, which  -->
-<!-- we detect here and pass on to other more specialized  -->
-<!-- templates for implementation specifics                -->
-<!-- In order: Arabic (0-based), Arabic (1-based)          -->
-<!-- lower-case Latin, upper-case Latin,                   -->
-<!-- lower-case Roman numeral, upper-case Roman numeral    -->
-<!-- Absent a label attribute, defaults go 4 levels deep   -->
-<!-- (max for Latex) as: Arabic, lower-case Latin,         -->
-<!-- lower-case Roman numeral, upper-case Latin            -->
-<xsl:template match="ol" mode="format-code">
-    <xsl:choose>
-        <xsl:when test="@marker">
-            <xsl:choose>
-                <xsl:when test="contains(@marker,'0')">0</xsl:when>
-                <xsl:when test="contains(@marker,'1')">1</xsl:when>
-                <xsl:when test="contains(@marker,'a')">a</xsl:when>
-                <xsl:when test="contains(@marker,'A')">A</xsl:when>
-                <xsl:when test="contains(@marker,'i')">i</xsl:when>
-                <xsl:when test="contains(@marker,'I')">I</xsl:when>
-                <!-- DEPRECATED 2015-12-12 -->
-                <xsl:when test="@marker=''" />
-                <xsl:otherwise>
-                    <xsl:message>MBX:ERROR: ordered list label (<xsl:value-of select="@marker" />) not recognized</xsl:message>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:variable name="level">
-                <xsl:apply-templates select="." mode="ordered-list-level" />
-            </xsl:variable>
-            <xsl:choose>
-                <xsl:when test="$level='0'">1</xsl:when>
-                <xsl:when test="$level='1'">a</xsl:when>
-                <xsl:when test="$level='2'">i</xsl:when>
-                <xsl:when test="$level='3'">A</xsl:when>
-                <xsl:otherwise>
-                    <xsl:message>PTX:ERROR: ordered list is more than 4 levels deep (at level <xsl:value-of select="$level" />) or is inside an "exercise" and is more than 3 levels deep  (at level <xsl:value-of select="$level - 1" />)</xsl:message>
-                </xsl:otherwise>
-            </xsl:choose>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5861,12 +5861,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Utility templates to translate PTX              -->
 <!-- enumeration style to HTML list-style-type       -->
-<!-- NB: this is currently inferior to latex version -->
-<!-- NB: all pre-, post-formatting is lost           -->
+<!-- NB: this may not be needed any more             -->
 <xsl:template match="ol" mode="html-list-class">
-    <xsl:variable name="mbx-format-code">
-        <xsl:apply-templates select="." mode="format-code" />
-    </xsl:variable>
+    <xsl:variable name="mbx-format-code" select="./@format-code" />
     <xsl:choose>
         <xsl:when test="$mbx-format-code = '0'">decimal</xsl:when>
         <xsl:when test="$mbx-format-code = '1'">decimal</xsl:when>
@@ -5904,14 +5901,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- need to switch on 0-1 for ol Arabic -->
     <!-- no harm if called on "ul"           -->
     <xsl:variable name="mbx-format-code">
-        <xsl:apply-templates select="." mode="format-code" />
+        <xsl:choose>
+            <xsl:when test="self::ol">
+                <xsl:value-of select="./@format-code" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="." mode="format-code" />
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:variable>
     <xsl:element name="{local-name(.)}">
-        <xsl:if test="$mbx-format-code = '0'">
-            <xsl:attribute name="start">
-                <xsl:text>0</xsl:text>
-            </xsl:attribute>
-        </xsl:if>
         <xsl:attribute name="class">
             <xsl:apply-templates select="." mode="html-list-class" />
             <xsl:variable name="cols-class-name">
@@ -5923,10 +5922,60 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:value-of select="$cols-class-name"/>
             </xsl:if>
         </xsl:attribute>
+        <xsl:attribute name="id">
+            <xsl:apply-templates select="." mode="html-id" />
+        </xsl:attribute>
         <xsl:apply-templates select="li">
             <xsl:with-param name="b-original" select="$b-original" />
         </xsl:apply-templates>
     </xsl:element>
+</xsl:template>
+
+<!-- Markers -->
+<xsl:template match="ol" mode="ol-marker-style">
+    <xsl:variable name="mbx-format-code" select="./@format-code" />
+    <xsl:variable name="mbx-html-id">
+        <xsl:apply-templates select="." mode="html-id" />
+    </xsl:variable>
+    <!-- set up custom counter for this ol -->
+    <xsl:text>#</xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text> { counter-set: </xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text>&#x20;</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$mbx-format-code = '0'">-1</xsl:when>
+        <xsl:otherwise>0</xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>; }&#xa;</xsl:text>
+    <!-- format child li's -->
+    <xsl:text>#</xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text> &gt; li::marker { content: &quot;</xsl:text>
+    <xsl:value-of select="./@marker-prefix" />
+    <xsl:text>&quot;counter(</xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text>,</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$mbx-format-code = '0'">decimal</xsl:when>
+        <xsl:when test="$mbx-format-code = '1'">decimal</xsl:when>
+        <xsl:when test="$mbx-format-code = 'a'">lower-alpha</xsl:when>
+        <xsl:when test="$mbx-format-code = 'A'">upper-alpha</xsl:when>
+        <xsl:when test="$mbx-format-code = 'i'">lower-roman</xsl:when>
+        <xsl:when test="$mbx-format-code = 'I'">upper-roman</xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:BUG: bad ordered list label format code in HTML conversion</xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>)&quot;</xsl:text>
+    <xsl:value-of select="./@marker-suffix" />
+    <xsl:text>&quot;; }&#xa;</xsl:text>
+    <!-- increment custom counter -->
+    <xsl:text>#</xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text> &gt; li { counter-increment: </xsl:text>
+    <xsl:value-of select="$mbx-html-id" />
+    <xsl:text>; }&#xa;</xsl:text>
 </xsl:template>
 
 <!-- We let CSS react to narrow titles for dl -->
@@ -10648,6 +10697,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:call-template name="css" />
             <xsl:call-template name="runestone-header"/>
             <xsl:call-template name="font-awesome" />
+            <!-- Custom styles for li where parent ol has @marker specified -->
+            <style>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:apply-templates select="$document-root//ol" mode="ol-marker-style"/>
+            </style>
         </head>
         <body>
             <!-- potential document-id per-page -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -7064,21 +7064,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Utility templates to translate @marker specification -->
 <!-- for use with LaTeX enumitem package's label keyword  -->
 <xsl:template match="ol" mode="latex-list-label">
-    <xsl:variable name="format-code">
-        <xsl:apply-templates select="." mode="format-code" />
-    </xsl:variable>
-    <!-- deconstruct the left and right adornments of the label   -->
-    <!-- or provide the default adornments, consistent with LaTeX -->
-    <!-- in the middle, translate PTX codes for enumitem package  -->
-    <xsl:choose>
-        <xsl:when test="@marker">
-            <xsl:value-of select="substring-before(@marker, $format-code)" />
-        </xsl:when>
-        <xsl:when test="$format-code='a'">
-            <xsl:text>(</xsl:text>
-        </xsl:when>
-        <xsl:otherwise />
-    </xsl:choose>
+    <xsl:variable name="format-code" select="./@format-code" />
+    <xsl:value-of select="./@marker-prefix" />
     <xsl:choose>
         <xsl:when test="$format-code = '0'">\arabic*</xsl:when>
         <xsl:when test="$format-code = '1'">\arabic*</xsl:when>
@@ -7090,18 +7077,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:message>PTX:BUG: bad ordered list label format code in LaTeX conversion</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:choose>
-        <xsl:when test="@marker">
-            <xsl:value-of select="substring-after(@marker, $format-code)" />
-        </xsl:when>
-        <xsl:when test="$format-code='a'">
-            <xsl:text>)</xsl:text>
-        </xsl:when>
-        <xsl:when test="($format-code='a') or ($format-code='i') or ($format-code='A')">
-            <xsl:text>.</xsl:text>
-        </xsl:when>
-        <xsl:otherwise />
-    </xsl:choose>
+    <xsl:value-of select="./@marker-suffix" />
 </xsl:template>
 
 <xsl:template match="ul" mode="latex-list-label">
@@ -7148,9 +7124,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="ol">
     <!-- need to switch on 0-1 for ol Arabic -->
     <!-- no harm if called on "ul"           -->
-    <xsl:variable name="format-code">
-        <xsl:apply-templates select="." mode="format-code" />
-    </xsl:variable>
+    <xsl:variable name="format-code" select="./@format-code" />
     <!-- Determine the number of columns -->
     <!-- Restrict to 1-6 via the schema  -->
     <xsl:variable name="ncols">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -7146,12 +7146,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\begin{enumerate}</xsl:text>
     <!-- override LaTeX defaults as indicated -->
     <xsl:if test="@marker or ($format-code = '0') or ancestor::exercises or ancestor::worksheet or ancestor::reading-questions or ancestor::references">
-        <xsl:text>[label=</xsl:text>
+        <xsl:text>[label={</xsl:text>
         <xsl:apply-templates select="." mode="latex-list-label" />
         <xsl:if test="$format-code = '0'">
             <xsl:text>, start=0</xsl:text>
         </xsl:if>
-        <xsl:text>]</xsl:text>
+        <xsl:text>}]</xsl:text>
     </xsl:if>
     <xsl:text>&#xa;</xsl:text>
      <xsl:apply-templates />


### PR DESCRIPTION
Analyse `@marker` for `ol` at the assembly stage and "augment" source tree with the results.

For LaTeX output, processing the sample article produced an identical `.tex` file as when processed using the master branch.

For HTML output, use custom item counters based on `html-id` for each `ol`, then style these separately according to the marker. Style for every `ol` in the entire source tree needs to go in every chunk file because of the possibility of nesting content from other "chunks" in knowls.