### PR TITLE
Bugfix single line program

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10688,6 +10688,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </program>
             </listing>
 
+            <p>Although a program should have a <tag>code</tag> element surrounding its code, we attempt to provide one when it is missing. This next sample tests that and intentionally has no leading or trailing newline inside the program.</p>
+
+            <program languge="python">print("Hello world")</program>
+
             <p>If you are discussing algorithms in the abstract (or even concretely), you can set them off like a theorem, with a number, a title and a target for cross-references.  Sometimes you claim an algorithm produces something in particular, or has certain properties, such as a theoretical run time, so a proof may be included.  See the discussion just preceding about (limited) options for pseudo-code.</p>
 
             <algorithm xml:id="algorithm-sieve-eratosthenes">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9202,9 +9202,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:with-param name="substr" select="'&#xA;'" />
                         </xsl:call-template>
                     </xsl:if>
-                    <xsl:call-template name="substring-before-last">
-                        <xsl:with-param name="input" select="code" />
-                        <xsl:with-param name="substr" select="'&#xA;'" />
+                    <!-- code section MUST end with newline, which author may or may not have included      -->
+                    <!-- so remove up to one newline and trailing space from end of code then add a newline -->
+                    <xsl:call-template name="strip-trailing-whitespace-line">
+                        <xsl:with-param name="text" select="code" />
                     </xsl:call-template>
                     <xsl:text>&#xA;</xsl:text>
                     <xsl:if test="postamble[not(@visible = 'no')]">

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -849,6 +849,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- Working from end, remove whitespace back to and including last newline -->
+<xsl:template name="strip-trailing-whitespace-line">
+    <xsl:param name="text" />
+    <xsl:variable name="last-char" select="substring($text, string-length($text), 1)" />
+    <xsl:choose>
+        <!-- if empty, quit -->
+        <xsl:when test="not($last-char)" />
+        <!-- if last character is newline, return everything else -->
+        <xsl:when test="$last-char = '&#xa;'">
+            <xsl:value-of select="substring($text, 1, string-length($text)-1)" />
+        </xsl:when>
+        <!-- if last character is whitespace, drop it -->
+        <xsl:when test="contains($whitespaces, $last-char)">
+            <xsl:call-template name="strip-trailing-whitespace">
+                <xsl:with-param name="text" select="substring($text, 1, string-length($text)-1)" />
+            </xsl:call-template>
+        </xsl:when>
+        <!-- else finished stripping, output as-is -->
+        <xsl:otherwise>
+            <xsl:value-of select="$text" />
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- spurious newlines introduce whitespace on either side -->
 <!-- we split at newlines, strip consecutive whitesapce on either side, -->
 <!-- and replace newlines by spaces (could restore a single newline) -->


### PR DESCRIPTION
I just discovered the recent program update doesn't handle the case where the contents of `<program><code>` does not include any newlines. Samples:

`<program>print("Hello")</program>`
`<program><code>print("Hello")</code></program>`

`substring-before-last` is being used to clean up the trailing whitespace, but that template returns `''` if there is no newline. So currently, the code in those samples is dropped.

First commit adds a parma to `substring-before-last` that allows the caller to ask for the $input back if there is no match. That generates clean diffs for sample-book and sample-article in all formats.

Other commits use that to fix pretext-html and adds a test case to the sample article.

Sorry about this one, I missed that this test case was no where in sample-book or article and thus not getting checked.