### PR TITLE
PreFigure format "all" support in prefigure_conversion

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -607,7 +607,7 @@ def main():
     if args.validate:
         ptx.validate(xml_source, out_file, dest_dir)
     elif args.component == "prefigure":
-        if args.format in ["source", "svg", "pdf", "png", "tactile"]:
+        if args.format in ["source", "svg", "pdf", "png", "tactile", "all"]:
             ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format)
         else:
             raise NotImplementedError('cannot make Prefigure graphics in "{}" format'.format(args.format) )


### PR DESCRIPTION
"all" is added as an implemented format for prefigure source in `pretext`

`prefigure_conversion` inside `pretext.py` reworked for format "all".  With this format choice, tactile PDF goes into `destination_directory/tactile`