### PR TITLE
Add slide number option to revealjs

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -740,8 +740,9 @@
 
             <p>The<cd>
                 <cline>/publication/revealjs/appearance</cline>
-            </cd>element can have the following attribute:<ul>
+            </cd>element can have the following attributes:<ul>
                 <li><attr>theme</attr>: the base name of a file that is a reveal.js theme.  For example if the desired theme/CSS file is <c>css/theme/solarized.css</c>, then set the value of this attribute to <c>solarized</c>.</li>
+                <li><attr>number</attr>: whether to include slide numbers on slides.  Values are <c>yes</c> or <c>no</c>.  The default is <c>no</c>.  Note that with the <c>grid</c> navigation mode the slide numbers will be ordered pairs.</li>
             </ul></p>
         </subsection>
 

--- a/examples/sample-slideshow/publication.xml
+++ b/examples/sample-slideshow/publication.xml
@@ -24,7 +24,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <revealjs>
-        <appearance theme="solarized"/>
+        <!-- there are many reveal.js themes                    -->
+        <!-- see https://revealjs.com/themes/                   -->
+        <!-- to turn slide numbering on, use "yes"              -->
+        <!-- numbering on with "grid" mode gives ordered pairs  -->
+        <appearance theme="solarized" number="no"/>
         <!-- these are "resources" defaults, but best for a sample -->
         <!-- @minified is not even necessary with @host = 'cdn'    -->
         <resources host="cdn"/>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -292,6 +292,9 @@ dfn {
                 <xsl:value-of select="$reveal-navigation-mode"/>
             <xsl:text>',&#xa;</xsl:text>
             <xsl:text>  progress: false,&#xa;</xsl:text>
+            <xsl:if test="$b-reveal-slide-number">
+                <xsl:text>  slideNumber: true,&#xa;</xsl:text>
+            </xsl:if>
             <xsl:text>  center: false,&#xa;</xsl:text>
             <xsl:text>  hash: true,&#xa;</xsl:text>
             <xsl:text>  transition: 'fade',&#xa;</xsl:text>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3000,6 +3000,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/revealjs/appearance/pi:pub-attribute[@name='theme']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!-- Reveal.js Slide Numbering -->
+
+<xsl:variable name="reveal-slide-number">
+    <xsl:apply-templates select="$publisher-attribute-options/revealjs/appearance/pi:pub-attribute[@name='number']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<!-- Convert "yes"/"no" to a boolean variable -->
+<xsl:variable name="b-reveal-slide-number" select="$reveal-slide-number= 'yes'"/>
+
 <!-- Reveal.js Controls Back Arrows -->
 
 <xsl:variable name="reveal-control-backarrow">
@@ -3074,8 +3082,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- for publisher file attributes. Each pi:pub-attribute has a name.   -->
 <!-- The following attributes are optional.                             -->
 <!-- default: default string to use (should not contain spaces)         -->
-<!-- options: space-separated lits of options aside from the default    -->
-<!-- freeform: if 'yes' then pub attributee can be anything             -->
+<!-- options: space-separated list of options aside from the default    -->
+<!-- freeform: if 'yes' then pub attribute can be anything              -->
 <!-- stringparam: a stringparam that can override the pubfile entry     -->
 <!-- legacy-stringparam: a deprecated stringparam, last in chain        -->
 <!-- legacy-options: space separated list of retired options            -->
@@ -3176,6 +3184,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <revealjs>
         <appearance>
             <pi:pub-attribute name="theme" default="simple" freeform="yes"/>
+            <pi:pub-attribute name="number" default="no" options="yes"/>
         </appearance>
         <controls>
             <pi:pub-attribute name="backarrows" default="faded" options="hidden visible"/>


### PR DESCRIPTION
This adds an option to use the revealjs slide numbering.  Note that with the default "grid" option this creates ordered pairs, so I didn't make it the default option; I don't mind the ordered pairs personally, but I figure others might find them distracting.  With "linear" slides it would be fine for anyone, I think.