### PR TITLE
PreFigure integration with EPUB conversion

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -225,6 +225,40 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         </description>
                     </image>
                 </figure>
+
+                <p>A Scalable Vector Graphics (SVG) image produced from <prefigure/> source with the <c>pretext</c> script.</p>
+                <figure xml:id="figure-prefigure-tangent">
+                    <caption>The graph of a function and a tangent line</caption>
+                    <image width="60%">
+                        <prefigure label="prefigure-tangent"
+                                   xmlns="https://prefigure.org">
+                            <diagram dimensions="(300,300)" margins="5">
+                                <definition>a=1</definition>
+                                <definition>f(x) = exp(x/3)*cos(x)</definition>
+                                <coordinates bbox="[-4,-4,4,4]">
+                                    <grid-axes xlabel="x" ylabel="y"/>
+                                    <graph at="graph" function='f' />
+                                    <tangent-line at="tangent" function="f" point="a"/>
+                                    <point at="point" p="(a, f(a))">
+                                        <m>(a,f(a))</m>
+                                    </point>
+                                </coordinates>
+
+                                <annotations>
+                                    <annotation ref="figure"
+                                                text="The graph of a function and its tangent line at the point a equals 1">
+                                        <annotation ref="graph-tangent" text="The graph and its tangent line">
+                                            <annotation ref="graph" text="The graph of the function f" sonify="yes"/>
+                                            <annotation ref="point" text="The point a comma f of a"/>
+                                            <annotation ref="tangent" text="The tangent line to the graph of f at the point"/>
+                                        </annotation>
+                                    </annotation>
+                                </annotations>
+                            </diagram>
+                        </prefigure>
+                    </image>
+                </figure>
+
                 <p>Here we drop a small reference to an equation
                 earlier, notably <xref ref="zeta-2" />.</p>
                 <p>A Scalable Vector Graphics (SVG) image created externally in Sage and then included here as a vector image (no file extension given).</p>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -21,6 +21,7 @@
                 xmlns:epub="http://www.idpf.org/2007/ops"
                 xmlns:exsl="http://exslt.org/common"
                 xmlns:date="http://exslt.org/dates-and-times"
+                xmlns:pf="https://prefigure.org"
                 exclude-result-prefixes="pi svg math epub"
                 extension-element-prefixes="exsl date">
 
@@ -1020,7 +1021,7 @@ width: 100%
                 </xsl:choose>
             </xsl:if>
         </xsl:when>
-        <xsl:when test="latex-image|sageplot|asymptote">
+        <xsl:when test="latex-image|sageplot|asymptote|pf:prefigure">
             <xsl:choose>
                 <xsl:when test="$purpose = 'read'">
                     <xsl:value-of select="$generated-directory-source"/>
@@ -1041,6 +1042,10 @@ width: 100%
                 <xsl:when test="asymptote">
                     <xsl:text>asymptote/</xsl:text>
                     <xsl:apply-templates select="asymptote" mode="image-source-basename"/>
+                </xsl:when>
+                <xsl:when test="pf:prefigure">
+                    <xsl:text>prefigure/</xsl:text>
+                    <xsl:apply-templates select="pf:prefigure" mode="image-source-basename"/>
                 </xsl:when>
             </xsl:choose>
             <xsl:choose>
@@ -1095,7 +1100,7 @@ width: 100%
                 <xsl:when test="@source and ($extension='svg' or $extension='')">
                     <xsl:text>image/svg+xml</xsl:text>
                 </xsl:when>
-                <xsl:when test="latex-image|sageplot|asymptote">
+                <xsl:when test="latex-image|sageplot|asymptote|pf:prefigure">
                     <xsl:text>image/svg+xml</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>


### PR DESCRIPTION
Updates to the `pretext-epub.xsl` stylesheet to support the inclusion of PreFigure source in the EPUB converstion.  The source for a PreFigure diagram is also included in `epub-sampler.xml`.

Using the included publication file, the `pretext/pretext` script built the requested SVG image from PreFigure source and placed it in `gen/prefigure`.  Building epub-svg from the sample EPUB document included the image appropriately in the EPUB output.  

This felt a little too easy, but we seem to be getting to the point where we can treat a #prefigure element in the same way as #latex-image, which is all I've done here.