### PR TITLE
Update rune.xml

### DIFF
--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3064,7 +3064,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </match>
     <match>
       <response>Power</response>
-      <premise order="2"><m>y=x^2</m></premise>
+      <premise order="2"><m>y=x^3</m></premise>
       <premise order="3"><m>y=\sqrt{x}</m></premise>
     </match>
     </matches>


### PR DESCRIPTION
fixed non-bijective matching example to avoid a function that could belong to two different categories.  It might be worth noting that as I understand it, the proposed expanded (terrific!) functionality still won't handle that case.