### PR TITLE
LaTeX: make it less likely to page break following solution-like heading

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -6399,12 +6399,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-answer" />
     <xsl:param name="b-has-solution" />
 
+    <!-- Make it less likely there will be a page break between the heading and first piece of content -->
+    <xsl:text>{\makeatletter\@beginparpenalty=10000\makeatother</xsl:text>
     <xsl:apply-templates select="." mode="solution-heading">
         <xsl:with-param name="b-original" select="$b-original" />
         <xsl:with-param name="purpose" select="$purpose" />
         <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
     </xsl:apply-templates>
-    <xsl:apply-templates>
+    <xsl:apply-templates select="*[1]">
+        <xsl:with-param name="b-original" select="$b-original" />
+    </xsl:apply-templates>
+    <xsl:text>}</xsl:text>
+    <xsl:apply-templates select="*[position() > 1]">
         <xsl:with-param name="b-original" select="$b-original" />
     </xsl:apply-templates>
     <!-- separate hints after all but final one -->
@@ -6419,12 +6425,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-component-heading"/>
     <xsl:param name="b-has-solution" />
 
+    <!-- Make it less likely there will be a page break between the heading and first piece of content -->
+    <xsl:text>{\makeatletter\@beginparpenalty=10000\makeatother</xsl:text>
     <xsl:apply-templates select="." mode="solution-heading">
         <xsl:with-param name="b-original" select="$b-original" />
         <xsl:with-param name="purpose" select="$purpose" />
         <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
     </xsl:apply-templates>
-    <xsl:apply-templates>
+    <xsl:apply-templates select="*[1]">
+        <xsl:with-param name="b-original" select="$b-original" />
+    </xsl:apply-templates>
+    <xsl:text>}</xsl:text>
+    <xsl:apply-templates select="*[position() > 1]">
         <xsl:with-param name="b-original" select="$b-original" />
     </xsl:apply-templates>
     <!-- separate answers after all but final one -->
@@ -6438,12 +6450,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="purpose" />
     <xsl:param name="b-component-heading"/>
 
+    <!-- Make it less likely there will be a page break between the heading and first piece of content -->
+    <xsl:text>{\makeatletter\@beginparpenalty=10000\makeatother</xsl:text>
     <xsl:apply-templates select="." mode="solution-heading">
         <xsl:with-param name="b-original" select="$b-original" />
         <xsl:with-param name="purpose" select="$purpose" />
         <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
     </xsl:apply-templates>
-    <xsl:apply-templates>
+    <xsl:apply-templates select="*[1]">
+        <xsl:with-param name="b-original" select="$b-original" />
+    </xsl:apply-templates>
+    <xsl:text>}</xsl:text>
+    <xsl:apply-templates select="*[position() > 1]">
         <xsl:with-param name="b-original" select="$b-original" />
     </xsl:apply-templates>
     <!-- separate solutions after all but final one -->


### PR DESCRIPTION
In LaTeX/PDF. This is a proposal for your consideration.

Sometimes the first piece of content following a solution-like heading is something that naturally uses a `\par` before getting started. Examples of this would be like when a solution immediately goes into a list or a tabular. When that happens, the heading (like "Solution") could be at the bottom of a page, and then there is a page break before you get to the first piece of content for that solution. Here is a screenshot where "Solution" has been renamed to "Explanation", and you can see such a header at the bottom.

<img width="598" alt="Screenshot 2024-07-07 at 4 16 37 PM" src="https://github.com/PreTeXtBook/pretext/assets/4732672/795fbeb0-fecd-465f-b86a-3e2f90da7b2d">

This PR proposes increasing the page break penalty in as minimal a way I could think of, so that it's less likely to have a page break in between the solution-like heading and the first piece of content. After this PR, it looks like:

<img width="598" alt="Screenshot 2024-07-07 at 4 04 03 PM" src="https://github.com/PreTeXtBook/pretext/assets/4732672/736846df-413b-4a42-83fa-7d0447bad5d2">

The verso page now looks like:

<img width="598" alt="Screenshot 2024-07-07 at 4 20 39 PM" src="https://github.com/PreTeXtBook/pretext/assets/4732672/1ca73256-96e3-411a-bc53-05b676dd427a">


 