### PR TITLE
Auto add input element to programs that only contain text

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10060,14 +10060,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>And some self-referential XSL:</p>
 
+            <!-- input element intentionally ommited here. Pretext processor should correct. -->
             <program language="xslt" margins="15%">
-                <input>
-                <![CDATA[<xsl:template match="biblio" mode="number">
-                    <xsl:apply-templates select="." mode="structural-number" />
-                    <xsl:text>.</xsl:text>
-                    <xsl:number from="references" level="any" count="biblio" />
-                </xsl:template>]]>
-                </input>
+            <![CDATA[<xsl:template match="biblio" mode="number">
+                <xsl:apply-templates select="." mode="structural-number" />
+                <xsl:text>.</xsl:text>
+                <xsl:number from="references" level="any" count="biblio" />
+            </xsl:template>]]>
             </program>
 
             <p>Matlab is a commercial language for mathematics, while Octave in an open source version.  The <attr>language</attr> values of <c>matlab</c> and <c>octave</c> are somewhat interchangeable.  Following is a very slighlty edited version of an example from <url href="http://www.public.asu.edu/~hhuang38/hph_matlab_basic2013_1.pdf" visual="www.public.asu.edu/~hhuang38/hph_matlab_basic2013_1.pdf"><articletitle>50 Basic Examples for Matlab</articletitle></url>.</p>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -963,6 +963,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- no more "conclusion", so drop it here; deprecation will warn -->
 <xsl:template match="glossary/conclusion" mode="repair"/>
 
+<!-- Add input element around text in program when missing -->
+<xsl:template match="program[not(input)]" mode="repair">
+    <xsl:copy>
+        <xsl:apply-templates select="@*" mode="repair"/>
+        <input>
+            <xsl:value-of select="."/>
+        </input>
+    </xsl:copy>
+</xsl:template>
+
 <!-- 2022-04-22 replace Python Tutor with Runestone CodeLens -->
 <xsl:template match="program/@interactive" mode="repair">
     <xsl:choose>


### PR DESCRIPTION
Based on recent support discussion...

If a program lacks an **input** element around the text inside it, auto-supply the **input**. This tries to be very conservative and only does so if there are no other children in the parent element. (e.g. if you have a **tests** in the program you will not get an automatic **input**.)

I am quite sure that the XSL selection could be done better. Took this on as an XSL exercise, let me know how it should have looked. :)