### PR TITLE
Fix credit <p> tag

### DIFF
--- a/css/pretext.css
+++ b/css/pretext.css
@@ -1006,7 +1006,7 @@ xxxxxx[data-ruler="sunriseunderline"] .onelineX:hover + .onelineX {
 }
 
 .ptx-footnote {
-    display: inline;
+    display: inline-block;
 }
 
 .ptx-footnote[open] {

--- a/css/pretext.css
+++ b/css/pretext.css
@@ -679,6 +679,10 @@ https://yoshiwarabooks.org/mfg/MathModels.html */
     white-space: pre;
 }
 
+.ptx-content .colophon .credit {
+  margin-top: 1em;
+}
+
 button {
    font: inherit;
 }

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -65,7 +65,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <edition>Annual Edition 2015</edition>
 
         <website>
-            <url href="http://abstract.pugetsound.edu" visual="abstract.pugetsound.edu"/>
+            <url href="http://abstract.pugetsound.edu" visual="abstract.pugetsound.edu">Some text to test bug report</url>
         </website>
 
         <copyright>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1069,28 +1069,28 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="bibinfo/credit[role]">
-    <p class="credit">
+    <div class="credit">
         <b class="title">
             <xsl:apply-templates select="role" />
         </b>
         <xsl:text> </xsl:text>
         <xsl:apply-templates select="entity"/>
-    </p>
+    </div>
 </xsl:template>
 
 <xsl:template match="bibinfo/edition">
-    <p class="credit">
+    <div class="credit">
         <b class="title">
             <xsl:apply-templates select="." mode="type-name" />
         </b>
         <xsl:text> </xsl:text>
         <xsl:apply-templates/>
-    </p>
+    </div>
 </xsl:template>
 
 <!-- website for the book -->
 <xsl:template match="bibinfo/website">
-    <p class="credit">
+    <div class="credit">
         <b class="title">
             <xsl:apply-templates select="." mode="type-name" />
         </b>
@@ -1100,7 +1100,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- source, but the pre-processor adds a footnote    -->
         <!-- Only one presumed, and thus enforced here        -->
         <xsl:apply-templates select="url[1]|fn[1]" />
-    </p>
+    </div>
 </xsl:template>
 
 <xsl:template match="bibinfo/copyright">


### PR DESCRIPTION
Fixes https://github.com/PreTeXtBook/pretext/issues/2273

Source of the issue was the user of HTML `<p`> for the `<credit>` tag. Changed it to a div and added styling to retain spacing around the credit.