### PR TITLE
Ptx slate

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8284,7 +8284,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </slate>
 
                         <sidebyside width="35%" margins="10%">
-                            <tabular label="ggb_2__17_table1" halign="right">
+                            <slate surface="ptx" label="ggb_2__17_table1">
+                            <tabular halign="right">
                                 <col width="10%" halign="center"/>
                                 <col width="10%" halign="center"/>
                                 <col width="10%" halign="center"/>
@@ -8312,6 +8313,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <cell/>
                                 </row>
                             </tabular>
+                            </slate>
                             <slate surface="html">
                                 <p xmlns="http://www.w3.org/1999/xhtml">
                                     <button id="a_to_b">Show A to B</button>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9809,6 +9809,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </xsl:template>
 
+<xsl:template match="slate[@surface = 'ptx']">
+    <xsl:call-template name="latex-macros"/>
+    <div id="{@label}" class="slate-ptx">
+        <xsl:apply-templates/>
+    </div>
+</xsl:template>
+
 <xsl:template match="slate[@surface='svg']">
     <svg>
         <xsl:attribute name="id">


### PR DESCRIPTION
This PR creates a #slate to wrap and render PreTeXt content within #interactives.  This gives the resulting HTML an @id so that it can be addressed by javascript.

A couple of thoughts:

1.  I need an @id on an ancestor of the content -- it could be another element like #sidebyside or #interactive, but @labels aren't permitted on #sidebysides, and the #html:div for the #interactive doesn't actually wrap the #sidebyside.
2. `<xsl:apply-templates/>`  will render any content.  This probably should be restricted to a reasonable subset by the schema.   #tabular and #p for sure, but probably others.
3. `<xsl:call-template name="latex-macros"/>`  is needed so that the macros are available in the iframe.  