### PR TITLE
PreFigure additions to sample article and prefigure-conversion

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2980,15 +2980,64 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <p>There is nothing useful here just yet, testing preparations for integration of PreFigure images.</p>
 
                 <image>
-                    <prefigure label="one">
-                        <foo/>
-                    </prefigure>
+                  <prefigure label="one">
+		    <diagram dimensions="(300,300)" margins="5">
+		      <definition>f(t,y) = (y[1], -pi*y[0])</definition>
+		      <coordinates bbox="[-1,-3,6,3]">
+			<grid-axes xlabel="t"/>
+			<de-solve function="f" t0="0" t1="bbox[2]"
+				  y0="(0,2)" name="oscillator"
+				  N="200"/>
+			<plot-de-solution at="x" solution="oscillator"
+					  axes="(t,y0)" />
+			<plot-de-solution at="xprime" solution="oscillator"
+					  axes="(t,y1)" stroke="red"
+					  tactile-dash="9 9"/>
+			<legend at="legend" anchor="(bbox[2], bbox[3])"
+				alignment="sw" scale="0.9" opacity="0.5">
+			  <item ref="x"><m>x(t)</m></item>
+			  <item ref="xprime"><m>x'(t)</m></item>
+			</legend>
+		      </coordinates>
+		    </diagram>
+                  </prefigure>
                 </image>
 
                 <image>
-                    <prefigure label="two">
-                        <bar/>
-                    </prefigure>
+                  <prefigure label="two">
+		    <diagram dimensions="(300,180)" margins="5">
+		      <coordinates bbox="(0,0,10,6)">
+			<define-shapes>
+			  <circle at="A" center="(4,3)" radius="2"/>
+			  <circle at="B" center="(6,3)" radius="2"/>
+			</define-shapes>
+
+			<shape shapes="A,B" operation="difference"
+			       fill="magenta" stroke="black"/>
+			<shape shape="A" stroke="black"/>
+			<shape shape="B" stroke="black"/>
+			<rectangle lower-left="(0,0)"
+				   dimensions="(10,6)"
+				   stroke="black"/>
+
+			<label anchor="(2,3)" alignment="nw"><m>A</m></label>
+			<label anchor="(8,3)" alignment="ne"><m>B</m></label>
+			<label anchor="(5,0.5)"><m>A\setminus B</m></label>
+		      </coordinates>
+		      <annotations>
+			<annotation ref="figure"
+				    text="Two sets A and B and the difference A minus B">
+			  <annotation ref="set_A"
+				      text="The set A"/>
+			  <annotation ref="set_B"
+				      text="The set B"/>
+			  <annotation ref="diff"
+				      text="The difference A minus B"/>
+			</annotation>
+		      </annotations>
+
+		    </diagram>
+                  </prefigure>
                 </image>
             </subsection>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2982,7 +2982,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <image>
                   <prefigure label="one">
 		    <diagram dimensions="(300,300)" margins="5">
-		      <definition>f(t,y) = (y[1], -pi*y[0])</definition>
+		      <definition>f(t,y) = (y[1], -pi*y[0]-0.3*y[1])</definition>
 		      <coordinates bbox="[-1,-3,6,3]">
 			<grid-axes xlabel="t"/>
 			<de-solve function="f" t0="0" t1="bbox[2]"
@@ -3007,8 +3007,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                   <prefigure label="two">
 		    <diagram dimensions="(300,300)" margins="5">
 		      <definition>a=1</definition>
-		      <definition>g(x) = exp(x/3)*cos(x)</definition>
-		      <definition>f(x) = g(x) - g(a) + 1</definition>
+		      <definition>f(x) = exp(x/3)*cos(x)</definition>
 		      <coordinates bbox="[-4,-4,4,4]">
 			<grid-axes xlabel="x" ylabel="y"/>
 			<graph at="graph" function='f' />

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3005,34 +3005,31 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <image>
                   <prefigure label="two">
-		    <diagram dimensions="(300,180)" margins="5">
-		      <coordinates bbox="(0,0,10,6)">
-			<define-shapes>
-			  <circle at="A" center="(4,3)" radius="2"/>
-			  <circle at="B" center="(6,3)" radius="2"/>
-			</define-shapes>
-
-			<shape shapes="A,B" operation="difference"
-			       fill="magenta" stroke="black"/>
-			<shape shape="A" stroke="black"/>
-			<shape shape="B" stroke="black"/>
-			<rectangle lower-left="(0,0)"
-				   dimensions="(10,6)"
-				   stroke="black"/>
-
-			<label anchor="(2,3)" alignment="nw"><m>A</m></label>
-			<label anchor="(8,3)" alignment="ne"><m>B</m></label>
-			<label anchor="(5,0.5)"><m>A\setminus B</m></label>
+		    <diagram dimensions="(300,300)" margins="5">
+		      <definition>a=1</definition>
+		      <definition>g(x) = exp(x/3)*cos(x)</definition>
+		      <definition>f(x) = g(x) - g(a) + 1</definition>
+		      <coordinates bbox="[-4,-4,4,4]">
+			<grid-axes xlabel="x" ylabel="y"/>
+			<graph at="graph" function='f' />
+			<tangent-line at="tangent" function="f" point="a"/>
+			<point at="point" p="(a, f(a))">
+			  <m>(a,f(a))</m>
+			</point>
 		      </coordinates>
+
 		      <annotations>
 			<annotation ref="figure"
-				    text="Two sets A and B and the difference A minus B">
-			  <annotation ref="set_A"
-				      text="The set A"/>
-			  <annotation ref="set_B"
-				      text="The set B"/>
-			  <annotation ref="diff"
-				      text="The difference A minus B"/>
+				    text="The graph of a function and its tangent line at the point a equals 1">
+			  <annotation ref="graph-tangent"
+				      text="The graph and its tangent line">
+			    <annotation ref="graph"
+					text="The graph of the function f" sonify="yes"/>
+			    <annotation ref="point"
+					text="The point a comma f of a"/>
+			    <annotation ref="tangent"
+					text="The tangent line to the graph of f at the point"/>
+			  </annotation>
 			</annotation>
 		      </annotations>
 

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -608,7 +608,7 @@ def main():
         ptx.validate(xml_source, out_file, dest_dir)
     elif args.component == "prefigure":
         # if args.format in ["pdf", "svg", "png", "html", "all"]:
-        if args.format in ["source"]:
+        if args.format in ["source", "svg", "pdf", "braille"]:
             ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format)
         else:
             raise NotImplementedError('cannot make Prefigure graphics in "{}" format'.format(args.format) )

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -270,12 +270,23 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
     log.info("string parameters passed to extraction stylesheet: {}".format(stringparams))
     xsltproc(extraction_xslt, xml_source, None, tmp_dir, stringparams)
 
+    prefigure_executable_cmd = get_executable_cmd("prefigure")
     # Resulting *.asy files are in tmp_dir, switch there to work
     with working_directory(tmp_dir):
         if outformat == "source":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("copying source file {}".format(pfdiagram))
-                shutil.copy2(pfdiagram, dest_dir)
+                subprocess.run(
+                    prefigure_executable_cmd + [
+                        'build',
+                        pfdiagram
+                    ]
+                )
+            shutil.copytree(
+                'output',
+                dest_dir,
+                dirs_exist_ok=True
+            )
 
 
 def asymptote_conversion(

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -249,6 +249,11 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
     # stringparams is a dictionary, best for lxml parsing
     import glob
 
+    try:
+        import prefig
+    except ImportError:
+        raise ImportError(__module_warning.format("prefig"))
+
     # to ensure provided stringparams aren't mutated unintentionally
     stringparams = stringparams.copy()
 
@@ -266,28 +271,42 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
         stringparams["subtree"] = xmlid_root
     # no output (argument 3), stylesheet writes out per-image file
     # outputs a list of ids, but we just loop over created files
-    log.info("extracting Asymptote diagrams from {}".format(xml_source))
+    log.info("extracting PreFigure diagrams from {}".format(xml_source))
     log.info("string parameters passed to extraction stylesheet: {}".format(stringparams))
     xsltproc(extraction_xslt, xml_source, None, tmp_dir, stringparams)
 
-    prefigure_executable_cmd = get_executable_cmd("prefigure")
     # Resulting *.asy files are in tmp_dir, switch there to work
     with working_directory(tmp_dir):
         if outformat == "source":
-            for pfdiagram in os.listdir(tmp_dir):
-                log.info("copying source file {}".format(pfdiagram))
-                subprocess.run(
-                    prefigure_executable_cmd + [
-                        'build',
-                        pfdiagram
-                    ]
-                )
+            log.info("copying PreFigure source files into {}".format(dest_dir))
             shutil.copytree(
-                'output',
+                tmp_dir,
                 dest_dir,
                 dirs_exist_ok=True
             )
+            return
 
+        if outformat == "svg":
+            for pfdiagram in os.listdir(tmp_dir):
+                log.info("compiling PreFigure source file {} to SVG".format(pfdiagram))
+                prefig.engine.build('svg', pfdiagram)
+
+        elif outformat == "pdf":
+            for pfdiagram in os.listdir(tmp_dir):
+                log.info("compiling PreFigure source file {} to PDF".format(pfdiagram))
+                prefig.engine.pdf('svg', pfdiagram, dpi=100)
+
+        elif outformat == "braille":
+            for pfdiagram in os.listdir(tmp_dir):
+                log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
+                prefig.engine.pdf('tactile', pfdiagram)
+
+        log.info("copying PreFigure output to {}".format(dest_dir))
+        shutil.copytree(
+            'output',
+            dest_dir,
+            dirs_exist_ok=True
+        )
 
 def asymptote_conversion(
     xml_source, pub_file, stringparams, xmlid_root, dest_dir, outformat, method


### PR DESCRIPTION
This PR adds two prefigures to the sample-article, one with annotations.  It also adds the prefigure executable into the function prefigure-conversion and copies the output into the destination directory.  This assumes the user has added the line "prefigure = prefig" to pretext/user/pretext.cfg so perhaps this could be incorporated into pretext/pretext/pretext.cfg.