### PR TITLE
Listing filenames

### DIFF
--- a/css/pretext_add_on.css
+++ b/css/pretext_add_on.css
@@ -91,8 +91,12 @@
     white-space: pre;
 }
 
-.ptx-content figure > figcaption:first-child {
-    margin-top: 1.5em;
+.ptx-content figure.figure > figcaption{
+    margin-top: 1em;
+}
+
+.ptx-content figure.listing > figcaption + * {
+    margin-top: 1em;
 }
 
 .ptx-content figcaption + .named-list-content {

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10015,7 +10015,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>A <c>program</c> may also be nested inside a <c>listing</c>, which behaves similar to a <c>figure</c>.  You can provide a <c>caption</c>, and the listing will be numbered along with tables and figures.  This then makes it possible to cross-reference the listing, such as <xref ref="listing-c-hello" text="type-global" />.  It also removes the requirement of wrapping the <c>program</c> in a <c>sidebyside</c>.  For technical reasons, the three examples above will not split across a page break in PDF output, but the placement inside a <c>listing</c> will allow splits, as you should see in at least one example following.</p>
 
-            <listing xml:id="listing-c-hello">
+            <p>If a <attr>filename</attr> is supplied for the listing, it will be rendered as part of the listing caption. Filenames do not have to be unique - thus a particular filename can "evolve" throughout a work.</p>
+
+            <listing xml:id="listing-c-hello" filename="helloworld.c">
                 <caption>C Version of <q>Hello, World!</q></caption>
                 <program language="c">
                     <input>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1722,6 +1722,7 @@
                 element listing {
                     MetaDataCaption,
                     Landscape?,
+                    attribute filename {"yes" | "no"}?,
                     (
                         Program |
                         Console

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1964,9 +1964,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- knowl, hence original or duplicate     -->
             <xsl:when test="self::figure or (self::listing and $has-valid-activecode != 'yes')">
                 <xsl:call-template name="space-styled"/>
-                <xsl:apply-templates select="." mode="caption-full">
-                    <xsl:with-param name="b-original" select="$b-original"/>
-                </xsl:apply-templates>
+                <span class="figcaption__caption">
+                    <xsl:apply-templates select="." mode="caption-full">
+                        <xsl:with-param name="b-original" select="$b-original"/>
+                    </xsl:apply-templates>
+                </span>
             </xsl:when>
             <xsl:when test="self::table or self::list or (self::listing and $has-valid-activecode = 'yes')">
                 <xsl:call-template name="space-styled"/>
@@ -2956,12 +2958,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="b-place-title-below" select="($fig-placement = 'subnumber') or ($fig-placement = 'panel')"/>
     <xsl:choose>
         <!-- caption at the bottom, always -->
-        <xsl:when test="self::figure|self::listing">
+        <xsl:when test="self::figure">
             <xsl:apply-templates select="*">
                 <xsl:with-param name="b-original" select="$b-original" />
             </xsl:apply-templates>
             <xsl:apply-templates select="." mode="figure-caption">
                 <xsl:with-param name="b-original" select="$b-original"/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- caption at the top as per CMoS -->
+        <xsl:when test="self::listing">
+            <xsl:apply-templates select="." mode="figure-caption">
+                <xsl:with-param name="b-original" select="$b-original"/>
+            </xsl:apply-templates>
+            <xsl:apply-templates select="*">
+                <xsl:with-param name="b-original" select="$b-original" />
             </xsl:apply-templates>
         </xsl:when>
         <!-- table only contains a tabular; if not subnumbered  -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1945,18 +1945,34 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </span>
             </xsl:otherwise>
         </xsl:choose>
-        <xsl:call-template name="space-styled"/>
+        <!-- When a listing has an activecode, the caption will be picked -->
+        <!-- up by the activecode, so we don't want to duplicate it.      -->
+        <xsl:variable name="has-valid-activecode">
+            <!-- must be @interactive="activecode" and have a valid language -->
+            <!-- to be rendered as activecode                                -->
+            <xsl:if test="program[@interactive = 'activecode']">
+                <xsl:for-each select="program">
+                    <xsl:variable name="active-language">
+                        <xsl:apply-templates select="." mode="active-language"/>
+                    </xsl:variable>
+                    <xsl:if test="$active-language != ''">yes</xsl:if>
+                </xsl:for-each>
+            </xsl:if>
+        </xsl:variable>
         <xsl:choose>
             <!-- a caption can have a footnote, hence a -->
             <!-- knowl, hence original or duplicate     -->
-            <!-- activecode captions will be included in RS element -->
-            <xsl:when test="self::figure or self::listing[not(program[@interactive = 'activecode'])]">
+            <xsl:when test="self::figure or (self::listing and $has-valid-activecode != 'yes')">
+                <xsl:call-template name="space-styled"/>
                 <xsl:apply-templates select="." mode="caption-full">
                     <xsl:with-param name="b-original" select="$b-original"/>
                 </xsl:apply-templates>
             </xsl:when>
-            <xsl:when test="self::table or self::list">
-                <xsl:apply-templates select="." mode="title-full"/>
+            <xsl:when test="self::table or self::list or (self::listing and $has-valid-activecode = 'yes')">
+                <xsl:call-template name="space-styled"/>
+                <span class="figcaption__title">
+                    <xsl:apply-templates select="." mode="title-full"/>
+                </span>
             </xsl:when>
         </xsl:choose>
     </figcaption>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1945,6 +1945,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </span>
             </xsl:otherwise>
         </xsl:choose>
+        <!-- listings may have an @filename that should be displayed-->
+        <xsl:if test="self::listing[@filename]">
+            <xsl:call-template name="space-styled"/>
+            <span class="filename">
+                <xsl:value-of select="@filename"/>
+            </span>
+        </xsl:if>
         <!-- When a listing has an activecode, the caption will be picked -->
         <!-- up by the activecode, so we don't want to duplicate it.      -->
         <xsl:variable name="has-valid-activecode">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1949,7 +1949,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:choose>
             <!-- a caption can have a footnote, hence a -->
             <!-- knowl, hence original or duplicate     -->
-            <xsl:when test="self::figure or self::listing">
+            <!-- activecode captions will be included in RS element -->
+            <xsl:when test="self::figure or self::listing[not(program[@interactive = 'activecode'])]">
                 <xsl:apply-templates select="." mode="caption-full">
                     <xsl:with-param name="b-original" select="$b-original"/>
                 </xsl:apply-templates>

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -8610,6 +8610,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}{</xsl:text>
     <xsl:apply-templates select="." mode="type-name"/>
     <xsl:text>}{</xsl:text>
+    <xsl:if test="self::listing[@filename]">
+        <xsl:value-of select="@filename"/>
+        <xsl:text>\space</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="caption-full"/>
     <xsl:apply-templates select="." mode="caption-full"/>
     <xsl:text>}{</xsl:text>
     <xsl:apply-templates select="." mode="unique-id"/>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1977,13 +1977,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:value-of select="$rsid"/>
                         </xsl:attribute>
                         <!-- add some lead-in text to the window -->
-                        <xsl:if test="$exercise-statement">
+                        <xsl:if test="$exercise-statement or parent::listing/caption">
                             <div class="ac_question">
                                 <xsl:attribute name="id">
                                     <xsl:value-of select="$rsid"/>
                                     <xsl:text>_question</xsl:text>
                                 </xsl:attribute>
-                                <xsl:apply-templates select="$exercise-statement"/>
+                                <xsl:choose>
+                                  <xsl:when test="$exercise-statement">
+                                    <xsl:apply-templates select="$exercise-statement"/>
+                                  </xsl:when>
+                                  <xsl:otherwise>
+                                    <!-- if in a listing we steal the caption from there -->
+                                    <xsl:apply-templates select="parent::listing/caption/node()"/>
+                                  </xsl:otherwise>
+                                </xsl:choose>
                             </div>
                         </xsl:if>
                         <textarea data-lang="{$active-language}" data-timelimit="25000" data-audio="" data-coach="true" style="visibility: hidden;">


### PR DESCRIPTION
Basic implementation of filenames for listings. No fancy download links, but I'm not convinced they are needed as anywhere a link would be active the reader can copy/paste into an editor.

It is quite likely there is a more ideal LaTeX implementation.

Built off of https://github.com/PreTeXtBook/pretext/pull/2272 - suggest resolving it first.