### PR TITLE
Slideshow styling update

### DIFF
--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -181,6 +181,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </li>
                 </dl></p>
             </slide>
+        </section>
+
+        <section>
+            <title>Blocks and code</title>
 
             <slide>
                 <title>Blocks: <tag>definition</tag></title>
@@ -215,6 +219,33 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </theorem>
             </slide>
 
+            <slide>
+                <title>Code</title>
+
+                <p>Here is an inline bit of code with surrounding text. <c>print("hello world")</c>. Here is a more text. And some more. And yet more. And a full program... with Prism support.</p>
+                <program language="python" line-numbers="yes">
+                    <title>A simple program</title>
+                    <input>
+                        def f(x):
+                            return x**2
+                        
+                        # many intentional blank lines below...
+                        # you may to zoom out, but at some point better to scroll a long listing
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        print(f(3))
+                    </input>
+                </program>
+            </slide>
+
         </section>
 
         <section>
@@ -223,7 +254,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <slide>
                 <title>Ramanujan and Integration</title>
 
-                <p>This Sage Cell should execute properly, but some extra CSS is being applied.  It is also difficult to edit properly.  Perhaps the two are related.  You may need to zoom out your browser to see all the content, especially after running the cell.</p>
+                <p>This Sage Cell is testing styling.</p>
 
                 <p>We have some mathematics on the page, to look for Javascript interference with MathJax.  An identity due to Ramanujan:<me>\frac{1}{\Bigl(\sqrt{\phi \sqrt{5}}-\phi\Bigr) e^{\frac25 \pi}} = 1+\frac{e^{-2\pi}} {1+\frac{e^{-4\pi}} {1+\frac{e^{-6\pi}} {1+\frac{e^{-8\pi}} {1+\ldots} } } }</me>.</p>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9318,7 +9318,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="out" />
     <xsl:param name="b-original"/>
 
-    <xsl:element name="pre">
+    <xsl:element name="div">
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="." mode="permid-attribute"/>
         <xsl:attribute name="class">
@@ -12520,7 +12520,7 @@ TODO:
     <xsl:param name="language-text" />
 
     <xsl:element name="script">
-        <xsl:text>// Make *any* pre with class '</xsl:text>
+        <xsl:text>// Make *any* div with class '</xsl:text>
         <xsl:call-template name="sagecell-class-name">
             <xsl:with-param name="language-attribute" select="$language-attribute"/>
             <xsl:with-param name="b-autoeval" select="$b-autoeval"/>
@@ -12532,7 +12532,7 @@ TODO:
             <xsl:with-param name="content">
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
                     <string key="inputLocation">
-                        <xsl:text>pre.</xsl:text>
+                        <xsl:text>div.</xsl:text>
                         <xsl:call-template name="sagecell-class-name">
                             <xsl:with-param name="language-attribute" select="$language-attribute"/>
                             <xsl:with-param name="b-autoeval" select="$b-autoeval"/>
@@ -12574,12 +12574,12 @@ TODO:
 <!-- template for a "display only" version -->
 <xsl:template name="sagecell-display">
     <xsl:element name="script">
-        <xsl:text>// Make *any* pre with class 'sage-display' a visible, uneditable Sage cell&#xa;</xsl:text>
+        <xsl:text>// Make *any* div with class 'sage-display' a visible, uneditable Sage cell&#xa;</xsl:text>
         <xsl:text>sagecell.makeSagecell(</xsl:text>
         <xsl:call-template name="json">
             <xsl:with-param name="content">
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
-                    <string key="inputLocation">pre.sage-display</string>
+                    <string key="inputLocation">div.sage-display</string>
                     <string key="editor">codemirror-readonly</string>
                     <array key="hide">
                         <string>evalButton</string>
@@ -12597,13 +12597,13 @@ TODO:
 <!-- Generic button, drop-down for languages -->
 <xsl:template name="sagecell-practice">
     <xsl:element name="script">
-        <xsl:text>// Make *any* pre with class 'sagecell-practice' an executable Sage cell&#xa;</xsl:text>
+        <xsl:text>// Make *any* div with class 'sagecell-practice' an executable Sage cell&#xa;</xsl:text>
         <xsl:text>// Their results will be linked, only within language type&#xa;</xsl:text>
         <xsl:text>sagecell.makeSagecell(</xsl:text>
         <xsl:call-template name="json">
             <xsl:with-param name="content">
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
-                    <string key="inputLocation">pre.sagecell-practice</string>
+                    <string key="inputLocation">div.sagecell-practice</string>
                     <boolean key="linked">true</boolean>
                     <string key="evalButtonText">
                         <xsl:apply-templates select="." mode="type-name">

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -200,46 +200,46 @@ code[class*="language-"], pre[class*="language-"] {
 dfn {
   font-weight: bold;
 }
-.pretext-content ol.no-marker,
-.pretext-content ul.no-marker,
-.pretext-content li.no-marker {
+.ptx-content ol.no-marker,
+.ptx-content ul.no-marker,
+.ptx-content li.no-marker {
     list-style-type: none;
 }
 
-.pretext-content ol.decimal {
+.ptx-content ol.decimal {
     list-style-type: decimal;
 }
-.pretext-content ol.lower-alpha {
+.ptx-content ol.lower-alpha {
     list-style-type: lower-alpha;
 }
-.pretext-content ol.upper-alpha {
+.ptx-content ol.upper-alpha {
     list-style-type: upper-alpha;
 }
-.pretext-content ol.lower-roman {
+.ptx-content ol.lower-roman {
     list-style-type: lower-roman;
 }
-.pretext-content ol.upper-roman {
+.ptx-content ol.upper-roman {
     list-style-type: upper-roman;
 }
-.pretext-content ul.disc {
+.ptx-content ul.disc {
     list-style-type: disc;
 }
-.pretext-content ul.square {
+.ptx-content ul.square {
     list-style-type: square;
 }
-.pretext-content ul.circle {
+.ptx-content ul.circle {
     list-style-type: circle;
 }
-.pretext-content ol.no-marker,
-.pretext-content ul.no-marker {
+.ptx-content ol.no-marker,
+.ptx-content ul.no-marker {
     list-style-type: none;
 }
-.pretext-content .cols1 li,
-.pretext-content .cols2 li,
-.pretext-content .cols3 li,
-.pretext-content .cols4 li,
-.pretext-content .cols5 li,
-.pretext-content .cols6 li {
+.ptx-content .cols1 li,
+.ptx-content .cols2 li,
+.ptx-content .cols3 li,
+.ptx-content .cols4 li,
+.ptx-content .cols5 li,
+.ptx-content .cols6 li {
     float: left;
     padding-right:2em;
 }
@@ -248,7 +248,7 @@ dfn {
         </head>
 
         <body>
-            <div class="reveal pretext-content">
+            <div class="reveal ptx-content">
                 <!-- For mathematics/MathJax, must be located -->
                 <!-- within div.reveal to be effective        -->
                 <xsl:call-template name="latex-macros"/>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -93,6 +93,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <xsl:call-template name="sagecell-code" />
             <xsl:apply-templates select="." mode="sagecell" />
+            <xsl:call-template name="syntax-highlight"/>
 
             <!-- load reveal.js resources; w/ v 4.1.2 -->
             <!-- these seem to be *always* minified   -->
@@ -115,25 +116,73 @@ ul {
   border-radius: 2px 10px 2px;
   padding: 4px;
 }
+.reveal pre {
+  box-shadow: none;
+  line-height: 1;
+  font-size: inherit;
+  width: auto;
+  margin: inherit;
+}
+.reveal pre code {
+  display: block;
+  padding: 0;
+  overflow: unset;
+  max-height: unset;
+  word-wrap: normal;
+}
 .definition-like,.theorem-like,.project-like {
   border-width: 0.5px;
   border-style: solid;
   border-radius: 2px 10px 2px;
   padding: 1%;
-  margin-bottom: 2em;
+  margin-bottom: var(--r-block-margin);
 }
 .definition-like {
-  background: #00608010;
+  background: #006080;
+  background: color-mix(in srgb, var(--r-background-color) 75%, #006080);
 }
 .theorem-like {
   background: #ff000010;
+  background:  color-mix(in srgb, var(--r-background-color) 75%, #aa0000);
 }
 .proof-like {
-  background: #ffffff90;
+  background: #ffffff;
+  background:  color-mix(in srgb, var(--r-background-color) 75%, #aaaaaa);
 }
 .project-like {
   background: #60800010;
+  background:  color-mix(in srgb, var(--r-background-color) 75%, #608000);
 }
+.code-inline {
+  background: #60800010;
+  background:  color-mix(in srgb, var(--r-background-color) 75%, var(--r-link-color));
+  padding: 0 3px;
+  border: 1px solid;
+  margin: 3px;
+  display: inline-block;
+}
+.sagecell_sessionOutput {
+  background: white;
+  color: black;
+  border: 0.5px solid var(--r-main-color);
+}
+
+.program {
+  background: #60800010;
+  background:  color-mix(in srgb, var(--r-background-color) 75%, var(--r-link-color));
+  max-height: 450px;
+  overflow: auto;
+  border: 0.5px solid var(--r-main-color);
+}
+.ptx-sagecell, .reveal .program {
+  font-size: calc(var(--r-main-font-size) * 0.6);
+}
+
+code[class*="language-"], pre[class*="language-"] {
+  padding: 0;
+  line-height: 1.2;
+}
+
 dfn {
   font-weight: bold;
 }

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -178,6 +178,20 @@ ul {
   font-size: calc(var(--r-main-font-size) * 0.6);
 }
 
+
+.ptx-content :is(.image-box, .audio-box, .video-box, .asymptote-box) {
+  position: relative;
+}
+
+.ptx-content iframe.asymptote, .ptx-content iframe.asymptote, .ptx-content .video-box .video, .ptx-content .video-box .video-poster {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+
 code[class*="language-"], pre[class*="language-"] {
   padding: 0;
   line-height: 1.2;


### PR DESCRIPTION
Fixes to revealjs styling.

Changed the container for `sagecell-sage` elements.  Having them as `pre` was causing all kinds of slideshow styling issues. The [sage examples](https://sagecell.sagemath.org/static/about.html?v=0141c2bee781881e735b5e98a913a0de5f2b2efc011158c7627de0318c02f6cc569f07beefc2eca4bdba7e55ec59235a4ba78ce37797ae52d0978386182bd413) show a div for that container. Tested this against sample-article - does not appear to adversely affect HTML builds.

Added Prism highlighting for code and a code sample.

Pushed this PR independent of ongoing CSS bundling as I know others are working on slides. Bundling will slightly change how the CSS gets written but can be done independently of this.

I think this is ready, but happy to tweak anything.