### PR TITLE
Javascript: improve TOC scroll behavior

### DIFF
--- a/js/pretext.js
+++ b/js/pretext.js
@@ -35,7 +35,9 @@ function scrollTocToActive() {
     //  Don't use scrollIntoView because it changes users tab position in Chrome
     //  and messes up keyboard navigation
     tocEntry.closest("li").classList.add("active");
-    document.querySelector("#ptx-toc").scrollTop = tocEntry.offsetTop;
+    // Scroll only if the tocEntry is below the bottom third of the window,
+    // scrolling to that position.
+    document.querySelector("#ptx-toc").scrollTop = tocEntry.offsetTop - 0.66 * self.innerHeight;
 }
 
 function toggletoc() {

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -35,9 +35,9 @@ function scrollTocToActive() {
     //  Don't use scrollIntoView because it changes users tab position in Chrome
     //  and messes up keyboard navigation
     tocEntry.closest("li").classList.add("active");
-    // Scroll only if the tocEntry is below the bottom third of the window,
+    // Scroll only if the tocEntry is below the bottom half of the window,
     // scrolling to that position.
-    document.querySelector("#ptx-toc").scrollTop = tocEntry.offsetTop - 0.66 * self.innerHeight;
+    document.querySelector("#ptx-toc").scrollTop = tocEntry.offsetTop - 0.4 * self.innerHeight;
 }
 
 function toggletoc() {
@@ -53,12 +53,12 @@ function toggletoc() {
    scrollTocToActive();
 }
 
-window.addEventListener("load",function(event) {
+window.addEventListener("DOMContentLoaded",function(event) {
        thetocbutton = document.getElementsByClassName("toc-toggle")[0];
        thetocbutton.addEventListener('click', () => toggletoc() );
 });
 
-window.addEventListener("load",function(event) {
+window.addEventListener("DOMContentLoaded",function(event) {
        scrollTocToActive();
 });
 


### PR DESCRIPTION
Currently, if you have a long table of contents and you click on the third entry, the javascript scrolls that to the very top of the page, hiding the first two entries.  I propose that it would be better to only scroll if the item clicked on is near the bottom (in this case, below the bottom third of the page).  This has the advantage of always showing elements above and below the highlighted division, which the reader would likely want to click on.

Pinging @davidfarmer just to make sure he is okay with this.