### PR TITLE
use searchparams rather than magic URL for preview

### DIFF
--- a/css-obsolete/pretext_add_on.css
+++ b/css-obsolete/pretext_add_on.css
@@ -2709,32 +2709,6 @@ body.standalone.worksheet .ptx-content section.worksheet > .heading + .para {
     overflow: auto !important;
 }
 
-/* Preview of annual edition */
-
-.pretext main .para.newstuff {
-    border-right: 6px solid #6f6;
-    background:  #dfd;
-}
-.pretext main li.newstuff {
-    border-right: 6px solid #66f;
-    background:  #eef;
-}
-.pretext main li.newstuff .para.newstuff {
-    border-right: none;
-    background: inherit;
-}
-.pretext main article.newstuff {
-    border-right: 6px solid #ff6;
-    background:  #ffd;
-}
-.pretext main section.newstuff {
-    border-right: 10px solid #f6f;
-}
-.pretext main a[data-knowl].newstuff {
-    border: 1px solid #f33;
-    background: #fdd;
-}
-
 #aboelkins-ACS .ptx-main .ptx-content > section:first-of-type > section:first-of-type > .project-like:first-of-type li {
     font-size: 300%
 }

--- a/css/pretext_add_on.css
+++ b/css/pretext_add_on.css
@@ -2792,32 +2792,6 @@ body.standalone.worksheet .ptx-content section.worksheet > .heading + .para {
     overflow: auto !important;
 }
 
-/* Preview of annual edition */
-
-.pretext main .para.newstuff {
-    border-right: 6px solid #6f6;
-    background:  #dfd;
-}
-.pretext main li.newstuff {
-    border-right: 6px solid #66f;
-    background:  #eef;
-}
-.pretext main li.newstuff .para.newstuff {
-    border-right: none;
-    background: inherit;
-}
-.pretext main article.newstuff {
-    border-right: 6px solid #ff6;
-    background:  #ffd;
-}
-.pretext main section.newstuff {
-    border-right: 10px solid #f6f;
-}
-.pretext main a[data-knowl].newstuff {
-    border: 1px solid #f33;
-    background: #fdd;
-}
-
 #aboelkins-ACS .ptx-main .ptx-content > section:first-of-type > section:first-of-type > .project-like:first-of-type li {
     font-size: 300%
 }

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -545,9 +545,9 @@ window.addEventListener("load",function(event) {
      });
 });
 
-window.addEventListener("load",function(event) {
-       if(window.location.href.includes("/preview/")) {
-           console.log("            found preview", window.location.href);
+window.addEventListener("load", function(event) {
+       if((new URLSearchParams(window.location.search)).has("ptxpreview")) {
+           console.log("            found ptxpreview", window.location.href);
            $("main p[id], main article[id], main li[id], main section[id], main a[data-knowl]").each(function() {
                var thisid = $(this).attr('id');
                if( thisid && ( (thisid.length > 3 && !thisid.includes("-part") && !thisid.startsWith("fn-")) || thisid.startsWith("p-") ) ) {
@@ -556,7 +556,7 @@ window.addEventListener("load",function(event) {
                }
            })
        } else {
-           console.log("not preview", window.location.href);
+           console.log("no ptxpreview", window.location.href);
        }
 });
 

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -545,20 +545,7 @@ window.addEventListener("load",function(event) {
      });
 });
 
-window.addEventListener("load", function(event) {
-       if((new URLSearchParams(window.location.search)).has("ptxpreview")) {
-           console.log("            found ptxpreview", window.location.href);
-           $("main p[id], main article[id], main li[id], main section[id], main a[data-knowl]").each(function() {
-               var thisid = $(this).attr('id');
-               if( thisid && ( (thisid.length > 3 && !thisid.includes("-part") && !thisid.startsWith("fn-")) || thisid.startsWith("p-") ) ) {
-                 $( this ).addClass("newstuff");
-                 console.log("           found new", this)
-               }
-           })
-       } else {
-           console.log("no ptxpreview", window.location.href);
-       }
-});
+
 
 /*
 window.addEventListener("load",function(event) {


### PR DESCRIPTION
See discussion at https://groups.google.com/g/pretext-dev/c/UtJRHp_mgPU/m/bazSzI8FBQAJ

This enhancement allows for deploying a PreTeXt document to a URL that includes `/preview/` without automatically injecting the `newstuff` classes. E.g. if my book is named `Calculus Preview` and I deploy my work to `https://my-great-calculus-book.org/preview/` I may not want the `newstuff` classes.

It also allows for injecting the `newstuff` classes into any desired PreTeXt document, by appending `?ptxpreview` to the end of the URL, without having to make a separate deployment for a "preview" version.