### PR TITLE
Fitb update and documentation

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2180,6 +2180,130 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
             <idx><h>interactive exercises</h><h>fill-in </h></idx>
             <idx><h>exercise</h><h>interactive</h><h>fill-in </h></idx>
 
+            <p>A <term>fill-in-the-blank</term> problem allows the reader to submit free text that is evaluated for correctness. The signal for a fill-in problem is a <tag>statement</tag> containing a sequence of <tag>fillin</tag> elements with a sibling <tag>evaluation</tag> element. Randomized elements to appear in the statement and solution and to be used in evaluation of reader responses requires the presence of an additional <tag>setup</tag> element that is also a sibling to the <tag>statement</tag>. The presence of the <tag>setup</tag> provides the ability for the statement and evaluation of the responses to incorporate random, dynamically generated elements.</p>
+
+            <p>The body of the <tag>statement</tag> is the same as for any exercise-like statement, with the addition of two elements of markup. A <tag>fillin</tag> is placed at the location a blank would be required for the reader's response. Details for this element are described in the next paragraph. When the question includes a <tag>setup</tag>, content can reference the string or TeX representation of the object (if defined) by using a <tag>eval</tag> element, where the name of the object is provided by a <attr>object</attr> attribute.</p>
+
+            <p>The <tag>fillin</tag> element is required to have an <attr>answer</attr> attribute that contains an answer that would be evaluated as correct, in the case that the question has a known, static, valid answer, or an <attr>ansobj</attr> attribute that contains the variable name of a dynamically generated object representing a correct answer, in the case that the problem has an associated <tag>setup</tag>. In addition, the <tag>fillin</tag> is required to have a <c>@mode</c> that characterizes the mode by which the submitted answer will be parsed. Current possible modes are <c>string</c>, <c>number</c>, and <c>math</c> (only for the dynamic implementation). The <tag>fillin</tag> element may have a <attr>width</attr> attribute specifying the number of characters for the static-version blank. For questions that involve dynamic evaluation, a <attr>name</attr> attribute may be used to identify a variable name that will reference the reader's response during dynamic evaluation of <em>other</em> blanks. (A standard <c>ans</c> variable will always be available in the context of each individual response's evaluation.)</p>
+
+            <p>The <tag>evaluation</tag> block will have a sequence of <tag>evaluate</tag> elements, one associated with each of the corresponding <tag>fillin</tag> elements appearing in the <tag>statement</tag>. By default, the association is by order. If each <tag>fillin</tag> has an associated <attr>name</attr>, the association does not need to be in order. Within each <tag>evaluate</tag> element, there will be a sequence of <tag>test</tag> elements that define a comparison rule for the test and the associated feedback provided when the test evaluates as true. Default behavior is that the <attr>answer</attr> or <attr>ansobj</attr> attribute of the corresponding <tag>fillin</tag> is used for comparison to evaluate a correct response. If the author wishes to override this default or wishes to provide specific feedback for a correct response which will also be used for the automatic solution for static versions, the author will identify one <tag>test</tag> element with the attribute <attr>correct="yes"</attr>.</p>
+
+            <p>Within each <tag>test</tag>, the author needs to specify which type of comparison will be used. For non-dynamic questions, three comparisons are available: <tag>numcmp</tag>, <tag>strcmp</tag>, and <tag>jscmp</tag>. For dynamic questions that include <tag>setup</tag>, additional options include <tag>mathcmp</tag> comparisons involving math objects and <tag>logic</tag> elements to construct more complex boolean tests involving these objects, described later. Feedback that is provided to the reader when the comparison is true, beyond saying the response is correct/incorrect, is provided in a <tag>feedback</tag> element which can itself contain structured <pretext/> text including <tag>eval</tag> elements to reference dynamically generated objects.</p>
+
+            <p>A <tag>numcmp</tag> and a <tag>strcmp</tag> can specify that the comparison should be to match the provided answer for the corresponding <tag>fillin</tag> by including the attribute <attr>use-answer="yes"</attr>. Otherwise, these comparisons must specify the value being compared. A <tag>numcmp</tag> provides this with an attribute <attr>value</attr> that indicates the matching value. If the <tag>numcmp</tag> includes the optional <attr>tolerance</attr> attribute, any response in the range of from the given value plus or minus the tolerance will be accepted. Alternatively, the <tag>numcmp</tag> can directly provide a <attr>min</attr> and <attr>max</attr> attribute to specify an arbitrary interval. A <tag>strcmp</tag> that does not include the <attr>use-answer</attr> will have content that defines a matching string or more generally a matching regular-expression. By default, <pretext/> augments the provided string to match the entire response after stripping leading and trailing white space. The attribute <attr>strip="no"</attr> overrides this behavior so that, for example, the match can look for the presence of a pattern within the response rather than matching the entire response. In addition, the attribute <attr>case="insensitive"</attr> makes the regular expression ignore case during the comparison.</p>
+
+            <p>A comparison involving <tag>jscmp</tag> allows the author to provide arbitrary Javascript code that will evaluate to either true/false or a string containing feedback for a valid match, where the reader's evaluated response is available as a variable <c>ans</c> and all of the reader's responses are in an array <c>ans_array</c>. This allows custom evaluation that can allow the evaluation of one blank to depend on what was answered in another blank. The Javascript is evaluated in the context of a local, anonymous function. Nevertheless, the author should take care that no commands are included that invoke mutable side-effects.</p>
+
+            <p>To create dynamic, randomizable versions of a fill-in-the-blank question, a <tag>setup</tag> element is required as a sibling of the <tag>statement</tag> and <tag>evaluation</tag> elements. For the interactive version of these questions, the problem will created with a random number generator initialized with a seed that is stored by the Runestone Component for the reader. This results in the reader seeing the same version the next time they open the question. A button allowing the reader to request a new randomized version changes the seed and regenerates the question. Static representations need to provide consistent versions each time, so the <tag>setup</tag> requires a <attr>seed</attr> attribute.</p>
+
+            <p>Within the <tag>setup</tag>, the author provides statements that will initialize Javascript objects that will be accessible in the <tag>statement</tag>, <tag>solution</tag>, and <tag>evaluation</tag> elements. The author can provide Javascript code within a <tag>setupScript</tag> child of the <tag>setup</tag>. It is likely that the script contents will need to be escaped to avoid XML conflicts, for example by individually escaping problematic characters or surrounding the code with <c>&lt;![CDATA[...]]&gt;</c>. In the context in which the script runs, there is an object <c>v</c> representing the dynamic variable namespace. Any object that the author wants to access should be created as a member of that object, such as <c>v.myObject = ...</c>. The name <c>myObject</c> could then be used (without reference to <c>v</c>) in an <attr>ansobj</attr> attribute of a <tag>fillin</tag>, in an <attr>object</attr> attribute of an <tag>eval</tag> or directly in a <tag>jscmp</tag> comparison.</p>
+
+            <p>To provide randomization, a random number generator based on the current seed is available in the <tag>setupScript</tag> using the object name <c>RNG</c>. The <c>RNG</c> object includes the following methods for generating various types of random values.
+                <ol>
+                    <li><c>RNG.random()</c>: Uniform random values between <m>0</m> and <m>1</m>.</li>
+                    <li><c>RNG.randSign()</c>: Random values <m>+1</m> and <m>-1</m>.</li>
+                    <li><c>RNG.randInt(a,b)</c>: Random integer from <m>a,a+1,a+2,\ldots,b</m>.</li>
+                    <li><c>RNG.randUniform(a,b)</c>: Random floating value <m>a &lt; x &lt; b</m>.</li>
+                    <li><c>RNG.randDiscrete(a,b,dx,nonzero)</c>: Random value <m>x</m> from <m>a,a+dx,a+2dx,\ldots</m> with <m>x \le b</m>. If <c>nonzero=true</c> (optional parameter), then <m>x=0</m> is excluded.</li>
+                </ol>
+            Using this generator will ensure that subsequent visits by the reader to the question will see the same version.</p>
+
+            <p>If the author wishes for reader responses to be parsed to assess format prior to evaluating correctness, <tag>setupScript</tag> should include a declaration of an entry <c>v.types</c>. The value can either be a single parser function applied to all blanks or an array of separate parser functions, one for each <tag>fillin</tag>. A parser function takes a string representing the response for the blank and returns the parsed object. If there is an error in the structure of the response, the function should <c>throw new TypeError(errMsg)</c>, and the <c>errMsg</c> will be provided as feedback for the response without performing any of the tests.</p>
+
+            <p>The Runestone Component that implements interactivity takes the HTML generated from the <tag>statement</tag> after the <tag>setup</tag> is processed and performs substitutions of any <tag>eval</tag> elements. The recomputed HTML is then inserted into live webpage. A <tag>postRenderScript</tag> entry in <tag>setup</tag> can be used as a second script that runs as a call-back after this substitution occurs. Such a script would be useful if the script requires access to the actual webpage elements and not just defining objects for the evaluation context.</p>
+
+            <paragraphs>
+                <title>Math Objects in Dynamic Problems</title>
+
+                <p>A Javascript library that supports some mathematical objects in the dynamic setup and evaluation of fill-in-the-blank problems. In order to access these objects, an XML-interface is provided to interact with the objects in the <tag>setup</tag> and <tag>evaluation</tag> elements. Any <tag>fillin</tag> elements expecting to parse as mathematical objects should use <attr>mode="math"</attr> and assign <attr>ansobj</attr> to the name of a dynamic expression object created in <tag>setup</tag> that represents a correct answer.</p>
+
+                <p>For the <tag>setup</tag> stage, a sequence of <tag>de-object</tag> elements can be used to define mathematical dynamic expression objects. Each <tag>de-object</tag> will have a <attr>name</attr> attribute representing the object name. The mathematical nature of the <tag>de-object</tag> is indicated with a <attr>context</attr> attribute. Currently supported expression types are to represent numbers using <attr>context="number"</attr> and formulas using <attr>context="formula"</attr>.</p>
+
+                <p> The content of the <tag>de-object</tag> element is an XML element that defines the actual expression. The following choices are available, described in the following paragraphs:
+                <ol>
+                    <li><tag>de-random</tag>: create a randomly generated number</li>
+                    <li><tag>de-number</tag>: create a number by providing its value or formula</li>
+                    <li><tag>de-expression</tag>: create an expression or formula involving variables by directly providing a formula or by performing a substitution or a derivative on a previously-defined expression object</li>
+                    <li><tag>de-evaluate</tag>: create a number by evaluating an expression object by replacing each variable with a specified number value</li>
+                </ol>
+                As elements are defined in sequence, formulas used at any stage may include the name of any previously generated object as a valid symbol in the formula.</p>
+
+                <p>To define a random number, use a <tag>de-random</tag> element. The same random number generation routines provided by the <c>RNG</c> object are accessible through this element using a <attr>distribution</attr> attribute and additional attributes for the distribution parameters, some of which come with default values.
+                <ol>
+                    <li><attr>distribution="uniform"</attr>: Parameters are <attr>min=0</attr>, <attr>max=1</attr> as decimal values. Gives a value from the interval <m>(\mathrm{min},\mathrm{max}</m>.</li>
+                    <li><attr>distribution="sign"</attr>: No parameters. Gives <m>\pm 1</m> as possible values.</li>
+                    <li><attr>distribution="integer"</attr>: Parameters are <attr>min</attr>, <attr>max</attr> as integer values. Value is an integer chosen inclusively between <m>\mathrm{min}</m> and <m>\mathrm{max}</m>.</li>
+                    <li><attr>distribution="discrete"</attr>: Parameters include <attr>min</attr>, <attr>max</attr>, <attr>by="1"</attr>, and <attr>nonzero="yes"</attr>. Values chosen from the sequence <m>\mathrm{min} + k \cdot \mathrm{by}</m>, <m>k=0, 1, 2, \ldots</m> that are not greater than <m>\mathrm{max}</m>.</li>
+                </ol>
+                In practice, all distributions can be obtained using just the uniform and discrete distributions.</p>
+
+                <p>To define a number by formula, including defining rational numbers as fractions, use a <tag>de-number</tag> element. The content of the element should be a single number or a formula that results in a constant value. Symbols of previously defined numbers as well as mathematical constants like <c>pi</c> or <c>e</c> may be part of the formula. Any undefined symbols will result in an error.</p>
+
+                <p>To define an expression using a formula that might involve variables, use a <tag>de-expression</tag> with <attr>mode="formula"</attr>. The content of the element can be a mathematical formula that includes both numbers and variables. Previously defined numbers and expressions can be used in the formula by referencing their object name.</p>
+
+                <p>To define an expression that is the partial derivative of another expression with respect to a variable, use <tag>de-expression</tag> with <attr>mode="derivative</attr>. Such an expression must have a <tag>formula</tag> child that contains an object representing the original expression. The content can be either a <tag>eval</tag> with <attr>object</attr> to reference a previously-defined object or a separate <tag>de-expression</tag> defining an expression not saved as a separate object. In addition, the element must contain a <tag>variable</tag> element with <attr>name</attr> indicating the name of the variable of differentiation.</p>
+
+                <p>Formula evaluation and substitution follow a similar pattern. Formula evaluation to compute a number is performed with a <tag>de-evaluate</tag> element, which requires that every variable in the expression is assigned a specific numerical value. Formula substitution is like function composition and allows for any subset of the involved variables to be assigned either number or expression values and uses <tag>de-expression</tag> with <attr>mode="substitution"</attr>. In either event, the element requires a <tag>formula</tag> child element to specify a starting expression using a <tag>eval</tag> element to specify a previously-defined <tag>de-object</tag> or a <tag>de-expression</tag> element to generate a new formula expression. For each variable that will be replaced by a value or another expression, we will include a <tag>variable</tag> with <attr>name</attr> specifying which variable is being replaced. The content of the <tag>variable</tag> element can be an <tag>eval</tag> to reference an existing object or any of the elements that can be used to generate a <tag>de-object</tag>.</p>
+
+                <p>For the <tag>evaluation</tag> block, two comparison elements are accessible<mdash/><tag>mathcmp</tag> for testing whether two math objects are equivalent and <tag>logic</tag> for constructing compound tests involving simple Boolean logical operations. The <tag>mathcmp</tag> comparison is performed by numerically evaluating the two expressions being compared over a range of values for each variable present and verifying that they are numerically within a comparison tolerance.</p>
+
+                <p>To compare the reader's submitted response to the provided correct answer with <tag>mathcmp</tag>, use <attr>use-answer="yes"</attr>. To compare the submitted response to any other object, the <tag>mathcmp</tag> element should have a single evaluated math object as content, which could include a newly generated expression using <tag>de-expression</tag> that is based on the submitted responses. To compare two different math objects, the <tag>mathcmp</tag> should have two math objects. For convenience, there are some implicit representations available as well, illustrated in <xref ref="list-mathcmp-expressions-structure"/>.</p>
+
+                <listing xml:id="list-mathcmp-expressions-structure">
+                    <program>
+                        <input><![CDATA[
+                            <!-- Compare submitted response with fillin answer -->
+                            <mathcmp use-answer="yes"/>
+        
+                            <!-- Compare submitted response with pre-computed object -->
+                            <mathcmp obj="objName"/>
+        
+                            <!-- Compare submitted response with pre-computed object (alternate) -->
+                            <mathcmp>
+                              <eval obj="objName"/>
+                            </mathcmp
+        
+                            <!-- Implicit mathcmp with submitted response (alternate) -->
+                            <eval obj="objName"/>
+        
+                            <!-- Compare submitted response with newly generated object -->
+                            <mathcmp>
+                              <de-expression/>
+                            </mathcmp>
+        
+                            <!-- Implicit mathcmp with submitted response (alternate) -->
+                            <de-expression/>
+        
+                            <!-- Compare with newly generated object with pre-computed object -->
+                            <mathcmp>
+                              <de-expression/>
+                              <eval obj="objName"/>
+                            </mathcmp>
+        
+                            <!-- Compare two newly generated objects -->
+                            <mathcmp>
+                              <de-expression/>
+                              <de-expression/>
+                            </mathcmp>
+                        ]]>
+                        </input>
+                    </program>
+                    <caption>Possible structures for using <tag>mathcmp</tag> within a <tag>test</tag>. The <tag>de-expression</tag> would be replaced by any valid construction as described for the <tag>setup</tag>.</caption>
+                </listing>
+
+                <p>Compound logical structures are created using the <tag>logic</tag> element in the place of a comparison. To specify which operation is being used, the <attr>op</attr> attribute is set to one of <attr>op="and"</attr>, <attr>op="or"</attr>, or <attr>op="not"</attr>. The operations are considered <m>n</m>-ary, meaning that the contents should be one or more comparison elements, which might include additional logic. The <attr>op="and"</attr> will evaluate as true when <em>all</em> of the children comparisons evaluate as true. The <attr>op="or"</attr> will evaluate as true when <em>at least one</em> of the children comparisons evaluates as true. The <attr>op="not"</attr> is technically implemented as the negation of <attr>op="and"</attr>, and so will evaluate as true when <em>at least one</em> of the children comparisons evaluates as <em>false</em>. In the absence of any <tag>logic</tag>, there is always an implicit <attr>op="and"</attr> so that any sequence of comparisons within a single <tag>test</tag>, all comparisons are required to evaluate as true.</p>
+            </paragraphs>
+
+            <paragraphs>
+                <title>Static Representations</title>
+
+                <p>A static version will include an automatic <tag>solution</tag> which <q>fills in</q> each blank with the correct answer that is provided by the <tag>fillin</tag>. The feedback text specified in the <tag>evaluation</tag> that associated with a correct response for each of the <tag>fillin</tag> blanks are then provided in sequence. Consequently, the author should ensure that the feedback for a <tag>test</tag> with <attr>correct="yes"</attr> makes sense in the context of a back-of-the-book solution and not just as immediate feedback in an interactive setting.</p>
+
+                <p>If the author provides an optional <tag>solution</tag> element, this text will also be included as a solution. This solution may contain <tag>eval</tag> elements in the same manner as described for the <tag>statement</tag> element. The automatic solution can be disabled by including <attr>include-automatic="no"</attr> as an attribute of the <tag>solution</tag>.</p>
+
+                <p>To build the static version, <pretext/> needs to generate the dynamic substitution rules. Each dynamic question that includes <tag>setup</tag> is processed using its corresponding static seed to evaluate the potential substitutions. The resulting substitutions are stored in one of the generated files. Using the <pretext/>-CLI, the substitution file is generated using the command <c>pretext generate dynamic-subs -t static-target</c> where <c>static-target</c> is replaced by a static project target such as PDF.</p>
+            </paragraphs>
+
             <p>As of 2022-06-14 a major effort is underway to provide comprehensive markup for <term>fill-in-the-blank</term> problems.  Until then, there is transitional markup intended only to supply a migration path for projects originally authored for Runestone servers (<xref ref="runestone"/>).  So (a) our documentation is sparse, and (b) there will be no backward-compatible improvements.  So in particular, new projects should wait for the new markup.  Also, studying examples may be a useful way to augment what is described here.</p>
 
             <p>A <tag>statement</tag> is enriched with empty <tage>var</tage> elements which will render as the blanks in the problem.</p>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8905,12 +8905,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                     <statement>
                         <p>Complete the following line of a Python program so that it will declare an integer variable <c>age</c> with an initial value of <c>5</c>.</p>
-                        <p><fillin mode="string" correct="int"/> <c>age = </c> <fillin mode="number" correct="5"/><c>;</c></p>
+                        <p><fillin mode="string" answer="int"/> <c>age = </c> <fillin mode="number" answer="5"/><c>;</c></p>
                     </statement>
                     <evaluation>
                         <evaluate>
                             <test>
-                                <strcmp use-correct='yes'/>
+                                <strcmp use-answer='yes'/>
                                 <feedback>
                                   <p>A variable of type <c>int</c> is appropriate for whole number ages.</p>
                                 </feedback>
@@ -8924,7 +8924,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </evaluate>
                         <evaluate>
                             <test>
-                                <numcmp use-correct='yes'/>
+                                <numcmp use-answer='yes'/>
                                 <feedback>
                                     <p>An integer variable may be initialized to a value.</p>
                                 </feedback>
@@ -8942,25 +8942,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <exercise label="dynamic-fitb-simple-formula">
                     <title>Fill-In Formula (Dynamic)</title>
                     <statement>
-                        <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval expr="x1"/></m>,  <m>x=<eval expr="x2"/></m>, and <m>x=<eval expr="x3"/></m> and so that <m>f(0)=<eval expr="y0"/></m>.</p>
-                        <p><m>f(x)=</m> <fillin name="st_cubic" mode="math-formula" correct="x3"/></p>
+                        <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval obj="x1"/></m>,  <m>x=<eval obj="x2"/></m>, and <m>x=<eval obj="x3"/></m> and so that <m>f(0)=<eval obj="y0"/></m>.</p>
+                        <p><m>f(x)=</m> <fillin name="st_cubic" mode="math-formula" ansobj="x3"/></p>
                     </statement>
                     <solution>
                         <p>
                             Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form, 
-                            <me>f(x) = A <eval expr="base_cubic"/></me>
+                            <me>f(x) = A <eval obj="base_cubic"/></me>
                             with an unknown scaling multiple <m>A</m>.
                         </p>
                         <p>
                             When we evaluate <m>f(x)</m> at <m>x=0</m> using this formula, we find
-                            <me>f(0) = <eval expr="base_yint"/>A</me>.
-                            Since we also know <m>f(0)=<eval expr="y0"/></m>, we can write down the equation
-                            <me>A <eval expr="base_cubic"/> = <eval expr="y0"/></me>
-                            and find that <m>A=<eval expr="A"/></m>.
+                            <me>f(0) = <eval obj="base_yint"/>A</me>.
+                            Since we also know <m>f(0)=<eval obj="y0"/></m>, we can write down the equation
+                            <me>A <eval obj="base_cubic"/> = <eval obj="y0"/></me>
+                            and find that <m>A=<eval obj="A"/></m>.
                         </p>
                         <p>
                             Consequently, we can write our function in the form
-                            <me>f(x)=<eval expr="cubic"/></me>.
+                            <me>f(x)=<eval obj="cubic"/></me>.
                         </p>
                     </solution>
                     <setup seed="314159">
@@ -8977,38 +8977,31 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <de-random distribution="discrete" min="1" max="4" by="1"/>
                         </de-object>
                         <de-object name="x2" context="number">
-                            <de-number>{{x1}}+{{d1}}</de-number>
+                            <de-number>x1+d1</de-number>
                         </de-object>
                         <de-object name="x3" context="number">
-                            <de-number>{{x2}}+{{d2}}</de-number>
+                            <de-number>x2+d2</de-number>
                         </de-object>
                         <de-object name="base_cubic" context="formula">
-                            <de-expression>(x-{{x1}})*(x-{{x2}})*(x-{{x3}})</de-expression>
+                            <de-expression>(x-x1)*(x-x2)*(x-x3)</de-expression>
                         </de-object>
                         <de-object name="base_yint" context="number">
                             <de-evaluate>
-                                <formula><eval expr="base_cubic"/></formula>
+                                <formula><eval obj="base_cubic"/></formula>
                                 <variable name="x">0</variable>
                             </de-evaluate>                            
                         </de-object>
                         <de-object name="A" context="number">
-                            <de-number>{{y0}}/{{base_yint}}</de-number>
+                            <de-number>y0/base_yint</de-number>
                         </de-object>
                         <de-object name="cubic" context="formula">
-                            <de-expression>{{A}}*(x-{{x1}})*(x-{{x2}})*(x-{{x3}})</de-expression>
+                            <de-expression>A*(x-x1)*(x-x2)*(x-x3)</de-expression>
                         </de-object>
                     </setup>
                     <evaluation>
                         <evaluate name="st_cubic">
                             <test correct="yes">
-                                <mathcmp expr="cubic"/>
-                            </test>
-                            <test>
-                                <mathcmp>
-                                    <de-expression>x+1</de-expression>
-                                    <eval expr="ans"/>
-                                </mathcmp>
-                                <feedback>Short</feedback>
+                                <mathcmp obj="cubic"/>
                             </test>
                         </evaluate>
                     </evaluation>
@@ -9017,20 +9010,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <title>Decompose the Function</title>
                     <statement>
                         <p>
-                        Consider the function <me>h(x)=<eval expr="composition"/></me>.
+                        Consider the function <me>h(x)=<eval obj="composition"/></me>.
                         Find two nontrivial functions <m>f(x)</m> and <m>g(x)</m> so that <m>h(x) = f(g(x))</m>.
                         </p>
                         <p>
-                        <m>f(x) = </m> <fillin width="15" mode="math-formula" correct="outerFormula" name="fGiven"/> 
-                        and <m>g(x)=</m> <fillin width="15" mode="math-formula" correct="innerFormula" name="gGiven"/>
+                        <m>f(x) = </m> <fillin width="15" mode="math-formula" ansobj="outerFormula" name="fGiven"/> 
+                        and <m>g(x)=</m> <fillin width="15" mode="math-formula" ansobj="innerFormula" name="gGiven"/>
                         </p>
                     </statement>
                     <solution>
                         <p>
-                        Noticing that the expression <m><eval expr="innerFormula"/></m> appears inside parentheses with a power,
-                        it makes sense to think of that as the inner function, defining <m>g(x) = <eval expr="innerFormula"/></m>.
+                        Noticing that the expression <m><eval obj="innerFormula"/></m> appears inside parentheses with a power,
+                        it makes sense to think of that as the inner function, defining <m>g(x) = <eval obj="innerFormula"/></m>.
                         The outer function describes what happens to that.
-                        If we imagined replacing the formula <m><eval expr="innerFormula"/></m> with a box and then call that box our variable <m>x</m>, we find the outer function is given by <m>f(x) = <eval expr="outerFormula"/></m>.
+                        If we imagined replacing the formula <m><eval obj="innerFormula"/></m> with a box and then call that box our variable <m>x</m>, we find the outer function is given by <m>f(x) = <eval obj="outerFormula"/></m>.
                         </p>
                         <p>
                         This is not the only non-trivial composition. Can you find others?
@@ -9053,78 +9046,78 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <de-random distribution="discrete" min="-10" max="10" by="1" nonzero="yes" />
                         </de-object>
                         <de-object name="outerFormula" context="formula">
-                            <de-expression>{{a}}*x^{{n}}+{{b}}</de-expression>
+                            <de-expression>a*x^n+b</de-expression>
                         </de-object>
                         <de-object name="innerFormula" context="formula">
-                            <de-expression>{{c}}*x+{{d}}</de-expression>
+                            <de-expression>c*x+d</de-expression>
                         </de-object>
                         <de-object name="identityFunction" context="formula">
                             <de-expression>x</de-expression>
                         </de-object>
                         <de-object name="composition" context="formula">
                             <de-expression mode="substitution">
-                                <formula><eval expr="outerFormula"/></formula>
-                                <variable name="x"><eval expr="innerFormula"/></variable>
+                                <formula><eval obj="outerFormula"/></formula>
+                                <variable name="x"><eval obj="innerFormula"/></variable>
                             </de-expression>
                         </de-object>
                     </setup>
                     <evaluation answers-coupled="yes">
                         <evaluate name="fGiven">
                             <test>
-                                <mathcmp expr="identityFunction"/>
+                                <mathcmp obj="identityFunction"/>
                                 <feedback><m>f(x)=x</m> is not allowed for nontrivial compositions.</feedback>
                             </test>
                             <test>
-                                <logical op="and">
-                                    <logical op="not">
+                                <logic op="and">
+                                    <logic op="not">
                                         <mathcmp>
-                                            <eval expr="composition"/>
+                                            <eval obj="composition"/>
                                             <de-expression context="formula" mode="substitution">
-                                                <formula><eval expr="fGiven"/></formula>
-                                                <variable name="x"><eval expr="gGiven"/></variable>
+                                                <formula><eval obj="fGiven"/></formula>
+                                                <variable name="x"><eval obj="gGiven"/></variable>
                                             </de-expression>
                                         </mathcmp>
-                                    </logical>
+                                    </logic>
                                     <mathcmp>
-                                        <eval expr="composition"/>
+                                        <eval obj="composition"/>
                                         <de-expression context="formula" mode="substitution">
-                                            <formula><eval expr="gGiven"/></formula>
-                                            <variable name="x"><eval expr="fGiven"/></variable>
+                                            <formula><eval obj="gGiven"/></formula>
+                                            <variable name="x"><eval obj="fGiven"/></variable>
                                         </de-expression>
                                     </mathcmp>
-                                </logical>
+                                </logic>
                                 <feedback>You have composed in the wrong order.</feedback>
                             </test>
                         </evaluate>
                         <evaluate name="gGiven">
                             <test>
-                                <mathcmp expr="identityFunction"/>
+                                <mathcmp obj="identityFunction"/>
                                 <feedback><m>g(x)=x</m> is not allowed for nontrivial compositions.</feedback>
                             </test>
                         </evaluate>
                         <evaluate all="yes">
                             <test correct="yes">
-                                <logical op="and">
+                                <logic op="and">
                                     <mathcmp>
-                                        <eval expr="composition"/>
+                                        <eval obj="composition"/>
                                         <de-expression context="formula" mode="substitution">
-                                            <formula><eval expr="fGiven"/></formula>
-                                            <variable name="x"><eval expr="gGiven"/></variable>
+                                            <formula><eval obj="fGiven"/></formula>
+                                            <variable name="x"><eval obj="gGiven"/></variable>
                                         </de-expression>
                                     </mathcmp>
-                                    <logical op="not">
+                                    <logic op="not">
                                         <mathcmp>
-                                            <eval expr="fGiven"/>
-                                            <eval expr="identityFunction"/>
+                                            <eval obj="fGiven"/>
+                                            <eval obj="identityFunction"/>
                                         </mathcmp>
-                                    </logical>
-                                    <logical op="not">
+                                    </logic>
+                                    <logic op="not">
                                         <mathcmp>
-                                            <eval expr="gGiven"/>
-                                            <eval expr="identityFunction"/>
+                                            <eval obj="gGiven"/>
+                                            <eval obj="identityFunction"/>
                                         </mathcmp>
-                                    </logical>
-                                </logical>
+                                    </logic>
+                                </logic>
                                 <feedback>Excellent!</feedback>
                             </test>
                         </evaluate>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -460,7 +460,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Dynamic Substitutions                                 -->
 <!-- Cut out dynamic setup and evaluation for static mode. -->
 <!-- ##################################################### -->
-<xsl:template match="setup[de-object|postSetupScript]|evaluation" mode="dynamic-substitution">
+<xsl:template match="setup[de-object|postSetupScript]" mode="dynamic-substitution">
     <xsl:if test="$exercise-style = 'dynamic'">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*" mode="dynamic-substitution"/>
@@ -468,23 +468,70 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="eval[@expr]" mode="dynamic-substitution">
+<!-- <xsl:template match="evaluation" mode="dynamic-substitution">
     <xsl:choose>
-        <!-- static, for multiple conversions, but primarily LaTeX -->
         <xsl:when test="$exercise-style = 'static'">
-            <xsl:variable name="parent-id" select="ancestor::exercise/@label">
-               <!--<xsl:apply-templates select="ancestor::exercise" mode="assembly-id" />-->
+            <evaluation/>
+        </xsl:when>
+        <xsl:when test="$exercise-style = 'dynamic'">
+            <xsl:copy>
+                <xsl:apply-templates select="node()|@*" mode="dynamic-substitution"/>
+            </xsl:copy>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+ -->
+<xsl:template match="fillin[@ansobj]" mode="dynamic-substitution">
+    <xsl:choose>
+        <xsl:when test="$exercise-style = 'static'">
+            <xsl:variable name="parent-id">
+                <xsl:apply-templates select="ancestor::exercise/@label" />
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
-            <xsl:variable name="expression" select="@expr"/>
+            <xsl:variable name="object" select="@ansobj"/>
             <xsl:variable name="substitution">
-                <xsl:value-of select="$eval-subs//dynamic-substitution[@id=$parent-id]/eval-subst[@expr=$expression]"/>
+                <xsl:value-of select="$eval-subs//dynamic-substitution[@id=$parent-id]/eval-subst[@obj=$object]"/>
             </xsl:variable>
             <xsl:message>
                 <xsl:text>DYNAMIC SUBSTITUTION::</xsl:text>
                 <xsl:value-of select="$parent-id"/>
                 <xsl:text>$</xsl:text>
-                <xsl:value-of select="$expression"/>
+                <xsl:value-of select="$object"/>
+                <xsl:text>=</xsl:text>
+                <xsl:value-of select="$substitution"/>
+            </xsl:message>
+            <xsl:copy>
+                <xsl:attribute name="answer">
+                    <xsl:value-of select="$substitution"/>
+                </xsl:attribute>
+                <xsl:apply-templates select="@*|node()" mode="dynamic-substitution"/>
+            </xsl:copy>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy>
+                <xsl:apply-templates select="node()|@*" mode="dynamic-substitution"/>
+            </xsl:copy>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="eval[@obj]" mode="dynamic-substitution">
+    <xsl:choose>
+        <!-- static, for multiple conversions, but primarily LaTeX -->
+        <xsl:when test="$exercise-style = 'static'">
+            <xsl:variable name="parent-id">
+               <xsl:apply-templates select="ancestor::exercise/@label" />
+            </xsl:variable>
+            <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
+            <xsl:variable name="object" select="@obj"/>
+            <xsl:variable name="substitution">
+                <xsl:value-of select="$eval-subs//dynamic-substitution[@id=$parent-id]/eval-subst[@obj=$object]"/>
+            </xsl:variable>
+            <xsl:message>
+                <xsl:text>DYNAMIC SUBSTITUTION::</xsl:text>
+                <xsl:value-of select="$parent-id"/>
+                <xsl:text>$</xsl:text>
+                <xsl:value-of select="$object"/>
                 <xsl:text>=</xsl:text>
                 <xsl:value-of select="$substitution"/>
             </xsl:message>
@@ -1992,7 +2039,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- new dynamic fillin goes here, perhaps:                     -->
             <!-- statement//fillin[(@*|node()) and not(@characters|@fill)]? -->
-            <xsl:when test="statement[.//fillin and ancestor::exercise/evaluation]">
+            <xsl:when test="statement//fillin and evaluation">
                 <xsl:text>fillin</xsl:text>
             </xsl:when>
             <!-- only interactive programs make sense after a "statement" -->
@@ -2081,6 +2128,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                (@exercise-interactive = 'clickablearea') or
                                (@exercise-interactive = 'select') or
                                (@exercise-interactive = 'fillin-basic') or
+                               (@exercise-interactive = 'fillin') or
                                (@exercise-interactive = 'coding') or
                                (@exercise-interactive = 'shortanswer')]
                       |

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -44,11 +44,9 @@
     </xsl:element>
 </xsl:template>
 
-<xsl:variable name="defaultCorrectResponse">
-    <xsl:text>Correct.</xsl:text>
-</xsl:variable>
 <xsl:variable name="defaultIncorrectResponse">
-    <xsl:text>Try again.</xsl:text>
+    <xsl:value-of select="key(localization-key,'incorrect')"/>
+    <xsl:text>.</xsl:text>
 </xsl:variable>
 
 <!-- ========================================================= -->
@@ -70,85 +68,90 @@
                 </xsl:attribute>
                 <script type="application/json">
                     <xsl:text>{&#xa;</xsl:text>
-                        <!-- A seed is provided to generate consistent static content -->
-                        <xsl:if test="$b-dynamics-static-seed">
-                            <xsl:text>"static_seed": "</xsl:text>
-                            <xsl:choose>
-                                <xsl:when test="setup/@seed">
-                                    <xsl:value-of select="setup/@seed"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <!-- Report if a seed is not provided-->
-                                    <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="$the-id"/>" is missing setup @seed for static content generation.</xsl:message>
-                                    <xsl:text>1234</xsl:text>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            <xsl:text>",&#xa;</xsl:text>
-                        </xsl:if>
-                        <!-- The formatted HTML presentation of the problem, -->
-                        <!-- with escape codes for dynamic content, all of   -->
-                        <!-- which is serialized and escaped to a string.    -->
-                        <xsl:text>"problemHtml": </xsl:text>
-                        <xsl:call-template name="escape-quote-xml">
-                            <xsl:with-param name="xml_content">
-                                <xsl:apply-templates select="statement/*" mode="body" />
-                                <xsl:if test="$b-dynamics-static-seed">
-                                    <div>
-                                        <xsl:attribute name="id">
-                                            <xsl:apply-templates select="." mode="html-id"/>
-                                            <xsl:text>-substitutions</xsl:text>
-                                        </xsl:attribute>
-                                        <xsl:apply-templates select="(statement|solution)//eval[@expr]" mode="track-evaluation" />
-                                    </div>
-                                </xsl:if>
-                            </xsl:with-param>
-                        </xsl:call-template>
-                        <!-- The formatted HTML presentation of the solution, -->
-                        <!-- similar to statement but no fillins              -->
-                        <xsl:text>,&#xa;"solutionHtml": </xsl:text>
-                        <xsl:call-template name="escape-quote-xml">
-                            <xsl:with-param name="xml_content">
-                                <xsl:apply-templates select="solution/*" mode="body" />
-                            </xsl:with-param>
-                        </xsl:call-template>
-                        <!-- Add packages that need to be loaded as javascript -->
-                        <xsl:if test="$b-is-dynamic">
-                            <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
-                            <xsl:text>"BTM"</xsl:text>
-                            <!-- Future: add additional packages here -->
-                            <xsl:text>]</xsl:text>
-                        </xsl:if>
-                        <!-- Names assigned to the blanks. (Inclusion is     -->
-                        <!-- really so that evaluation of answers can refer  -->
-                        <!-- to submitted work by name.)                     -->
-                        <xsl:if test="statement//fillin[@name]">
-                            <xsl:text>,&#xa;"blankNames": {</xsl:text>
-                            <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
-                            <xsl:text>}</xsl:text>
-                        </xsl:if>
-                        <xsl:if test="$b-is-dynamic">
-                            <!-- The actual setup code is javascript enclosed in quotes. -->
-                            <!-- The declaration creates the objects that are needed.    -->
-                            <!-- The script is included as an escaped string             -->
-                            <xsl:text>,&#xa;"dyn_vars": </xsl:text>
-                            <xsl:call-template name="dynamic-setup" />
-                        </xsl:if>
-                        <!-- An array of tests and feedback for answer evaluation    -->
-                        <!-- Each blank has a corresponding array of test/feedback   -->
-                        <!-- response. The test is Javascript (stringified) that     -->
-                        <!-- returns a boolean response. The first test is for       -->
-                        <!-- correctness. The last response is default.              -->
-                        <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
-                        <!-- In case all answers are based on one test               -->
-                        <xsl:variable name="multiAns">
-                            <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
-                        </xsl:variable>
-                        <!-- Generate test/feedback pair for each fillin             -->
-                        <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
-                            <xsl:with-param name="multiAns" select="$multiAns" />
-                        </xsl:apply-templates>
+                    <!-- A seed is provided to generate consistent static content -->
+                    <xsl:if test="$b-dynamics-static-seed">
+                        <xsl:text>"static_seed": "</xsl:text>
+                        <xsl:choose>
+                            <xsl:when test="setup/@seed">
+                                <xsl:value-of select="setup/@seed"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <!-- Report if a seed is not provided-->
+                                <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="$the-id"/>" is missing setup @seed for static content generation.</xsl:message>
+                                <xsl:text>1234</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:text>",&#xa;</xsl:text>
+                    </xsl:if>
+                    <!-- The formatted HTML presentation of the problem, -->
+                    <!-- with escape codes for dynamic content, all of   -->
+                    <!-- which is serialized and escaped to a string.    -->
+                    <xsl:text>"problemHtml": </xsl:text>
+                    <xsl:call-template name="escape-quote-xml">
+                        <xsl:with-param name="xml_content">
+                            <xsl:apply-templates select="statement/*" mode="body" />
+                            <xsl:if test="$b-dynamics-static-seed">
+                                <div>
+                                    <xsl:attribute name="id">
+                                        <xsl:apply-templates select="." mode="html-id"/>
+                                        <xsl:text>-substitutions</xsl:text>
+                                    </xsl:attribute>
+                                    <xsl:apply-templates select="(statement|solution)//eval[@obj]|statement//fillin[@ansobj]" mode="track-evaluation" />
+                                </div>
+                            </xsl:if>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                    <!-- The formatted HTML presentation of the solution, -->
+                    <!-- similar to statement but no fillins              -->
+                    <xsl:text>,&#xa;"solutionHtml": </xsl:text>
+                    <xsl:call-template name="escape-quote-xml">
+                        <xsl:with-param name="xml_content">
+                            <xsl:apply-templates select="solution/*" mode="body" />
+                        </xsl:with-param>
+                    </xsl:call-template>
+                    <!-- Add packages that need to be loaded as javascript -->
+                    <xsl:if test="$b-is-dynamic">
+                        <xsl:text>,&#xa;"dyn_imports": [</xsl:text>
+                        <xsl:text>"BTM"</xsl:text>
+                        <!-- Future: add additional packages here -->
                         <xsl:text>]</xsl:text>
-                    <xsl:text>&#xa;}</xsl:text>
+                    </xsl:if>
+                    <!-- Names assigned to the blanks.      -->
+                    <!-- Empty if none named.               -->
+                    <xsl:text>,&#xa;"blankNames": {</xsl:text>
+                    <xsl:apply-templates select="statement//fillin" mode="declare-blanks" />
+                    <xsl:text>}</xsl:text>
+                    <xsl:if test="$b-is-dynamic">
+                        <!-- The actual setup code is javascript enclosed in quotes. -->
+                        <!-- The declaration creates the objects that are needed.    -->
+                        <!-- The script is included as an escaped string             -->
+                        <xsl:text>,&#xa;"dyn_vars": </xsl:text>
+                        <xsl:call-template name="dynamic-setup" />
+                    </xsl:if>
+                    <!-- An array of tests and feedback for answer evaluation    -->
+                    <!-- Each blank has a corresponding array of test/feedback   -->
+                    <!-- response. The test is Javascript (stringified) that     -->
+                    <!-- returns a boolean response. The first test is for       -->
+                    <!-- correctness. The last response is default.              -->
+                    <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
+                    <!-- In case all answers are based on one test               -->
+                    <xsl:variable name="multiAns">
+                        <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
+                    </xsl:variable>
+                    <!-- Generate test/feedback pair for each fillin             -->
+                    <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
+                        <xsl:with-param name="multiAns" select="$multiAns" />
+                    </xsl:apply-templates>
+                    <xsl:text>]</xsl:text>
+                    <xsl:text>,&#xa;"localize_feedback": ["</xsl:text>
+                    <xsl:apply-templates select="." mode="type-name">
+                        <xsl:with-param name="string-id" select="'correct'"/>
+                    </xsl:apply-templates>
+                    <xsl:text>!", "</xsl:text>
+                    <xsl:apply-templates select="." mode="type-name">
+                        <xsl:with-param name="string-id" select="'incorrect'"/>
+                    </xsl:apply-templates>
+                    <xsl:text>."]&#xa;}</xsl:text>
                 </script>
             </div>
             <xsl:text>&#xa;</xsl:text>
@@ -192,16 +195,16 @@
 <!-- knows how to formulate a LaTeX representation          -->
 <!-- The `toTeX` javascript function is defined in BTM.js   -->
 <!-- which is loaded by Runestone.                          -->
-<xsl:template match="exercise[//setup]//eval[@expr]">
+<xsl:template match="eval[@obj]">
     <xsl:text>[%= </xsl:text>
     <xsl:choose>
         <xsl:when test="ancestor::m|ancestor::me|ancestor::mrow">
             <xsl:text>toTeX(</xsl:text>
-            <xsl:value-of select="@expr"/>
+            <xsl:value-of select="@obj"/>
             <xsl:text>)</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:value-of select="@expr"/>
+            <xsl:value-of select="@obj"/>
         </xsl:otherwise>
     </xsl:choose>
     <xsl:text> %]</xsl:text>
@@ -212,33 +215,57 @@
 <!-- this creates elements that will be pulled from the  -->
 <!-- stand-alone page into a generated XML document that -->
 <!-- gives the actual substitution in static mode.       -->
-<xsl:template match="eval[@expr]" mode="track-evaluation">
+<xsl:template match="eval[@obj]" mode="track-evaluation">
     <eval-subst>
-        <xsl:attribute name="expr">
-            <xsl:value-of select="@expr"/>
+        <xsl:attribute name="obj">
+            <xsl:value-of select="@obj"/>
         </xsl:attribute>
         <xsl:apply-templates select="."/>
     </eval-subst>
-    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="fillin[@ansobj]" mode="track-evaluation">
+    <eval-subst>
+        <xsl:attribute name="obj">
+            <xsl:value-of select="@ansobj"/>
+        </xsl:attribute>
+        <xsl:variable name="temp-eval">
+            <xsl:choose>
+                <xsl:when test="@mode='math' or @mode='number'">
+                    <m><eval>
+                        <xsl:attribute name="obj">
+                            <xsl:value-of select="@ansobj"/>
+                        </xsl:attribute>
+                    </eval></m>
+                </xsl:when>
+                <xsl:otherwise>
+                    <eval>
+                        <xsl:attribute name="obj">
+                            <xsl:value-of select="@ansobj"/>
+                        </xsl:attribute>
+                    </eval>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:apply-templates select="exsl:node-set($temp-eval)//eval"/>
+    </eval-subst>
 </xsl:template>
 
 
 <!-- Create the dynamic aspect of the problem.           -->
 <!-- Define all of the mathematical elements as well as  -->
 <!-- objects (e.g. graphs) that might depend on them     -->
-<!-- A script in setup/postSetupScript is executed after -->
-<!-- the environment setup.                              -->
+<!-- A script in setup/setupScript is executed after -->
+<!-- object-based setup concludes.                       -->
 <!-- A script in setup/postRenderScript is executed      -->
 <!-- after the dynamic creation is complete.             -->
 <xsl:template name="dynamic-setup">
     <xsl:variable name="js_code">
         <!-- Initialize the evaluation environment -->
-        <xsl:if test="setup/de-object">
-            <xsl:call-template name="setup-evaluation-environment"/>
-        </xsl:if>
+        <xsl:call-template name="setup-evaluation-environment"/>
         <!-- Any direct JS for environment setup   -->
-        <xsl:if test="setup/postSetupScript">
-            <xsl:value-of select="setup/postSetupScript"/>
+        <xsl:if test="setup/setupScript">
+            <xsl:value-of select="setup/setupScript"/>
         </xsl:if>
         <!-- Prepare evaluation and feedback       -->
         <xsl:call-template name="setup-fillin-parsers"/>
@@ -252,12 +279,13 @@
 
 <!-- Parse any settings for the math environment for the problem -->
 <xsl:template name="setup-evaluation-environment">
-    <xsl:text>v._menv = new BTM({</xsl:text>
+    <xsl:text>v._mobjs = new BTM({</xsl:text>
         <!-- Setup seeded random number generator  -->
         <xsl:text>'rand': rand</xsl:text>
         <!-- FUTURE: Pull additional settings from an environment element -->
         <xsl:apply-templates select="de-environment" mode="runestone-setup"/>
     <xsl:text>});&#xa;</xsl:text>
+    <xsl:text>var RNG = v._mobjs.menv.rng;&#xa;</xsl:text>
     <!-- Generate all of the XML-declared math objects -->
     <xsl:apply-templates select="setup/de-object" mode="runestone-setup"/>
 </xsl:template>
@@ -265,7 +293,7 @@
 <!-- Environment Setup: Define the mathematical objects -->
 <xsl:template match="de-object" mode="runestone-setup">
     <xsl:text>v.</xsl:text><xsl:value-of select="@name"/>
-    <xsl:text> = v._menv.addMathObject(</xsl:text>
+    <xsl:text> = v._mobjs.addMathObject(</xsl:text>
     <xsl:call-template name="quote-string">
         <xsl:with-param name="text" select="@name"/>
     </xsl:call-template>
@@ -319,7 +347,7 @@
     </xsl:if>
      <xsl:choose>
         <xsl:when test="@mode='math-formula'">
-            <xsl:text>v._menv.getParser()</xsl:text>
+            <xsl:text>v._mobjs.getParser()</xsl:text>
         </xsl:when>
         <xsl:when test="@mode='number'">
             <xsl:text>Number</xsl:text>
@@ -391,33 +419,51 @@
                 <xsl:with-param name="b-correct" select="'yes'" />
             </xsl:apply-templates>
         </xsl:when>
-        <!-- If no explicit test is provided, use given correct info. -->
+        <!-- If no explicit test is provided, use given answer. -->
         <xsl:otherwise>
             <xsl:text>{</xsl:text>
             <xsl:choose>
-                <xsl:when test="$curFillIn/@mode='number'">
-                    <xsl:text>"number": [</xsl:text>
-                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
-                    <xsl:text>,</xsl:text>
-                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
+                <xsl:when test="$curFillIn/@answer">
+                    <xsl:choose>
+                        <xsl:when test="$curFillIn/@mode='number'">
+                            <xsl:text>"number": [</xsl:text>
+                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                            <xsl:text>,</xsl:text>
+                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                        </xsl:when>
+                        <xsl:when test="$curFillIn/@mode='string'">
+                            <xsl:text>"regex": </xsl:text>
+                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                        </xsl:when>
+                    </xsl:choose>
                 </xsl:when>
-                <xsl:when test="$curFillIn/@mode='string'">
-                    <xsl:text>"regex": </xsl:text>
-                    <xsl:value-of select="exsl:node-set($curFillIn)/@correct"/>
+                <xsl:when test="$curFillIn/@ansobj">
+                    <xsl:choose>
+                        <xsl:when test="$curFillIn/@mode='number'">
+                            <xsl:text>function() {&#xa;</xsl:text>
+                            <xsl:text>    return (Math.abs(</xsl:text>
+                            <xsl:value-of select="$curFillIn/@ansobj"/>
+                            <xsl:text>- ans) &lt; 1e-10);&#xa;}</xsl:text>
+                        </xsl:when>
+                        <xsl:when test="$curFillIn/@mode='string'">
+                            <xsl:text>function() {&#xa;</xsl:text>
+                            <xsl:text>    return (</xsl:text>
+                            <xsl:value-of select="$curFillIn/@ansobj"/>
+                            <xsl:text>== ans);&#xa;}</xsl:text>
+                        </xsl:when>
+                    </xsl:choose>
                 </xsl:when>
                 <xsl:when test="$curFillIn/@mode='math'">
                     <xsl:text>function() {&#xa;</xsl:text>
-                    <xsl:text>    return _menv.compareExpressions(</xsl:text>
-                    <xsl:value-of select="$curFillIn/@correct"/>
+                    <xsl:text>    return _mobjs.compareExpressions(</xsl:text>
+                    <xsl:value-of select="$curFillIn/@ansobj"/>
                     <xsl:text>, ans</xsl:text>
                     <!-- Can we use ans above instead of $curFillIn/@name? -->
                     <!-- xsl:value-of select="exsl:node-set($curFillIn)/@name"/-->
                     <xsl:text>);&#xa;}</xsl:text>
                 </xsl:when>
             </xsl:choose>
-            <xsl:text>, "feedback": "</xsl:text>
-            <xsl:value-of select="$defaultCorrectResponse"/>
-            <xsl:text>"}</xsl:text>
+            <xsl:text>, "feedback": ""}</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
 
@@ -429,9 +475,7 @@
         </xsl:apply-templates>
     </xsl:for-each>
     <!-- Default feedback for the blank. Always evaluates true.   -->
-    <xsl:text>, {"feedback": "</xsl:text>
-    <xsl:value-of select="$defaultIncorrectResponse"/>
-    <xsl:text>"}]</xsl:text>
+    <xsl:text>, {"feedback": ""}]</xsl:text>
 </xsl:template>
 
 <xsl:template match="test" mode="create-test-feedback">
@@ -445,23 +489,15 @@
         <xsl:with-param name="fillin" select="$fillin" />
     </xsl:apply-templates>
     <xsl:text>, "feedback": "</xsl:text>
-    <xsl:choose>
-        <xsl:when test="feedback">
-            <!-- serialize HTML as text, then escape as JSON -->
-            <xsl:call-template name="escape-json-string">
-                <xsl:with-param name="text">
-                    <xsl:apply-templates select="exsl:node-set($feedback-rtf)" mode="serialize"/>
-                </xsl:with-param>
-            </xsl:call-template>
-        </xsl:when>
-        <xsl:when test="$b-correct='yes'">
-            <xsl:value-of select="$defaultCorrectResponse"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:value-of select="$defaultIncorrectResponse"/>
-        </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>"}</xsl:text>
+    <xsl:if test="feedback">
+        <!-- serialize HTML as text, then escape as JSON -->
+        <xsl:call-template name="escape-json-string">
+            <xsl:with-param name="text">
+                <xsl:apply-templates select="exsl:node-set($feedback-rtf)" mode="serialize"/>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:if>
+<xsl:text>"}</xsl:text>
 </xsl:template>
 
 <!-- Template for simple answer checkers: no interaction between different fillins. -->
@@ -469,19 +505,81 @@
 <!-- JSON dictionary for numerical condition -->
 <xsl:template match="test[numcmp]" mode="create-test">
     <xsl:param name="fillin"/>
-    <xsl:variable name="answer">
+    <xsl:choose>
+        <xsl:when test="(numcmp/@use-answer='yes' and $fillin/@ansobj) or numcmp/@object">
+            <xsl:apply-templates select="." mode="create-test-ansobj">
+                <xsl:with-param name="fillin" select="$fillin"/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:variable name="answer">
+                <xsl:choose>
+                    <xsl:when test="numcmp/@use-answer='yes' and $fillin/@answer">
+                        <xsl:value-of select="$fillin/@answer"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="numcmp/@value"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="tolerance">
+                <xsl:choose>
+                    <xsl:when test="numcmp/@use-answer='yes' and $fillin/@tolerance">
+                        <xsl:value-of select="$fillin/@tolerance"/>
+                    </xsl:when>
+                    <xsl:when test="numcmp/@tolerance">
+                        <xsl:value-of select="numcmp/@tolerance"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>0</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="min-val">
+              <xsl:choose>
+                <xsl:when test="numcmp/@min">
+                  <xsl:value-of select="numcmp/@min"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="$answer - $tolerance"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="max-val">
+              <xsl:choose>
+                <xsl:when test="numcmp/@max">
+                  <xsl:value-of select="numcmp/@max"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="$answer + $tolerance"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:text>"number": [</xsl:text>
+            <xsl:value-of select="$min-val"/>
+            <xsl:text>,</xsl:text>
+            <xsl:value-of select="$max-val"/>
+            <xsl:text>]</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- When the comparison is with an object, we rely on function comparisons. -->
+<xsl:template match="test[numcmp]" mode="create-test-ansobj">
+    <xsl:param name="fillin"/>
+    <xsl:variable name="ansObject">
         <xsl:choose>
-            <xsl:when test="numcmp/@use-correct='yes'">
-                <xsl:value-of select="$fillin/@correct"/>
+            <xsl:when test="numcmp/@use-answer='yes' and $fillin/@ansobj">
+                <xsl:value-of select="$fillin/@ansobj"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="$numcmp"/>
+                <xsl:value-of select="numcmp/@object"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="tolerance">
         <xsl:choose>
-            <xsl:when test="numcmp/@use-correct='yes' and $fillin/@tolerance">
+            <xsl:when test="numcmp/@use-answer='yes' and $fillin/@tolerance">
                 <xsl:value-of select="$fillin/@tolerance"/>
             </xsl:when>
             <xsl:when test="numcmp/@tolerance">
@@ -492,29 +590,121 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:text>"number": [</xsl:text>
-    <xsl:value-of select="$answer - $tolerance"/>
-    <xsl:text>,</xsl:text>
-    <xsl:value-of select="$answer + $tolerance"/>
-    <xsl:text>]</xsl:text>
+    <xsl:variable name="min-val">
+        <xsl:choose>
+            <xsl:when test="numcmp/@min">
+                <xsl:value-of select="numcmp/@min"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$ansObject"/>
+                <xsl:text> - </xsl:text>
+                <xsl:value-of select="$tolerance"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="max-val">
+        <xsl:choose>
+            <xsl:when test="numcmp/@max">
+            <xsl:value-of select="numcmp/@max"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$ansObject"/>
+                <xsl:text> + </xsl:text>
+                <xsl:value-of select="$tolerance"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:text>"solution_code": </xsl:text>
+    <xsl:variable name="js_code">
+        <xsl:text>function() { </xsl:text>
+        <xsl:text>return (ans &gt;= </xsl:text>
+        <xsl:value-of select="$min-val"/>
+        <xsl:text>) &amp;&amp; (ans &lt;= </xsl:text>
+        <xsl:value-of select="$max-val"/>
+        <xsl:text>); }()</xsl:text>
+    </xsl:variable>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text" select="$js_code"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- JSON dictionary for string condition -->
 <xsl:template match="test[strcmp]" mode="create-test">
     <xsl:param name="fillin"/>
-    <xsl:variable name="answer">
+    <xsl:choose>
+        <xsl:when test="strcmp/@use-answer='yes' and $fillin/@ansobj or strcmp//eval">
+            <xsl:apply-templates mode="create-test-ansobj">
+                <xsl:with-param name="fillin" select="$fillin"/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:variable name="answer">
+                <xsl:choose>
+                    <xsl:when test="strcmp/@use-answer='yes'">
+                        <xsl:value-of select="$fillin/@answer"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="strcmp"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="regexFlags">
+                <xsl:choose>
+                    <xsl:when test="strcmp/@use-answer='yes' and $fillin/@case = 'insensitive'">
+                        <xsl:text>i</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="strcmp/@case = 'insensitive'">
+                        <xsl:text>i</xsl:text>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:variable>
+            <!-- regex string match, drop    -->
+            <!-- leading/trailing whitespace -->
+            <xsl:text>"regex": "</xsl:text>
+            <!-- JSON escapes necessary for regular expression -->
+            <xsl:call-template name="escape-json-string">
+                <xsl:with-param name="text">
+                    <xsl:choose>
+                        <xsl:when test="strcmp/@strip = 'no'">
+                            <xsl:value-of select="$answer"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>^\s*</xsl:text>
+                            <xsl:value-of select="$answer"/>
+                            <xsl:text>\s*$</xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:with-param>
+            </xsl:call-template>
+            <xsl:text>"</xsl:text>
+            <!-- flag for case-sensitive match -->
+            <!-- default:  'sensitive'         -->
+            <xsl:text>, "regexFlags": "</xsl:text>
+            <xsl:value-of select="$regexFlags"/>
+            <xsl:text>"</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- When the comparison is with an object, we rely on function comparisons. -->
+<xsl:template match="test[strcmp]" mode="create-test-ansobj">
+    <xsl:variable name="regex">
         <xsl:choose>
-            <xsl:when test="strcmp/@use-correct='yes'">
-                <xsl:value-of select="$fillin/@correct"/>
+            <xsl:when test="strcmp/@use-answer='yes' and $fillin/@ansobj">
+                <xsl:text>`${</xsl:text>
+                <xsl:value-of select="$fillin/@ansobj"/>
+                <xsl:text>}`</xsl:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="strcmp"/>
+                <xsl:text>`</xsl:text>
+                <xsl:apply-templates select="strcmp/*" mode="strcmp-object-substitution"/>
+                <xsl:text>`</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="regexFlags">
         <xsl:choose>
-            <xsl:when test="strcmp/@use-correct='yes' and $fillin/@case = 'insensitive'">
+            <xsl:when test="strcmp/@use-answer='yes' and $fillin/@case = 'insensitive'">
                 <xsl:text>i</xsl:text>
             </xsl:when>
             <xsl:when test="strcmp/@case = 'insensitive'">
@@ -522,23 +712,30 @@
             </xsl:when>
         </xsl:choose>
     </xsl:variable>
-    <!-- regex string match, drop    -->
-    <!-- leading/trailing whitespace -->
-    <xsl:text>"regex": "</xsl:text>
-    <!-- JSON escapes necessary for regular expression -->
-    <xsl:call-template name="escape-json-string">
-        <xsl:with-param name="text">
-            <xsl:text>^\s*</xsl:text>
-            <xsl:value-of select="$answer"/>
-            <xsl:text>\s*$</xsl:text>
-        </xsl:with-param>
+    <!-- create a function to do the regex -->
+    <xsl:text>"solution_code": </xsl:text>
+    <xsl:variable name="js_code">
+        <xsl:text>function(){&#xa;</xsl:text>
+            <xsl:text>  const re_str = </xsl:text><xsl:value-of select="$regex"/><xsl:text>;&#xa;</xsl:text>
+            <xsl:text>  const re = new RegExp(re_str, "</xsl:text>
+            <xsl:value-of select="$regexFlags"/>
+            <xsl:text>");&#xa;</xsl:text>
+            <xsl:text>  return re.test(ans);&#xa;</xsl:text>
+            <xsl:text>}()&#xa;</xsl:text>
+            </xsl:variable>
+    <xsl:call-template name="escape-quote-string">
+        <xsl:with-param name="text" select="$js_code"/>
     </xsl:call-template>
-    <xsl:text>"</xsl:text>
-    <!-- flag for case-sensitive match -->
-    <!-- default:  'sensitive'         -->
-    <xsl:text>, "regexFlags": "</xsl:text>
-    <xsl:value-of select="$regexFlags"/>
-    <xsl:text>"</xsl:text>
+</xsl:template>
+
+<xsl:template match="eval" mode="strcmp-object-substitution">
+    <xsl:text>${</xsl:text>
+    <xsl:value-of select="."/>
+    <xsl:text>}</xsl:text>
+</xsl:template>
+
+<xsl:template match="*" mode="strcmp-object-substitution">
+    <xsl:copy-of select="."/>
 </xsl:template>
 
 <!-- Otherwise create a function that deals with the test. -->
@@ -583,14 +780,14 @@
     <xsl:param name="level" select="0" />
     <xsl:choose>
         <!-- Test might be coded directly in javascript -->
-        <xsl:when test="name($curTest) = 'raw-js'">
+        <xsl:when test="name($curTest) = 'jscmp'">
             <xsl:text>    testResults[</xsl:text>
             <xsl:value-of select="$level" />
             <xsl:text>] = </xsl:text>
             <xsl:value-of select="$curTest"/>
         </xsl:when>
         <!-- Test might require logic -->
-        <xsl:when test="name($curTest)='logical'">
+        <xsl:when test="name($curTest)='logic'">
             <xsl:call-template name="checker-layer">
                 <xsl:with-param name="fillin" select="$fillin" />
                 <xsl:with-param name="tests" select="$curTest/*" />
@@ -610,21 +807,29 @@
             <xsl:text>    testResults[</xsl:text>
             <xsl:value-of select="$level" />
             <xsl:text>] = </xsl:text>
-            <xsl:text>_menv.compareExpressions(</xsl:text>
+            <xsl:text>_mobjs.compareExpressions(</xsl:text>
             <xsl:choose>
                 <!-- An equal element must have two expression children. -->
-                <xsl:when test="name($curTest) = 'mathcmp' and $curTest/@expr">
-                    <xsl:apply-templates select="$curTest/@expr" mode="evaluate"/>
+                <xsl:when test="name($curTest)='mathcmp' and $curTest/@use-answer='yes'">
+                    <xsl:value-of select="$fillin/@ansobj"/>
                     <xsl:text>, ans</xsl:text>
                 </xsl:when>
-                <xsl:when test="name($curTest) = 'mathcmp'">
+                <xsl:when test="name($curTest)='mathcmp' and $curTest/@obj">
+                    <xsl:value-of select="$curTest/@obj"/>
+                    <xsl:text>, ans</xsl:text>
+                </xsl:when>
+                <xsl:when test="name($curTest)='mathcmp' and count($curTest/*)=1">
+                    <xsl:apply-templates select="$curTest/*[1]" mode="evaluate"/>
+                    <xsl:text>, ans</xsl:text>
+                </xsl:when>
+                <xsl:when test="name($curTest)='mathcmp' and count($curTest/*)=2">
                     <xsl:apply-templates select="$curTest/*[1]" mode="evaluate"/>
                     <xsl:text>, </xsl:text>
                     <xsl:apply-templates select="$curTest/*[2]" mode="evaluate"/>
                 </xsl:when>
                 <!-- An implied equal compares the submitted answer to the given expression. -->
-                <xsl:otherwise>   <!-- Must be expression: #var or #de-object -->
-                <xsl:apply-templates select="$curTest" mode="evaluate"/>
+                <xsl:otherwise>   <!-- Must be expression: #eval or #de-expression -->
+                    <xsl:apply-templates select="$curTest" mode="evaluate"/>
                     <xsl:text>, ans</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -670,7 +875,7 @@
                     <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="tests" select="./*" />
                     <xsl:with-param name="level" select="$level+1" />
-                    <xsl:with-param name="logic" select="'or'" /> <!-- Default: All tests at first layer must be true -->
+                    <xsl:with-param name="logic" select="'or'" /> 
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="name()='not'">
@@ -678,7 +883,7 @@
                     <xsl:with-param name="fillin" select="$fillin" />
                     <xsl:with-param name="tests" select="./*" />
                     <xsl:with-param name="level" select="$level+1" />
-                    <xsl:with-param name="logic" select="'not'" /> <!-- Default: All tests at first layer must be true -->
+                    <xsl:with-param name="logic" select="'not'" /> 
                 </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
@@ -724,7 +929,7 @@
     </xsl:variable>
     <xsl:variable name="de_env">
         <xsl:value-of select="$prefix"/>
-        <xsl:text>_menv</xsl:text>
+        <xsl:text>_mobjs</xsl:text>
     </xsl:variable>
     <xsl:value-of select="$de_env"/>
     <xsl:text>.parseExpression(</xsl:text>
@@ -743,7 +948,7 @@
     </xsl:variable>
     <xsl:variable name="de_env">
         <xsl:value-of select="$prefix"/>
-        <xsl:text>_menv</xsl:text>
+        <xsl:text>_mobjs</xsl:text>
     </xsl:variable>
     <xsl:value-of select="$de_env"/>
     <xsl:text>.evaluateExpression(</xsl:text>
@@ -760,7 +965,7 @@
 </xsl:template>
 
 <xsl:template match="de-random[@distribution='discrete']" mode="evaluate">
-    <xsl:text>v._menv.generateRandom("discrete", { min:</xsl:text>
+    <xsl:text>v._mobjs.generateRandom("discrete", { min:</xsl:text>
     <xsl:choose>
         <xsl:when test="@min">
             <xsl:value-of select="@min"/>
@@ -811,7 +1016,7 @@
     </xsl:variable>
     <xsl:variable name="de_env">
         <xsl:value-of select="$prefix"/>
-        <xsl:text>_menv</xsl:text>
+        <xsl:text>_mobjs</xsl:text>
     </xsl:variable>
     <xsl:value-of select="$de_env"/>
     <xsl:text>.parseExpression(</xsl:text>
@@ -832,7 +1037,7 @@
     </xsl:variable>
     <xsl:variable name="de_env">
         <xsl:value-of select="$prefix"/>
-        <xsl:text>_menv</xsl:text>
+        <xsl:text>_mobjs</xsl:text>
     </xsl:variable>
     <xsl:value-of select="$de_env"/>
     <xsl:text>.composeExpression(</xsl:text>
@@ -857,7 +1062,7 @@
     </xsl:variable>
     <xsl:variable name="de_env">
         <xsl:value-of select="$prefix"/>
-        <xsl:text>_menv</xsl:text>
+        <xsl:text>_mobjs</xsl:text>
     </xsl:variable>
     <xsl:apply-templates select="formula/*" mode="evaluate">
         <xsl:with-param name="setupMode" select="$setupMode" />
@@ -866,7 +1071,7 @@
     <xsl:call-template name="quote-string">
         <xsl:with-param name="text" select="variable/@name"/>
     </xsl:call-template>
-    <xsl:text>)</xsl:text>
+    <xsl:text>).simplifyConstants()</xsl:text>
 </xsl:template>
 
 
@@ -886,8 +1091,8 @@
     </xsl:call-template>
     <xsl:text>: </xsl:text>
     <xsl:choose>
-        <xsl:when test="eval or de-object">
-            <xsl:apply-templates select="eval|de-object" mode="evaluate">
+        <xsl:when test="eval or de-number">
+            <xsl:apply-templates select="eval|de-number" mode="evaluate">
                 <xsl:with-param name="setupMode" select="$setupMode" />
             </xsl:apply-templates>
         </xsl:when>
@@ -908,7 +1113,7 @@
         </xsl:if>
     </xsl:variable>
     <xsl:value-of select="$prefix"/>
-    <xsl:value-of select="./@expr"/>
+    <xsl:value-of select="./@obj"/>
 </xsl:template>
 
 <!-- Nothing else is defined for evaluation during setup  -->

--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -794,6 +794,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:for-each select="ancestor::exercise/setup/var/condition[1]/feedback">
             <xsl:apply-templates select="node()" mode="fillin-solution"/>
         </xsl:for-each>
+        <xsl:for-each select=".//fillin[@answer]">
+            <xsl:variable name="fillin-name" select="@name"/>
+            <xsl:choose>
+                <!-- If #evaluate matches by name, find feedback on a correct result -->
+                <xsl:when test="ancestor::exercise/evaluation/evaluate[@name='$fillin-name']/test[@correct='yes']">
+                    <xsl:apply-templates select="ancestor::exercise/evaluation/evaluate[@name='$fillin-name']/test[@correct='yes']/feedback/node()" mode="fillin-solution"/>
+                </xsl:when>
+                <!-- Otherwise #evaluate matches by order, find feedback on a correct result -->
+                <xsl:when test="ancestor::exercise/evaluation/evaluate[position()]/test[@correct='yes']">
+                    <xsl:apply-templates select="ancestor::exercise/evaluation/evaluate[position()]/test[@correct='yes']/feedback/node()" mode="fillin-solution"/>/>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:for-each>
     </solution>
 </xsl:template>
 
@@ -817,6 +830,61 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$setup-var/condition[1]/@string">
             <xsl:value-of select="$setup-var/condition[1]/@string"/>
         </xsl:when>
+    </xsl:choose>
+    <fillin characters="1"/>
+</xsl:template>
+
+<!-- Fill-In the Blanks (Complete) -->
+
+<xsl:template match="*[@exercise-interactive = 'fillin']" mode="runestone-to-static">
+    <!-- metadata (idx, title) -->
+    <xsl:copy-of select="statement/preceding-sibling::*"/>
+    <!-- reproduce statement identically, but replace var w/ fillin -->
+    <xsl:apply-templates select="statement" mode="fillin-statement"/>
+    <!-- Any authored hints, answers, solutions, not derived from   -->
+    <!-- problem formulation. *Before* automatic ones, so numbering -->
+    <!-- matches interactive versions on authored ones.             -->
+    <xsl:copy-of select="hint"/>
+    <xsl:copy-of select="answer"/>
+    <xsl:choose>
+        <xsl:when test="solution[@include-automatic='no'">
+            <xsl:copy-of select="solution"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="statement" mode="fillin-solution"/>
+            <xsl:copy-of select="solution"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Fillin Statement -->
+<xsl:template match="fillin" mode="fillin-statement">
+    <fillin>
+        <xsl:attribute name="characters">
+            <xsl:choose>
+                <xsl:when test="@width">
+                    <xsl:value-of select="@width"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <!-- arbitrary default width -->
+                    <xsl:text>5</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+    </fillin>
+</xsl:template>
+
+<!-- Fillin complete solution -->
+<xsl:template match="fillin" mode="fillin-solution">
+    <!-- Correct answer is in @answer. -->
+    <fillin characters="1"/>
+    <xsl:choose>
+        <xsl:when test="@mode='math' or @mode='number'">
+            <m><xsl:value-of select="@answer"/></m>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@answer"/>
+        </xsl:otherwise>
     </xsl:choose>
     <fillin characters="1"/>
 </xsl:template>


### PR DESCRIPTION
Prepared documentation for the fill-in-the-blank exercise. While doing that work realized some modifications to the proposed markup would be beneficial, so made changes to that as proceeded.

Includes implementation of the automated solution for fillin problems based on given answers.   Feedback elements are assumed to be structured for now — need to add ability to identify text that needs to be surrounded by <p/> and this requires additional conversation.

Also note that the math object javascript requires Runestone services version that includes Runestone PR #504, which was merged July 16.