### PR TITLE
FITB: Update dynamic exercise markup scheme

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8896,15 +8896,58 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <exercises>
                 <title>Dynamic Fill-In</title>
 
+                <introduction>
+                  <p>The first problem illustrates revised markup for fill-in problems that don't involve randomization and use simple string and number comparison tests. Later exercises illustrate the use of dynamically generated mathematical expressions.</p>
+                </introduction>
+
+                <exercise label="fillin-string-integer-new">
+                    <title>Fill-In, String and Number Answers</title>
+
+                    <statement>
+                        <p>Complete the following line of a Python program so that it will declare an integer variable <c>age</c> with an initial value of <c>5</c>.</p>
+                        <p><fillin mode="string" correct="int"/> <c>age = </c> <fillin mode="number" correct="5"/><c>;</c></p>
+                    </statement>
+                    <evaluation>
+                        <evaluate>
+                            <test>
+                                <strcmp use-correct='yes'/>
+                                <feedback>
+                                  <p>A variable of type <c>int</c> is appropriate for whole number ages.</p>
+                                </feedback>
+                            </test>
+                            <test>
+                                <strcmp>.*</strcmp>
+                                <feedback>
+                                    <p>Remember that Java uses just the first three letters of the word <q>integer</q> to define an integral type.</p>
+                                </feedback>
+                            </test>
+                        </evaluate>
+                        <evaluate>
+                            <test>
+                                <numcmp use-correct='yes'/>
+                                <feedback>
+                                    <p>An integer variable may be initialized to a value.</p>
+                                </feedback>
+                            </test>
+                            <test>
+                                <strcmp>.*</strcmp>
+                                <feedback>
+                                    <p>Use <c>5</c> as the initial value of the variable.</p>
+                                </feedback>
+                            </test>
+                        </evaluate>
+                    </evaluation>
+                </exercise>
+
                 <exercise label="dynamic-fitb-simple-formula">
                     <title>Fill-In Formula (Dynamic)</title>
                     <statement>
                         <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval expr="x1"/></m>,  <m>x=<eval expr="x2"/></m>, and <m>x=<eval expr="x3"/></m> and so that <m>f(0)=<eval expr="y0"/></m>.</p>
-                        <p><m>f(x)=</m> <fillin name="st_cubic" correct="x3"/></p>
+                        <p><m>f(x)=</m> <fillin name="st_cubic" mode="math-formula" correct="x3"/></p>
                     </statement>
                     <solution>
                         <p>
-                            Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form,
+                            Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form, 
                             <me>f(x) = A <eval expr="base_cubic"/></me>
                             with an unknown scaling multiple <m>A</m>.
                         </p>
@@ -8921,38 +8964,51 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </p>
                     </solution>
                     <setup seed="314159">
-                        <de-object name="y0" context="number" mode="random">
-                            <options distribution="discrete" min="-8" max="8" by="1" nonzero="yes"/>
+                        <de-object name="y0" context="number">
+                            <de-random distribution="discrete" min="-8" max="8" by="1" nonzero="yes"/>
                         </de-object>
-                        <de-object name="x1" context="number" mode="random">
-                            <options distribution="discrete" min="-8" max="-4" by="1"/>
+                        <de-object name="x1" context="number">
+                            <de-random distribution="discrete" min="-8" max="-4" by="1"/>
                         </de-object>
-                        <de-object name="d1" context="number" mode="random">
-                            <options distribution="discrete" min="1" max="4" by="1"/>
+                        <de-object name="d1" context="number">
+                            <de-random distribution="discrete" min="1" max="4" by="1"/>
                         </de-object>
-                        <de-object name="d2" context="number" mode="random">
-                            <options distribution="discrete" min="1" max="4" by="1"/>
+                        <de-object name="d2" context="number">
+                            <de-random distribution="discrete" min="1" max="4" by="1"/>
                         </de-object>
-                        <de-object name="x2" context="number" mode="formula">{{x1}}+{{d1}}</de-object>
-                        <de-object name="x3" context="number" mode="formula">{{x2}}+{{d2}}</de-object>
-                        <de-object name="base_cubic" context="formula" mode="formula">
-                            (x-{{x1}})*(x-{{x2}})*(x-{{x3}})
+                        <de-object name="x2" context="number">
+                            <de-number>{{x1}}+{{d1}}</de-number>
                         </de-object>
-                        <de-object name="base_yint" context="number" mode="evaluate">
-                            <formula><eval expr="base_cubic"/></formula>
-                            <variable name="x">0</variable>
+                        <de-object name="x3" context="number">
+                            <de-number>{{x2}}+{{d2}}</de-number>
                         </de-object>
-                        <de-object name="A" context="number" mode="formula">
-                            {{y0}}/{{base_yint}}
+                        <de-object name="base_cubic" context="formula">
+                            <de-expression>(x-{{x1}})*(x-{{x2}})*(x-{{x3}})</de-expression>
                         </de-object>
-                        <de-object name="cubic" context="formula" mode="formula">
-                            {{A}}*(x-{{x1}})*(x-{{x2}})*(x-{{x3}})
+                        <de-object name="base_yint" context="number">
+                            <de-evaluate>
+                                <formula><eval expr="base_cubic"/></formula>
+                                <variable name="x">0</variable>
+                            </de-evaluate>                            
+                        </de-object>
+                        <de-object name="A" context="number">
+                            <de-number>{{y0}}/{{base_yint}}</de-number>
+                        </de-object>
+                        <de-object name="cubic" context="formula">
+                            <de-expression>{{A}}*(x-{{x1}})*(x-{{x2}})*(x-{{x3}})</de-expression>
                         </de-object>
                     </setup>
                     <evaluation>
-                        <evaluate submit="st_cubic">
+                        <evaluate name="st_cubic">
                             <test correct="yes">
-                                <eval expr="cubic"/>
+                                <mathcmp expr="cubic"/>
+                            </test>
+                            <test>
+                                <mathcmp>
+                                    <de-expression>x+1</de-expression>
+                                    <eval expr="ans"/>
+                                </mathcmp>
+                                <feedback>Short</feedback>
                             </test>
                         </evaluate>
                     </evaluation>
@@ -8965,8 +9021,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         Find two nontrivial functions <m>f(x)</m> and <m>g(x)</m> so that <m>h(x) = f(g(x))</m>.
                         </p>
                         <p>
-                        <m>f(x) = </m> <fillin width="15" correct="outerFormula" name="fGiven"/> 
-                        and <m>g(x)=</m> <fillin width="15" correct="innerFormula" name="gGiven"/>
+                        <m>f(x) = </m> <fillin width="15" mode="math-formula" correct="outerFormula" name="fGiven"/> 
+                        and <m>g(x)=</m> <fillin width="15" mode="math-formula" correct="innerFormula" name="gGiven"/>
                         </p>
                     </statement>
                     <solution>
@@ -8981,83 +9037,95 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </p>
                     </solution>
                     <setup seed="4321">
-                        <de-object name="a" context="number" mode="random">
-                            <options distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
+                        <de-object name="a" context="number">
+                            <de-random distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
                         </de-object>
-                        <de-object name="n" context="number" mode="random">
-                            <options distribution="discrete" min="2" max="5" />
+                        <de-object name="n" context="number">
+                            <de-random distribution="discrete" min="2" max="5" />
                         </de-object>
-                        <de-object name="b" context="number" mode="random">
-                            <options distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
+                        <de-object name="b" context="number">
+                            <de-random distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
                         </de-object>
-                        <de-object name="c" context="number" mode="random">
-                            <options distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
+                        <de-object name="c" context="number">
+                            <de-random distribution="discrete" min="-4" max="5" by="1" nonzero="yes" />
                         </de-object>
-                        <de-object name="d" context="number" mode="random">
-                            <options distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
+                        <de-object name="d" context="number">
+                            <de-random distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
                         </de-object>
-                        <de-object name="outerFormula" context="formula" mode="formula">{{a}}*x^{{n}}+{{b}}</de-object>
-                        <de-object name="innerFormula" context="formula" mode="formula">{{c}}*x+{{d}}</de-object>
-                        <de-object name="identityFunction" context="formula" mode="formula">x</de-object>
-                        <de-object name="composition" context="formula" mode="substitution">
-                        <formula><eval expr="outerFormula"/></formula>
-                        <variable name="x"><eval expr="innerFormula"/></variable>
+                        <de-object name="outerFormula" context="formula">
+                            <de-expression>{{a}}*x^{{n}}+{{b}}</de-expression>
+                        </de-object>
+                        <de-object name="innerFormula" context="formula">
+                            <de-expression>{{c}}*x+{{d}}</de-expression>
+                        </de-object>
+                        <de-object name="identityFunction" context="formula">
+                            <de-expression>x</de-expression>
+                        </de-object>
+                        <de-object name="composition" context="formula">
+                            <de-expression mode="substitution">
+                                <formula><eval expr="outerFormula"/></formula>
+                                <variable name="x"><eval expr="innerFormula"/></variable>
+                            </de-expression>
                         </de-object>
                     </setup>
                     <evaluation answers-coupled="yes">
-                        <evaluate submit="fGiven">
-                        <test>
-                            <eval expr="identityFunction"/>
-                            <feedback><m>f(x)=x</m> is not allowed for nontrivial compositions.</feedback>
-                        </test>
-                        <test>
-                            <not>
-                                <equal>
-                                    <eval expr="composition"/>
-                                    <de-object context="formula" mode="substitution">
-                                        <formula><eval expr="fGiven"/></formula>
-                                        <variable name="x"><eval expr="gGiven"/></variable>
-                                    </de-object>
-                                </equal>
-                            </not>
-                            <equal>
-                            <eval expr="composition"/>
-                            <de-object context="formula" mode="substitution">
-                                <formula><eval expr="gGiven"/></formula>
-                                <variable name="x"><eval expr="fGiven"/></variable>
-                            </de-object>
-                            </equal>
-                            <feedback>You have composed in the wrong order.</feedback>
-                        </test>
+                        <evaluate name="fGiven">
+                            <test>
+                                <mathcmp expr="identityFunction"/>
+                                <feedback><m>f(x)=x</m> is not allowed for nontrivial compositions.</feedback>
+                            </test>
+                            <test>
+                                <logical op="and">
+                                    <logical op="not">
+                                        <mathcmp>
+                                            <eval expr="composition"/>
+                                            <de-expression context="formula" mode="substitution">
+                                                <formula><eval expr="fGiven"/></formula>
+                                                <variable name="x"><eval expr="gGiven"/></variable>
+                                            </de-expression>
+                                        </mathcmp>
+                                    </logical>
+                                    <mathcmp>
+                                        <eval expr="composition"/>
+                                        <de-expression context="formula" mode="substitution">
+                                            <formula><eval expr="gGiven"/></formula>
+                                            <variable name="x"><eval expr="fGiven"/></variable>
+                                        </de-expression>
+                                    </mathcmp>
+                                </logical>
+                                <feedback>You have composed in the wrong order.</feedback>
+                            </test>
                         </evaluate>
-                        <evaluate submit="gGiven">
-                        <test>
-                            <eval expr="identityFunction"/>
-                            <feedback><m>g(x)=x</m> is not allowed for nontrivial compositions.</feedback>
-                        </test>
+                        <evaluate name="gGiven">
+                            <test>
+                                <mathcmp expr="identityFunction"/>
+                                <feedback><m>g(x)=x</m> is not allowed for nontrivial compositions.</feedback>
+                            </test>
                         </evaluate>
                         <evaluate all="yes">
                             <test correct="yes">
-                                <equal>
-                                    <eval expr="composition"/>
-                                    <de-object context="formula" mode="substitution">
-                                        <formula><eval expr="fGiven"/></formula>
-                                        <variable name="x"><eval expr="gGiven"/></variable>
-                                    </de-object>
-                                </equal>
-                                <not>
-                                    <equal>
-                                        <eval expr="fGiven"/>
-                                        <eval expr="identityFunction"/>
-                                    </equal>
-                                </not>
-                                <not>
-                                    <equal>
-                                        <eval expr="gGiven"/>
-                                        <eval expr="identityFunction"/>
-                                    </equal>
-                                </not>
-                            <feedback>Excellent!</feedback>
+                                <logical op="and">
+                                    <mathcmp>
+                                        <eval expr="composition"/>
+                                        <de-expression context="formula" mode="substitution">
+                                            <formula><eval expr="fGiven"/></formula>
+                                            <variable name="x"><eval expr="gGiven"/></variable>
+                                        </de-expression>
+                                    </mathcmp>
+                                    <logical op="not">
+                                        <mathcmp>
+                                            <eval expr="fGiven"/>
+                                            <eval expr="identityFunction"/>
+                                        </mathcmp>
+                                    </logical>
+                                    <logical op="not">
+                                        <mathcmp>
+                                            <eval expr="gGiven"/>
+                                            <eval expr="identityFunction"/>
+                                        </mathcmp>
+                                    </logical>
+                                </logical>
+                                <feedback>Excellent!</feedback>
                             </test>
                         </evaluate>
                     </evaluation>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1992,7 +1992,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- new dynamic fillin goes here, perhaps:                     -->
             <!-- statement//fillin[(@*|node()) and not(@characters|@fill)]? -->
-            <xsl:when test="statement[ancestor::exercise/setup]">
+            <xsl:when test="statement[.//fillin and ancestor::exercise/evaluation]">
                 <xsl:text>fillin</xsl:text>
             </xsl:when>
             <!-- only interactive programs make sense after a "statement" -->

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -62,95 +62,97 @@
         <xsl:apply-templates select="." mode="html-id"/>
     </xsl:variable>
     <xsl:variable name="b-is-dynamic" select="boolean(./setup)"/>
-    <div class="runestone">
-        <div data-component="fillintheblank" class="fillintheblank" style="visibility: hidden;">
-            <xsl:attribute name="id">
-                <xsl:value-of select="$the-id"/>
-            </xsl:attribute>
-            <script type="application/json">
-                <xsl:text>{&#xa;</xsl:text>
-                    <!-- A seed is provided to generate consistent static content -->
-                    <xsl:if test="$b-dynamics-static-seed">
-                        <xsl:text>"static_seed": "</xsl:text>
-                        <xsl:choose>
-                            <xsl:when test="setup/@seed">
-                                <xsl:value-of select="setup/@seed"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <!-- Report if a seed is not provided-->
-                                <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="$the-id"/>" is missing setup @seed for static content generation.</xsl:message>
-                                <xsl:text>1234</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                        <xsl:text>",&#xa;</xsl:text>
-                    </xsl:if>
-                    <!-- The formatted HTML presentation of the problem, -->
-                    <!-- with escape codes for dynamic content, all of   -->
-                    <!-- which is serialized and escaped to a string.    -->
-                    <xsl:text>"problemHtml": </xsl:text>
-                    <xsl:call-template name="escape-quote-xml">
-                        <xsl:with-param name="xml_content">
-                            <xsl:apply-templates select="statement/*" mode="body" />
-                            <xsl:if test="$b-dynamics-static-seed">
-                                <div>
-                                    <xsl:attribute name="id">
-                                        <xsl:apply-templates select="." mode="html-id"/>
-                                        <xsl:text>-substitutions</xsl:text>
-                                    </xsl:attribute>
-                                    <xsl:apply-templates select="(statement|solution)//eval[@expr]" mode="track-evaluation" />
-                                </div>
-                            </xsl:if>
-                        </xsl:with-param>
-                    </xsl:call-template>
-                    <!-- The formatted HTML presentation of the solution, -->
-                    <!-- similar to statement but no fillins              -->
-                    <xsl:text>,&#xa;"solutionHtml": </xsl:text>
-                    <xsl:call-template name="escape-quote-xml">
-                        <xsl:with-param name="xml_content">
-                            <xsl:apply-templates select="solution/*" mode="body" />
-                        </xsl:with-param>
-                    </xsl:call-template>
-                    <!-- Add packages that need to be loaded as javascript -->
-                    <xsl:if test="$b-is-dynamic">
-                        <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
-                        <xsl:text>"BTM"</xsl:text>
-                        <!-- Future: add additional packages here -->
+    <div class="ptx-runestone-container">
+        <div class="runestone">
+            <div data-component="fillintheblank" class="fillintheblank" style="visibility: hidden;">
+                <xsl:attribute name="id">
+                    <xsl:value-of select="$the-id"/>
+                </xsl:attribute>
+                <script type="application/json">
+                    <xsl:text>{&#xa;</xsl:text>
+                        <!-- A seed is provided to generate consistent static content -->
+                        <xsl:if test="$b-dynamics-static-seed">
+                            <xsl:text>"static_seed": "</xsl:text>
+                            <xsl:choose>
+                                <xsl:when test="setup/@seed">
+                                    <xsl:value-of select="setup/@seed"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <!-- Report if a seed is not provided-->
+                                    <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="$the-id"/>" is missing setup @seed for static content generation.</xsl:message>
+                                    <xsl:text>1234</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            <xsl:text>",&#xa;</xsl:text>
+                        </xsl:if>
+                        <!-- The formatted HTML presentation of the problem, -->
+                        <!-- with escape codes for dynamic content, all of   -->
+                        <!-- which is serialized and escaped to a string.    -->
+                        <xsl:text>"problemHtml": </xsl:text>
+                        <xsl:call-template name="escape-quote-xml">
+                            <xsl:with-param name="xml_content">
+                                <xsl:apply-templates select="statement/*" mode="body" />
+                                <xsl:if test="$b-dynamics-static-seed">
+                                    <div>
+                                        <xsl:attribute name="id">
+                                            <xsl:apply-templates select="." mode="html-id"/>
+                                            <xsl:text>-substitutions</xsl:text>
+                                        </xsl:attribute>
+                                        <xsl:apply-templates select="(statement|solution)//eval[@expr]" mode="track-evaluation" />
+                                    </div>
+                                </xsl:if>
+                            </xsl:with-param>
+                        </xsl:call-template>
+                        <!-- The formatted HTML presentation of the solution, -->
+                        <!-- similar to statement but no fillins              -->
+                        <xsl:text>,&#xa;"solutionHtml": </xsl:text>
+                        <xsl:call-template name="escape-quote-xml">
+                            <xsl:with-param name="xml_content">
+                                <xsl:apply-templates select="solution/*" mode="body" />
+                            </xsl:with-param>
+                        </xsl:call-template>
+                        <!-- Add packages that need to be loaded as javascript -->
+                        <xsl:if test="$b-is-dynamic">
+                            <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
+                            <xsl:text>"BTM"</xsl:text>
+                            <!-- Future: add additional packages here -->
+                            <xsl:text>]</xsl:text>
+                        </xsl:if>
+                        <!-- Names assigned to the blanks. (Inclusion is     -->
+                        <!-- really so that evaluation of answers can refer  -->
+                        <!-- to submitted work by name.)                     -->
+                        <xsl:if test="statement//fillin[@name]">
+                            <xsl:text>,&#xa;"blankNames": {</xsl:text>
+                            <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
+                            <xsl:text>}</xsl:text>
+                        </xsl:if>
+                        <xsl:if test="$b-is-dynamic">
+                            <!-- The actual setup code is javascript enclosed in quotes. -->
+                            <!-- The declaration creates the objects that are needed.    -->
+                            <!-- The script is included as an escaped string             -->
+                            <xsl:text>,&#xa;"dyn_vars": </xsl:text>
+                            <xsl:call-template name="dynamic-setup" />
+                        </xsl:if>
+                        <!-- An array of tests and feedback for answer evaluation    -->
+                        <!-- Each blank has a corresponding array of test/feedback   -->
+                        <!-- response. The test is Javascript (stringified) that     -->
+                        <!-- returns a boolean response. The first test is for       -->
+                        <!-- correctness. The last response is default.              -->
+                        <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
+                        <!-- In case all answers are based on one test               -->
+                        <xsl:variable name="multiAns">
+                            <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
+                        </xsl:variable>
+                        <!-- Generate test/feedback pair for each fillin             -->
+                        <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
+                            <xsl:with-param name="multiAns" select="$multiAns" />
+                        </xsl:apply-templates>
                         <xsl:text>]</xsl:text>
-                    </xsl:if>
-                    <!-- Names assigned to the blanks. (Inclusion is     -->
-                    <!-- really so that evaluation of answers can refer  -->
-                    <!-- to submitted work by name.)                     -->
-                    <xsl:if test="statement//fillin[@name]">
-                        <xsl:text>,&#xa;"blankNames": {</xsl:text>
-                        <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
-                        <xsl:text>}</xsl:text>
-                    </xsl:if>
-                    <xsl:if test="$b-is-dynamic">
-                        <!-- The actual setup code is javascript enclosed in quotes. -->
-                        <!-- The declaration creates the objects that are needed.    -->
-                        <!-- The script is included as an escaped string             -->
-                        <xsl:text>,&#xa;"dyn_vars": </xsl:text>
-                        <xsl:call-template name="dynamic-setup" />
-                    </xsl:if>
-                    <!-- An array of tests and feedback for answer evaluation    -->
-                    <!-- Each blank has a corresponding array of test/feedback   -->
-                    <!-- response. The test is Javascript (stringified) that     -->
-                    <!-- returns a boolean response. The first test is for       -->
-                    <!-- correctness. The last response is default.              -->
-                    <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
-                    <!-- In case all answers are based on one test               -->
-                    <xsl:variable name="multiAns">
-                        <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
-                    </xsl:variable>
-                    <!-- Generate test/feedback pair for each fillin             -->
-                    <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
-                        <xsl:with-param name="multiAns" select="$multiAns" />
-                    </xsl:apply-templates>
-                    <xsl:text>]</xsl:text>
-                <xsl:text>&#xa;}</xsl:text>
-            </script>
+                    <xsl:text>&#xa;}</xsl:text>
+                </script>
+            </div>
+            <xsl:text>&#xa;</xsl:text>
         </div>
-        <xsl:text>&#xa;</xsl:text>
     </div>
 </xsl:template>
 

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -23,16 +23,33 @@
         <xsl:apply-templates select="ancestor::exercise" mode="html-id" />
     </xsl:variable>
     <xsl:element name="input">
-        <xsl:attribute name="types"><xsl:text>text</xsl:text></xsl:attribute>
+        <xsl:attribute name="type">
+            <xsl:choose>
+                <xsl:when test="@mode = 'number'">
+                    <xsl:text>number</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>text</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
         <xsl:attribute name="id">
             <xsl:value-of select="$parent-id"/>
             <xsl:text>-</xsl:text>
-            <xsl:value-of select="@name"/>
+            <xsl:apply-templates select="." mode="blank-name"/>
         </xsl:attribute>
-        <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+        <xsl:if test="@name">
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+        </xsl:if>
     </xsl:element>
 </xsl:template>
 
+<xsl:variable name="defaultCorrectResponse">
+    <xsl:text>Correct.</xsl:text>
+</xsl:variable>
+<xsl:variable name="defaultIncorrectResponse">
+    <xsl:text>Try again.</xsl:text>
+</xsl:variable> 
 
 <!-- ========================================================= -->
 <!-- The Runestone element is based on JSON scripts describing -->
@@ -44,6 +61,7 @@
     <xsl:variable name="the-id">
         <xsl:apply-templates select="." mode="html-id"/>
     </xsl:variable>
+    <xsl:variable name="b-is-dynamic" select="boolean(./setup)"/>
     <div class="runestone">
         <div data-component="fillintheblank" class="fillintheblank" style="visibility: hidden;">
             <xsl:attribute name="id">
@@ -72,7 +90,7 @@
                     <xsl:text>"problemHtml": </xsl:text>
                     <xsl:call-template name="escape-quote-xml">
                         <xsl:with-param name="xml_content">
-                            <xsl:apply-templates select="statement" mode="body" />
+                            <xsl:apply-templates select="statement/*" mode="body" />
                             <xsl:if test="$b-dynamics-static-seed">
                                 <div>
                                     <xsl:attribute name="id">
@@ -89,25 +107,31 @@
                     <xsl:text>,&#xa;"solutionHtml": </xsl:text>
                     <xsl:call-template name="escape-quote-xml">
                         <xsl:with-param name="xml_content">
-                            <xsl:apply-templates select="solution" mode="body" />
+                            <xsl:apply-templates select="solution/*" mode="body" />
                         </xsl:with-param>
                     </xsl:call-template>
                     <!-- Add packages that need to be loaded as javascript -->
-                    <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
-                    <xsl:if test="setup/de-object">
+                    <xsl:if test="$b-is-dynamic">
+                        <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
                         <xsl:text>"BTM"</xsl:text>
+                        <!-- Future: add additional packages here -->
+                        <xsl:text>]</xsl:text>
                     </xsl:if>
-                    <xsl:text>]</xsl:text>
                     <!-- Names assigned to the blanks. (Inclusion is     -->
                     <!-- really so that evaluation of answers can refer  -->
-                    <!-- to submitted work by name.                      -->
-                    <xsl:text>,&#xa;"blankNames": {</xsl:text>
-                    <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
-                    <!-- The actual setup code is javascript enclosed in quotes. -->
-                    <!-- The declaration creates the objects that are needed.    -->
-                    <!-- The script is included as an escaped string             -->
-                    <xsl:text>},&#xa;"dyn_vars": </xsl:text>
-                    <xsl:call-template name="dynamic-setup" />
+                    <!-- to submitted work by name.)                     -->
+                    <xsl:if test="statement//fillin[@name]">
+                        <xsl:text>,&#xa;"blankNames": {</xsl:text>
+                        <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
+                        <xsl:text>}</xsl:text>
+                    </xsl:if>
+                    <xsl:if test="$b-is-dynamic">
+                        <!-- The actual setup code is javascript enclosed in quotes. -->
+                        <!-- The declaration creates the objects that are needed.    -->
+                        <!-- The script is included as an escaped string             -->
+                        <xsl:text>,&#xa;"dyn_vars": </xsl:text>
+                        <xsl:call-template name="dynamic-setup" />
+                    </xsl:if>
                     <!-- An array of tests and feedback for answer evaluation    -->
                     <!-- Each blank has a corresponding array of test/feedback   -->
                     <!-- response. The test is Javascript (stringified) that     -->
@@ -130,26 +154,42 @@
     </div>
 </xsl:template>
 
-<!-- Creating a list of blank names. -->
-<xsl:template match="fillin" mode="declare-blanks">
-    <xsl:if test="position()>1">
-        <xsl:text>, </xsl:text>
-    </xsl:if>
-    <xsl:if test="@name">
-        <xsl:call-template name="quote-string">
-            <xsl:with-param name="text" select="@name"/>
-        </xsl:call-template>
-        <xsl:text>: </xsl:text>
-        <xsl:value-of select="position()-1"/>
-    </xsl:if>
+<!-- Fillins can be provided a name or use a default rule -->
+<xsl:template match="fillin" mode="blank-name">
+    <xsl:choose>
+        <xsl:when test="@name">
+            <xsl:value-of select="@name"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>blank</xsl:text>
+            <xsl:number />
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
+<!-- Creating a list of blank names. -->
+<xsl:template match="fillin" mode="declare-blanks">
+    <xsl:variable name="blankNum">
+        <xsl:number />
+    </xsl:variable>
+    <xsl:if test="$blankNum>1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text">
+            <xsl:apply-templates select="." mode="blank-name"/>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>: </xsl:text>
+    <xsl:value-of select="$blankNum - 1"/>
+</xsl:template>
 
 <!-- #eval in a dynamic exercise (has setup) is to evaluate -->
 <!-- an expression that has been previously generated. If   -->
 <!-- in math-mode, we want to see if it is an object that   -->
 <!-- knows how to formulate a LaTeX representation          -->
 <!-- The `toTeX` javascript function is defined in BTM.js   -->
+<!-- which is loaded by Runestone.                          -->
 <xsl:template match="exercise[//setup]//eval[@expr]">
     <xsl:text>[%= </xsl:text>
     <xsl:choose>
@@ -243,7 +283,7 @@
         </xsl:with-param>
     </xsl:call-template>
     <xsl:text>, </xsl:text>
-    <xsl:apply-templates select="." mode="evaluate">
+    <xsl:apply-templates select="*" mode="evaluate">
         <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
     </xsl:apply-templates>
     <xsl:text>);&#xa;</xsl:text>
@@ -275,9 +315,17 @@
     <xsl:if test="position() > 1">
         <xsl:text>, </xsl:text>
     </xsl:if>
-    <!-- Future: There may be attributes of the fillin that declare parser type. -->
-    <!-- For now, simply assuming everything is an expression.                   -->
-    <xsl:text>v._menv.getParser()</xsl:text>
+     <xsl:choose>
+        <xsl:when test="@mode='math-formula'">
+            <xsl:text>v._menv.getParser()</xsl:text>
+        </xsl:when>
+        <xsl:when test="@mode='number'">
+            <xsl:text>Number</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>function(val){ return val; }</xsl:text>
+        </xsl:otherwise>
+     </xsl:choose>
 </xsl:template>
 
 
@@ -285,139 +333,251 @@
 <!-- Evaluation and Feedback                                    -->
 <!-- ========================================================== -->
 
+<!-- Deal with possibility of global checker for all blanks -->
+<xsl:template match="evaluation" mode="get-multianswer-check">
+    <xsl:variable name="responseTree" select="ancestor::exercise//statement//fillin" />
+    <xsl:if test="count($responseTree) > 1 and ancestor::exercise//evaluation/evaluate[@all='yes']/test">
+        <xsl:apply-templates select="ancestor::exercise//evaluation/evaluate[@all='yes']/test" mode="create-test-feedback">
+            <xsl:with-param name="fillin" select="$responseTree"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+
 <!-- Template for answer checking. Actual work done by specialized templates. -->
 <xsl:template match="fillin" mode="dynamic-feedback">
     <xsl:param name="multiAns"/>
     <xsl:variable name="curFillIn" select="."/>
-    <xsl:variable name="check" select="ancestor::exercise//evaluation/evaluate[@submit = $curFillIn/@name]" />
-    <xsl:if test="position() > 1">
+    <xsl:variable name="fillinName">
+        <xsl:apply-templates select="." mode="blank-name"/>
+    </xsl:variable>
+    <xsl:variable name="blankNum">
+        <xsl:number />
+    </xsl:variable>
+    <xsl:variable name="check">
+        <xsl:choose>
+            <xsl:when test="ancestor::exercise//evaluation/evaluate[@name = $fillinName]">
+                <xsl:copy-of select="ancestor::exercise//evaluation/evaluate[@name = $fillinName]"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="ancestor::exercise//evaluation/evaluate[position() = $blankNum]"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable> 
+    <xsl:variable name="checkCorrectTest">
+        <xsl:choose>
+            <xsl:when test="exsl:node-set($check)/evaluate/test[@correct='yes']">
+                <xsl:copy-of select="exsl:node-set($check)/evaluate/test[@correct='yes']"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="exsl:node-set($check)/evaluate/test[position()=1]"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="$blankNum > 1">
         <xsl:text>, </xsl:text>
     </xsl:if>
     <!-- First check is for correctness. -->
-    <xsl:text>[{"solution_code": </xsl:text>
-    <xsl:call-template name="escape-quote-string">
-        <xsl:with-param name="text">
+    <xsl:text>[</xsl:text>
+    <xsl:choose>
+        <xsl:when test="string-length($multiAns)>0">
+            <xsl:value-of select="$multiAns"/>
+        </xsl:when>
+        <xsl:when test="$checkCorrectTest">
+            <xsl:apply-templates select="exsl:node-set($checkCorrectTest)/test" mode="create-test-feedback">
+                <xsl:with-param name="fillin" select="$curFillIn" />
+                <xsl:with-param name="b-correct" select="'yes'" />
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- If no explicit test is provided, use given correct info. -->
+        <xsl:otherwise>
+            <xsl:text>{</xsl:text>
             <xsl:choose>
-                <xsl:when test="string-length($multiAns)>0">
-                    <xsl:value-of select="$multiAns"/>
+                <xsl:when test="$curFillIn/@mode='number'">
+                    <xsl:text>"number": [</xsl:text>
+                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
+                    <xsl:text>,</xsl:text>
+                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
                 </xsl:when>
-                <xsl:when test="$check/test[@correct='yes']">
-                    <xsl:call-template name="create-test">
-                        <xsl:with-param name="submit" select="$curFillIn/@name" />
-                        <xsl:with-param name="test" select="$check/test[@correct='yes']/*[not(self::feedback)]" />
-                    </xsl:call-template>
+                <xsl:when test="$curFillIn/@mode='string'">
+                    <xsl:text>"regex": </xsl:text>
+                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
                 </xsl:when>
-                <!-- If no explicit test, must be on the fillin. -->
-                <xsl:otherwise>
+                <xsl:when test="$curFillIn/@mode='math'">
                     <xsl:text>function() {&#xa;</xsl:text>
                     <xsl:text>    return _menv.compareExpressions(</xsl:text>
                     <xsl:value-of select="$curFillIn/@correct"/>
-                    <xsl:text>, </xsl:text>
-                    <xsl:value-of select="$curFillIn/@name"/>
+                    <xsl:text>, ans</xsl:text>
+                    <!-- Can we use ans above instead of $curFillIn/@name? -->
+                    <!-- xsl:value-of select="exsl:node-set($curFillIn)/@name"/-->
                     <xsl:text>);&#xa;}</xsl:text>
-                </xsl:otherwise>
+                </xsl:when>
             </xsl:choose>
-            <xsl:text>()</xsl:text>
-        </xsl:with-param>
-    </xsl:call-template>
-    <xsl:text>, "feedback": </xsl:text>
-    <xsl:choose>
-        <xsl:when test="$check/test[@correct='yes']/feedback">
-            <xsl:call-template name="quote-string">
-                <xsl:with-param name="text" select="$check/test[@correct='yes']/feedback"/>
-            </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text>"Correct."</xsl:text>
+            <xsl:text>, "feedback": "</xsl:text>
+            <xsl:value-of select="$defaultCorrectResponse"/>
+            <xsl:text>"}</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:text>}</xsl:text>
+
     <!-- Now add additional checks for feedback. -->
-    <xsl:for-each select="$check/test[not(@correct='yes')]">
-        <xsl:text>, {"solution_code": </xsl:text>
-        <xsl:call-template name="escape-quote-string">
-            <xsl:with-param name="text">
-                <xsl:call-template name="create-test">
-                    <xsl:with-param name="submit" select="$curFillIn/@name" />
-                    <xsl:with-param name="test" select="*[not(self::feedback)]" />
-                </xsl:call-template>
-                <xsl:text>()</xsl:text>
-            </xsl:with-param>
-        </xsl:call-template>
-        <xsl:text>, "feedback": </xsl:text>
-        <xsl:choose>
-            <xsl:when test="feedback">
-                <xsl:call-template name="quote-string">
-                    <xsl:with-param name="text" select="feedback"/>
-                </xsl:call-template>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>"Try again."</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>}</xsl:text>
+    <xsl:for-each select="exsl:node-set($check)//test[not(@correct='yes')]">
+        <xsl:text>, </xsl:text>
+        <xsl:apply-templates select="." mode="create-test-feedback">
+            <xsl:with-param name="fillin" select="$curFillIn"/>
+        </xsl:apply-templates>
     </xsl:for-each>
     <!-- Default feedback for the blank. Always evaluates true.   -->
-    <xsl:text>, {"feedback": </xsl:text>
-    <xsl:choose>
-        <!-- Allow the problem to define it: feedback with no test   -->
-        <xsl:when test="$check/feedback">
-            <xsl:call-template name="quote-string">
-                <xsl:with-param name="text" select="$check/feedback"/>
-            </xsl:call-template>
-        </xsl:when>
-        <!-- Maybe this should be a configurable default???   -->
-        <xsl:otherwise>
-            <xsl:text>"Try again."</xsl:text>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>}]</xsl:text>
+    <xsl:text>, {"feedback": "</xsl:text>
+    <xsl:value-of select="$defaultIncorrectResponse"/>
+    <xsl:text>"}]</xsl:text>         
 </xsl:template>
 
-<!-- Deal with possibility of global checker for all blanks -->
-<xsl:template match="evaluation" mode="get-multianswer-check">
-    <xsl:variable name="responseTree" select="ancestor::exercise//fillin" />
-    <xsl:if test="count($responseTree) > 1 and ancestor::exercise//evaluation/evaluate[@all='yes']/test">
-        <xsl:call-template name="create-test">
-            <xsl:with-param name="test" select="ancestor::exercise//evaluation/evaluate[@all='yes']/test/*[not(self::feedback)]" />
-        </xsl:call-template>
-    </xsl:if>
+<xsl:template match="test" mode="create-test-feedback">
+    <xsl:param name="fillin"/>
+    <xsl:param name="b-correct" select="'no'"/>
+    <xsl:variable name="feedback-rtf">
+        <xsl:apply-templates select="feedback"/>
+    </xsl:variable>
+    <xsl:text>{</xsl:text>
+    <xsl:apply-templates select="." mode="create-test">
+        <xsl:with-param name="fillin" select="$fillin" />
+    </xsl:apply-templates>
+    <xsl:text>, "feedback": "</xsl:text>
+    <xsl:choose>
+        <xsl:when test="feedback">
+            <!-- serialize HTML as text, then escape as JSON -->
+            <xsl:call-template name="escape-json-string">
+                <xsl:with-param name="text">
+                    <xsl:apply-templates select="exsl:node-set($feedback-rtf)" mode="serialize"/>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$b-correct='yes'">
+            <xsl:value-of select="$defaultCorrectResponse"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$defaultIncorrectResponse"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>"}</xsl:text>
 </xsl:template>
 
 <!-- Template for simple answer checkers: no interaction between different fillins. -->
 <!-- Add a post-filter to deal with additional feedback, similar to AnswerHints but allowing more complex logic. -->
+<!-- JSON dictionary for numerical condition -->
+<xsl:template match="test[numcmp]" mode="create-test">
+    <xsl:param name="fillin"/>
+    <xsl:variable name="answer">
+        <xsl:choose>
+            <xsl:when test="numcmp/@use-correct='yes'">
+                <xsl:value-of select="$fillin/@correct"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$numcmp"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="tolerance">
+        <xsl:choose>
+            <xsl:when test="numcmp/@use-correct='yes' and $fillin/@tolerance">
+                <xsl:value-of select="$fillin/@tolerance"/>
+            </xsl:when>
+            <xsl:when test="numcmp/@tolerance">
+                <xsl:value-of select="numcmp/@tolerance"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>0</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:text>"number": [</xsl:text>
+    <xsl:value-of select="$answer - $tolerance"/>
+    <xsl:text>,</xsl:text>
+    <xsl:value-of select="$answer + $tolerance"/>
+    <xsl:text>]</xsl:text>
+</xsl:template>
 
-<xsl:template name="create-test">
-    <xsl:param name="submit" />
-    <xsl:param name="test" />
-    <xsl:text>function() {&#xa;</xsl:text>
-    <!-- Create a checker function. Initialize a stack of flag variables to track results. -->
-    <xsl:text>    var testResults = new Array();&#xa;</xsl:text>
-    <xsl:choose>
-        <xsl:when test="count($test[not(self::feedback)]) = 1">
-            <xsl:call-template name="checker-simple">
-                <xsl:with-param name="submit" select="$submit" />
-                <xsl:with-param name="curTest" select="$test" />
-                <xsl:with-param name="level" select="0" />
-            </xsl:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:call-template name="checker-layer">
-                <xsl:with-param name="tests" select="$test" />
-                <xsl:with-param name="level" select="0" />
-                <xsl:with-param name="logic" select="'and'" /> <!-- All tests at first layer must be true -->
-            </xsl:call-template>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>    return (testResults[0]);&#xa;</xsl:text>
-    <xsl:text>}</xsl:text>
+<!-- JSON dictionary for string condition -->
+<xsl:template match="test[strcmp]" mode="create-test">
+    <xsl:param name="fillin"/>
+    <xsl:variable name="answer">
+        <xsl:choose>
+            <xsl:when test="strcmp/@use-correct='yes'">
+                <xsl:value-of select="$fillin/@correct"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="strcmp"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="regexFlags">
+        <xsl:choose>
+            <xsl:when test="strcmp/@use-correct='yes' and $fillin/@case = 'insensitive'">
+                <xsl:text>i</xsl:text>
+            </xsl:when>
+            <xsl:when test="strcmp/@case = 'insensitive'">
+                <xsl:text>i</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:variable>
+    <!-- regex string match, drop    -->
+    <!-- leading/trailing whitespace -->
+    <xsl:text>"regex": "</xsl:text>
+    <!-- JSON escapes necessary for regular expression -->
+    <xsl:call-template name="escape-json-string">
+        <xsl:with-param name="text">
+            <xsl:text>^\s*</xsl:text>
+            <xsl:value-of select="$answer"/>
+            <xsl:text>\s*$</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>"</xsl:text>
+    <!-- flag for case-sensitive match -->
+    <!-- default:  'sensitive'         -->
+    <xsl:text>, "regexFlags": "</xsl:text>
+    <xsl:value-of select="$regexFlags"/>
+    <xsl:text>"</xsl:text>
+</xsl:template>
+
+<!-- Otherwise create a function that deals with the test. -->
+<xsl:template match="test" mode="create-test">
+    <xsl:param name="fillin" />
+    <xsl:variable name="conditions" select="*[not(self::feedback)]"/>
+    <xsl:text>"solution_code": </xsl:text>
+    <xsl:variable name="js_code">
+        <xsl:text>function() {&#xa;</xsl:text>
+        <!-- Create a checker function. Initialize a stack of flag variables to track results. -->
+        <xsl:text>    var testResults = new Array();&#xa;</xsl:text>
+        <xsl:choose>
+            <xsl:when test="count($conditions) = 1">
+                <xsl:call-template name="checker-simple">
+                    <xsl:with-param name="fillin" select="$fillin" />
+                    <xsl:with-param name="curTest" select="$conditions" />
+                    <xsl:with-param name="level" select="0" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="checker-layer">
+                    <xsl:with-param name="fillin" select="$fillin" />
+                    <xsl:with-param name="tests" select="$conditions" />
+                    <xsl:with-param name="level" select="0" />
+                    <xsl:with-param name="logic" select="'and'" /> <!-- All tests at first layer must be true -->
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>    return (testResults[0]);&#xa;</xsl:text>
+        <xsl:text>}()</xsl:text>
+    </xsl:variable>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text" select="$js_code"/>
+    </xsl:call-template>
 </xsl:template>
 
 
 <!-- This template is called for a simple test (no compound logic). -->
 <xsl:template name="checker-simple">
     <xsl:param name="curTest" />
-    <xsl:param name="submit" />
+    <xsl:param name="fillin" />
     <xsl:param name="level" select="0" />
     <xsl:choose>
         <!-- Test might be coded directly in javascript -->
@@ -428,17 +588,17 @@
             <xsl:value-of select="$curTest"/>
         </xsl:when>
         <!-- Test might require logic -->
-        <xsl:when test="name($curTest)='and' or name($curTest)='or' or name($curTest)='not'">
+        <xsl:when test="name($curTest)='logical'">
             <xsl:call-template name="checker-layer">
-                <xsl:with-param name="submit" select="$submit" />
+                <xsl:with-param name="fillin" select="$fillin" />
                 <xsl:with-param name="tests" select="$curTest/*" />
-                <xsl:with-param name="level" select="$level+1" />
-                <xsl:with-param name="logic" select="name()" /> <!-- Default: All tests at first layer must be true -->
+                <xsl:with-param name="level" select="$level + 1" />
+                <xsl:with-param name="logic" select="$curTest/@op" /> <!-- Default: All tests at first layer must be true -->
             </xsl:call-template>
             <xsl:text>    testResults[</xsl:text>
             <xsl:value-of select="$level" />
             <xsl:text>] = testResults[</xsl:text>
-            <xsl:value-of select="$level+1" />
+            <xsl:value-of select="$level + 1" />
             <xsl:text>];&#xa;</xsl:text>
         </xsl:when>
         <!-- Otherwise simple test -->
@@ -451,16 +611,37 @@
             <xsl:text>_menv.compareExpressions(</xsl:text>
             <xsl:choose>
                 <!-- An equal element must have two expression children. -->
-                <xsl:when test="name($curTest) = 'equal'">
+                <xsl:when test="name($curTest) = 'mathcmp' and $curTest/@expr">
+                    <xsl:apply-templates select="$curTest/@expr" mode="evaluate"/>
+                    <xsl:text>, ans</xsl:text>
+                </xsl:when>
+                <xsl:when test="name($curTest) = 'mathcmp'">
+                    <xsl:message>
+                        <xsl:text>!mathcmp:1!</xsl:text>
+                        <xsl:value-of select="name($curTest/*[1])"/>
+                        <xsl:call-template name="escape-quote-xml">
+                            <xsl:with-param name="xml_content" select="$curTest/*[1]"/>
+                        </xsl:call-template> 
+                    </xsl:message>
+                    <xsl:message>
+                        <xsl:text>!mathcmp:2!</xsl:text>
+                        <xsl:value-of select="name($curTest/*[2])"/>
+                        <xsl:call-template name="escape-quote-xml">
+                            <xsl:with-param name="xml_content" select="$curTest/*[2]"/>
+                        </xsl:call-template> 
+                    </xsl:message>
                     <xsl:apply-templates select="$curTest/*[1]" mode="evaluate"/>
                     <xsl:text>, </xsl:text>
                     <xsl:apply-templates select="$curTest/*[2]" mode="evaluate"/>
                 </xsl:when>
                 <!-- An implied equal compares the submitted answer to the given expression. -->
-                <xsl:otherwise>   <!-- Must be expression: #var or #de-term -->
-                    <xsl:apply-templates select="$curTest" mode="evaluate"/>
-                    <xsl:text>, </xsl:text>
-                    <xsl:value-of select="$submit" />
+                <xsl:otherwise>   <!-- Must be expression: #var or #de-object -->
+                <xsl:message>
+                    <xsl:text>!other!</xsl:text>
+                    <xsl:value-of select="name($curTest)"/>
+                </xsl:message>
+                <xsl:apply-templates select="$curTest" mode="evaluate"/>
+                    <xsl:text>, ans</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
             <xsl:text>)</xsl:text>
@@ -472,7 +653,7 @@
 <!-- A test can also be composite involving a combination of logical tests -->
 <!-- This template works through one layer, recursively dealing with deeper layers as needed -->
 <xsl:template name="checker-layer" >
-    <xsl:param name="submit" />
+    <xsl:param name="fillin" />
     <xsl:param name="tests" />                   <!-- The layer of tests (subtree) -->
     <xsl:param name="level" select="0" />        <!-- Level (or depth) of the layer -->
     <xsl:param name="logic" select="'and'" />    <!-- and = all must be true, or = at least one, not = negation -->
@@ -491,7 +672,7 @@
                 <xsl:value-of select="$level+1" />
                 <xsl:text>] = 1;&#xa;</xsl:text>
                 <xsl:call-template name="checker-layer">
-                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="tests" select="./*" />
                     <xsl:with-param name="level" select="$level+1" />
                     <xsl:with-param name="logic" select="'and'" /> <!-- Default: All tests at first layer must be true -->
@@ -502,7 +683,7 @@
                 <xsl:value-of select="$level+1" />
                 <xsl:text>] = 0;&#xa;</xsl:text>
                 <xsl:call-template name="checker-layer">
-                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="tests" select="./*" />
                     <xsl:with-param name="level" select="$level+1" />
                     <xsl:with-param name="logic" select="'or'" /> <!-- Default: All tests at first layer must be true -->
@@ -510,7 +691,7 @@
             </xsl:when>
             <xsl:when test="name()='not'">
                 <xsl:call-template name="checker-layer">
-                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="tests" select="./*" />
                     <xsl:with-param name="level" select="$level+1" />
                     <xsl:with-param name="logic" select="'not'" /> <!-- Default: All tests at first layer must be true -->
@@ -518,7 +699,7 @@
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="checker-simple">
-                    <xsl:with-param name="submit" select="$submit" />
+                    <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="curTest" select="." />
                     <xsl:with-param name="level" select="$level+1" />
                 </xsl:call-template>
@@ -546,11 +727,11 @@
 <!-- Templates for working with evaluation objects    -->
 <!-- ================================================ -->
 
-<!-- Wrapper for calling appropriate javascript commands that  -->
+<!-- Wrappers for calling appropriate javascript commands that  -->
 <!-- will parse the expression for a number appropriately,     -->
 <!-- which could be written as an expression involving symbols -->
 <!-- or a random number                                        -->
-<xsl:template match="de-object[@context='number']" mode="evaluate">
+<xsl:template match="de-number" mode="evaluate">
     <xsl:param name="setupMode" />
     <xsl:variable name="prefix">
         <xsl:if test="$setupMode">
@@ -561,99 +742,83 @@
         <xsl:value-of select="$prefix"/>
         <xsl:text>_menv</xsl:text>
     </xsl:variable>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>.parseExpression(</xsl:text>
+    <xsl:call-template name="quote-strip-string">
+        <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+    <xsl:text>, "number")</xsl:text>
+</xsl:template>
+
+<xsl:template match="de-evaluate" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="de_env">
+        <xsl:value-of select="$prefix"/>
+        <xsl:text>_menv</xsl:text>
+    </xsl:variable>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>.evaluateExpression(</xsl:text>
+        <xsl:apply-templates select="formula/*" mode="evaluate">
+            <xsl:with-param name="setupMode" select="$setupMode"/>
+        </xsl:apply-templates>
+        <xsl:text>, "number", {</xsl:text>
+        <xsl:apply-templates select="variable" mode="evaluation-binding" >
+            <xsl:with-param name="setupMode" select="$setupMode" />
+        </xsl:apply-templates>
+    <xsl:text>}).reduce(</xsl:text>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
+<xsl:template match="de-random[@distribution='discrete']" mode="evaluate">
+    <xsl:text>v._menv.generateRandom("discrete", { min:</xsl:text>
     <xsl:choose>
-        <xsl:when test="@mode='value' or @mode='formula'">
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>.parseExpression(</xsl:text>
-            <xsl:call-template name="quote-strip-string">
-                <xsl:with-param name="text" select="."/>
-            </xsl:call-template>
-            <xsl:text>, "number")</xsl:text>
+        <xsl:when test="@min">
+            <xsl:value-of select="@min"/>
         </xsl:when>
-        <xsl:when test="@mode='evaluate'">
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>.evaluateMathObject(</xsl:text>
-                <xsl:apply-templates select="formula/*" mode="evaluate">
-                    <xsl:with-param name="setupMode" select="$setupMode"/>
-                </xsl:apply-templates>
-                <xsl:text>, "number", {</xsl:text>
-                <xsl:apply-templates select="variable" mode="evaluation-binding" >
-                    <xsl:with-param name="setupMode" select="$setupMode" />
-                </xsl:apply-templates>
-            <xsl:text>}).reduce(</xsl:text>
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>)</xsl:text>
-        </xsl:when>
-        <xsl:when test="@mode='random'">
-            <!-- Different types of random number generation -->
-            <xsl:choose>
-                <xsl:when test="options[@distribution='discrete']">
-                    <xsl:variable name="rnd-min">
-                        <xsl:choose>
-                            <xsl:when test="options/@min">
-                                <xsl:value-of select="options/@min"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:text>0</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:variable>
-                    <xsl:variable name="rnd-max">
-                        <xsl:choose>
-                            <xsl:when test="options/@max">
-                                <xsl:value-of select="options/@max"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:text>1</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:variable>
-                    <xsl:variable name="rnd-by">
-                        <xsl:choose>
-                            <xsl:when test="options/@by">
-                                <xsl:value-of select="options/@by"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:text>1</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:variable>
-                    <xsl:variable name="rnd-nonzero">
-                        <xsl:choose>
-                            <xsl:when test="options/@nonzero = 'yes'">
-                                <xsl:text>true</xsl:text>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:text>false</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:variable>
-                    <xsl:call-template name="generate-random-number">
-                        <xsl:with-param name="rnd-dist">
-                            <xsl:text>discrete</xsl:text>
-                        </xsl:with-param>
-                        <xsl:with-param name="rnd-options">
-                            <xsl:text>{ min:</xsl:text>
-                            <xsl:value-of select="$rnd-min"/>
-                            <xsl:text>, max:</xsl:text>
-                            <xsl:value-of select="$rnd-max"/>
-                            <xsl:text>, by:</xsl:text>
-                            <xsl:value-of select="$rnd-by"/>
-                            <xsl:text>, nonzero:</xsl:text>
-                            <xsl:value-of select="$rnd-nonzero"/>
-                            <xsl:text>}</xsl:text>
-                        </xsl:with-param>
-                    </xsl:call-template>
-                </xsl:when>
-            </xsl:choose>
-        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>0</xsl:text>
+        </xsl:otherwise>
     </xsl:choose>
+    <xsl:text>, max:</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@max">
+            <xsl:value-of select="@max"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>1</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>, by:</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@by">
+            <xsl:value-of select="@by"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>1</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>, nonzero:</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@nonzero = 'yes'">
+            <xsl:text>true</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>false</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>})</xsl:text>
 </xsl:template>
 
 <!-- Objects defined as formulas. Several possible modes: -->
 <!-- formula (literal), substitution (composition),       -->
 <!-- derivative and evaluate                              -->
-<xsl:template match="de-object[@context='formula']" mode="evaluate">
+<xsl:template match="de-expression[not(@mode) or @mode='formula']" mode="evaluate">
     <xsl:param name="setupMode" />
     <xsl:variable name="prefix">
         <xsl:if test="$setupMode">
@@ -664,60 +829,62 @@
         <xsl:value-of select="$prefix"/>
         <xsl:text>_menv</xsl:text>
     </xsl:variable>
-    <xsl:choose>
-        <!-- Simple formula is provided, with or without pattern matching -->
-        <xsl:when test="@mode='formula'">
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>.parseExpression(</xsl:text>
-            <xsl:call-template name="quote-strip-string">
-                <xsl:with-param name="text" select="."/>
-            </xsl:call-template>
-            <xsl:text>, "formula")</xsl:text>
-        </xsl:when>
-        <!-- Composition of two formulas (same look as evaluation)                -->
-        <!-- Requires descendent nodes: formula and values to substitute          -->
-        <xsl:when test="@mode='substitution'">
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>.composeExpression(</xsl:text>
-            <xsl:apply-templates select="formula/*" mode="evaluate">
-                <xsl:with-param name="setupMode" select="$setupMode"/>
-            </xsl:apply-templates>
-            <xsl:text>, {</xsl:text>
-                <xsl:apply-templates select="variable" mode="evaluation-binding" >
-                    <xsl:with-param name="setupMode" select="$setupMode" />
-                </xsl:apply-templates>
-            <xsl:text>}).reduce(</xsl:text>
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>)</xsl:text>
-        </xsl:when>
-        <!-- Derivative of a formula.                        -->
-        <!-- Requires descendent nodes: formula, variable    -->
-        <xsl:when test="@mode='derivative'">
-            <xsl:apply-templates select="formula" mode="evaluate">
-                <xsl:with-param name="setupMode" select="$setupMode" />
-            </xsl:apply-templates>
-            <xsl:text>.derivative(</xsl:text>
-            <xsl:call-template name="quote-string">
-                <xsl:with-param name="text" select="variable/@name"/>
-            </xsl:call-template>
-            <xsl:text>)</xsl:text>
-        </xsl:when>
-        <!-- Evaluate a formula at specific values.          -->
-        <!-- Values for variables define a binding.          -->
-        <xsl:when test="@mode='evaluate'">
-            <xsl:apply-templates select="formula" mode="evaluate">
-                <xsl:with-param name="setupMode" select="$setupMode"/>
-            </xsl:apply-templates>
-            <xsl:text>.evaluate(</xsl:text>
-            <xsl:value-of select="$de_env"/>
-            <xsl:text>, {</xsl:text>
-            <xsl:apply-templates select="variable" mode="evaluation-binding" >
-                <xsl:with-param name="setupMode" select="$setupMode" />
-            </xsl:apply-templates>
-            <xsl:text>})</xsl:text>
-        </xsl:when>
-    </xsl:choose>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>.parseExpression(</xsl:text>
+    <xsl:call-template name="quote-strip-string">
+        <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+    <xsl:text>, "formula").reduce(</xsl:text>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>)</xsl:text>
 </xsl:template>
+
+<xsl:template match="de-expression[@mode='substitution']" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="de_env">
+        <xsl:value-of select="$prefix"/>
+        <xsl:text>_menv</xsl:text>
+    </xsl:variable>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>.composeExpression(</xsl:text>
+    <xsl:apply-templates select="formula/*" mode="evaluate">
+        <xsl:with-param name="setupMode" select="$setupMode"/>
+    </xsl:apply-templates>
+    <xsl:text>, {</xsl:text>
+        <xsl:apply-templates select="variable" mode="evaluation-binding" >
+            <xsl:with-param name="setupMode" select="$setupMode" />
+        </xsl:apply-templates>
+    <xsl:text>}).reduce(</xsl:text>
+    <xsl:value-of select="$de_env"/>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
+<xsl:template match="de-expression[@mode='derivative']" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:variable name="prefix">
+        <xsl:if test="$setupMode">
+            <xsl:text>v.</xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="de_env">
+        <xsl:value-of select="$prefix"/>
+        <xsl:text>_menv</xsl:text>
+    </xsl:variable>
+    <xsl:apply-templates select="formula/*" mode="evaluate">
+        <xsl:with-param name="setupMode" select="$setupMode" />
+    </xsl:apply-templates>
+    <xsl:text>.derivative(</xsl:text>
+    <xsl:call-template name="quote-string">
+        <xsl:with-param name="text" select="variable/@name"/>
+    </xsl:call-template>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
 
 <!-- Used during composition or evaluation of a variable-->
 <xsl:template match="variable" mode="evaluation-binding">
@@ -746,41 +913,6 @@
     </xsl:choose>
 </xsl:template>
 
-<!-- Generate a random parameter. -->
-<xsl:template name="generate-random-number">
-    <xsl:param name="rnd-dist" />
-    <xsl:param name="rnd-options" />
-    <xsl:text>v._menv.generateRandom(</xsl:text>
-        <xsl:call-template name="quote-string">
-            <xsl:with-param name="text" select="$rnd-dist"/>
-        </xsl:call-template>
-        <xsl:text>, </xsl:text>
-        <xsl:value-of select="$rnd-options"/>
-    <xsl:text>)&#xa;</xsl:text>
-</xsl:template>
-
-
-<!-- mode="evaluate" is used during setup and during feedback evaluation            -->
-<!-- Define an expressions that will be parsed in their math context                -->
-<!-- The expression can be defined in terms of the parameters and other expressions -->
-<xsl:template match="de-object[@context='formula' and @mode='formula']|de-term[@context='formula']" mode="evaluate">
-    <xsl:param name="setupMode" />
-    <xsl:variable name="de_env">
-        <xsl:if test="$setupMode">
-            <xsl:text>v.</xsl:text>
-        </xsl:if>
-        <xsl:text>_menv</xsl:text>
-    </xsl:variable>
-    <xsl:value-of select="$de_env"/>
-    <xsl:text>.parseExpression(</xsl:text>
-    <xsl:call-template name="quote-strip-string">
-        <xsl:with-param name="text" select="."/>
-    </xsl:call-template>
-    <xsl:text>).reduce(</xsl:text>
-    <xsl:value-of select="$de_env"/>
-    <xsl:text>)</xsl:text>
-</xsl:template>
-
 
 <!-- var elements in expressions (evaluate) are replaced by their name -->
 <!-- During setup, we need to use the context of the `v` object        -->
@@ -791,39 +923,27 @@
             <xsl:text>v.</xsl:text>
         </xsl:if>
     </xsl:variable>
+    <xsl:message>
+        <xsl:text>!eval!evaluate!!</xsl:text>
+        <xsl:value-of select="./@expr"/>
+    </xsl:message>
     <xsl:value-of select="$prefix"/>
-    <xsl:value-of select="@expr"/>
+    <xsl:value-of select="./@expr"/>
 </xsl:template>
 
 <!-- Nothing else is defined for evaluation during setup  -->
 <xsl:template match="/" mode="evaluate"/>
 
-<!-- How to *add* expressions/formulas to the math context -->
-<xsl:template match="de-object[@context='formula' and @mode='formula']|de-term[@context='formula']" mode="runestone-setup-old">
-    <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
-    <xsl:text> = v._menv.addMathObject(</xsl:text>
-    <xsl:call-template name="quote-string">
-        <xsl:with-param name="text" select="@name"/>
+<xsl:template match="feedback" mode="serialize-feedback">
+    <xsl:variable name="feedback-rtf">
+        <xsl:apply-templates select="*" mode="body"/>
+    </xsl:variable>
+    <!-- serialize HTML as text, then escape as JSON -->
+    <xsl:call-template name="escape-json-string">
+        <xsl:with-param name="text">
+            <xsl:apply-templates select="exsl:node-set($feedback-rtf)" mode="serialize"/>
+        </xsl:with-param>
     </xsl:call-template>
-    <xsl:text>, "formula", </xsl:text>
-    <xsl:apply-templates select="." mode="evaluate">
-        <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
-    </xsl:apply-templates>
-    <xsl:text>);&#xa;</xsl:text>
-</xsl:template>
-
-<!-- How to *add* expressions defined by substitution to the math context -->
-<xsl:template match="de-object[@context='formula' and @mode='substitution']|de-term[@context='substitution']" mode="runestone-setup-old">
-    <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
-    <xsl:text> = v._menv.addExpression(</xsl:text>
-    <xsl:call-template name="quote-string">
-        <xsl:with-param name="text" select="@name"/>
-    </xsl:call-template>
-    <xsl:text>, </xsl:text>
-    <xsl:apply-templates select="." mode="evaluate">
-        <xsl:with-param name="setupMode"><xsl:text>1</xsl:text></xsl:with-param>
-    </xsl:apply-templates>
-    <xsl:text>);&#xa;</xsl:text>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -49,7 +49,7 @@
 </xsl:variable>
 <xsl:variable name="defaultIncorrectResponse">
     <xsl:text>Try again.</xsl:text>
-</xsl:variable> 
+</xsl:variable>
 
 <!-- ========================================================= -->
 <!-- The Runestone element is based on JSON scripts describing -->
@@ -363,7 +363,7 @@
                 <xsl:copy-of select="ancestor::exercise//evaluation/evaluate[position() = $blankNum]"/>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:variable> 
+    </xsl:variable>
     <xsl:variable name="checkCorrectTest">
         <xsl:choose>
             <xsl:when test="exsl:node-set($check)/evaluate/test[@correct='yes']">
@@ -429,7 +429,7 @@
     <!-- Default feedback for the blank. Always evaluates true.   -->
     <xsl:text>, {"feedback": "</xsl:text>
     <xsl:value-of select="$defaultIncorrectResponse"/>
-    <xsl:text>"}]</xsl:text>         
+    <xsl:text>"}]</xsl:text>
 </xsl:template>
 
 <xsl:template match="test" mode="create-test-feedback">
@@ -616,30 +616,12 @@
                     <xsl:text>, ans</xsl:text>
                 </xsl:when>
                 <xsl:when test="name($curTest) = 'mathcmp'">
-                    <xsl:message>
-                        <xsl:text>!mathcmp:1!</xsl:text>
-                        <xsl:value-of select="name($curTest/*[1])"/>
-                        <xsl:call-template name="escape-quote-xml">
-                            <xsl:with-param name="xml_content" select="$curTest/*[1]"/>
-                        </xsl:call-template> 
-                    </xsl:message>
-                    <xsl:message>
-                        <xsl:text>!mathcmp:2!</xsl:text>
-                        <xsl:value-of select="name($curTest/*[2])"/>
-                        <xsl:call-template name="escape-quote-xml">
-                            <xsl:with-param name="xml_content" select="$curTest/*[2]"/>
-                        </xsl:call-template> 
-                    </xsl:message>
                     <xsl:apply-templates select="$curTest/*[1]" mode="evaluate"/>
                     <xsl:text>, </xsl:text>
                     <xsl:apply-templates select="$curTest/*[2]" mode="evaluate"/>
                 </xsl:when>
                 <!-- An implied equal compares the submitted answer to the given expression. -->
                 <xsl:otherwise>   <!-- Must be expression: #var or #de-object -->
-                <xsl:message>
-                    <xsl:text>!other!</xsl:text>
-                    <xsl:value-of select="name($curTest)"/>
-                </xsl:message>
                 <xsl:apply-templates select="$curTest" mode="evaluate"/>
                     <xsl:text>, ans</xsl:text>
                 </xsl:otherwise>
@@ -923,10 +905,6 @@
             <xsl:text>v.</xsl:text>
         </xsl:if>
     </xsl:variable>
-    <xsl:message>
-        <xsl:text>!eval!evaluate!!</xsl:text>
-        <xsl:value-of select="./@expr"/>
-    </xsl:message>
     <xsl:value-of select="$prefix"/>
     <xsl:value-of select="./@expr"/>
 </xsl:template>


### PR DESCRIPTION
The original PR for dynamic exercises used a markup that had too many elements as attributes. Going forward, to easier facilitate definition of new options, wanted to transition from attributes to child elements.

In addition, there were some unexpected issues relating to the use of the original number and string (regexp) checkers when used in combination with the new markup. This was addressed in a separate PR to Runestone that Brad merged today.
The markup requires that new Runestone build for interactives to function properly.

The sample article problems have been verified to continue to work in both html and static form.