### PR TITLE
Docinfo default programming language

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -122,6 +122,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- Expects favicon/favicon-32x32.png, and favicon/favicon-16x16.png,       -->
             <!-- possibly in external images directory, when specified in publisher file -->
             <favicon/>
+            <!-- If provided, the default programming-language will be used for -->
+            <!-- any programsor runestone interactives that lack @language      -->
+            <!-- <defaults programming-language="python"/> -->
         </html>
 
         <!--

--- a/examples/sample-book/bookinfo.xml
+++ b/examples/sample-book/bookinfo.xml
@@ -72,5 +72,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     \usetikzlibrary{arrows,matrix}
     \usetikzlibrary{snakes}
     </latex-image-preamble>
+    
+    <html>
+      <!-- Any program or Runestone interactive without a @language will -->
+      <!-- assumed to be python                                          -->
+      <defaults programming-language="python"/>
+    </html>
 
 </docinfo>

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -147,9 +147,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>The following Python program is in a <tag>listing</tag> since we will want to reference it shortly.  The program does not do very much, it just defines four variables whose values are lists of statistics.  It should run, and there will be no syntax errors, but it is a bit boring since there is no output.</p>
 
+        <p>If you examine the source, you will also notice the <tag>program</tag> lacks a <attr>language</attr> attribute. It is relying on the <c>docinfo/html/defaults/@programming-language</c> value that is in bookinfo.xml. If present, that attribute will be used for any programs or Runestone interactives that lack a <attr>language</attr>.</p>
+
         <listing xml:id="listing-python-included">
             <caption>A Python program that defines some statistics</caption>
-            <program xml:id="python-statistics" interactive='activecode' language="python" label="statistics">
+            <program xml:id="python-statistics" interactive='activecode' label="statistics">
                 <input>
                 loan_amount = [1250.0, 500.0, 1450.0, 200.0, 700.0, 100.0, 250.0, 225.0, 1200.0, 150.0, 600.0, 300.0, 700.0, 125.0, 650.0, 175.0, 1800.0, 1525.0, 575.0, 700.0, 1450.0, 400.0, 200.0, 1000.0, 350.0]
 

--- a/xsl/extract-trace.xsl
+++ b/xsl/extract-trace.xsl
@@ -51,7 +51,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>,</xsl:text>
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>,</xsl:text>
-    <xsl:apply-templates select="@language"/>
+    <xsl:apply-templates select="." mode="active-language"/>
     <xsl:text>,</xsl:text>
     <xsl:variable name="code-with-newlines">
         <xsl:call-template name="sanitize-text">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7983,10 +7983,25 @@ Book (with parts), "section" at level 3
 <!-- Define the key for indexing into the data list -->
 <xsl:key name="proglang" match="language" use="@ptx" />
 
+<!-- Determine programming language to use. First choice is @language       -->
+<!-- on current element. If that is not available, check docinfo default.   -->
+<xsl:template name="get-programming-language">
+  <xsl:choose>
+    <xsl:when test="@language">
+      <xsl:value-of select="@language" />
+    </xsl:when>
+    <xsl:when test="$docinfo/html/defaults/@programming-language">
+      <xsl:value-of select="$docinfo/html/defaults/@programming-language" />
+    </xsl:when>
+  </xsl:choose>
+</xsl:template>
+
 <!-- A whole <program> node comes in,  -->
 <!-- text of ActiveCode name comes out -->
 <xsl:template match="*" mode="active-language">
-    <xsl:variable name="language"><xsl:value-of select="@language" /></xsl:variable>
+    <xsl:variable name="language">
+      <xsl:call-template name="get-programming-language"/>
+    </xsl:variable>
     <xsl:for-each select="document('')/*/mb:programming">
         <xsl:value-of select="key('proglang', $language)/@active" />
     </xsl:for-each>
@@ -7995,7 +8010,9 @@ Book (with parts), "section" at level 3
 <!-- A whole <program> node comes in,  -->
 <!-- text of listings name comes out -->
 <xsl:template match="*" mode="listings-language">
-    <xsl:variable name="language"><xsl:value-of select="@language" /></xsl:variable>
+  <xsl:variable name="language">
+    <xsl:call-template name="get-programming-language"/>
+  </xsl:variable>
     <xsl:for-each select="document('')/*/mb:programming">
         <xsl:value-of select="key('proglang', $language)/@listings" />
     </xsl:for-each>
@@ -8004,7 +8021,9 @@ Book (with parts), "section" at level 3
 <!-- A whole <program> node comes in,  -->
 <!-- text of prism name comes out -->
 <xsl:template match="*" mode="prism-language">
-    <xsl:variable name="language"><xsl:value-of select="@language" /></xsl:variable>
+  <xsl:variable name="language">
+    <xsl:call-template name="get-programming-language"/>
+  </xsl:variable>
     <xsl:for-each select="document('')/*/mb:programming">
         <xsl:value-of select="key('proglang', $language)/@prism" />
     </xsl:for-each>

--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -163,7 +163,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="*[@exercise-interactive = 'parson']" mode="runestone-to-static">
     <!-- determine these options before context switches -->
     <!-- default for @language is "natural" -->
-    <xsl:variable name="b-natural" select="not(@language) or (@language = 'natural')"/>
+    <xsl:variable name="language">
+      <xsl:apply-templates select="." mode="active-language"/>
+    </xsl:variable>
+    <xsl:variable name="b-natural" select="($language = '') or ($language = 'natural')"/>
     <!-- default for @indentation is "show", regards presentation -->
     <xsl:variable name="b-indent" select="@indentation = 'hide'"/>
     <!-- we use numbers in static versions, if requested, but ignore left/right distinction -->
@@ -384,7 +387,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- structure, reconstruct as a program/input      -->
                 <program>
                     <xsl:attribute name="language">
-                        <xsl:value-of select="@language"/>
+                      <xsl:apply-templates select="." mode="active-language"/>
                     </xsl:attribute>
                     <input>
                         <xsl:for-each select="blocks/block">

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1096,12 +1096,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Parsons Problem -->
 
 <xsl:template match="*[@exercise-interactive = 'parson']" mode="runestone-to-interactive">
-    <!-- determine this option before context switches -->
-    <xsl:variable name="b-natural" select="not(@language) or (@language = 'natural')"/>
     <!-- active-language only used if runnable but needed multiple places -->
     <xsl:variable name="active-language">
         <xsl:apply-templates select="." mode="active-language"/>
     </xsl:variable>
+    <!-- determine this option before context switches -->
+    <xsl:variable name="b-natural" select="($active-language = '') or ($active-language = 'natural')"/>
     <div class="ptx-runestone-container">
         <div class="runestone parsons_section" style="max-width: none;">
             <div data-component="parsons" class="parsons">
@@ -1135,8 +1135,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:text>natural</xsl:text>
                             </xsl:when>
                             <xsl:otherwise>
-                                <!-- must now have @language -->
-                                <xsl:value-of select="@language"/>
+                                <!-- must now have a language -->
+                                <xsl:value-of select="$active-language"/>
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:attribute>
@@ -1316,7 +1316,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template  match="exercise[@exercise-interactive = 'parson-horizontal']" mode="runestone-to-interactive">
     <!-- determine these options before context switches -->
-    <xsl:variable name="b-natural" select="not(@language) or (@language = 'natural')"/>
+    <xsl:variable name="active-language">
+      <xsl:apply-templates select="." mode="active-language"/>
+    </xsl:variable>
+    <xsl:variable name="b-natural" select="($active-language = '') or ($active-language = 'natural')"/>
     <!-- randomize by default, so must explicitly turn off -->
     <xsl:variable name="b-randomize" select="not(blocks/@randomize = 'no')"/>
     <!-- A @ref is automatic indicator, else reuse has been requested on blocks -->
@@ -1359,7 +1362,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- for natural language, just skip attribute -->
                     <xsl:if test="not($b-natural)">
                         <xsl:attribute name="data-language">
-                            <xsl:value-of select="@language"/>
+                            <xsl:value-of select="$active-language"/>
                         </xsl:attribute>
                     </xsl:if>
                     <!-- default is to randomize, so only set -->
@@ -2136,12 +2139,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ######## -->
 
 <xsl:template match="program[@interactive = 'codelens']" mode="runestone-codelens">
+    <xsl:variable name="active-language">
+      <xsl:apply-templates select="." mode="active-language"/>
+    </xsl:variable>
     <!-- as a variable so it does not look like an AVT -->
     <xsl:variable name="parameter-dictionary">
         <xsl:text>{</xsl:text>
         <xsl:text>"embeddedMode": true, </xsl:text>
         <xsl:text>"lang": "</xsl:text>
-        <xsl:value-of select="@language"/>
+        <xsl:value-of select="$active-language"/>
         <xsl:text>", </xsl:text>
         <xsl:text>"jumpToEnd": false</xsl:text>
         <xsl:text>}</xsl:text>


### PR DESCRIPTION
This should allow authors to specify a default value for `@language` on things like programs and Runestone interactives.

Added the setting to docinfo on the sample-book and sample-article, but commented out in sample-article (where there are more pseudocode samples we don't want to assume are python).