### PR TITLE
@workspace fix

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -14280,6 +14280,61 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </sidebyside>
                 </page>
             </worksheet>
+            <worksheet label="worksheet-activity-no-task">
+              <page>
+                <activity workspace="1in">
+                  <statement>
+                    <p>
+                      Just a simple activity here.
+                    </p>
+                  </statement>
+                </activity>
+                <activity workspace="1in">
+                  <statement>
+                    <p>
+                      Here is a second activity.
+                    </p>
+                  </statement>
+                </activity>
+              </page>
+            </worksheet>
+            <worksheet label="worksheet-activity-with-task">
+              <page>
+                <activity>
+                  <introduction>
+                    <p>
+                      This is going to be an activity with tasks.
+                    </p>
+                  </introduction>
+                  <task workspace="0.75in">
+                    <statement>
+                      <p>
+                        Here is the first task.
+                      </p>
+                    </statement>
+                  </task>
+                  <task workspace="0.25in">
+                    <statement>
+                      <p>
+                        Here is the second task.
+                      </p>
+                    </statement>
+                  </task>
+                  <task workspace="1.75in">
+                    <statement>
+                      <p>
+                        Here is the third task.
+                      </p>
+                    </statement>
+                  </task>
+                  <conclusion>
+                    <p>
+                      This is a conclusion that comes after the last task.
+                    </p>
+                  </conclusion>
+                </activity>
+              </page>
+            </worksheet>
         </section>
 
         <section xml:id="exercises-single" label="section-exercises-single">

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1175,7 +1175,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <xsl:text>\hypertarget{#4}{}}, after={\notblank{#3}{\newline\rule{\workspacestrutwidth}{#3}\newline\vfill}{\par}}}&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="$document-root//exercise[@workspace]">
+    <xsl:if test="$document-root//@workspace">
         <xsl:text>%% Worksheet exercises may have workspaces&#xa;</xsl:text>
         <xsl:text>\newlength{\workspacestrutwidth}&#xa;</xsl:text>
         <xsl:choose>


### PR DESCRIPTION
`pretext-latex.xsl` currently only defines the length `\workspacestrutwidth` when the file contains `exercise[@workspace]`. To support `@workspace` living on other possible `worksheet` descendants, this changes to define the length any time `@workspace` occurs in the document. Two rudimentary worksheets are added to the sample article: one with two `activity` elements each with `@workspace` and one where `@workspace` only appears on `activity/task`.