### PR TITLE
add vertical space after sidebyside

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1762,7 +1762,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>%% tcolorbox styles for sidebyside layout&#xa;</xsl:text>
                 <!-- "frame empty" is needed to counteract very faint outlines in some PDF viewers -->
                 <!-- framecol=white is inadvisable, "frame hidden" is ineffective for default skin -->
-                <xsl:text>\tcbset{ sbsstyle/.style={raster before skip=2.0ex, raster equal height=rows, raster force size=false} }&#xa;</xsl:text>
+                <xsl:text>\tcbset{ sbsstyle/.style={raster before skip=2.0ex, raster equal height=rows, raster force size=false,raster after skip=10pt} }&#xa;</xsl:text>
                 <xsl:text>\tcbset{ sbspanelstyle/.style={bwminimalstyle, fonttitle=\blocktitlefont} }&#xa;</xsl:text>
             </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
This adds a 10pt gap after a sidebyside.

In some environments the current setting looks OK, because there is indentation of the paragraph after a sidebyside.
But in `example` (and perhaps some other environments), if you have a `sidebyside` containing two figures with captions, there is no identation of the following paragraph, and it is hard to tell where the caption ends and the paragraph begins.

Adding the gap makes it clear where the sidebyside ends and the following paragraph begins.