### PR TITLE
Change p.intertext into div.para.intertext

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5354,9 +5354,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="b-nonumbers" select="$b-nonumbers" />
     </xsl:apply-templates>
     <xsl:text>}&#xa;</xsl:text>
-    <p class="intertext">
+    <div class="para intertext">
         <xsl:apply-templates />
-    </p>
+    </div>
     <xsl:text>&#xa;</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="parent::*" mode="displaymath-alignment">


### PR DESCRIPTION
It looks like the `<p>` generated for intertext paragraphs missed the shift to `div.para`.