### PR TITLE
Slideshow: ensure svg in sidebyside uses full panel width

### DIFF
--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -243,6 +243,10 @@ dfn {
     float: left;
     padding-right:2em;
 }
+
+div[style*="display:table-cell"] img[src$=".svg"] {
+    width: 100%;
+}
           </style>
 
         </head>


### PR DESCRIPTION
This updates the `pretext-revealjs.xsl` stylesheet to write an extra CSS rule into the HTML file produced for a slideshow.

For SVG images within a sidebyside (which will include any generated images from latex-image) this ensures that the SVG width is equal to the width of the sidebyside panel containing it.

Credit to @ascholerChemeketa for the CSS rule.
One question for @rbeezer : do we want this to apply to all image formats, and not just SVG? If so, it is an easy edit to remove the filter in the rule that restricts it to SVG.