### PR TITLE
FITB: correct attributes on fillins relating to static representation

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8753,11 +8753,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <title>Fill-In Formula (Dynamic)</title>
                     <statement>
                         <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval obj="x1"/></m>,  <m>x=<eval obj="x2"/></m>, and <m>x=<eval obj="x3"/></m> and so that <m>f(0)=<eval obj="y0"/></m>.</p>
-                        <p><m>f(x)=</m> <fillin name="st_cubic" mode="math-formula" ansobj="x3"/></p>
+                        <p><m>f(x)=</m> <fillin name="st_cubic" mode="math" ansobj="cubic"/></p>
                     </statement>
                     <solution>
                         <p>
-                            Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form, 
+                            Knowing the roots of a polynomial allows us to write down the formula of <m>f(x)</m> in factored form,
                             <me>f(x) = A <eval obj="base_cubic"/></me>
                             with an unknown scaling multiple <m>A</m>.
                         </p>
@@ -8799,7 +8799,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <de-evaluate>
                                 <formula><eval obj="base_cubic"/></formula>
                                 <variable name="x">0</variable>
-                            </de-evaluate>                            
+                            </de-evaluate>
                         </de-object>
                         <de-object name="A" context="number">
                             <de-number>y0/base_yint</de-number>
@@ -8824,8 +8824,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         Find two nontrivial functions <m>f(x)</m> and <m>g(x)</m> so that <m>h(x) = f(g(x))</m>.
                         </p>
                         <p>
-                        <m>f(x) = </m> <fillin width="15" mode="math-formula" ansobj="outerFormula" name="fGiven"/> 
-                        and <m>g(x)=</m> <fillin width="15" mode="math-formula" ansobj="innerFormula" name="gGiven"/>
+                        <m>f(x) = </m> <fillin width="15" mode="math" ansobj="outerFormula" name="fGiven"/>
+                        and <m>g(x)=</m> <fillin width="15" mode="math" ansobj="innerFormula" name="gGiven"/>
                         </p>
                     </statement>
                     <solution>

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3479,7 +3479,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <title>Fill-In, Dynamic Math with Simple Numerical Answer</title>
             <statement>
                 <p>Solve the equation <me><eval obj="theFunction"/>=0</me> to get the value of <m>x</m>.</p>
-                <p><m>x = </m> <fillin width="5" ansobj="theAnswer"/></p>
+                <p><m>x = </m> <fillin width="5" mode="math" ansobj="theAnswer"/></p>
             </statement>
             <solution>
                 <p>We want to isolate the <m>x</m> in the equation <m><eval obj="theFunction"/>=0</m>. Because addition of <m><eval obj="b"/></m> is the last operation, we apply the inverse by adding <m><eval obj="negB"/></m> to both sides. The new, but equivalent equation is now <m><eval obj="m"/>x = <eval obj="negB"/></m>. Dividing both sides of the equation by <m><eval obj="m"/></m>, we obtain the solution <m>x=<eval obj="theAnswer"/></m>.</p>


### PR DESCRIPTION
Addresses the wrong reference in the fillin that should be a cubic (was referencing the wrong object) and fixes `@mode` for fillins that were supposed to be math so that the LaTeX was within `<m>`.