### PR TITLE
Fix wrapping issue for standalone-worksheet print versions

### DIFF
--- a/css/pretext_add_on.css
+++ b/css/pretext_add_on.css
@@ -2618,15 +2618,6 @@ body.standalone.worksheet .ptx-content .onepage .workspace.squashed.tight {
 body.has-sidebar-left.mathbook-loaded.standalone.worksheet .ptx-page .ptx-main {
     margin-left: 0;
 }
-body.standalone.worksheet .ptx-page > .ptx-main .ptx-content {
-    max-width: 1030px;
-    width: 1030px;
-    margin-right: 0;
-}
-body.standalone.worksheet.a4 .ptx-page > .ptx-main .ptx-content {
-    max-width: 1001px;
-    width: 1001px;
-}
 
 body.standalone.worksheet .ptx-content .goal-like {
     border: none;


### PR DESCRIPTION
Per Andrew Scholer in [this google groups discussion](https://groups.google.com/g/pretext-support/c/i32M1zm4SUc/m/kgaF26TdBAAJ), this is a css edit to fix an issue where text goes beyond the right edge of the page when a standalone worksheet is printed in portrait mode.

