### PR TITLE
LaTeX: remove hidelinks argument

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1906,7 +1906,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:if test="$b-latex-print">
         <xsl:text>%% For a print PDF, no surrounding boxes, so simply textcolor (but still active to preserve spacing)&#xa;</xsl:text>
-        <xsl:text>\hypersetup{hidelinks=true}&#xa;</xsl:text>
+        <xsl:text>\hypersetup{hidelinks}&#xa;</xsl:text>
     </xsl:if>
     <!-- Hyperref gives names to destinations for links that look like      -->
     <!-- "section*.5.2" which you can guess is the second section of        -->


### PR DESCRIPTION
I get a warning from the `=true` that this has right now. Consulting documentation, it's not supposed to take an argument.