### PR TITLE
Create schema for publication files

### DIFF
--- a/schema/build.sh
+++ b/schema/build.sh
@@ -75,6 +75,11 @@ trang -I rnc -O rng pretext-dev.rnc pretext-dev.rng
 # "abstract groups" make schema browser too obtuse
 trang -o disable-abstract-elements -I rnc -O xsd pretext.rnc pretext.xsd
 
+# And the same steps for the publication-schema
+xsltproc ${MBXSL}/pretext-litprog.xsl publication-schema.xml
+trang -I rnc -O rng publication-schema.rnc publication-schema.rng
+trang -o disable-abstract-elements -I rnc -O xsd publication-schema.rnc publication-schema.xsd
+
 # ************************
 # Documentation Generation
 # ************************

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -1,0 +1,314 @@
+
+            grammar {
+            
+            start = Publication
+            
+            Publication =
+                element publication {
+                    Common? &
+                    Source? &
+                    Numbering? &
+                    Latex? &
+                    Html? &
+                    Revealjs? &
+                    Epub? &
+                    Webwork?
+                }
+            
+            Common =
+                element common {
+                    element chunking {
+                        attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                    }? &
+                    element tableofcontents {
+                        attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                    }? &
+                    element exercise-inline {
+                        ExerciseAttributes
+                    }? &
+                    element exercise-dividional {
+                        ExerciseAttributes
+                    }? &
+                    element exercise-worksheet {
+                        ExerciseAttributes
+                    }? &
+                    element exercise-reading {
+                        ExerciseAttributes
+                    }? &
+                    element exercise-project {
+                        ExerciseAttributes
+                    }? &
+                    element fillin {
+                        attribute textstyle { "underline" | "box" | "shade" }?,
+                        attribute mathstyle { "underline" | "box" | "shade" }?
+                    }? &
+                    element watermark {
+                        attribute scale { xsd:decimal },
+                        text
+                    }? &
+                    element mermaid {
+                        attribute theme { text }
+                    }? &
+                    element qrcode {
+                        attribute image { text }
+                    }
+                }
+
+            ExerciseAttributes =
+                attribute statement { "yes" | "no" }?,
+                attribute hint { "yes" | "no" }?,
+                attribute answer { "yes" | "no" }?,
+                attribute solution { "yes" | "no" }?
+            
+            Source =
+                element source {
+                    attribute customizations { text }?,
+                    attribute private-solutions { text }?,
+                    attribute webwork-solutions { text }?,
+                    (Directories? & Version?)
+                }
+
+            Directories =
+                element directories {
+                    attribute external { text },
+                    attribute generated { text }
+                }
+
+            Version =
+                element version {
+                    attribute include { text }
+                }
+            
+            Numbering =
+                element numbering {
+                    Divisions? &
+                    Blocks? &
+                    Projects? &
+                    Equations? &
+                    Footnotes?
+                }
+
+            Divisions =
+                element divisions {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?,
+                    attribute chapter-start { xsd:integer }?,
+                    attribute parts-structure { "decorative" | "structural" }?
+                }
+
+            Blocks =
+                element blocks {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Projects =
+                element projects {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Equations =
+                element equations {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Footnotes =
+                element footnotes {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?
+                }
+            
+            Latex =
+                element latex {
+                    attribute latex-style {text}?,
+                    attribute print { "yes" | "no" }?,
+                    attribute sides { "one" | "two" }?,
+                    attribute open-odd { "add-blanks" | "skip-pages" | "no" }?,
+                    attribute font-size { "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    attribute page-ref { "yes" | "no" }?,
+                    attribute draft { "yes" | "no" }?,
+                    attribute snapshow { "yes" | "no" }?,
+                    ( Page? & Worksheet? & Cover? & Asymptote?)
+                }
+
+            Page =
+                element page {
+                    attribute right-alignment { "flush" | "ragged" }?,
+                    attribute bottom-alignment { "flush" | "ragged" }?,
+                    attribute crop-marks { "none" | "a0" | "a1" | "a2" | "a3" | "a4" | "a5" | "a6" | "b0" | "b1" | "b2" | "b3" | "b4" | "b5" | "b6" | "letter" | "legal" | "executive" }?,
+                    element geometry { text }?
+                }
+
+            Worksheet =
+                element worksheet {
+                    attribute formatted { "yes" | "no" }?
+                }
+
+            Cover =
+                element cover {
+                    attribute front { text }?,
+                    attribute back { text }?
+                }
+
+            Asymptote =
+                element asymptote {
+                    attribute links { "yes" | "no" }?
+                }
+            
+            Html =
+                element html {
+                    attribute platform { "web" | "runestone" }?,
+                    attribute short-answer-responses { "graded" | "always" }?,
+                    (Analytics? & Baseurl? & Calculator? & WebworkDynamism? & Indexpage? & Knowls? & Exercises? & Css? & Search? & Video? & Asymptote? & Feedback? & NavigationHTML? & Tableofcontents? & Crossreferences?)
+                }
+
+            Analytics =
+                element analytics {
+                    attribute google-gst { text }?,
+                    attribute statcounter-project { text }?,
+                    attribute statcounter-security { text }?
+                }
+
+            Baseurl =
+                element baseurl {
+                    attribute href { text }
+                }
+
+            Calculator =
+                element calculator {
+                    attribute model { "geogebra-classic" | "geogebra-graphing" | "geogebra-geometry" | "geogebra-3d" | "none "}?,
+                    attribute activecode { "python" | "javascript" | "html" | "sql" | "c" | "cpp" | "java" | "python3" | "octave" | "none"}?
+                }
+
+            Crossreferences =
+                element cross-references {
+                    attribute knowled { "maximum" | "never" | "cross-page" }
+                }
+
+            Css =
+                element css {
+                    attribute colors { text }?,
+                    attribute style { text }?,
+                    attribute knowls { text }?,
+                    attribute toc { text }?,
+                    attribute banner { text }?,
+                    attribute navbar { text }?,
+                    attribute shell { text }?
+                }
+
+            Exercises =
+                element exercises {
+                    attribute tabbed-tasks { "divisional" | "inline" | "reading" | "project" }
+                }
+
+            Feedback =
+                element feedback {
+                    attribute href { text }
+                }
+
+            Indexpage =
+                element index-page {
+                    attribute ref { text }
+                }
+
+            Knowls =
+                element knowl {
+                    attribute theorem { "yes" | "no" }?,
+                    attribute proof { "yes" | "no" }?,
+                    attribute definition { "yes" | "no" }?,
+                    attribute example { "yes" | "no" }?,
+                    attribute example-solution { "yes" | "no" }?,
+                    attribute project { "yes" | "no" }?,
+                    attribute task { "yes" | "no" }?,
+                    attribute remark { "yes" | "no" }?,
+                    attribute objectives { "yes" | "no" }?,
+                    attribute outcomes { "yes" | "no" }?,
+                    attribute figure { "yes" | "no" }?,
+                    attribute table { "yes" | "no" }?,
+                    attribute listing { "yes" | "no" }?,
+                    attribute list { "yes" | "no" }?,
+                    attribute exercise-inline { "yes" | "no" }?,
+                    attribute exercise-divisional { "yes" | "no" }?,
+                    attribute exercise-worksheet { "yes" | "no" }?,
+                    attribute exercise-readingquestion { "yes" | "no" }?
+                }
+
+            NavigationHTML =
+                element navigation {
+                    attribute logic { "linear" | "tree" }?,
+                    attribute upbutton { "yes" | "no" }?
+                }
+            Search =
+                element search {
+                    attribute variant { "textbook" | "reference" | "none" }?,
+                    attribute google-cx { text }?
+                }
+
+            Tableofcontents =
+                element table-of-contents {
+                    attribute focused { "yes" | "no" }?,
+                    attribute preexpanded-levels { "0" | "1" | "2" | "3" | "4" | "5" | "6"}?
+                }
+
+            Video =
+                element video {
+                    attribute privacy { "yes" | "no" }
+                }
+
+            WebworkDynamism =
+                element webwork {
+                    attribute inline { "dynamic" | "static" }?,
+                    attribute divisional { "dynamic" | "static" }?,
+                    attribute reading { "dynamic" | "static" }?,
+                    attribute worksheet { "dynamic" | "static" }?,
+                    attribute project { "dynamic" | "static" }?
+                }
+
+            
+            Revealjs =
+                element revealjs {
+                    Appearance? &
+                    Controls? &
+                    NavigationReveal? &
+                    Resources?
+                }
+
+            Appearance =
+                element appearance {
+                    attribute theme { text }
+                }
+
+            Controls =
+                element controls {
+                    attribute backarrow { "faded" | "hidden" | "visible" }?,
+                    attribute display { "yes" | "no" }?,
+                    attribute layout { "edges" | "bottom-right" }?,
+                    attribute tutorial { "yes" | "no" }?
+                }
+
+            NavigationReveal =
+                element navigation {
+                    attribute mode { "default" | "linear" | "grid" }
+                }
+
+            Resources =
+                element resources {
+                    attribute host { "local" | "cdn" }
+                }
+            
+            Epub =
+                element epub {
+                    element cover {
+                        attribute front { text }
+                    }
+                }
+            
+            Webwork =
+                element webwork {
+                    attribute server { text },
+                    attribute course { text }?,
+                    attribute coursepassord { text }?,
+                    attribute user { text }?,
+                    attribute userpassword { text }?,
+                    attribute task-reveal { "preceding-correct" | "all" }?
+                }
+            
+            }
+            

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -1,0 +1,1030 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="Publication"/>
+  </start>
+  <define name="Publication">
+    <element name="publication">
+      <interleave>
+        <optional>
+          <ref name="Common"/>
+        </optional>
+        <optional>
+          <ref name="Source"/>
+        </optional>
+        <optional>
+          <ref name="Numbering"/>
+        </optional>
+        <optional>
+          <ref name="Latex"/>
+        </optional>
+        <optional>
+          <ref name="Html"/>
+        </optional>
+        <optional>
+          <ref name="Revealjs"/>
+        </optional>
+        <optional>
+          <ref name="Epub"/>
+        </optional>
+        <optional>
+          <ref name="Webwork"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Common">
+    <element name="common">
+      <interleave>
+        <optional>
+          <element name="chunking">
+            <attribute name="level">
+              <choice>
+                <value>0</value>
+                <value>1</value>
+                <value>2</value>
+                <value>3</value>
+                <value>4</value>
+                <value>5</value>
+                <value>6</value>
+              </choice>
+            </attribute>
+          </element>
+        </optional>
+        <optional>
+          <element name="tableofcontents">
+            <attribute name="level">
+              <choice>
+                <value>0</value>
+                <value>1</value>
+                <value>2</value>
+                <value>3</value>
+                <value>4</value>
+                <value>5</value>
+                <value>6</value>
+              </choice>
+            </attribute>
+          </element>
+        </optional>
+        <optional>
+          <element name="exercise-inline">
+            <ref name="ExerciseAttributes"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="exercise-dividional">
+            <ref name="ExerciseAttributes"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="exercise-worksheet">
+            <ref name="ExerciseAttributes"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="exercise-reading">
+            <ref name="ExerciseAttributes"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="exercise-project">
+            <ref name="ExerciseAttributes"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="fillin">
+            <optional>
+              <attribute name="textstyle">
+                <choice>
+                  <value>underline</value>
+                  <value>box</value>
+                  <value>shade</value>
+                </choice>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="mathstyle">
+                <choice>
+                  <value>underline</value>
+                  <value>box</value>
+                  <value>shade</value>
+                </choice>
+              </attribute>
+            </optional>
+          </element>
+        </optional>
+        <optional>
+          <element name="watermark">
+            <attribute name="scale">
+              <data type="decimal"/>
+            </attribute>
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="mermaid">
+            <attribute name="theme"/>
+          </element>
+        </optional>
+        <element name="qrcode">
+          <attribute name="image"/>
+        </element>
+      </interleave>
+    </element>
+  </define>
+  <define name="ExerciseAttributes">
+    <optional>
+      <attribute name="statement">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="hint">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="answer">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="solution">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="Source">
+    <element name="source">
+      <optional>
+        <attribute name="customizations"/>
+      </optional>
+      <optional>
+        <attribute name="private-solutions"/>
+      </optional>
+      <optional>
+        <attribute name="webwork-solutions"/>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="Directories"/>
+        </optional>
+        <optional>
+          <ref name="Version"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Directories">
+    <element name="directories">
+      <attribute name="external"/>
+      <attribute name="generated"/>
+    </element>
+  </define>
+  <define name="Version">
+    <element name="version">
+      <attribute name="include"/>
+    </element>
+  </define>
+  <define name="Numbering">
+    <element name="numbering">
+      <interleave>
+        <optional>
+          <ref name="Divisions"/>
+        </optional>
+        <optional>
+          <ref name="Blocks"/>
+        </optional>
+        <optional>
+          <ref name="Projects"/>
+        </optional>
+        <optional>
+          <ref name="Equations"/>
+        </optional>
+        <optional>
+          <ref name="Footnotes"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Divisions">
+    <element name="divisions">
+      <optional>
+        <attribute name="level">
+          <choice>
+            <value>0</value>
+            <value>1</value>
+            <value>2</value>
+            <value>3</value>
+            <value>4</value>
+            <value>5</value>
+            <value>6</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="chapter-start">
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="parts-structure">
+          <choice>
+            <value>decorative</value>
+            <value>structural</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Blocks">
+    <element name="blocks">
+      <attribute name="level">
+        <choice>
+          <value>0</value>
+          <value>1</value>
+          <value>2</value>
+          <value>3</value>
+          <value>4</value>
+          <value>5</value>
+          <value>6</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Projects">
+    <element name="projects">
+      <attribute name="level">
+        <choice>
+          <value>0</value>
+          <value>1</value>
+          <value>2</value>
+          <value>3</value>
+          <value>4</value>
+          <value>5</value>
+          <value>6</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Equations">
+    <element name="equations">
+      <attribute name="level">
+        <choice>
+          <value>0</value>
+          <value>1</value>
+          <value>2</value>
+          <value>3</value>
+          <value>4</value>
+          <value>5</value>
+          <value>6</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Footnotes">
+    <element name="footnotes">
+      <optional>
+        <attribute name="level">
+          <choice>
+            <value>0</value>
+            <value>1</value>
+            <value>2</value>
+            <value>3</value>
+            <value>4</value>
+            <value>5</value>
+            <value>6</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Latex">
+    <element name="latex">
+      <optional>
+        <attribute name="latex-style"/>
+      </optional>
+      <optional>
+        <attribute name="print">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="sides">
+          <choice>
+            <value>one</value>
+            <value>two</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="open-odd">
+          <choice>
+            <value>add-blanks</value>
+            <value>skip-pages</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="font-size">
+          <choice>
+            <value>9</value>
+            <value>10</value>
+            <value>11</value>
+            <value>12</value>
+            <value>14</value>
+            <value>17</value>
+            <value>20</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="page-ref">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="draft">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="snapshow">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="Page"/>
+        </optional>
+        <optional>
+          <ref name="Worksheet"/>
+        </optional>
+        <optional>
+          <ref name="Cover"/>
+        </optional>
+        <optional>
+          <ref name="Asymptote"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Page">
+    <element name="page">
+      <optional>
+        <attribute name="right-alignment">
+          <choice>
+            <value>flush</value>
+            <value>ragged</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="bottom-alignment">
+          <choice>
+            <value>flush</value>
+            <value>ragged</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="crop-marks">
+          <choice>
+            <value>none</value>
+            <value>a0</value>
+            <value>a1</value>
+            <value>a2</value>
+            <value>a3</value>
+            <value>a4</value>
+            <value>a5</value>
+            <value>a6</value>
+            <value>b0</value>
+            <value>b1</value>
+            <value>b2</value>
+            <value>b3</value>
+            <value>b4</value>
+            <value>b5</value>
+            <value>b6</value>
+            <value>letter</value>
+            <value>legal</value>
+            <value>executive</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <element name="geometry">
+          <text/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="Worksheet">
+    <element name="worksheet">
+      <optional>
+        <attribute name="formatted">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Cover">
+    <element name="cover">
+      <optional>
+        <attribute name="front"/>
+      </optional>
+      <optional>
+        <attribute name="back"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Asymptote">
+    <element name="asymptote">
+      <optional>
+        <attribute name="links">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Html">
+    <element name="html">
+      <optional>
+        <attribute name="platform">
+          <choice>
+            <value>web</value>
+            <value>runestone</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="short-answer-responses">
+          <choice>
+            <value>graded</value>
+            <value>always</value>
+          </choice>
+        </attribute>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="Analytics"/>
+        </optional>
+        <optional>
+          <ref name="Baseurl"/>
+        </optional>
+        <optional>
+          <ref name="Calculator"/>
+        </optional>
+        <optional>
+          <ref name="WebworkDynamism"/>
+        </optional>
+        <optional>
+          <ref name="Indexpage"/>
+        </optional>
+        <optional>
+          <ref name="Knowls"/>
+        </optional>
+        <optional>
+          <ref name="Exercises"/>
+        </optional>
+        <optional>
+          <ref name="Css"/>
+        </optional>
+        <optional>
+          <ref name="Search"/>
+        </optional>
+        <optional>
+          <ref name="Video"/>
+        </optional>
+        <optional>
+          <ref name="Asymptote"/>
+        </optional>
+        <optional>
+          <ref name="Feedback"/>
+        </optional>
+        <optional>
+          <ref name="NavigationHTML"/>
+        </optional>
+        <optional>
+          <ref name="Tableofcontents"/>
+        </optional>
+        <optional>
+          <ref name="Crossreferences"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Analytics">
+    <element name="analytics">
+      <optional>
+        <attribute name="google-gst"/>
+      </optional>
+      <optional>
+        <attribute name="statcounter-project"/>
+      </optional>
+      <optional>
+        <attribute name="statcounter-security"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Baseurl">
+    <element name="baseurl">
+      <attribute name="href"/>
+    </element>
+  </define>
+  <define name="Calculator">
+    <element name="calculator">
+      <optional>
+        <attribute name="model">
+          <choice>
+            <value>geogebra-classic</value>
+            <value>geogebra-graphing</value>
+            <value>geogebra-geometry</value>
+            <value>geogebra-3d</value>
+            <value>none </value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="activecode">
+          <choice>
+            <value>python</value>
+            <value>javascript</value>
+            <value>html</value>
+            <value>sql</value>
+            <value>c</value>
+            <value>cpp</value>
+            <value>java</value>
+            <value>python3</value>
+            <value>octave</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Crossreferences">
+    <element name="cross-references">
+      <attribute name="knowled">
+        <choice>
+          <value>maximum</value>
+          <value>never</value>
+          <value>cross-page</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Css">
+    <element name="css">
+      <optional>
+        <attribute name="colors"/>
+      </optional>
+      <optional>
+        <attribute name="style"/>
+      </optional>
+      <optional>
+        <attribute name="knowls"/>
+      </optional>
+      <optional>
+        <attribute name="toc"/>
+      </optional>
+      <optional>
+        <attribute name="banner"/>
+      </optional>
+      <optional>
+        <attribute name="navbar"/>
+      </optional>
+      <optional>
+        <attribute name="shell"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Exercises">
+    <element name="exercises">
+      <attribute name="tabbed-tasks">
+        <choice>
+          <value>divisional</value>
+          <value>inline</value>
+          <value>reading</value>
+          <value>project</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Feedback">
+    <element name="feedback">
+      <attribute name="href"/>
+    </element>
+  </define>
+  <define name="Indexpage">
+    <element name="index-page">
+      <attribute name="ref"/>
+    </element>
+  </define>
+  <define name="Knowls">
+    <element name="knowl">
+      <optional>
+        <attribute name="theorem">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="proof">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="definition">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="example">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="example-solution">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="project">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="task">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="remark">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="objectives">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="outcomes">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="figure">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="table">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="listing">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="list">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="exercise-inline">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="exercise-divisional">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="exercise-worksheet">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="exercise-readingquestion">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="NavigationHTML">
+    <element name="navigation">
+      <optional>
+        <attribute name="logic">
+          <choice>
+            <value>linear</value>
+            <value>tree</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="upbutton">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Search">
+    <element name="search">
+      <optional>
+        <attribute name="variant">
+          <choice>
+            <value>textbook</value>
+            <value>reference</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="google-cx"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Tableofcontents">
+    <element name="table-of-contents">
+      <optional>
+        <attribute name="focused">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="preexpanded-levels">
+          <choice>
+            <value>0</value>
+            <value>1</value>
+            <value>2</value>
+            <value>3</value>
+            <value>4</value>
+            <value>5</value>
+            <value>6</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Video">
+    <element name="video">
+      <attribute name="privacy">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="WebworkDynamism">
+    <element name="webwork">
+      <optional>
+        <attribute name="inline">
+          <choice>
+            <value>dynamic</value>
+            <value>static</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="divisional">
+          <choice>
+            <value>dynamic</value>
+            <value>static</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="reading">
+          <choice>
+            <value>dynamic</value>
+            <value>static</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="worksheet">
+          <choice>
+            <value>dynamic</value>
+            <value>static</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="project">
+          <choice>
+            <value>dynamic</value>
+            <value>static</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Revealjs">
+    <element name="revealjs">
+      <interleave>
+        <optional>
+          <ref name="Appearance"/>
+        </optional>
+        <optional>
+          <ref name="Controls"/>
+        </optional>
+        <optional>
+          <ref name="NavigationReveal"/>
+        </optional>
+        <optional>
+          <ref name="Resources"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Appearance">
+    <element name="appearance">
+      <attribute name="theme"/>
+    </element>
+  </define>
+  <define name="Controls">
+    <element name="controls">
+      <optional>
+        <attribute name="backarrow">
+          <choice>
+            <value>faded</value>
+            <value>hidden</value>
+            <value>visible</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="display">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="layout">
+          <choice>
+            <value>edges</value>
+            <value>bottom-right</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="tutorial">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="NavigationReveal">
+    <element name="navigation">
+      <attribute name="mode">
+        <choice>
+          <value>default</value>
+          <value>linear</value>
+          <value>grid</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Resources">
+    <element name="resources">
+      <attribute name="host">
+        <choice>
+          <value>local</value>
+          <value>cdn</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="Epub">
+    <element name="epub">
+      <element name="cover">
+        <attribute name="front"/>
+      </element>
+    </element>
+  </define>
+  <define name="Webwork">
+    <element name="webwork">
+      <attribute name="server"/>
+      <optional>
+        <attribute name="course"/>
+      </optional>
+      <optional>
+        <attribute name="coursepassord"/>
+      </optional>
+      <optional>
+        <attribute name="user"/>
+      </optional>
+      <optional>
+        <attribute name="userpassword"/>
+      </optional>
+      <optional>
+        <attribute name="task-reveal">
+          <choice>
+            <value>preceding-correct</value>
+            <value>all</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+</grammar>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -1,0 +1,555 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--   = one, mandatory -->
+<!-- ? = one, optional  -->
+<!-- * = zero or more   -->
+<!-- + = one or more    -->
+
+<pretext>
+
+    <docinfo>
+        <cross-references text="type-global" />
+    </docinfo>
+
+    <article xml:id="publication">
+        <title>PreTeXt Publication File RELAX-NG Schema</title>
+
+        <frontmatter>
+            <bibinfo>
+
+               <!-- There can be several authors here -->
+               <author>
+                    <personname>Robert A.<nbsp/>Beezer</personname>
+                    <!-- department here is one line, so unstructured -->
+                    <department>Department of Mathematics and Computer Science</department>
+                    <!-- institution uses two lines, so structured as such -->
+                    <institution>
+                        <line>University of Puget Sound</line>
+                        <line>Tacoma, Washington, USA</line>
+                    </institution>
+                    <email>beezer@pugetsound.edu</email>
+                </author>
+
+                <author>
+                    <personname>Oscar Levin</personname>
+                    <!-- department here is one line, so unstructured -->
+                    <department>Mathematical Sciences</department>
+                    <!-- institution uses two lines, so structured as such -->
+                    <institution>
+                        <line>University of Northern Colorado</line>
+                        <line>Greeley, Co 80639</line>
+                    </institution>
+                    <email>oscar.levin@unco.edu</email>
+                </author>
+
+                <!-- Can set date manually or use the "today" element -->
+                <date><today/></date>
+            </bibinfo>
+
+            <titlepage>
+                <titlepage-items />
+            </titlepage>
+        </frontmatter>
+
+    <introduction>
+        <p>
+            This is a literate programming version of the <init>RELAX-NG</init> schema for <pretext/>'s Pulbication Files.  It is based on the corresponding version for <pretext/>'s <init>RELAX-NG</init> schema written by Rob Beezer.  It is used to generate the <init>RELAX-NG</init> compact syntax version (<c>pretext.rnc</c>) and other versions are derived from the compact version with standard tools.
+        </p>
+
+        <p>
+            The main use for this schema currently is to let <em>publishers</em> more easily write publication files for <pretext/> projects since the <c>pretext-tools</c> extension for VS Code uses (the derived version) of this schema to provide completions and (eventually) validation.
+        </p>
+
+        <p>
+            Comments in this file are kept to a minimum.  Full documentation of publisher options are presented in the <url href="https://pretextbook.org/doc/guide/html/publication-file-reference.html"><pretext/> guide</url>.
+        </p>
+
+        <p>
+            More information about how <init>RELAX-NG</init> schemas work, as well as how the literate programming version of this schema works, can be found in the <pretext /> schema.
+        </p>
+    </introduction>
+
+    <section>
+        <title>Start Element</title>
+
+        <p>
+            The only <c>start</c> element for a publication file is <tag>publication</tag>.
+        </p>
+
+        <fragment xml:id="start-element">
+            <title>Start element</title>
+            <code>
+            start = Publication
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Gross Structure</title>
+
+        <p>
+            A publication file always has the root element <tag>publication</tag>.  After that, all elements are optional.  Those elements include common options, and options for numbering, latex, html, reveal.js, epub, source, and <webwork/>.  These can come in any order.
+        </p>
+
+        <fragment xml:id="gross-structure">
+            <title>Gross structure</title>
+            <code>
+            Publication =
+                element publication {
+                    Common? &amp;
+                    Source? &amp;
+                    Numbering? &amp;
+                    Latex? &amp;
+                    Html? &amp;
+                    Revealjs? &amp;
+                    Epub? &amp;
+                    Webwork?
+                }
+            </code>
+        </fragment>
+    </section>
+
+
+    <section>
+        <title>Common Options</title>
+
+        <p>
+            These options will affect more than one output format.
+        </p>
+
+        <fragment xml:id="common">
+            <title>Common Options</title>
+            <code>
+            Common =
+                element common {
+                    element chunking {
+                        attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                    }? &amp;
+                    element tableofcontents {
+                        attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                    }? &amp;
+                    element exercise-inline {
+                        ExerciseAttributes
+                    }? &amp;
+                    element exercise-divisional {
+                        ExerciseAttributes
+                    }? &amp;
+                    element exercise-worksheet {
+                        ExerciseAttributes
+                    }? &amp;
+                    element exercise-reading {
+                        ExerciseAttributes
+                    }? &amp;
+                    element exercise-project {
+                        ExerciseAttributes
+                    }? &amp;
+                    element fillin {
+                        attribute textstyle { "underline" | "box" | "shade" }?,
+                        attribute mathstyle { "underline" | "box" | "shade" }?
+                    }? &amp;
+                    element watermark {
+                        attribute scale { xsd:decimal },
+                        text
+                    }? &amp;
+                    element mermaid {
+                        attribute theme { text }
+                    }? &amp;
+                    element qrcode {
+                        attribute image { text }
+                    }
+                }
+
+            ExerciseAttributes =
+                attribute statement { "yes" | "no" }?,
+                attribute hint { "yes" | "no" }?,
+                attribute answer { "yes" | "no" }?,
+                attribute solution { "yes" | "no" }?
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Source Options</title>
+
+        <p>
+            These options relate to how the source files are interpreted and organized.
+        </p>
+
+        <fragment xml:id="source">
+            <title>Source Options</title>
+            <code>
+            Source =
+                element source {
+                    attribute customizations { text }?,
+                    attribute private-solutions { text }?,
+                    attribute webwork-solutions { text }?,
+                    (Directories? &amp; Version?)
+                }
+
+            Directories =
+                element directories {
+                    attribute external { text },
+                    attribute generated { text }
+                }
+
+            Version =
+                element version {
+                    attribute include { text }
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Numbering Options</title>
+
+        <p>
+            These options will affect multiplt output formats, all related to numbering.
+        </p>
+
+        <fragment xml:id="numbering">
+            <title>Numbering Options</title>
+            <code>
+            Numbering =
+                element numbering {
+                    Divisions? &amp;
+                    Blocks? &amp;
+                    Projects? &amp;
+                    Equations? &amp;
+                    Footnotes?
+                }
+
+            Divisions =
+                element divisions {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?,
+                    attribute chapter-start { xsd:integer }?,
+                    attribute parts-structure { "decorative" | "structural" }?
+                }
+
+            Blocks =
+                element blocks {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Projects =
+                element projects {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Equations =
+                element equations {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }
+                }
+
+            Footnotes =
+                element footnotes {
+                    attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>LaTeX Options</title>
+
+        <p>
+            These options are specific to the PDF/LaTeX output formats.
+        </p>
+
+        <fragment xml:id="latex">
+            <title>LaTeX Options</title>
+            <code>
+            Latex =
+                element latex {
+                    attribute latex-style {text}?,
+                    attribute print { "yes" | "no" }?,
+                    attribute sides { "one" | "two" }?,
+                    attribute open-odd { "add-blanks" | "skip-pages" | "no" }?,
+                    attribute font-size { "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    attribute page-ref { "yes" | "no" }?,
+                    attribute draft { "yes" | "no" }?,
+                    attribute snapshow { "yes" | "no" }?,
+                    ( Page? &amp; Worksheet? &amp; Cover? &amp; Asymptote?)
+                }
+
+            Page =
+                element page {
+                    attribute right-alignment { "flush" | "ragged" }?,
+                    attribute bottom-alignment { "flush" | "ragged" }?,
+                    attribute crop-marks { "none" | "a0" | "a1" | "a2" | "a3" | "a4" | "a5" | "a6" | "b0" | "b1" | "b2" | "b3" | "b4" | "b5" | "b6" | "letter" | "legal" | "executive" }?,
+                    element geometry { text }?
+                }
+
+            Worksheet =
+                element worksheet {
+                    attribute formatted { "yes" | "no" }?
+                }
+
+            Cover =
+                element cover {
+                    attribute front { text }?,
+                    attribute back { text }?
+                }
+
+            Asymptote =
+                element asymptote {
+                    attribute links { "yes" | "no" }?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>HTML Options</title>
+
+        <p>
+            These options control the Online/HTML output's presentation.
+        </p>
+
+        <p>
+            Note that the named pattern for Asymptote is defined in the <latex /> section above.
+        </p>
+
+        <fragment xml:id="html">
+            <title>HTML Options</title>
+            <code>
+            Html =
+                element html {
+                    attribute platform { "web" | "runestone" }?,
+                    attribute short-answer-responses { "graded" | "always" }?,
+                    (Analytics? &amp; Baseurl? &amp; Calculator? &amp; WebworkDynamism? &amp; Indexpage? &amp; Knowls? &amp; Exercises? &amp; Css? &amp; Search? &amp; Video? &amp; Asymptote? &amp; Feedback? &amp; NavigationHTML? &amp; Tableofcontents? &amp; Crossreferences?)
+                }
+
+            Analytics =
+                element analytics {
+                    attribute google-gst { text }?,
+                    attribute statcounter-project { text }?,
+                    attribute statcounter-security { text }?
+                }
+
+            Baseurl =
+                element baseurl {
+                    attribute href { text }
+                }
+
+            Calculator =
+                element calculator {
+                    attribute model { "geogebra-classic" | "geogebra-graphing" | "geogebra-geometry" | "geogebra-3d" | "none "}?,
+                    attribute activecode { "python" | "javascript" | "html" | "sql" | "c" | "cpp" | "java" | "python3" | "octave" | "none"}?
+                }
+
+            Crossreferences =
+                element cross-references {
+                    attribute knowled { "maximum" | "never" | "cross-page" }
+                }
+
+            Css =
+                element css {
+                    attribute colors { text }?,
+                    attribute style { text }?,
+                    attribute knowls { text }?,
+                    attribute toc { text }?,
+                    attribute banner { text }?,
+                    attribute navbar { text }?,
+                    attribute shell { text }?
+                }
+
+            Exercises =
+                element exercises {
+                    attribute tabbed-tasks { "divisional" | "inline" | "reading" | "project" }
+                }
+
+            Feedback =
+                element feedback {
+                    attribute href { text }
+                }
+
+            Indexpage =
+                element index-page {
+                    attribute ref { text }
+                }
+
+            Knowls =
+                element knowl {
+                    attribute theorem { "yes" | "no" }?,
+                    attribute proof { "yes" | "no" }?,
+                    attribute definition { "yes" | "no" }?,
+                    attribute example { "yes" | "no" }?,
+                    attribute example-solution { "yes" | "no" }?,
+                    attribute project { "yes" | "no" }?,
+                    attribute task { "yes" | "no" }?,
+                    attribute remark { "yes" | "no" }?,
+                    attribute objectives { "yes" | "no" }?,
+                    attribute outcomes { "yes" | "no" }?,
+                    attribute figure { "yes" | "no" }?,
+                    attribute table { "yes" | "no" }?,
+                    attribute listing { "yes" | "no" }?,
+                    attribute list { "yes" | "no" }?,
+                    attribute exercise-inline { "yes" | "no" }?,
+                    attribute exercise-divisional { "yes" | "no" }?,
+                    attribute exercise-worksheet { "yes" | "no" }?,
+                    attribute exercise-readingquestion { "yes" | "no" }?
+                }
+
+            NavigationHTML =
+                element navigation {
+                    attribute logic { "linear" | "tree" }?,
+                    attribute upbutton { "yes" | "no" }?
+                }
+            Search =
+                element search {
+                    attribute variant { "textbook" | "reference" | "none" }?,
+                    attribute google-cx { text }?
+                }
+
+            Tableofcontents =
+                element table-of-contents {
+                    attribute focused { "yes" | "no" }?,
+                    attribute preexpanded-levels { "0" | "1" | "2" | "3" | "4" | "5" | "6"}?
+                }
+
+            Video =
+                element video {
+                    attribute privacy { "yes" | "no" }
+                }
+
+            WebworkDynamism =
+                element webwork {
+                    attribute inline { "dynamic" | "static" }?,
+                    attribute divisional { "dynamic" | "static" }?,
+                    attribute reading { "dynamic" | "static" }?,
+                    attribute worksheet { "dynamic" | "static" }?,
+                    attribute project { "dynamic" | "static" }?
+                }
+
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Reveal.js Options</title>
+
+        <p>
+            These options control the Reveal.js slides presentation.
+        </p>
+
+        <fragment xml:id="revealjs">
+            <title>Reveal.js Options</title>
+            <code>
+            Revealjs =
+                element revealjs {
+                    Appearance? &amp;
+                    Controls? &amp;
+                    NavigationReveal? &amp;
+                    Resources?
+                }
+
+            Appearance =
+                element appearance {
+                    attribute theme { text }
+                }
+
+            Controls =
+                element controls {
+                    attribute backarrow { "faded" | "hidden" | "visible" }?,
+                    attribute display { "yes" | "no" }?,
+                    attribute layout { "edges" | "bottom-right" }?,
+                    attribute tutorial { "yes" | "no" }?
+                }
+
+            NavigationReveal =
+                element navigation {
+                    attribute mode { "default" | "linear" | "grid" }
+                }
+
+            Resources =
+                element resources {
+                    attribute host { "local" | "cdn" }
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>EPUB Options</title>
+
+        <p>
+            These option(s) control the EPUB output.
+        </p>
+
+        <fragment xml:id="epub">
+            <title>EPUB Options</title>
+            <code>
+            Epub =
+                element epub {
+                    element cover {
+                        attribute front { text }
+                    }
+                }
+            </code>
+        </fragment>
+    </section>
+
+
+    <section>
+        <title><webwork/> Options</title>
+
+        <p>
+            These options are for when an author wants to pull out <webwork/> problems for use on a <webwork /> server.
+        </p>
+
+        <fragment xml:id="webwork">
+            <title><webwork /> Options</title>
+            <code>
+            Webwork =
+                element webwork {
+                    attribute server { text },
+                    attribute course { text }?,
+                    attribute coursepassord { text }?,
+                    attribute user { text }?,
+                    attribute userpassword { text }?,
+                    attribute task-reveal { "preceding-correct" | "all" }?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Hierarchical Structure</title>
+
+        <p>
+            We collect all the specifications, roughly in a top-down order, so the generated schema files have a rational ordering to them, even if the order presented here is different.
+        </p>
+
+        <fragment filename="publication-schema.rnc">
+            <title>Hierarchical Structure</title>
+            <code>
+            grammar {
+            </code>
+            <fragref ref="start-element" />
+            <fragref ref="gross-structure" />
+            <fragref ref="common" />
+            <fragref ref="source" />
+            <fragref ref="numbering" />
+            <fragref ref="latex" />
+            <fragref ref="html" />
+            <fragref ref="revealjs" />
+            <fragref ref="epub" />
+            <fragref ref="webwork" />
+            <code>
+            }
+            </code>
+            </fragment>
+    </section>
+
+    <backmatter>
+        <appendix xml:id="fragment-list">
+            <title>
+                    Fragments</title>
+
+            <list-of elements="fragment"/>
+        </appendix>
+    </backmatter>
+
+    </article>
+</pretext>

--- a/schema/publication-schema.xsd
+++ b/schema/publication-schema.xsd
@@ -1,0 +1,954 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="publication">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="common"/>
+        <xs:element ref="source"/>
+        <xs:element ref="numbering"/>
+        <xs:element ref="latex"/>
+        <xs:element ref="html"/>
+        <xs:element ref="revealjs"/>
+        <xs:element ref="epub"/>
+        <xs:group ref="Webwork"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="common">
+    <xs:complexType>
+      <xs:all>
+        <xs:element minOccurs="0" ref="chunking"/>
+        <xs:element minOccurs="0" ref="tableofcontents"/>
+        <xs:element minOccurs="0" ref="exercise-inline"/>
+        <xs:element minOccurs="0" ref="exercise-dividional"/>
+        <xs:element minOccurs="0" ref="exercise-worksheet"/>
+        <xs:element minOccurs="0" ref="exercise-reading"/>
+        <xs:element minOccurs="0" ref="exercise-project"/>
+        <xs:element minOccurs="0" ref="fillin"/>
+        <xs:element minOccurs="0" ref="watermark"/>
+        <xs:element minOccurs="0" ref="mermaid"/>
+        <xs:element ref="qrcode"/>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="chunking">
+    <xs:complexType>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tableofcontents">
+    <xs:complexType>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise-inline">
+    <xs:complexType>
+      <xs:attributeGroup ref="ExerciseAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise-dividional">
+    <xs:complexType>
+      <xs:attributeGroup ref="ExerciseAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise-worksheet">
+    <xs:complexType>
+      <xs:attributeGroup ref="ExerciseAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise-reading">
+    <xs:complexType>
+      <xs:attributeGroup ref="ExerciseAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercise-project">
+    <xs:complexType>
+      <xs:attributeGroup ref="ExerciseAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fillin">
+    <xs:complexType>
+      <xs:attribute name="textstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="underline"/>
+            <xs:enumeration value="box"/>
+            <xs:enumeration value="shade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mathstyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="underline"/>
+            <xs:enumeration value="box"/>
+            <xs:enumeration value="shade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="watermark">
+    <xs:complexType mixed="true">
+      <xs:attribute name="scale" use="required" type="xs:decimal"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mermaid">
+    <xs:complexType>
+      <xs:attribute name="theme" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="qrcode">
+    <xs:complexType>
+      <xs:attribute name="image" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="ExerciseAttributes">
+    <xs:attribute name="statement">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="yes"/>
+          <xs:enumeration value="no"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="hint">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="yes"/>
+          <xs:enumeration value="no"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="answer">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="yes"/>
+          <xs:enumeration value="no"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="solution">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="yes"/>
+          <xs:enumeration value="no"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="source">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="directories"/>
+        <xs:element ref="version"/>
+      </xs:choice>
+      <xs:attribute name="customizations"/>
+      <xs:attribute name="private-solutions"/>
+      <xs:attribute name="webwork-solutions"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="directories">
+    <xs:complexType>
+      <xs:attribute name="external" use="required"/>
+      <xs:attribute name="generated" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="include" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="numbering">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="divisions"/>
+        <xs:element ref="blocks"/>
+        <xs:element ref="projects"/>
+        <xs:element ref="equations"/>
+        <xs:element ref="footnotes"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="divisions">
+    <xs:complexType>
+      <xs:attribute name="level">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="chapter-start" type="xs:integer"/>
+      <xs:attribute name="parts-structure">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="decorative"/>
+            <xs:enumeration value="structural"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="blocks">
+    <xs:complexType>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="projects">
+    <xs:complexType>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equations">
+    <xs:complexType>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="footnotes">
+    <xs:complexType>
+      <xs:attribute name="level">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="latex">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="page"/>
+        <xs:element ref="worksheet"/>
+        <xs:element ref="cover"/>
+        <xs:element ref="asymptote"/>
+      </xs:choice>
+      <xs:attribute name="latex-style"/>
+      <xs:attribute name="print">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="sides">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="open-odd">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="add-blanks"/>
+            <xs:enumeration value="skip-pages"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="font-size">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="9"/>
+            <xs:enumeration value="10"/>
+            <xs:enumeration value="11"/>
+            <xs:enumeration value="12"/>
+            <xs:enumeration value="14"/>
+            <xs:enumeration value="17"/>
+            <xs:enumeration value="20"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="page-ref">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="snapshow">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="page">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="geometry"/>
+      </xs:sequence>
+      <xs:attribute name="right-alignment">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="flush"/>
+            <xs:enumeration value="ragged"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bottom-alignment">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="flush"/>
+            <xs:enumeration value="ragged"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="crop-marks">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="a0"/>
+            <xs:enumeration value="a1"/>
+            <xs:enumeration value="a2"/>
+            <xs:enumeration value="a3"/>
+            <xs:enumeration value="a4"/>
+            <xs:enumeration value="a5"/>
+            <xs:enumeration value="a6"/>
+            <xs:enumeration value="b0"/>
+            <xs:enumeration value="b1"/>
+            <xs:enumeration value="b2"/>
+            <xs:enumeration value="b3"/>
+            <xs:enumeration value="b4"/>
+            <xs:enumeration value="b5"/>
+            <xs:enumeration value="b6"/>
+            <xs:enumeration value="letter"/>
+            <xs:enumeration value="legal"/>
+            <xs:enumeration value="executive"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="geometry" type="xs:string"/>
+  <xs:element name="worksheet">
+    <xs:complexType>
+      <xs:attribute name="formatted">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cover">
+    <xs:complexType>
+      <xs:attribute name="front"/>
+      <xs:attribute name="back"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="asymptote">
+    <xs:complexType>
+      <xs:attribute name="links">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="html">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="analytics"/>
+        <xs:element ref="baseurl"/>
+        <xs:element ref="calculator"/>
+        <xs:group ref="WebworkDynamism"/>
+        <xs:element ref="index-page"/>
+        <xs:element ref="knowl"/>
+        <xs:element ref="exercises"/>
+        <xs:element ref="css"/>
+        <xs:element ref="search"/>
+        <xs:element ref="video"/>
+        <xs:element ref="asymptote"/>
+        <xs:element ref="feedback"/>
+        <xs:group ref="NavigationHTML"/>
+        <xs:element ref="table-of-contents"/>
+        <xs:element ref="cross-references"/>
+      </xs:choice>
+      <xs:attribute name="platform">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="web"/>
+            <xs:enumeration value="runestone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="short-answer-responses">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="graded"/>
+            <xs:enumeration value="always"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="analytics">
+    <xs:complexType>
+      <xs:attribute name="google-gst"/>
+      <xs:attribute name="statcounter-project"/>
+      <xs:attribute name="statcounter-security"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="baseurl">
+    <xs:complexType>
+      <xs:attribute name="href" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="calculator">
+    <xs:complexType>
+      <xs:attribute name="model">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="geogebra-classic"/>
+            <xs:enumeration value="geogebra-graphing"/>
+            <xs:enumeration value="geogebra-geometry"/>
+            <xs:enumeration value="geogebra-3d"/>
+            <xs:enumeration value="none "/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="activecode">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="python"/>
+            <xs:enumeration value="javascript"/>
+            <xs:enumeration value="html"/>
+            <xs:enumeration value="sql"/>
+            <xs:enumeration value="c"/>
+            <xs:enumeration value="cpp"/>
+            <xs:enumeration value="java"/>
+            <xs:enumeration value="python3"/>
+            <xs:enumeration value="octave"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cross-references">
+    <xs:complexType>
+      <xs:attribute name="knowled" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="maximum"/>
+            <xs:enumeration value="never"/>
+            <xs:enumeration value="cross-page"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="css">
+    <xs:complexType>
+      <xs:attribute name="colors"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="knowls"/>
+      <xs:attribute name="toc"/>
+      <xs:attribute name="banner"/>
+      <xs:attribute name="navbar"/>
+      <xs:attribute name="shell"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="exercises">
+    <xs:complexType>
+      <xs:attribute name="tabbed-tasks" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="divisional"/>
+            <xs:enumeration value="inline"/>
+            <xs:enumeration value="reading"/>
+            <xs:enumeration value="project"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="feedback">
+    <xs:complexType>
+      <xs:attribute name="href" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="index-page">
+    <xs:complexType>
+      <xs:attribute name="ref" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="knowl">
+    <xs:complexType>
+      <xs:attribute name="theorem">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="proof">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="definition">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="example">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="example-solution">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="project">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="task">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="remark">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="objectives">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="outcomes">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="figure">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="table">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="listing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="list">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="exercise-inline">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="exercise-divisional">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="exercise-worksheet">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="exercise-readingquestion">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="NavigationHTML">
+    <xs:sequence>
+      <xs:element name="navigation">
+        <xs:complexType>
+          <xs:attribute name="logic">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="linear"/>
+                <xs:enumeration value="tree"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="upbutton">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="yes"/>
+                <xs:enumeration value="no"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="search">
+    <xs:complexType>
+      <xs:attribute name="variant">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="textbook"/>
+            <xs:enumeration value="reference"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="google-cx"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table-of-contents">
+    <xs:complexType>
+      <xs:attribute name="focused">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="preexpanded-levels">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="video">
+    <xs:complexType>
+      <xs:attribute name="privacy" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="WebworkDynamism">
+    <xs:sequence>
+      <xs:element name="webwork">
+        <xs:complexType>
+          <xs:attribute name="inline">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="dynamic"/>
+                <xs:enumeration value="static"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="divisional">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="dynamic"/>
+                <xs:enumeration value="static"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="reading">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="dynamic"/>
+                <xs:enumeration value="static"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="worksheet">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="dynamic"/>
+                <xs:enumeration value="static"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="project">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="dynamic"/>
+                <xs:enumeration value="static"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="revealjs">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="appearance"/>
+        <xs:element ref="controls"/>
+        <xs:group ref="NavigationReveal"/>
+        <xs:element ref="resources"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="appearance">
+    <xs:complexType>
+      <xs:attribute name="theme" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="controls">
+    <xs:complexType>
+      <xs:attribute name="backarrow">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="faded"/>
+            <xs:enumeration value="hidden"/>
+            <xs:enumeration value="visible"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="display">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="layout">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="edges"/>
+            <xs:enumeration value="bottom-right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tutorial">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="NavigationReveal">
+    <xs:sequence>
+      <xs:element name="navigation">
+        <xs:complexType>
+          <xs:attribute name="mode" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="linear"/>
+                <xs:enumeration value="grid"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="resources">
+    <xs:complexType>
+      <xs:attribute name="host" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="local"/>
+            <xs:enumeration value="cdn"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="epub">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="cover">
+          <xs:complexType>
+            <xs:attribute name="front" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="Webwork">
+    <xs:sequence>
+      <xs:element name="webwork">
+        <xs:complexType>
+          <xs:attribute name="server" use="required"/>
+          <xs:attribute name="course"/>
+          <xs:attribute name="coursepassord"/>
+          <xs:attribute name="user"/>
+          <xs:attribute name="userpassword"/>
+          <xs:attribute name="task-reveal">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="preceding-correct"/>
+                <xs:enumeration value="all"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+</xs:schema>


### PR DESCRIPTION
This creates a schema for publication files, consistent with the documentation as of 2024-10-22.  Uses the same style (xml to rnc to rng and xsd) as the pretext schema.  Named everything `publication-schema` to avoid confusion with the file `publication.xml` which is the actual publication file for the schema.

`build.sh` updated to include this. 