### PR TITLE
LaTeX: fix space after division exercise and glossary item titles

### DIFF
--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1147,7 +1147,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- https://tex.stackexchange.com/questions/89082/hspace-vs-hspace             -->
         <xsl:text>\tcbset{ divisionexercisestyle/.style={bwminimalstyle, runintitlestyle, exercisespacingstyle, left=5ex, breakable, before upper app={\setparstyle} } }&#xa;</xsl:text>
         <xsl:text>\newtcolorbox{divisionexercise}[4]</xsl:text>
-        <xsl:text>{divisionexercisestyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2\space}{}}, phantom={</xsl:text>
+        <xsl:text>{divisionexercisestyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2}{}}, after title={\space}, phantom={</xsl:text>
         <xsl:if test="$b-pageref">
             <xsl:text>\label{#4}</xsl:text>
         </xsl:if>
@@ -1163,7 +1163,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- https://tex.stackexchange.com/questions/89082/hspace-vs-hspace             -->
         <xsl:text>\tcbset{ divisionexerciseegstyle/.style={bwminimalstyle, runintitlestyle, exercisespacingstyle, left=5ex, left skip=\egindent, breakable, before upper app={\setparstyle} } }&#xa;</xsl:text>
         <xsl:text>\newtcolorbox{divisionexerciseeg}[4]</xsl:text>
-        <xsl:text>{divisionexerciseegstyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2\space}{}}, phantom={</xsl:text>
+        <xsl:text>{divisionexerciseegstyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2}{}}, after title={\space}, phantom={</xsl:text>
         <xsl:if test="$b-pageref">
             <xsl:text>\label{#4}</xsl:text>
         </xsl:if>
@@ -1178,7 +1178,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- https://tex.stackexchange.com/questions/89082/hspace-vs-hspace             -->
         <xsl:text>\tcbset{ divisionexerciseegcolstyle/.style={bwminimalstyle, runintitlestyle, exercisespacingstyle, left=5ex, halign=flush left, unbreakable, before upper app={\setparstyle} } }&#xa;</xsl:text>
         <xsl:text>\newtcolorbox{divisionexerciseegcol}[4]</xsl:text>
-        <xsl:text>{divisionexerciseegcolstyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2\space}{}}, phantom={</xsl:text>
+        <xsl:text>{divisionexerciseegcolstyle, before title={\hspace*{-5ex}\makebox[5ex][l]{#1.}}, title={\notblank{#2}{#2}{}}, after title={\space}, phantom={</xsl:text>
         <xsl:if test="$b-pageref">
             <xsl:text>\label{#4}</xsl:text>
         </xsl:if>
@@ -2890,7 +2890,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\tcbset{ glossaryitemstyle/.style={</xsl:text>
     <xsl:apply-templates select="." mode="tcb-style" />
     <xsl:text>} }&#xa;</xsl:text>
-    <xsl:text>\newtcolorbox{glossaryitem}[2]{title={#1\space}, phantomlabel={#2}, breakable, before upper app={\setparstyle}, glossaryitemstyle}&#xa;</xsl:text>
+    <xsl:text>\newtcolorbox{glossaryitem}[2]{title={#1}, after title={\space}, phantomlabel={#2}, breakable, before upper app={\setparstyle}, glossaryitemstyle}&#xa;</xsl:text>
 </xsl:template>
 
 <!-- "paragraphs" -->


### PR DESCRIPTION
For me with LaTeX 2023, working from the master PTX branch, I get things like here:

<img width="464" alt="Screenshot 2024-09-12 at 4 50 14 PM" src="https://github.com/user-attachments/assets/aed40388-f57b-490e-ae64-2bb110c6af64">

where there is no space between the title and the bodytext. I do not see this happening at [the canonical example at pretextbook.org](https://pretextbook.org/examples/webwork/sample-chapter/sample-chapter.pdf#page=13). So I guess it is something about the LaTeX distribution.

The change I am making here addresses the issue for me, and seems semantically correct. Instead of having the space be in the title, the space is moved to the `after title` key. I reviewed structures like these and only found three instances for flavors of divisional exercise and for glossary items. Then I get like:

<img width="464" alt="Screenshot 2024-09-12 at 4 51 16 PM" src="https://github.com/user-attachments/assets/62fccbaf-94b5-4df9-a06f-503e27dddad9">
