### PR TITLE
Publisher variables: change common/qr-code to common/qrcode

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -150,15 +150,15 @@
 
         <subsection xml:id="common-qrcode-image">
             <title>QR code image</title>
-            <idx><h>common option</h><h>qr-code</h></idx>
-            <idx><h>qr-code</h><h>common option</h></idx>
+            <idx><h>common option</h><h>qrcode</h></idx>
+            <idx><h>qrcode</h><h>common option</h></idx>
 
             <p>
                 QR codes for videos and interactive elements can have an image placed in their
                 center. This image file should be square, and stored in the external assets folder.
                 To use this image in your QR codes, use
                 <cd>
-                    <cline>/publication/common/qr-code/@image</cline>
+                    <cline>/publication/common/qrcode/@image</cline>
                 </cd>
                 with a value of the file path, relative to external assets folder.
             </p>

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -40,7 +40,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- fillin styles are "underline" (the default for text),  -->
         <!-- "box", and "shade" (the default for math)              -->
         <fillin textstyle="underline" mathstyle="shade"/>
-        <qr-code image="misc/ptx-logo-square.png"/>
+        <qrcode image="misc/ptx-logo-square.png"/>
     </common>
 
     <!-- we use customizations-two for the oscarlevin style example -->

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -2134,14 +2134,15 @@ def qrcode(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
     stringparams = stringparams.copy()
 
     # Establish whether there is an image from pub file
-    pub_tree = ET.parse(pub_file)
+    has_image = False
     try:
-        image = pub_tree.find('common').find('qr-code').get('image')
+        image = get_publisher_variable(xml_source, pub_file, stringparams, 'qrcode-image')
         _, external_dir = get_managed_directories(xml_source, pub_file)
         image_path = os.path.join(external_dir, image)
-        has_image = True
+        if (image != '' and os.path.exists(image_path)):
+            has_image = True
     except:
-        has_image = False
+        pass
 
     # https://pypi.org/project/qrcode/
     try:
@@ -4520,7 +4521,7 @@ def get_publisher_variable(xml_source, pub_file, params, variable):
     # Apply the stylesheet, with source and publication file
     xsltproc(reporting_xslt, xml_source, temp_file, None, params)
 
-    # pardse file into a dictionary, interogate with variable
+    # parse file into a dictionary, interrogate with variable
     pairs = {}
     with open(temp_file, 'r') as f:
         for line in f:

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -147,6 +147,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/common/mermaid/pi:pub-attribute[@name='theme']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!-- QR code image to be placed at center of QR codes -->
+<xsl:variable name="qrcode-image">
+    <xsl:apply-templates select="$publisher-attribute-options/common/qrcode/pi:pub-attribute[@name='image']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
 <!-- Em dash Width -->
 
 <xsl:variable name="emdash-space">
@@ -3088,6 +3093,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <pi:pub-attribute name="textstyle" default="underline" options="box shade"/>
             <pi:pub-attribute name="mathstyle" default="shade" options="underline box"/>
         </fillin>
+        <qrcode>
+            <pi:pub-attribute name="image" default="" freeform="yes"/>
+        </qrcode>
         <mermaid>
             <pi:pub-attribute name="theme" default="default" options="dark forest light"/>
         </mermaid>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -78,6 +78,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$mermaid-theme"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2024-07-07 QR code image -->
+    <xsl:text>qrcode-image</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$qrcode-image"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- -->
 
     <!--


### PR DESCRIPTION
This follows up on #2194. It changes the correct publisher file element to use from `qr-code` to `qrcode`.

It does not deprecate `qr-code`. I could relatively easily do a one-off where someone's `common/qr-code/@image` would be recognized and used. I was hoping instead to have/make a general tool for retiring publication file elements and attributes, but it's too big of a project and I can't afford time on that.

`qr-code` was never actually in the publisher file, it was only "official" in that it was demonstrated in the sample article. And until yesterday's merge of #2194, even the documentation didn't direct people to `qr-code`. There was a `-announce` message but it was directly people to the bad documentation.

So it's not unreasonable to just end support ungracefully for `common/qr-code/@image`. But if you would prefer, I could do the one-off extended support right now.