### PR TITLE
Add tests to program schema

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1440,9 +1440,9 @@
                     attribute highlight-lines {text}?,
                     attribute interactive {"codelens"}?,
                     (
-                        element input {text} | text
-                    )
-                    element tests {text}?
+                        element input {text},
+                        element tests {text}?
+                    ) | text
                 }
             </code>
         </fragment>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1442,6 +1442,7 @@
                     (
                         element input {text} | text
                     )
+                    element tests {text}?
                 }
             </code>
         </fragment>


### PR DESCRIPTION
I noticed that `<tests>` was missing from `<program>`.

Not sure if that should change the notation or implementation for `<input>`. `<input>` is only really optional if there are no `<tests>` in the program.