### PR TITLE
Enable latex style xsl via publication file

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -208,6 +208,17 @@
             See <xref ref="pdf-print"/> for a more general overview of this conversion with more details.  This includes some existing options that will eventually migrate to the publication file.</p>
         </introduction>
 
+        <subsection xml:id="latex-style-options">
+            <title><latex/> Style Option</title>
+            <idx><h>style option</h><h>LaTeX, PDF</h></idx>
+            <idx><h>LaTeX</h><h>style option</h></idx>
+            <idx><h>PDF</h><h>style option</h></idx>
+
+            <p>A limited number of custom <latex /> styles are available and more are in development (see <xref ref="latex-styles"/>). The<cd>
+                    <cline>/publication/latex/@latex-style</cline>
+                </cd>attribute can be set to one of the provided styles to build the <latex /> or <init>PDF</init> output with that style.  As of 2024-10-04, the supported styles (and values of this attribute) are <c>AIM</c>, <c>chaos</c>, <c>CLP</c>, <c>dyslexic-font</c>, and <c>guide</c>.  (Note that some of these are meant as demos and not intended for production.)</p>
+        </subsection>
+
         <subsection xml:id="latex-print-options">
             <title><latex/> Print Option</title>
             <idx><h>print option</h><h>LaTeX, PDF</h></idx>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3750,9 +3750,17 @@ def latex(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir):
     # support publisher file, not subtree argument
     if pub_file:
         stringparams["publisher"] = pub_file
+        # Get extra XSL from publication file, if specified
+        latex_style = get_publisher_variable(xml_source=xml, pub_file=pub_file, params=stringparams, variable="latex-style")
+
     # Optional extra XSL could be None, or sanitized full filename
     if extra_xsl:
         extraction_xslt = extra_xsl
+        if latex_style:
+            log.warning("Ignoring the publisher file's latex-style in favor of the extra XSL specified.")
+    elif latex_style:
+        log.debug("Using LaTeX style: {}".format(latex_style))
+        extraction_xslt = os.path.join(get_ptx_xsl_path(), "latex", f"pretext-latex-{latex_style}.xsl")
     else:
         extraction_xslt = os.path.join(get_ptx_xsl_path(), "pretext-latex.xsl")
     # form output filename based on source filename,

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2694,6 +2694,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/latex/pi:pub-attribute[@name='open-odd']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!-- Used to determine which xsl file to processess with.  Current options are based on what is present in xsl/latex.   -->
+<!-- To build with `pretext-latex-styleName.xsl` variable should have valuse `stylename`. Default of empty string means -->
+<!-- build with the default `pretext-latex.xsl` -->
+<xsl:variable name="latex-style">
+    <xsl:apply-templates select="$publisher-attribute-options/latex/pi:pub-attribute[@name='latex-style']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
 <!-- LaTeX/Page -->
 
 <!-- Right Alignment -->
@@ -3158,6 +3165,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <pi:pub-attribute name="pageref" options="yes no" legacy-stringparam="latex.pageref"/>
         <pi:pub-attribute name="draft" default="no" options="yes" legacy-stringparam="latex.draft"/>
         <pi:pub-attribute name="open-odd" default="no" options="add-blanks skip-pages"/>
+        <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide"/>
         <page>
             <pi:pub-attribute name="bottom-alignment" default="ragged" options="flush"/>
         </page>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -83,6 +83,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$qrcode-image"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2024-10-04 LaTeX style xsl -->
+    <xsl:text>latex-style</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$latex-style"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- -->
 
     <!--


### PR DESCRIPTION
Added publisher variable as `publication/latex/latex-style`.  Added variable to `publisher-variables.xsl` and enabled reporting  in `report-publisher-variables.xsl`. 

LaTeX conversion in `pretext/pretext` looks for that variable, but only uses it if extra xsl was not specified (a warning is logged if both extra xsl and the publisher variable are used).  

Added to the documentation (I put it at the top, since this seems like the most "overall" latex option, but am happy to organize differently).