### PR TITLE
Handle pub variable with no value

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -4524,7 +4524,7 @@ def get_publisher_variable(xml_source, pub_file, params, variable):
     with open(temp_file, 'r') as f:
         for line in f:
             parts = line.split()
-            pairs[parts[0]] =  parts[1]
+            pairs[parts[0]] = parts[1] if len(parts) > 1 else None
 
     if variable in pairs:
         return pairs[variable]


### PR DESCRIPTION
If a pub variable results in an empty string the get_publisher_varaible function chokes. 

This provides `None` for missing values. Defaulting to `""` might require less code for handling but also be more likely to result in sneaky errors based on assuming a non-empty string came back.