### PR TITLE
Keywords support

### DIFF
--- a/css/pretext.css
+++ b/css/pretext.css
@@ -489,6 +489,27 @@ https://yoshiwarabooks.org/mfg/MathModels.html */
     display: inline;
 }
 
+.ptx-content .keywords {
+    margin-top: 1em;
+}
+.ptx-content .keywords > .title {
+    font-weight: 600;
+    line-height: 1.125em;
+    display: inline;
+}
+.ptx-content .keywords > .title::after {
+    content: ".\2009\2009\2009";
+}
+.ptx-content .keywords > .title + .para {
+    display: inline;
+}
+
+.ptx-content .support {
+    display: block;
+    margin-top: 1em;
+}
+
+
 /*       -----      */
 
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -227,6 +227,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <!-- Can set date manually or use the "today" element -->
                 <date><today /></date>
+                <keywords>
+                <keyword>samples</keyword><keyword>PreTeXt</keyword><keyword>testing document</keyword>
+                </keywords>
+                <keywords authority="msc" variant="2010">
+                    <keyword primary="yes">00-01</keyword>
+                    <keyword>00-02</keyword>
+                    <keyword primary="no">00A99</keyword>
+                </keywords>
+                <support><p>This is an example of a statement describing funding support for the current document.</p></support>
             </bibinfo>
 
             <titlepage>

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -89,6 +89,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <minilicense>GFDL License</minilicense>
             <shortlicense>Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the appendix entitled <q>GNU Free Documentation License.</q>  All trademarks<trademark /> are the registered<registered /> marks of their respective owners. An <url href="https://example.com" visual="example.com">external link</url> is included<fn>A second footnote, as well.</fn> to test its footnote.</shortlicense>
         </copyright>
+
+        <keywords>
+            <keyword>abstract algebra</keyword>
+            <keyword>PreTeXt</keyword>
+            <keyword>samples</keyword>
+        </keywords>
+
+        <support>
+        <p>This work has received assistance from numerous volunteer contributors.</p>
+        </support>
     </bibinfo>
 
     <titlepage>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -200,18 +200,13 @@
                         (Author+, Editor*)
                         |
                         (Editor+)
-                    ),
-                    Credit*,
-                    Date?,
-                    ColophonCredit*,
-                    element edition {text}?,
-                    element version {text}?,
-                    Event?,
-                    Keywords*,
-                    Affiliation?,
-                    Support?,
-                    Website?,
-                    Copyright?
+                    )?,
+                    ((Credit | ColophonCredit)* &
+                    Date? &
+                    Edition? &
+                    Keywords* &
+                    Website? &
+                    Copyright?)
                 }
             TitlePage =
                 element titlepage {
@@ -227,6 +222,7 @@
                 }
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
+            Support = element support {TextParagraph}
             Location = element address {TextSimple | ShortLine+}
             Keywords = element keywords {
                 attribute authority {text}?,
@@ -238,10 +234,7 @@
                 attribute primary {"yes"|"no"}?,
                 TextSimple
             }
-            Support = element funding {
-                Title?,
-                Paragraph+
-            }
+            Edition = element edition {text}
             Event = element event {
                 TextLong
             }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -592,56 +592,44 @@
   </define>
   <define name="Bibinfo">
     <element name="bibinfo">
-      <choice>
-        <group>
+      <optional>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="Author"/>
+            </oneOrMore>
+            <zeroOrMore>
+              <ref name="Editor"/>
+            </zeroOrMore>
+          </group>
           <oneOrMore>
-            <ref name="Author"/>
-          </oneOrMore>
-          <zeroOrMore>
             <ref name="Editor"/>
-          </zeroOrMore>
-        </group>
-        <oneOrMore>
-          <ref name="Editor"/>
-        </oneOrMore>
-      </choice>
-      <zeroOrMore>
-        <ref name="Credit"/>
-      </zeroOrMore>
-      <optional>
-        <ref name="Date"/>
+          </oneOrMore>
+        </choice>
       </optional>
-      <zeroOrMore>
-        <ref name="ColophonCredit"/>
-      </zeroOrMore>
-      <optional>
-        <element name="edition">
-          <text/>
-        </element>
-      </optional>
-      <optional>
-        <element name="version">
-          <text/>
-        </element>
-      </optional>
-      <optional>
-        <ref name="Event"/>
-      </optional>
-      <zeroOrMore>
-        <ref name="Keywords"/>
-      </zeroOrMore>
-      <optional>
-        <ref name="Affiliation"/>
-      </optional>
-      <optional>
-        <ref name="Support"/>
-      </optional>
-      <optional>
-        <ref name="Website"/>
-      </optional>
-      <optional>
-        <ref name="Copyright"/>
-      </optional>
+      <interleave>
+        <zeroOrMore>
+          <choice>
+            <ref name="Credit"/>
+            <ref name="ColophonCredit"/>
+          </choice>
+        </zeroOrMore>
+        <optional>
+          <ref name="Date"/>
+        </optional>
+        <optional>
+          <ref name="Edition"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="Keywords"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="Website"/>
+        </optional>
+        <optional>
+          <ref name="Copyright"/>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="TitlePage">
@@ -696,6 +684,11 @@
       </choice>
     </element>
   </define>
+  <define name="Support">
+    <element name="support">
+      <ref name="TextParagraph"/>
+    </element>
+  </define>
   <define name="Location">
     <element name="address">
       <choice>
@@ -735,14 +728,9 @@
       <ref name="TextSimple"/>
     </element>
   </define>
-  <define name="Support">
-    <element name="funding">
-      <optional>
-        <ref name="Title"/>
-      </optional>
-      <oneOrMore>
-        <ref name="Paragraph"/>
-      </oneOrMore>
+  <define name="Edition">
+    <element name="edition">
+      <text/>
     </element>
   </define>
   <define name="Event">

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3019,18 +3019,13 @@
                         (Author+, Editor*)
                         |
                         (Editor+)
-                    ),
-                    Credit*,
-                    Date?,
-                    ColophonCredit*,
-                    element edition {text}?,
-                    element version {text}?,
-                    Event?,
-                    Keywords*,
-                    Affiliation?,
-                    Support?,
-                    Website?,
-                    Copyright?
+                    )?,
+                    ((Credit | ColophonCredit)* &amp;
+                    Date? &amp;
+                    Edition? &amp;
+                    Keywords* &amp;
+                    Website? &amp;
+                    Copyright?)
                 }
             TitlePage =
                 element titlepage {
@@ -3046,6 +3041,7 @@
                 }
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
+            Support = element support {TextParagraph}
             Location = element address {TextSimple | ShortLine+}
             Keywords = element keywords {
                 attribute authority {text}?,
@@ -3057,10 +3053,7 @@
                 attribute primary {"yes"|"no"}?,
                 TextSimple
             }
-            Support = element funding {
-                Title?,
-                Paragraph+
-            }
+            Edition = element edition {text}
             Event = element event {
                 TextLong
             }

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -427,29 +427,27 @@
   <xs:element name="bibinfo">
     <xs:complexType>
       <xs:sequence>
-        <xs:choice>
+        <xs:choice minOccurs="0">
           <xs:sequence>
             <xs:group maxOccurs="unbounded" ref="Author"/>
             <xs:group minOccurs="0" maxOccurs="unbounded" ref="Editor"/>
           </xs:sequence>
           <xs:group maxOccurs="unbounded" ref="Editor"/>
         </xs:choice>
-        <xs:group minOccurs="0" maxOccurs="unbounded" ref="Credit"/>
-        <xs:element minOccurs="0" ref="date"/>
-        <xs:group minOccurs="0" maxOccurs="unbounded" ref="ColophonCredit"/>
-        <xs:element minOccurs="0" ref="edition"/>
-        <xs:element minOccurs="0" ref="version"/>
-        <xs:element minOccurs="0" ref="event"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="keywords"/>
-        <xs:element minOccurs="0" ref="affiliation"/>
-        <xs:element minOccurs="0" ref="funding"/>
-        <xs:element minOccurs="0" ref="website"/>
-        <xs:group minOccurs="0" ref="Copyright"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:choice>
+            <xs:group ref="Credit"/>
+            <xs:group ref="ColophonCredit"/>
+          </xs:choice>
+          <xs:element ref="date"/>
+          <xs:element ref="edition"/>
+          <xs:element ref="keywords"/>
+          <xs:element ref="website"/>
+          <xs:group ref="Copyright"/>
+        </xs:choice>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="edition" type="xs:string"/>
-  <xs:element name="version" type="xs:string"/>
   <xs:element name="titlepage">
     <xs:complexType>
       <xs:sequence>
@@ -491,6 +489,11 @@
       </xs:choice>
     </xs:complexType>
   </xs:element>
+  <xs:element name="support">
+    <xs:complexType mixed="true">
+      <xs:group ref="TextParagraph"/>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="address">
     <xs:complexType mixed="true">
       <xs:choice>
@@ -522,14 +525,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="funding">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:group minOccurs="0" ref="Title"/>
-        <xs:group maxOccurs="unbounded" ref="Paragraph"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="edition" type="xs:string"/>
   <xs:element name="event">
     <xs:complexType mixed="true">
       <xs:group ref="TextLong"/>
@@ -551,7 +547,7 @@
             </xs:choice>
             <xs:element minOccurs="0" ref="email"/>
             <xs:element minOccurs="0" ref="biography"/>
-            <xs:element minOccurs="0" ref="funding"/>
+            <xs:element minOccurs="0" ref="support"/>
           </xs:sequence>
           <xs:attribute name="corresponding">
             <xs:simpleType>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -281,6 +281,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='edition'>Edition</localization>
     <localization string-id='website'>Website</localization>
     <localization string-id='copyright'>Copyright</localization>
+    <localization string-id='keywords'>Keywords</localization>
     <!-- HTML clickables (lowercase strings to click on) -->
     <localization string-id='permalink'>permalink</localization>
     <localization string-id='incontext'>in-context</localization>

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -242,7 +242,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Various -->
     <localization string-id='todo'>Para hacer</localization>
     <localization string-id='editor'>Editor</localization>
-    <localization string-id='edition'>Edición</localization> 
+    <localization string-id='edition'>Edición</localization>
+    <localization string-id='keywords'>Palabras clave</localization>
     <!-- <localization string-id='website'>Website</localization> -->
     <localization string-id='copyright'>Derechos de autor</localization>
     <!-- HTML clickables (lowercase strings to click on) -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2641,7 +2641,7 @@ Book (with parts), "section" at level 3
 <!-- Some items have default titles that make sense         -->
 <!-- Typically these are one-off subdivisions (eg preface), -->
 <!-- or repeated generic divisions (eg exercises)           -->
-<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|abstract|references|glossary|exercises|worksheet|reading-questions|exercisegroup|solutions|backmatter|index|case|interactive/instructions" mode="has-default-title">
+<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|abstract|references|glossary|exercises|worksheet|reading-questions|exercisegroup|solutions|backmatter|index|case|interactive/instructions|keywords" mode="has-default-title">
     <xsl:text>true</xsl:text>
 </xsl:template>
 <xsl:template match="*" mode="has-default-title">
@@ -2649,6 +2649,22 @@ Book (with parts), "section" at level 3
 </xsl:template>
 
 <!-- NB: these templates return a property of the title's parent -->
+
+<xsl:template match="keywords" mode="default-title">
+    <xsl:choose>
+        <xsl:when test="@authority='msc'">
+            <xsl:if test="@variant">
+                <xsl:value-of select="@variant"/>
+                <xsl:text>&#160;</xsl:text>
+            </xsl:if>
+            <xsl:text>Math Subject Classification</xsl:text>
+        </xsl:when>
+        <!-- Default is @authority='author' or no recognized authority given -->
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="type-name"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
 
 <!-- Normally a default title is the "type-name" of the object. -->
 <!-- But to indicate that a "worksheet" or "exercises" division -->
@@ -7110,6 +7126,19 @@ Book (with parts), "section" at level 3
 <!-- No conversion will create content directly from bibinfo -->
 <xsl:template match="bibinfo"/>
 
+<!-- Keywords: create a comma-separated list.  No punctuation after final keyword -->
+<xsl:template match="keywords/keyword">
+    <xsl:if test="@primary='yes'">
+        <xsl:text>Primary </xsl:text>
+    </xsl:if>
+    <xsl:if test="@primary='no' or @secondary='yes'">
+        <xsl:text>Secondary </xsl:text>
+    </xsl:if>
+    <xsl:value-of select="."/>
+    <xsl:if test="following-sibling::keyword">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+</xsl:template>
 
 
 <!-- ############# -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -834,6 +834,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="title-full"/>
         </span>
         <xsl:apply-templates select="*"/>
+        <!-- Display keywords.  Note: the placement of this here works for  -->
+        <!-- articles that have an abstract.  Books (no abstract) will put  -->
+        <!-- their keywords in the colophon.                                -->
+        <xsl:apply-templates select="$bibinfo/keywords" />
+        <!-- Display general support (funding) statement -->
+        <xsl:apply-templates select="$bibinfo/support" />
     </div>
 </xsl:template>
 
@@ -1065,6 +1071,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="line" />
 </xsl:template>
 
+<!-- Keywords -->
+<xsl:template match="bibinfo/keywords">
+    <div class="keywords">
+        <span class="title">
+            <xsl:apply-templates select="." mode="title-full"/>
+        </span>
+        <xsl:apply-templates select="*" />
+        <xsl:text>.</xsl:text>
+    </div>
+</xsl:template>
+
+<!-- General support (not for a particular author) -->
+<xsl:template match="bibinfo/support">
+    <div class="support">
+        <xsl:apply-templates select="*"/>
+    </div>
+</xsl:template>
+
+
 <!-- Front Colophon -->
 <!-- Licenses, ISBN, Cover Designer, etc -->
 <!-- We process pieces, in document order -->
@@ -1081,6 +1106,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
      <xsl:apply-templates select="$bibinfo/edition" />
      <xsl:apply-templates select="$bibinfo/website" />
      <xsl:apply-templates select="$bibinfo/copyright" />
+     <!-- NB: keywords are included in a colophon for a book, but under the abstract of an article -->
+     <xsl:apply-templates select="$bibinfo/keywords" />
+     <xsl:apply-templates select="$bibinfo/support" />
 </xsl:template>
 
 <xsl:template match="bibinfo/credit[role]">
@@ -10481,7 +10509,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:if>
                 <xsl:apply-templates select="." mode="title-plain" />
             </title>
-            <meta name="Keywords" content="Authored in PreTeXt" />
+            <!-- Add keywords, including those in bibinfo -->
+            <xsl:call-template name="keywords-meta-element"/>
             <!-- http://webdesignerwall.com/tutorials/responsive-design-in-3-steps -->
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
             <!-- canonical link for better SEO -->
@@ -10643,7 +10672,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:call-template name="language-attributes"/>
         <!-- Open Graph Protocol only in "meta" elements, within "head" -->
         <head xmlns:og="http://ogp.me/ns#" xmlns:book="https://ogp.me/ns/book#">
-            <meta name="Keywords" content="Authored in PreTeXt" />
+            <!-- keywords, including those from bibinfo -->
+            <xsl:call-template name="keywords-meta-element" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
             <!-- canonical link for better SEO -->
             <xsl:call-template name="canonical-link">
@@ -10707,6 +10737,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="'yes'"/>
         </xsl:attribute>
     </xsl:if>
+</xsl:template>
+
+<!-- ############# -->
+<!-- Meta keywords -->
+<!-- ############# -->
+
+<xsl:template name="keywords-meta-element" >
+    <meta name="Keywords">
+        <xsl:attribute name="content">
+            <xsl:if test="$bibinfo/keywords[not(@authority='msc')]">
+                <xsl:apply-templates select="$bibinfo/keywords[not(@authority='msc')]/keyword" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:text>Authord in PreTeXt</xsl:text>
+        </xsl:attribute>
+    </meta>
 </xsl:template>
 
 <!-- ################### -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1434,6 +1434,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:if>
+    <!-- If there is a <support> tag in an article, create a unnumbered footnote environment for it -->
+    <xsl:if test="$b-is-article and $bibinfo/support">
+        <xsl:text>%% add a \support command as unnumbered footnote&#xa;</xsl:text>
+        <xsl:text>\let\svdthefootnote\thefootnote%&#xa;</xsl:text>
+        <xsl:text>\newcommand\support[1]{%&#xa;</xsl:text>
+        <xsl:text>  \let\thefootnote\relax%&#xa;</xsl:text>
+        <xsl:text>  \footnotetext{#1}%&#xa;</xsl:text>
+        <xsl:text>  \let\thefootnote\svdthefootnote%&#xa;</xsl:text>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- Font Awesome package -->
@@ -3953,6 +3963,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <xsl:apply-templates select="$docinfo/event" />
     </xsl:if>
+    <xsl:if test="$bibinfo/support">
+        <xsl:text>\support{</xsl:text>
+        <xsl:apply-templates select="$bibinfo/support" mode="article-info"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>}&#xa;</xsl:text>
     <xsl:if test="$bibinfo/author or $bibinfo/editor">
         <xsl:text>\author{</xsl:text>
@@ -4209,9 +4224,23 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:for-each>
 
     <xsl:text>\vspace*{\stretch{1}}&#xa;</xsl:text>
+    <!-- Add support statement from bibinfo if present. -->
+    <xsl:if test="$bibinfo/support">
+        <xsl:apply-templates select="$bibinfo/support" mode="copyright-page"/>
+    </xsl:if>
     <!-- Something so page is not totally nothing -->
     <xsl:text>\null\clearpage&#xa;</xsl:text>
     <xsl:text>%% end:   copyright-page&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Only for a book with a colophon, we put the statement of support at the bottom of the colophon -->
+<xsl:template match="bibinfo/support" mode="copyright-page">
+    <xsl:text>%% Funding/Support statement:</xsl:text>
+    <xsl:text>\par\medskip&#xa;</xsl:text>
+    <xsl:text>\noindent{}</xsl:text>
+    <xsl:apply-templates select="*" />
+    <xsl:text>\par&#xa;</xsl:text>
+    <xsl:text>\vspace*{\stretch{1}}&#xa;</xsl:text>
 </xsl:template>
 
 <!-- URL for canonical project website -->
@@ -4297,6 +4326,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
+<xsl:template match="bibinfo/support" mode="article-info">
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<xsl:template match="bibinfo/support" mode="article-info">
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
 <!-- Departments, Institutions, and Addresses are free-form, or sequences of lines  -->
 <!-- Line breaks are inserted above, due to \and, etc, so do not end last line here -->
 <xsl:template match="department|institution|location">
@@ -4343,14 +4380,28 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Articles may have an abstract in the frontmatter. We -->
 <!-- accept the LaTeX article class approach and switch   -->
 <!-- to a localization of the heading just prior to use.  -->
+<!-- Keywords are placed inside the abstract, at the end. -->
 <xsl:template match="article/frontmatter/abstract">
     <xsl:text>\renewcommand*{\abstractname}{</xsl:text>
     <xsl:apply-templates select="." mode="type-name"/>
     <xsl:text>}&#xa;</xsl:text>
     <xsl:text>\begin{abstract}&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
+    <xsl:if test="$bibinfo/keywords">
+        <xsl:apply-templates select="$bibinfo/keywords"/>
+    </xsl:if>
     <xsl:text>\end{abstract}&#xa;</xsl:text>
 </xsl:template>
+
+<xsl:template match="bibinfo/keywords">
+    <xsl:text>\par\medskip&#xa;</xsl:text>
+    <xsl:text>\noindent{\bfseries </xsl:text>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:text>}. </xsl:text>
+    <xsl:apply-templates select="*" />
+    <xsl:text>.&#xa;</xsl:text>
+</xsl:template>
+
 
 <!-- ################### -->
 <!-- Front Matter, Books -->


### PR DESCRIPTION
This still needs a lot of work, but sharing in case @rbeezer has time and wants to redirect.  Mostly still trying to figure out where things should live in the xsl.

So far, only working on HTML conversion.  Added title support in `pretext-common`.

Need to think more about the how keywords interact with other components.  In a book, keywords should go in colophon, I think.  In article, they should go *after* the abstract, so not in the titlepage, even though in html the abstract is shown on the "first" page (if there is chunking).