### PR TITLE
Updated knowl.js for MathJax compatibility of hidden content 

### DIFF
--- a/js_lib/knowl.js
+++ b/js_lib/knowl.js
@@ -57,7 +57,7 @@ class SlideRevealer {
       this.triggerElement.setAttribute("open","");
       this.contentElement.style.display = '';
       // Trigger the animation to expand or collapse the knowl.
-      // We delay the MathJax typesetting until the knowl is visible to ensure proper measurements
+      // Delay the MathJax typesetting until the knowl is visible to ensure proper measurements
       // are taken, but before the unrolling begins. This helps avoid layout shifts and ensures
       // smooth animation with correctly sized content.
       MathJax.typesetPromise().then(() => window.requestAnimationFrame(() => this.toggle(true)));

--- a/js_lib/knowl.js
+++ b/js_lib/knowl.js
@@ -56,8 +56,11 @@ class SlideRevealer {
       this.animatedElement.setAttribute("open","");
       this.triggerElement.setAttribute("open","");
       this.contentElement.style.display = '';
-      // Wait for the next frame to call the toggle function
-      window.requestAnimationFrame(() => this.toggle(true));
+      // Trigger the animation to expand or collapse the knowl.
+      // We delay the MathJax typesetting until the knowl is visible to ensure proper measurements
+      // are taken, but before the unrolling begins. This helps avoid layout shifts and ensures
+      // smooth animation with correctly sized content.
+      MathJax.typesetPromise().then(() => window.requestAnimationFrame(() => this.toggle(true)));
     } else if (this.animationState === SlideRevealer.STATE.EXPANDING || this.animatedElement.hasAttribute("open")) {
       this.toggle(false);
     }
@@ -312,7 +315,6 @@ class LinkKnowl {
           this.outputElement.append(...children);
 
           // render any knowls and mathjax in the knowl
-          MathJax.typesetPromise([this.outputElement]);
           addKnowls(this.outputElement);
 
           // force any scripts (e.g. sagecell) to execute by evaling them


### PR DESCRIPTION
The following PR is based on [the suggestions](https://github.com/mathjax/MathJax/issues/3266#issuecomment-2273886865) provided by MathJax.

Removed line 315, which previously called MathJax.typesetPromise() before the knowl's visibility was updated. MathJax could not accurately measure the dimensions of elements while they were still hidden (display: none).

Updated line 60 to delay the call to MathJax.typesetPromise() until after the knowl becomes visible, but before the unrolling animation begins. This ensures that MathJax has the correct layout context for typesetting, preventing layout shifts and improving the smoothness of the animation.

I verified that knowls containing mathematical content is rendered correctly without layout shifts and ensured that the unrolling animation remains smooth and that no visual glitches occur during the transition.