### PR TITLE
Count pad length speedup

### DIFF
--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -146,25 +146,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Compute length of indentation of first line                   -->
 <!-- Assumes no leading blank lines                                -->
-<!-- Assumes each line, including last, ends in a carriage return  -->
 <xsl:template name="count-pad-length">
-   <xsl:param name="text"/>
-   <xsl:param name="pad" select="''"/>
-   <xsl:variable name="first-char" select="substring($text, 1, 1)" />
-   <xsl:choose>
-        <xsl:when test="$first-char='&#xA;'">
-            <xsl:value-of select="string-length($pad)" />
+    <xsl:param name="text"/>
+    <xsl:param name="cur-index" select="1"/>
+    <xsl:variable name="first-char" select="substring($text, $cur-index, 1)" />
+    <xsl:choose>
+        <!-- reached end of string or newline... bail out -->
+        <xsl:when test="$first-char = '' or $first-char = '&#xA;'">
+            <xsl:value-of select="$cur-index - 1"/>
         </xsl:when>
         <xsl:when test="contains($whitespaces, $first-char)">
             <xsl:call-template name="count-pad-length">
-                <xsl:with-param name="text" select="substring($text, 2)" />
-                <xsl:with-param name="pad"  select="concat($pad, $first-char)" />
+                <xsl:with-param name="text" select="$text" />
+                <xsl:with-param name="cur-index" select="$cur-index + 1" />
             </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:value-of select="string-length($pad)" />
+            <xsl:value-of select="$cur-index - 1" />
         </xsl:otherwise>
-   </xsl:choose>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Compute width of left margin        -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -182,7 +182,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- Non-destructively count leading whitespace -->
             <xsl:variable name="pad-top-line">
                 <xsl:call-template name="count-pad-length">
-                    <xsl:with-param name="text" select="$text" />
+                    <xsl:with-param name="text" select="substring-before($text, '&#xa;')" />
                 </xsl:call-template>
             </xsl:variable>
             <xsl:variable name="content-top-line" select="substring-before($text, '&#xa;')" />


### PR DESCRIPTION
When building sample-book for html, xsltproc identifies count-pad-length as the template that accounts for the second most time ~12-15% of the total.

This reimplements count-pad-length to use counters as parameters instead of strings to avoid lots of string building and slicing. That provides ~3-4x speedup. 

Second commit changes the left-margin template to only pass in the first line to count pad length. Which prevents count-pad-length from passing copies of a possibly giant multiline string to itself over and over.
That is another ~3-4x speedup

count-pad-length now accounts for ~1-1.5% of the total time.

Generates clean diffs on the sample book & article.