### PR TITLE
Don't add MOM when extracting pg

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2411,7 +2411,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="@*" mode="representations"/>
         <!-- Now bifurcate on static/dynamic.  PG problem creation should not fall in here. -->
         <xsl:choose>
-            <xsl:when test="$exercise-style = 'static'">
+            <xsl:when test="($exercise-style = 'static') and not($b-extracting-pg)">
                 <!-- locate the static representation in a file, generated independently -->
                 <!-- NB: this filename is relative to the author's source                -->
                 <xsl:variable name="filename">


### PR DESCRIPTION
This fixes the circular dependency for books that have both WeBWorK and MyOpenMath.  Authors must generate the ww-representations file first, then ensure they have fetched any MyOpenMath problems, all before trying to build or generate other assets.  

The CLI already uses `ensure_webwork()` before building.  It can easily add an `ensure_myopenmath()` as well.  That way asking for other html assets before myopenmath has been fetched would be caught gracefully.

Alternatively, the assembly xsl could be further modified so that other assets can be generated without first fetching the `mom.xml` files.  Unless of course those xml files could contain assets that need to be generated, in which case it is good this isn't possible.