### PR TITLE
name anonymously duplicate elements

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -70,7 +70,7 @@
         <fragment xml:id="start-elements">
             <title>Start elements</title>
             <code>
-            start = Pretext | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
+            start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
             </code>
         </fragment>
     </section>
@@ -83,7 +83,7 @@
         <fragment xml:id="gross-structure">
             <title>Gross structure</title>
             <code>
-            Pretext =
+            PretextRoot =
                 element pretext {
                     XMLLang?,
                     DocInfo?,
@@ -754,6 +754,8 @@
         <fragment xml:id="exotic-character">
             <title>Exotic characters</title>
             <code>
+            CopyrightCharacter =
+                element copyright {empty}
             Character |=
                 element ellipsis {empty} |
                 element midpoint {empty} |
@@ -762,7 +764,7 @@
                 element pilcrow {empty} |
                 element section-mark {empty} |
                 element copyleft {empty} |
-                element copyright {empty} |
+                CopyrightCharacter |
                 element registered {empty} |
                 element trademark {empty} |
                 element phonomark {empty} |
@@ -801,11 +803,15 @@
         <fragment xml:id="music-character">
             <title>Music characters</title>
             <code>
+            MusicFlat =
+                element flat {empty}
+            MusicSharp =
+                element sharp {empty}
             Music =
                 element doublesharp {empty} |
-                element sharp {empty} |
+                MusicSharp |
                 element natural {empty} |
-                element flat {empty} |
+                MusicFlat |
                 element doubleflat {empty} |
                 element scaledeg {"0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"10"} |
                 element timesignature {
@@ -829,8 +835,8 @@
                     attribute parentheses {"yes"|"no"}?,
                     element alteration {
                         (TextSimple |
-                        element sharp {empty} |
-                        element flat {empty})*
+                        MusicSharp |
+                        MusicFlat)*
                     }*
                 }
                 </code>
@@ -920,7 +926,7 @@
             <code>
             Verbatim =
                 element c {text} |
-                element email {text}
+                Email
             </code>
         </fragment>
 
@@ -946,7 +952,6 @@
             Group |=
                 element q {TextLong} |
                 element sq {TextLong} |
-                element dblbrackets {TextLong} |
                 element angles {TextLong} |
                 element dblbrackets {TextLong}
                 </code>
@@ -1246,13 +1251,8 @@
             Url =
                 element url {
                     attribute href {text},
-                    (
-                        (attribute visual {text},
-                        TextShort
-                        )|(
-                        attribute visual {text}?
-                        )
-                    )
+                    attribute visual {text}?,
+                    TextShort?
                 }
             Xref =
                 element xref {
@@ -1265,12 +1265,14 @@
                         attribute detail {text}?,
                         TextShort
                 }
+            NotationDescription =
+                element description {
+                    TextShort
+                }
             Notation =
                 element notation {
                     element usage {MathInline},
-                    element description {
-                        TextShort
-                    }
+                    NotationDescription
                 }
             </code>
         </fragment>
@@ -1323,29 +1325,6 @@
             </code>
         </fragment>
 
-    </section>
-
-    <section>
-        <title>References (experimental)</title>
-        <p>Here we collect experimental versions of reference-like elements.  Specifically, changes to Url, that only recommend a visual element when the URL element contains content.</p>
-
-        <fragment xml:id="reference-dev">
-            <title>References (experimental)</title>
-            <code>
-            Url |=
-                element url {
-                    attribute href {text},
-                    (
-                        (attribute visual {text},
-                        TextShort
-                        )| TextShort |
-                        (
-                        attribute visual {text}?
-                        )
-                    )
-                }
-            </code>
-        </fragment>
     </section>
 
     <section>
@@ -1417,6 +1396,13 @@
                 element pre {
                     text | CodeLine+
                 }
+            ConsoleOutput =
+                element output {text}
+            ConsoleInput =
+                element input {
+                    attribute prompt {text}?,
+                    text
+                }
             Console =
                 element console {
                     PermanentID?,
@@ -1425,13 +1411,11 @@
                     attribute width {text}?,
                     attribute margins {text}?,
                     (
-                        element input {
-                            attribute prompt {text}?,
-                            text
-                        },
-                        element output {text}?
+                        ConsoleInput,
+                        ConsoleOutput?
                     )+
                 }
+            ProgramInput = element input {text}
             Program =
                 element program {
                     PermanentID?,
@@ -1443,11 +1427,7 @@
                     attribute highlight-lines {text}?,
                     attribute interactive {"codelens"}?,
                     (
-                        (
-                            element input {text},
-                            element tests {text}?
-                        )
-                        | text
+                        ProgramInput | text
                     )
                 }
             </code>
@@ -1464,41 +1444,37 @@
         <fragment xml:id="list">
             <title>Lists</title>
             <code>
+            ListItem = element li {
+                (
+                    (MetaDataTarget, TextParagraph)
+                |
+                    (MetaDataTitleOptional, BlockStatement+)
+                )
+            }
+            DefinitionListItem = element li {
+                MetaDataTitle,
+                BlockStatement+
+            }
             List =
                 element ol {
                     PermanentID?,
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
-                    element li {
-                        (
-                            (MetaDataTarget, TextParagraph)
-                        |
-                            (MetaDataTitleOptional, BlockStatement+)
-                        )
-                    }+
+                    ListItem+
                 } |
                 element ul {
                     PermanentID?,
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {"disc" | "circle" | "square" | ""}?,
-                    element li {
-                        (
-                            (MetaDataTarget, TextParagraph)
-                        |
-                            (MetaDataTitleOptional, BlockStatement+)
-                        )
-                    }+
+                    ListItem+
                 } |
                 element dl {
                     PermanentID?,
                     Component?,
                     attribute width {"narrow" | "medium" | "wide"}?,
-                    element li {
-                        MetaDataTitle,
-                        BlockStatement+
-                    }+
+                    DefinitionListItem+
                 }
             </code>
         </fragment>
@@ -1947,6 +1923,11 @@
             <title>Images</title>
             <code>
             Image = ImageRaster | ImageCode
+            ImageDescription = element description {(Paragraph | Tabular)+}
+            ImageShortDescription = element shortdescription {text}
+            ImageShortDescriptionCode = element shortdescription {
+                (text | WWVariable)+
+            }
             ImageRaster =
                 element image {
                     UniqueID?,
@@ -1962,11 +1943,17 @@
                       (
                         attribute decorative {"no"}?,
                         (
-                          element shortdescription {text}? &amp;
-                          element description {(Paragraph | Tabular)+}?
+                          ImageShortDescription? &amp;
+                          ImageDescription?
                         )
                       )
                     )
+                }
+            CodeLatexImage =
+                element latex-image {
+                    LabelID?,
+                    Component?,
+                    text
                 }
             ImageCode =
                 element image {
@@ -1981,14 +1968,10 @@
                       (
                         attribute decorative {"no"}?,
                         (
-                          element shortdescription {(text | WWVariable)+}? &amp;
-                          element description {(Paragraph | Tabular)+}? &amp;
+                          ImageShortDescriptionCode ? &amp;
+                          ImageDescription? &amp;
                           (
-                            element latex-image {
-                              LabelID?,
-                              Component?,
-                              text
-                            } |
+                            CodeLatexImage |
                             element asymptote {
                               LabelID?,
                               Component?,
@@ -2006,6 +1989,9 @@
                       )
                     )
                 }
+            WWLatexImage = element latex-image {
+                text
+              }
             ImageWW =
                 element image {
                     attribute pg-name {text}?,
@@ -2015,11 +2001,9 @@
                       (
                         attribute decorative {"no"}?,
                         (
-                          element shortdescription {(text | WWVariable)+}? &amp;
-                          element description {(Paragraph | Tabular)+}? &amp;
-                          element latex-image {
-                            text
-                          }?
+                          ImageShortDescriptionCode? &amp;
+                          ImageDescription? &amp;
+                          WWLatexImage?
                         )
                       )
                     )
@@ -2036,6 +2020,8 @@
         <fragment xml:id="sage">
             <title>Sage code</title>
             <code>
+            SageOutput = element output {text}
+            SageInput = element input {text}
             Sage = element sage {
                 PermanentID?,
                 Component?,
@@ -2044,7 +2030,7 @@
                 attribute auto-evaluate {'no'|'yes'}?,
                 attribute language {text}?,
                 attribute type {text}?,
-                (element input {text}, element output {text}?)?
+                (SageInput, SageOutput?)?
             }
             </code>
         </fragment>
@@ -2155,13 +2141,6 @@
                 )
 
               SlateInput =
-                element xhtml:input {
-                  attribute type {text}?,
-                  attribute value {text}?,
-                  attribute onkeypress {text}?,
-                  attribute onclick {text}?,
-                  attribute style {text}?
-                } |
                 element input {
                   attribute type {text}?,
                   attribute value {text}?,
@@ -2248,14 +2227,16 @@
             <title>Poems</title>
             <code>
             AlignmentPoem = attribute halign {"left" | "center" | "right"}
+            PoemAuthor =
+                element author {
+                    AlignmentPoem?,
+                    TextShort
+                }
             Poem =
                 element poem {
                     MetaDataTitleOptional,
                     AlignmentPoem?,
-                    element author {
-                        AlignmentPoem?,
-                        TextShort
-                    }?,
+                    PoemAuthor?,
                     (PoemLine+ | Stanza+)
                 }
             Stanza =
@@ -2280,17 +2261,20 @@
         <fragment xml:id="exercise">
             <title>Exercises</title>
             <code>
+            ExerciseOrderedList =
+                element ol {
+                    attribute cols {text}?,
+                    attribute marker {text}?,
+                    ExerciseListItem+
+                }
+            ExerciseListItem = element li {
+                MetaDataTarget,
+                (TextParagraph | BlockText+)
+            }
             ExerciseBody =
                 (
                     BlockStatement |
-                    element ol {
-                        attribute cols {text}?,
-                        attribute marker {text}?,
-                        element li {
-                            MetaDataTarget,
-                            (TextParagraph | BlockText+)
-                        }+
-                    }
+                    ExerciseOrderedList
                 )+
             StatementExercise =
                 element statement { ExerciseBody }
@@ -2622,6 +2606,13 @@
                     attribute source {text}?,
                     attribute seed {xsd:integer}?
                 }
+            WWDescription =
+                element description {
+                    (
+                        TextSimple |
+                        SimpleLine+
+                    )
+                }
             WebWorkAuthored =
                 element webwork {
                     UniqueID?,
@@ -2629,12 +2620,7 @@
                     Component?,
                     attribute seed {xsd:integer}?,
                     attribute copy {text}?,
-                    element description {
-                        (
-                            TextSimple |
-                            SimpleLine+
-                        )
-                    }?,
+                    WWDescription?,
                     WWMacros?,
                     element pg-code {text}?,
                     (
@@ -2968,23 +2954,27 @@
                     Credit*,
                     Date?
                 }
+            Email = element email {text}
+            PersonName = element personname {TextSimple}
+            Department = element department {TextSimple | ShortLine+}
+            Institution = element institution {TextSimple | ShortLine+}
             Author =
                 element author {
-                    element personname {TextSimple},
-                    element department {TextSimple | ShortLine+}?,
-                    element institution {TextSimple | ShortLine+}?,
-                    element email {text}?
+                    PersonName,
+                    Department?,
+                    Institution?,
+                    Email?
                 }
             Editor =
                 element editor {
-                    element personname {TextSimple},
-                    element department {TextSimple | ShortLine+}?,
-                    element institution {TextSimple | ShortLine+}?,
-                    element email {text}?
+                    PersonName,
+                    Department?,
+                    Institution?,
+                    Email?
                 }
             Credit =
                 element credit {
-                    element title {TextLong},
+                    Title,
                     Author+
                 }
             Date =
@@ -2996,20 +2986,23 @@
                     MetaDataTarget,
                     BlockText+
                 }
+            ColophonCredit = element credit {
+                    element role {TextShort},
+                    element entity {TextLong}
+                }
+            ShortLicense = element shortlicense {TextLong}
+            Website = element website {Url}
             ColophonFront =
                 element colophon {
                     MetaDataTarget,
-                    element credit {
-                        element role {TextShort},
-                        element entity {TextLong}
-                    }*,
+                    ColophonCredit*,
                     element edition {text}?,
-                    element website {Url}?,
+                    Website?,
                     element copyright {
                         element year {TextShort},
                         element holder {text},
                         element minilicense {TextShort}?,
-                        element shortlicense {TextLong}?
+                        ShortLicense?
                     }?
                 }
             Biography =
@@ -3055,33 +3048,22 @@
 
         <p>A few simple tweaks to frontmatter elements.</p>
 
-        <p>We give an alternative definition of the ColophonFront to include footnotes in the shortlicense.  This is the only change currently.</p>
+        <p>We give an alternative definition of the two elements in the ColophonFront that are different.</p>
 
         <fragment xml:id="frontmatter-dev">
             <title>Front matter (dev)</title>
             <code>
-            ColophonFront |=
-                element colophon {
-                    MetaDataTarget,
-                    element credit {
-                        element role {TextShort},
-                        element entity {TextLong}
-                    }*,
-                    element edition {text}?,
-                    element website {
-                        element name {TextShort},
-                        element address {text}
-                    }?,
-                    element copyright {
-                        element year {TextShort},
-                        element holder {text},
-                        element minilicense {TextShort}?,
-                        element shortlicense {
-                            TextLong &amp;
-                            Footnote*
-                        }?
-                    }?
+            ShortLicense_X =
+                element shortlicense {
+                    TextLong &amp;
+                    Footnote*
                 }
+            ShortLicense |= ShortLicense_X
+            Website_X = element website {
+                element name {TextShort},
+                element address {text}
+            }
+            Website |= Website_X           
             </code>
         </fragment>
     </section>
@@ -3097,11 +3079,11 @@
             Contributor =
                 element contributor {
                     MetaDataTarget,
-                    element personname {TextSimple},
-                    element department {TextSimple}?,
-                    element institution {TextSimple}?,
+                    PersonName,
+                    Department?,
+                    Institution?,
                     element location {TextSimple}?,
-                    element email {text}?
+                    Email?
                 }
             Contributors =
                 element contributors {
@@ -3242,9 +3224,10 @@
         <fragment xml:id="feedback">
             <title>Feedback link</title>
             <code>
+            FeedbackUrl = element url {text}
             Configuration |=
                 element feedback {
-                    element url {text}
+                    FeedbackUrl
                 }
             </code>
         </fragment>


### PR DESCRIPTION
This removes any duplicate anonymously named elements in service of the new reference documentation workflow.  

Additionally, we clean up the schema for references, which will close #1993.

Finally, the new naming suggests an improvement for how to build the experimental schema, which is demonstrated in Frontmatter section.  A later PR will do similar improvements for the other experimental sections.