### PR TITLE
LaTeX: use \setparstyle in sbs panels

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1763,7 +1763,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- "frame empty" is needed to counteract very faint outlines in some PDF viewers -->
                 <!-- framecol=white is inadvisable, "frame hidden" is ineffective for default skin -->
                 <xsl:text>\tcbset{ sbsstyle/.style={raster before skip=2.0ex, raster equal height=rows, raster force size=false, raster after skip=0.7\baselineskip} }&#xa;</xsl:text>
-                <xsl:text>\tcbset{ sbspanelstyle/.style={bwminimalstyle, fonttitle=\blocktitlefont} }&#xa;</xsl:text>
+                <xsl:text>\tcbset{ sbspanelstyle/.style={bwminimalstyle, fonttitle=\blocktitlefont, before upper app={\setparstyle}} }&#xa;</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
         <xsl:text>%% Enviroments for side-by-side and components&#xa;</xsl:text>


### PR DESCRIPTION
`\setparstyle` makes sure that certain environments use the tex document's global values for `\parskip` and `\parindent`. It is not presently used in an sbs panel. You would never notice this until you have a `sidebyside/stack` with more than one `p`. You can see it here:

https://pretextbook.org/examples/sample-article/derivatives.pdf#page=144

But it is not the best example because those panels are so narrow. In the second column, you can see where the second and third `p` start only because you can see the previous paragraph ending shy of the right edge. I think you would want the second and third `p` to be indented. (And if using a nonzero `\parskip` you would want to see that too.)

So this change is so that sbs panels use `\setparstyle`.