### PR TITLE
Slideshow: Add devscript support

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -363,6 +363,7 @@ def get_cli_arguments():
         ("latex", "LaTeX source file (only, an intermediate format for developers)"),
         ("html", "HyperText Markup Language (online/web pages)"),
         ("html-zip", "HyperText Markup Language (single zip file)"),
+        ("revealjs", "reveal.js HTML slide format"),
         ("epub-svg", "EPUB container, math as SVG"),
         ("epub-mml", "EPUB container, math as MathML"),
         ("epub-speech", "EPUB container, math as speech"),
@@ -733,6 +734,17 @@ def main():
                 stringparams,
                 None,
                 "zip",
+                extra_stylesheet,
+                out_file,
+                dest_dir,
+            )
+        elif args.format == "revealjs":
+            ptx.revealjs(
+                xml_source,
+                publication_file,
+                stringparams,
+                args.xmlid,
+                "revealjs",
                 extra_stylesheet,
                 out_file,
                 dest_dir,


### PR DESCRIPTION
Changes to `pretext/pretext` and `pretext/pretext.py` to add support for reveal.js slides.

It is working for me, but my Python is not great, so another set of eyes is needed.

Note that I didn't add a reveal-zip target. I'm not sure if that would be wanted.