### PR TITLE
better static representation of matching exercise

### DIFF
--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -564,6 +564,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <cell>
             <xsl:copy-of select="premise/node()"/>
         </cell>
+        <!-- Add an empty column between premises and responses: -->
+        <cell bottom="none"><nbsp/><nbsp/></cell>
         <cell>
             <xsl:copy-of select="$all-matches[@order = $premise-number]/response/node()"/>
         </cell>


### PR DESCRIPTION
This inserts an extra "gutter" column in the tabular for the static version of a matching Runestone exercise, to make it obvious that the premises and responses might not be matched up already.  Note that the solutions version doesn't have this, so it looks like they really are matched up. 