### PR TITLE
Guide: fix typo about project manifest latex option

### DIFF
--- a/doc/guide/appendices/cli-v1vsv2.xml
+++ b/doc/guide/appendices/cli-v1vsv2.xml
@@ -90,7 +90,7 @@
           <target
             name="print"
             format="pdf"
-            pdf-method="xelatex"
+            latex-engine="xelatex"
             source="source/main.ptx"
             publication="publication/publication.ptx"
             output-dir="output/print"


### PR DESCRIPTION
A real quick fix for the guide, where I had `@pdf-method` instead of the correct `@latex-engine`.