### PR TITLE
PreFigure intermediate file clean up, prefigure-preamble added

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -67,7 +67,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         % comments anywhere get stripped, with or without faux % comment \% characters
         \newcommand{\indefiniteintegral}[2]{\int#1\,d#2}
         \newcommand{\testingescapedpercent}{ \% } % just testing
+        \newcommand{\bvec}{{\mathbf b}}
+        \newcommand{\vvec}{{\mathbf v}}
         </macros>
+        <prefigure-preamble>
+            <line stroke="blue"/>
+        </prefigure-preamble>
         <!-- We control the appearance of the text of cross-references here           -->
         <!-- (these are the "xref" elements).  Because this changes the words         -->
         <!-- that appear in your output, it is a decision with stays with the source. -->
@@ -3050,6 +3055,47 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <item ref="x"><m>x(t)</m></item>
                                     <item ref="xprime"><m>x'(t)</m></item>
                                 </legend>
+                            </coordinates>
+                        </diagram>
+                    </prefigure>
+                </image>
+
+                <image width="60%">
+                    <prefigure label="prefigure-projection"
+                               xmlns="https://prefigure.org">
+                        <diagram dimensions="(300,300)" margins="5">
+                            <definition>v=(2,1)</definition>
+                            <definition>b=(2,4)</definition>
+                            <definition>bhat=dot(v,b)/dot(v,v) * v</definition>
+                            <definition>bperp = b - bhat</definition>
+                            <coordinates bbox="[-1,-1,5,5]">
+                                <grid-axes/>
+                                <line endpoints="((0,0),v)"
+                                      infinite="yes"/>
+                                <label anchor="(4.4,2.5)">
+                                    <m>L</m>
+                                </label>
+
+                                <vector v="bperp" tail="bhat" stroke="gray"/>
+                                <label anchor="midpoint(b,bhat)"
+                                       alignment="ne">
+                                    <m>\bvec^\perp</m>
+                                </label>
+
+                                <vector v="b"/>
+                                <label anchor="b" alignment="nw">
+                                    <m>\bvec</m>
+                                </label>
+
+                                <vector v="bhat" stroke="red"/>
+                                <label anchor="bhat" alignment="se">
+                                    <m>\widehat{\bvec}</m>
+                                </label>
+
+                                <vector v="v"/>
+                                <label anchor="v" alignment="se">
+                                    <m>\vvec</m>
+                                </label>
                             </coordinates>
                         </diagram>
                     </prefigure>

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -284,43 +284,35 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
                 dest_dir,
                 dirs_exist_ok=True
             )
-            return
 
-        if outformat == "svg":
+        if outformat == "svg" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to SVG".format(pfdiagram))
                 prefig.engine.build('svg', pfdiagram)
 
-        elif outformat == "pdf":
+        if outformat == "pdf" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to PDF".format(pfdiagram))
                 prefig.engine.pdf('svg', pfdiagram, dpi=100)
 
-        elif outformat == "png":
+        if outformat == "png" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to PNG".format(pfdiagram))
                 prefig.engine.png('svg', pfdiagram)
 
-        elif outformat == "tactile":
+        if outformat == "tactile" or outformat == "all":
             for pfdiagram in os.listdir(tmp_dir):
                 log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
                 prefig.engine.pdf('tactile', pfdiagram)
 
-        # Some formats leave "extra" SVG versions, and XML
-        # annotation files, in the temporary directory, so we
-        # remove them before copying to the real destination.
-        if outformat in ["pdf", "png", "tactile"]:
-            for file in glob.glob(tmp_dir + '/output/*.svg'):
-                os.remove(file)
-            for file in glob.glob(tmp_dir + '/output/*-annotations.xml'):
-                os.remove(file)
-
-        log.info("copying PreFigure output to {}".format(dest_dir))
-        shutil.copytree(
-            'output',
-            dest_dir,
-            dirs_exist_ok=True
-        )
+        # Check to see if we made any diagrams before copying
+        if os.path.exists('output'):
+            log.info("copying PreFigure output to {}".format(dest_dir))
+            shutil.copytree(
+                'output',
+                dest_dir,
+                dirs_exist_ok=True
+            )
 
 def asymptote_conversion(
     xml_source, pub_file, stringparams, xmlid_root, dest_dir, outformat, method


### PR DESCRIPTION
This adds a few LaTeX macros and a #prefigure-preamble into the sample-article, along with a third #prefigure diagram that can make use of them.

Also, the prefigure_conversion function is cleaned up a bit, changing elif to if.  The nightly prefig build (not prefigure!) will clean up after itself when building pdf, png, and tactile versions.  