### PR TITLE
Add most common practices for hand-editing LaTeX (issue 1996)

### DIFF
--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -212,9 +212,11 @@
         <note xml:id="edit-latex">
             <title>Only Edit <latex/> Files Rarely</title>
 
-            <p>We want to stress that the <latex/> file created by various conversions is mean to be an <em>intermediate</em> format.  In other words, it is <em>ephemeral</em>.   We try to make it clean and organized, but it is not the <latex/> a human would write.  You might be able to recycle a paragraph or two in other documents you create without <pretext/>.  But it is not meant to be stable or archival and no long-term use is supported in any way.  In other words, it is not a supported output format, beyond compiling to a <init>PDF</init> without errors.</p>
+            <p>We want to stress that the <latex/> file created by various conversions is meant to be an <em>intermediate</em> format.  In other words, it is <em>ephemeral</em>.   We try to make it clean and organized, but it is not the <latex/> a human would write.  You might be able to recycle a paragraph or two in other documents you create without <pretext/>.  But it is not meant to be stable or archival, and no long-term use is supported in any way.  In other words, it is not a supported output format, beyond compiling to a <init>PDF</init> without errors.</p>
 
-            <p>Having said all that, you may find it necessary to manually adjust a file to control widows or orphans, or maybe the placement of a graphics file, or similar adjustments.  We view this as the final step before making a new edition, which might be a <init>PDF</init> that you submit to a print-on-demand service (<xref ref="print-on-demand"/>).  So this might be an annual exercise, at the most frequent.</p>
+            <p>Because of that, you may find it necessary to manually adjust a file to control widows or orphans, or maybe the placement of a graphics file, or similar adjustments.  Some of the most the common adjustments used by <pretext/> authors are inserting <c>\newpage</c>, <c>\noindent</c>, or <c>\par</c> to avoid awkward transitions, or to remove an occasional <c>\leavevmode</c>; consult a good <latex/> reference before making such changes, as effects later in the output may be unpredictable.</p>
+
+            <p>We view this as the final step before making a new edition, which might be a <init>PDF</init> that you submit to a print-on-demand service (<xref ref="print-on-demand"/>).  So hand-editing might be an annual exercise, at the most frequent.  One way to keep track of larger number of edits over long periods of time is to write a script (in an appropriate language), which looks for unique strings before or after trouble spots and replaces the nearby content.  Another minimally invasive option is to keep a separate git branch of the <latex/> file which makes the desired changes, which can then be applied on those rare occasions it is necessary (ideally, with little rebasing needed).</p>
         </note>
     </section>
 
@@ -224,6 +226,6 @@
 
         <p>We are careful about which <latex/> packages we use, trying to stick with well-established packages with active maintainers.  But it can be useful to have a record of <em>exactly</em> which packagees are in play, and better still, which versions of those packages are being used.  So you can use a publication entry to request loading the <url href="https://ctan.org/pkg/snapshot"><c>snapshot</c></url> package, which will then automatically generate such a record into a <c>&lt;job&gt;.dep</c> file.  See <xref ref="latex-snapshot-record-options"/> for details on electing this feature.</p>
 
-        <p>If you suspect some packages are not playing well with each other, this record might be helpful for debugging this (rare) situation.  It can aslo be useful if you wish to have a perfect archive of how some publication was produced.  See the package documentation for more on the format and use.</p>
+        <p>If you suspect some packages are not playing well with each other, this record might be helpful for debugging this (rare) situation.  It can also be useful if you wish to have a perfect archive of how some publication was produced.  See the package documentation for more on the format and use.</p>
     </section>
 </chapter>


### PR DESCRIPTION
This is meant to resolve #1996 .  Also caught two immediate neighbor typos.