### PR TITLE
PreFigure changes to sample article and added PNG support

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2996,62 +2996,63 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <li>Production of tactile versions, perhaps available via archive links, will be another addition.</li>
                 </ul></p>
 
-                <!-- Indentation needs to be cleaned up by a knowledgeable PreFigure author -->
-                <image width="70%">
-                  <prefigure label="prefigure-tangent">
-            <diagram dimensions="(300,300)" margins="5">
-              <definition>a=1</definition>
-              <definition>f(x) = exp(x/3)*cos(x)</definition>
-              <coordinates bbox="[-4,-4,4,4]">
-            <grid-axes xlabel="x" ylabel="y"/>
-            <graph at="graph" function='f' />
-            <tangent-line at="tangent" function="f" point="a"/>
-            <point at="point" p="(a, f(a))">
-              <m>(a,f(a))</m>
-            </point>
-              </coordinates>
+                <image width="60%">
+                    <prefigure label="prefigure-tangent"
+                               xmlns="https://prefigure.org">
+                        <diagram dimensions="(300,300)" margins="5">
+                            <definition>a=1</definition>
+                            <definition>f(x) = exp(x/3)*cos(x)</definition>
+                            <coordinates bbox="[-4,-4,4,4]">
+                                <grid-axes xlabel="x" ylabel="y"/>
+                                <graph at="graph" function='f' />
+                                <tangent-line at="tangent" function="f" point="a"/>
+                                <point at="point" p="(a, f(a))">
+                                    <m>(a,f(a))</m>
+                                </point>
+                            </coordinates>
 
-              <annotations>
-            <annotation ref="figure"
-                    text="The graph of a function and its tangent line at the point a equals 1">
-              <annotation ref="graph-tangent"
-                      text="The graph and its tangent line">
-                <annotation ref="graph"
-                    text="The graph of the function f" sonify="yes"/>
-                <annotation ref="point"
-                    text="The point a comma f of a"/>
-                <annotation ref="tangent"
-                    text="The tangent line to the graph of f at the point"/>
-              </annotation>
-            </annotation>
-              </annotations>
+                            <annotations>
+                                <annotation ref="figure"
+                                            text="The graph of a function and its tangent line at the point a equals 1">
+                                    <annotation ref="graph-tangent"
+                                                text="The graph and its tangent line">
+                                        <annotation ref="graph"
+                                                    text="The graph of the function f" sonify="yes"/>
+                                        <annotation ref="point"
+                                                    text="The point a comma f of a"/>
+                                        <annotation ref="tangent"
+                                                    text="The tangent line to the graph of f at the point"/>
+                                    </annotation>
+                                </annotation>
+                            </annotations>
 
-            </diagram>
-                  </prefigure>
+                        </diagram>
+                    </prefigure>
                 </image>
 
-                <image width="70%">
-                  <prefigure label="prefigure-diffeq">
-            <diagram dimensions="(300,300)" margins="5">
-              <definition>f(t,y) = (y[1], -pi*y[0]-0.3*y[1])</definition>
-              <coordinates bbox="[-1,-3,6,3]">
-            <grid-axes xlabel="t"/>
-            <de-solve function="f" t0="0" t1="bbox[2]"
-                  y0="(0,2)" name="oscillator"
-                  N="200"/>
-            <plot-de-solution at="x" solution="oscillator"
-                      axes="(t,y0)" />
-            <plot-de-solution at="xprime" solution="oscillator"
-                      axes="(t,y1)" stroke="red"
-                      tactile-dash="9 9"/>
-            <legend at="legend" anchor="(bbox[2], bbox[3])"
-                alignment="sw" scale="0.9" opacity="0.5">
-              <item ref="x"><m>x(t)</m></item>
-              <item ref="xprime"><m>x'(t)</m></item>
-            </legend>
-              </coordinates>
-            </diagram>
-                  </prefigure>
+                <image width="60%">
+                    <prefigure label="prefigure-diffeq"
+                               xmlns="https://prefigure.org">
+                        <diagram dimensions="(300,300)" margins="5">
+                            <definition>f(t,y) = (y[1], -pi*y[0]-0.3*y[1])</definition>
+                            <coordinates bbox="[-1,-3,6,3]">
+                                <grid-axes xlabel="t"/>
+                                <de-solve function="f" t0="0" t1="bbox[2]"
+                                          y0="(0,2)" name="oscillator"
+                                          N="200"/>
+                                <plot-de-solution at="x" solution="oscillator"
+                                                  axes="(t,y0)" />
+                                <plot-de-solution at="xprime" solution="oscillator"
+                                                  axes="(t,y1)" stroke="red"
+                                                  tactile-dash="9 9"/>
+                                <legend at="legend" anchor="(bbox[2], bbox[3])"
+                                        alignment="sw" scale="0.9" opacity="0.5">
+                                    <item ref="x"><m>x(t)</m></item>
+                                    <item ref="xprime"><m>x'(t)</m></item>
+                                </legend>
+                            </coordinates>
+                        </diagram>
+                    </prefigure>
                 </image>
 
                 <p>For sighted readers, here is an example of a tactile version of one of the above diagrams.  It is generated automatically from the same source as the other version.  Imagine this being <q>printed</q> with an embosser so that the parts of the diagram, and the braille labels, are raised up from the paper and can be explored with one's fingertips.</p>

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -608,7 +608,7 @@ def main():
         ptx.validate(xml_source, out_file, dest_dir)
     elif args.component == "prefigure":
         # if args.format in ["pdf", "svg", "png", "html", "all"]:
-        if args.format in ["source", "svg", "pdf", "braille"]:
+        if args.format in ["source", "svg", "pdf", "png", "tactile"]:
             ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format)
         else:
             raise NotImplementedError('cannot make Prefigure graphics in "{}" format'.format(args.format) )

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -277,7 +277,7 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
 
     # Resulting *.asy files are in tmp_dir, switch there to work
     with working_directory(tmp_dir):
-        if outformat == "source":
+        if outformat == "source" or outformat == "all":
             log.info("copying PreFigure source files into {}".format(dest_dir))
             shutil.copytree(
                 tmp_dir,
@@ -286,17 +286,22 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
             )
             return
 
-        if outformat == "svg":
+        if outformat == "svg" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to SVG".format(pfdiagram))
                 prefig.engine.build('svg', pfdiagram)
 
-        elif outformat == "pdf":
+        elif outformat == "pdf" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to PDF".format(pfdiagram))
                 prefig.engine.pdf('svg', pfdiagram, dpi=100)
 
-        elif outformat == "braille":
+        elif outformat == "png" or outformat == "all":
+            for pfdiagram in os.listdir(tmp_dir):
+                log.info("compiling PreFigure source file {} to PNG".format(pfdiagram))
+                prefig.engine.png('svg', pfdiagram, dpi=100)
+
+        elif outformat == "tactile" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
                 prefig.engine.pdf('tactile', pfdiagram)

--- a/xsl/extract-prefigure.xsl
+++ b/xsl/extract-prefigure.xsl
@@ -25,6 +25,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
     xmlns:exsl="http://exslt.org/common"
     extension-element-prefixes="exsl"
+    xmlns:pf="https://prefigure.org"
 >
 
 <!-- Get internal ID's for filenames, etc -->
@@ -45,7 +46,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- NB: don't match the empty element that is a text -->
 <!-- generator.  Once PreFigure has a namespace, then -->
 <!-- it should be used here instead.                  -->
-<xsl:template match="prefigure[node()]" mode="extraction">
+<xsl:template match="pf:prefigure[node()]" mode="extraction">
     <xsl:variable name="filebase">
         <xsl:apply-templates select="." mode="image-source-basename"/>
     </xsl:variable>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -35,6 +35,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     extension-element-prefixes="pi exsl date str"
     xmlns:mb="https://pretextbook.org/"
     exclude-result-prefixes="mb"
+    xmlns:pf="https://prefigure.org"
 >
 
 <!-- PreTeXt common templates                             -->
@@ -3608,7 +3609,7 @@ Book (with parts), "section" at level 3
 <!-- PreFigure images debuted after the switch to preferring a @label on -->
 <!-- the "prefigure" element, and not on the enclosing image, so we can  -->
 <!-- employ an improved version of the "image-source-basename" template. -->
-<xsl:template match="prefigure" mode="image-source-basename">
+<xsl:template match="pf:prefigure" mode="image-source-basename">
     <xsl:choose>
         <!-- Determine if @label is authored or generated for backwrd compatibility -->
         <xsl:when test="not(@authored-label)">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -52,6 +52,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
     exclude-result-prefixes="svg pi fn"
     extension-element-prefixes="exsl date str"
+    xmlns:pf="https://prefigure.org"
 >
 
 <!-- Allow writing of JSON from structured HTML -->
@@ -5813,7 +5814,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Minor variations to be dual-purpose      -->
 <!--   LaTeX source code images               -->
 <!--   PreFigure source code images           -->
-<xsl:template match="image[latex-image]|image[prefigure]" mode="image-inclusion">
+<xsl:template match="image[latex-image]|image[pf:prefigure]" mode="image-inclusion">
     <!-- $base-pathname needed later for archive links -->
     <xsl:variable name="base-pathname">
         <xsl:value-of select="$generated-directory"/>
@@ -5822,14 +5823,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:when test="latex-image">
                     <xsl:text>latex-image/</xsl:text>
                 </xsl:when>
-                <xsl:when test="prefigure">
+                <xsl:when test="pf:prefigure">
                     <xsl:text>prefigure/</xsl:text>
                 </xsl:when>
             </xsl:choose>
         </xsl:if>
         <!-- NB: node-set in @select will have exactly -->
         <!-- one (child) node, given @match above      -->
-        <xsl:apply-templates select="latex-image|prefigure" mode="image-source-basename"/>
+        <xsl:apply-templates select="latex-image|pf:prefigure" mode="image-source-basename"/>
     </xsl:variable>
     <xsl:apply-templates select="." mode="svg-png-wrapper">
         <xsl:with-param name="image-filename" select="concat($base-pathname, '.svg')" />

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -33,6 +33,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:str="http://exslt.org/strings"
     xmlns:pi="http://pretextbook.org/2020/pretext/internal"
     extension-element-prefixes="exsl date str"
+    xmlns:pf="https://prefigure.org"
 >
 
 <!-- Standard conversion groundwork -->
@@ -8926,14 +8927,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- PreFigure diagrams always produced as PDF for LaTeX -->
-<xsl:template match="image[prefigure]" mode="image-inclusion">
+<xsl:template match="image[pf:prefigure]" mode="image-inclusion">
     <xsl:text>\includegraphics[width=\linewidth]</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:value-of select="$generated-directory"/>
     <xsl:if test="$b-managed-directories">
         <xsl:text>prefigure/</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="prefigure" mode="image-source-basename"/>
+    <xsl:apply-templates select="pf:prefigure" mode="image-source-basename"/>
     <xsl:text>.pdf</xsl:text>
     <xsl:text>}%&#xa;</xsl:text>
 </xsl:template>


### PR DESCRIPTION
Edits to the sample article to put #prefigure elements in their own namespace and fix indentation (hopefully!).  Also added support for PNG conversion of PreFigure source and changed the format name from "braille" to "tactile" for tactile PreFigure diagrams.  

Necessary changes to several XSL stylesheets are in the second commit.

For the time being, compiling PreFigure source that is inside a namespace will require grabbing the PreFigure nightly build.