### PR TITLE
Affiliation for authors, editors, and contributors

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -197,21 +197,21 @@
             Bibinfo =
                 element bibinfo {
                     (
-                        (Author, Author*, Editor*)
+                        (Author+, Editor*)
                         |
-                        (Editor, Editor*)
+                        (Editor+)
                     ),
                     Credit*,
                     Date?,
                     ColophonCredit*,
                     element edition {text}?,
+                    element version {text}?,
+                    Event?,
+                    Keywords*,
+                    Affiliation?,
+                    Support?,
                     Website?,
-                    element copyright {
-                        element year {TextShort},
-                        element holder {text},
-                        element minilicense {TextShort}?,
-                        ShortLicense?
-                    }?
+                    Copyright?
                 }
             TitlePage =
                 element titlepage {
@@ -219,20 +219,52 @@
                 }
             Email = element email {text}
             PersonName = element personname {TextSimple}
+            Affiliation =
+                element affiliation {
+                    Department? &
+                    Institution? &
+                    Location?
+                }
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
+            Location = element address {TextSimple | ShortLine+}
+            Keywords = element keywords {
+                attribute authority {text}?,
+                attribute variant {text}?,
+                Title?,
+                Keyword+
+            }
+            Keyword = element keyword {
+                attribute primary {"yes"|"no"}?,
+                TextSimple
+            }
+            Support = element funding {
+                Title?,
+                Paragraph+
+            }
+            Event = element event {
+                TextLong
+            }
             Author =
                 element author {
+                    attribute corresponding {"yes" | "no"}?,
+                    attribute xml:id {text}?,
                     PersonName,
-                    Department?,
-                    Institution?,
-                    Email?
+                    (
+                        (Department? & Institution? & Location?) |
+                        Affiliation+
+                    )?,
+                    Email?,
+                    Biography?,
+                    Support?
                 }
             Editor =
                 element editor {
                     PersonName,
-                    Department?,
-                    Institution?,
+                    (
+                        (Department? & Institution? & Location?) |
+                        Affiliation+
+                    )?,
                     Email?
                 }
             Credit =
@@ -255,6 +287,13 @@
                 }
             ShortLicense = element shortlicense {TextLong}
             Website = element website {Url}
+            Copyright = 
+                element copyright {
+                    element year {TextShort},
+                    element holder {text},
+                    element minilicense {TextShort}?,
+                    ShortLicense?
+                }
             ColophonFront =
                 element colophon {
                     MetaDataTarget,
@@ -1126,9 +1165,15 @@
                 element contributor {
                     MetaDataTarget,
                     PersonName,
-                    Department?,
-                    Institution?,
-                    element location {TextSimple}?,
+                    (
+                        (
+                        Department?,
+                        Institution?,
+                        Location?
+                        )
+                        |
+                        Affiliation+
+                    )?,
                     Email?
                 }
             Contributors =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -594,20 +594,16 @@
     <element name="bibinfo">
       <choice>
         <group>
-          <ref name="Author"/>
-          <zeroOrMore>
+          <oneOrMore>
             <ref name="Author"/>
-          </zeroOrMore>
+          </oneOrMore>
           <zeroOrMore>
             <ref name="Editor"/>
           </zeroOrMore>
         </group>
-        <group>
+        <oneOrMore>
           <ref name="Editor"/>
-          <zeroOrMore>
-            <ref name="Editor"/>
-          </zeroOrMore>
-        </group>
+        </oneOrMore>
       </choice>
       <zeroOrMore>
         <ref name="Credit"/>
@@ -624,25 +620,27 @@
         </element>
       </optional>
       <optional>
+        <element name="version">
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <ref name="Event"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="Keywords"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="Affiliation"/>
+      </optional>
+      <optional>
+        <ref name="Support"/>
+      </optional>
+      <optional>
         <ref name="Website"/>
       </optional>
       <optional>
-        <element name="copyright">
-          <element name="year">
-            <ref name="TextShort"/>
-          </element>
-          <element name="holder">
-            <text/>
-          </element>
-          <optional>
-            <element name="minilicense">
-              <ref name="TextShort"/>
-            </element>
-          </optional>
-          <optional>
-            <ref name="ShortLicense"/>
-          </optional>
-        </element>
+        <ref name="Copyright"/>
       </optional>
     </element>
   </define>
@@ -661,6 +659,21 @@
   <define name="PersonName">
     <element name="personname">
       <ref name="TextSimple"/>
+    </element>
+  </define>
+  <define name="Affiliation">
+    <element name="affiliation">
+      <interleave>
+        <optional>
+          <ref name="Department"/>
+        </optional>
+        <optional>
+          <ref name="Institution"/>
+        </optional>
+        <optional>
+          <ref name="Location"/>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="Department">
@@ -683,17 +696,100 @@
       </choice>
     </element>
   </define>
-  <define name="Author">
-    <element name="author">
-      <ref name="PersonName"/>
+  <define name="Location">
+    <element name="address">
+      <choice>
+        <ref name="TextSimple"/>
+        <oneOrMore>
+          <ref name="ShortLine"/>
+        </oneOrMore>
+      </choice>
+    </element>
+  </define>
+  <define name="Keywords">
+    <element name="keywords">
       <optional>
-        <ref name="Department"/>
+        <attribute name="authority"/>
       </optional>
       <optional>
-        <ref name="Institution"/>
+        <attribute name="variant"/>
+      </optional>
+      <optional>
+        <ref name="Title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="Keyword"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Keyword">
+    <element name="keyword">
+      <optional>
+        <attribute name="primary">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="TextSimple"/>
+    </element>
+  </define>
+  <define name="Support">
+    <element name="funding">
+      <optional>
+        <ref name="Title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="Paragraph"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Event">
+    <element name="event">
+      <ref name="TextLong"/>
+    </element>
+  </define>
+  <define name="Author">
+    <element name="author">
+      <optional>
+        <attribute name="corresponding">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:id"/>
+      </optional>
+      <ref name="PersonName"/>
+      <optional>
+        <choice>
+          <interleave>
+            <optional>
+              <ref name="Department"/>
+            </optional>
+            <optional>
+              <ref name="Institution"/>
+            </optional>
+            <optional>
+              <ref name="Location"/>
+            </optional>
+          </interleave>
+          <oneOrMore>
+            <ref name="Affiliation"/>
+          </oneOrMore>
+        </choice>
       </optional>
       <optional>
         <ref name="Email"/>
+      </optional>
+      <optional>
+        <ref name="Biography"/>
+      </optional>
+      <optional>
+        <ref name="Support"/>
       </optional>
     </element>
   </define>
@@ -701,10 +797,22 @@
     <element name="editor">
       <ref name="PersonName"/>
       <optional>
-        <ref name="Department"/>
-      </optional>
-      <optional>
-        <ref name="Institution"/>
+        <choice>
+          <interleave>
+            <optional>
+              <ref name="Department"/>
+            </optional>
+            <optional>
+              <ref name="Institution"/>
+            </optional>
+            <optional>
+              <ref name="Location"/>
+            </optional>
+          </interleave>
+          <oneOrMore>
+            <ref name="Affiliation"/>
+          </oneOrMore>
+        </choice>
       </optional>
       <optional>
         <ref name="Email"/>
@@ -757,6 +865,24 @@
   <define name="Website">
     <element name="website">
       <ref name="Url"/>
+    </element>
+  </define>
+  <define name="Copyright">
+    <element name="copyright">
+      <element name="year">
+        <ref name="TextShort"/>
+      </element>
+      <element name="holder">
+        <text/>
+      </element>
+      <optional>
+        <element name="minilicense">
+          <ref name="TextShort"/>
+        </element>
+      </optional>
+      <optional>
+        <ref name="ShortLicense"/>
+      </optional>
     </element>
   </define>
   <define name="ColophonFront">
@@ -2830,15 +2956,22 @@
       <ref name="MetaDataTarget"/>
       <ref name="PersonName"/>
       <optional>
-        <ref name="Department"/>
-      </optional>
-      <optional>
-        <ref name="Institution"/>
-      </optional>
-      <optional>
-        <element name="location">
-          <ref name="TextSimple"/>
-        </element>
+        <choice>
+          <group>
+            <optional>
+              <ref name="Department"/>
+            </optional>
+            <optional>
+              <ref name="Institution"/>
+            </optional>
+            <optional>
+              <ref name="Location"/>
+            </optional>
+          </group>
+          <oneOrMore>
+            <ref name="Affiliation"/>
+          </oneOrMore>
+        </choice>
       </optional>
       <optional>
         <ref name="Email"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2963,6 +2963,36 @@
 
         <p>Articles and books have material at the start, which gets organized in interesting ways. <c>minilicense</c> is very restrictive, <c>shortlicense</c> allows references (<eg/> <init>URL</init>s).  <c>bibinfo</c> is like a very small database whose content migrates to a titlepage and colophon if <c>titlepage/titlepage-items</c> or <c>colophon/colophon-items</c> are present. For HTML, titlepage means the page for the <c>frontmatter</c> , and for <latex/> these items migrate to the half-title and title pages.  Since it generally makes no sense as the target of a cross-reference, <c>titlepage</c> does not allow an <c>@xml:id</c> attribute.</p>
 
+        <p>Some notes about new additions to <c>bibinfo</c>.
+        <ul>
+            <li>
+                <p>
+                    <c>version</c> might be useful for books (could be draft or preview for example) but is mainly for articles, where it's content could be <q>authors submitted version</q> or <q>revision 2.</q>  A book might have both a version and an edition, but editions don't really apply to articles.
+                </p>
+            </li>
+            <li>
+                <p>
+                    JATS has <c>permissions</c> but we have <c>copyright</c>.  It seems like these have the same content.
+                </p>
+            </li>
+            <li>
+                <p>
+                    We introduce <c>keywords</c> (equivalent to JATS <c>kwd-group</c>) which contains a sequence of <c>keyword</c> elements.  There can be multiple <c>keywords</c> elements, as this can be used for subject classifications, or author keywords, etc.  Attributes on the <c>keywords</c> element can be used to distinguish these: <attr>authority</attr> can be <q>msc</q> for Math Subject Classification, in which cas the <tag>keywords</tag> can also have <attr>variant</attr> to specify the year version of the MSC.  The default <attr>authority</attr> is <q>author.</q>
+                </p>
+            </li>
+            <li>
+                <p>
+                    To describe the financial support for the work, we use <c>support</c>.  This can go in <c>bibinfo</c> directly or tied directly to an author or authors.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Slideshows already have a <tag>event</tag>, which we make official here and use to describe a conference for which the work was prepared.  JATS uses <c>conference</c> for this, and structures it with elements such as <c>date</c>, <c>accronym</c>, and similar, but we do not go that far.
+                </p>
+            </li>
+        </ul>
+        </p>
+
         <fragment xml:id="frontmatter">
             <title>Front matter</title>
             <code>
@@ -2986,21 +3016,21 @@
             Bibinfo =
                 element bibinfo {
                     (
-                        (Author, Author*, Editor*)
+                        (Author+, Editor*)
                         |
-                        (Editor, Editor*)
+                        (Editor+)
                     ),
                     Credit*,
                     Date?,
                     ColophonCredit*,
                     element edition {text}?,
+                    element version {text}?,
+                    Event?,
+                    Keywords*,
+                    Affiliation?,
+                    Support?,
                     Website?,
-                    element copyright {
-                        element year {TextShort},
-                        element holder {text},
-                        element minilicense {TextShort}?,
-                        ShortLicense?
-                    }?
+                    Copyright?
                 }
             TitlePage =
                 element titlepage {
@@ -3008,20 +3038,52 @@
                 }
             Email = element email {text}
             PersonName = element personname {TextSimple}
+            Affiliation =
+                element affiliation {
+                    Department? &amp;
+                    Institution? &amp;
+                    Location?
+                }
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
+            Location = element address {TextSimple | ShortLine+}
+            Keywords = element keywords {
+                attribute authority {text}?,
+                attribute variant {text}?,
+                Title?,
+                Keyword+
+            }
+            Keyword = element keyword {
+                attribute primary {"yes"|"no"}?,
+                TextSimple
+            }
+            Support = element funding {
+                Title?,
+                Paragraph+
+            }
+            Event = element event {
+                TextLong
+            }
             Author =
                 element author {
+                    attribute corresponding {"yes" | "no"}?,
+                    attribute xml:id {text}?,
                     PersonName,
-                    Department?,
-                    Institution?,
-                    Email?
+                    (
+                        (Department? &amp; Institution? &amp; Location?) |
+                        Affiliation+
+                    )?,
+                    Email?,
+                    Biography?,
+                    Support?
                 }
             Editor =
                 element editor {
                     PersonName,
-                    Department?,
-                    Institution?,
+                    (
+                        (Department? &amp; Institution? &amp; Location?) |
+                        Affiliation+
+                    )?,
                     Email?
                 }
             Credit =
@@ -3044,6 +3106,13 @@
                 }
             ShortLicense = element shortlicense {TextLong}
             Website = element website {Url}
+            Copyright = 
+                element copyright {
+                    element year {TextShort},
+                    element holder {text},
+                    element minilicense {TextShort}?,
+                    ShortLicense?
+                }
             ColophonFront =
                 element colophon {
                     MetaDataTarget,
@@ -3124,9 +3193,15 @@
                 element contributor {
                     MetaDataTarget,
                     PersonName,
-                    Department?,
-                    Institution?,
-                    element location {TextSimple}?,
+                    (
+                        (
+                        Department?,
+                        Institution?,
+                        Location?
+                        )
+                        |
+                        Affiliation+
+                    )?,
                     Email?
                 }
             Contributors =

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -429,44 +429,27 @@
       <xs:sequence>
         <xs:choice>
           <xs:sequence>
-            <xs:group ref="Author"/>
-            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Author"/>
+            <xs:group maxOccurs="unbounded" ref="Author"/>
             <xs:group minOccurs="0" maxOccurs="unbounded" ref="Editor"/>
           </xs:sequence>
-          <xs:sequence>
-            <xs:group ref="Editor"/>
-            <xs:group minOccurs="0" maxOccurs="unbounded" ref="Editor"/>
-          </xs:sequence>
+          <xs:group maxOccurs="unbounded" ref="Editor"/>
         </xs:choice>
         <xs:group minOccurs="0" maxOccurs="unbounded" ref="Credit"/>
         <xs:element minOccurs="0" ref="date"/>
         <xs:group minOccurs="0" maxOccurs="unbounded" ref="ColophonCredit"/>
         <xs:element minOccurs="0" ref="edition"/>
+        <xs:element minOccurs="0" ref="version"/>
+        <xs:element minOccurs="0" ref="event"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="keywords"/>
+        <xs:element minOccurs="0" ref="affiliation"/>
+        <xs:element minOccurs="0" ref="funding"/>
         <xs:element minOccurs="0" ref="website"/>
-        <xs:element minOccurs="0" name="copyright">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="year">
-                <xs:complexType mixed="true">
-                  <xs:group ref="TextShort"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element ref="holder"/>
-              <xs:element minOccurs="0" ref="minilicense"/>
-              <xs:element minOccurs="0" ref="shortlicense"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
+        <xs:group minOccurs="0" ref="Copyright"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="edition" type="xs:string"/>
-  <xs:element name="holder" type="xs:string"/>
-  <xs:element name="minilicense">
-    <xs:complexType mixed="true">
-      <xs:group ref="TextShort"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="version" type="xs:string"/>
   <xs:element name="titlepage">
     <xs:complexType>
       <xs:sequence>
@@ -481,6 +464,15 @@
   <xs:element name="personname">
     <xs:complexType mixed="true">
       <xs:group ref="TextSimple"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="affiliation">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="department"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="address"/>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
   <xs:element name="department">
@@ -499,16 +491,77 @@
       </xs:choice>
     </xs:complexType>
   </xs:element>
+  <xs:element name="address">
+    <xs:complexType mixed="true">
+      <xs:choice>
+        <xs:group ref="TextSimple"/>
+        <xs:group maxOccurs="unbounded" ref="ShortLine"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keywords">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="Title"/>
+        <xs:element maxOccurs="unbounded" ref="keyword"/>
+      </xs:sequence>
+      <xs:attribute name="authority"/>
+      <xs:attribute name="variant"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="keyword">
+    <xs:complexType mixed="true">
+      <xs:group ref="TextSimple"/>
+      <xs:attribute name="primary">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funding">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group minOccurs="0" ref="Title"/>
+        <xs:group maxOccurs="unbounded" ref="Paragraph"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="event">
+    <xs:complexType mixed="true">
+      <xs:group ref="TextLong"/>
+    </xs:complexType>
+  </xs:element>
   <xs:group name="Author">
     <xs:sequence>
       <xs:element name="author">
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="personname"/>
-            <xs:element minOccurs="0" ref="department"/>
-            <xs:element minOccurs="0" ref="institution"/>
+            <xs:choice minOccurs="0">
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="department"/>
+                <xs:element ref="institution"/>
+                <xs:element ref="address"/>
+              </xs:choice>
+              <xs:element maxOccurs="unbounded" ref="affiliation"/>
+            </xs:choice>
             <xs:element minOccurs="0" ref="email"/>
+            <xs:element minOccurs="0" ref="biography"/>
+            <xs:element minOccurs="0" ref="funding"/>
           </xs:sequence>
+          <xs:attribute name="corresponding">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="yes"/>
+                <xs:enumeration value="no"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute ref="xml:id"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -519,8 +572,14 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="personname"/>
-            <xs:element minOccurs="0" ref="department"/>
-            <xs:element minOccurs="0" ref="institution"/>
+            <xs:choice minOccurs="0">
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="department"/>
+                <xs:element ref="institution"/>
+                <xs:element ref="address"/>
+              </xs:choice>
+              <xs:element maxOccurs="unbounded" ref="affiliation"/>
+            </xs:choice>
             <xs:element minOccurs="0" ref="email"/>
           </xs:sequence>
         </xs:complexType>
@@ -586,6 +645,30 @@
   <xs:element name="website">
     <xs:complexType>
       <xs:group ref="Url"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="Copyright">
+    <xs:sequence>
+      <xs:element name="copyright">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="year">
+              <xs:complexType mixed="true">
+                <xs:group ref="TextShort"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element ref="holder"/>
+            <xs:element minOccurs="0" ref="minilicense"/>
+            <xs:element minOccurs="0" ref="shortlicense"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="holder" type="xs:string"/>
+  <xs:element name="minilicense">
+    <xs:complexType mixed="true">
+      <xs:group ref="TextShort"/>
     </xs:complexType>
   </xs:element>
   <xs:group name="ColophonFront">
@@ -2494,17 +2577,17 @@
       <xs:sequence>
         <xs:group ref="MetaDataTarget"/>
         <xs:element ref="personname"/>
-        <xs:element minOccurs="0" ref="department"/>
-        <xs:element minOccurs="0" ref="institution"/>
-        <xs:element minOccurs="0" ref="location"/>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="department"/>
+            <xs:element minOccurs="0" ref="institution"/>
+            <xs:element minOccurs="0" ref="address"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="affiliation"/>
+        </xs:choice>
         <xs:element minOccurs="0" ref="email"/>
       </xs:sequence>
       <xs:attributeGroup ref="MetaDataTarget"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="location">
-    <xs:complexType mixed="true">
-      <xs:group ref="TextSimple"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="contributors">
@@ -3586,7 +3669,7 @@
         <xs:element ref="pilcrow"/>
         <xs:element ref="section-mark"/>
         <xs:element ref="copyleft"/>
-        <xs:element ref="copyright"/>
+        <xs:group ref="CopyrightCharacter"/>
         <xs:element ref="registered"/>
         <xs:element ref="trademark"/>
         <xs:element ref="phonomark"/>
@@ -3696,9 +3779,13 @@
       <xs:attribute name="name"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="copyright">
-    <xs:complexType/>
-  </xs:element>
+  <xs:group name="CopyrightCharacter">
+    <xs:sequence>
+      <xs:element name="copyright">
+        <xs:complexType/>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
   <xs:element name="flat">
     <xs:complexType/>
   </xs:element>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1405,6 +1405,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:copy>
 </xsl:template>
 
+<!-- We allow an author/editor/contributor to have their affiliation information not -->
+<!-- wrapped in affiliation tags, but in that case we put them in affiliation tags.  -->
+<xsl:template match="frontmatter//author[not(affiliation)]|frontmatter//editor[not(affiliation)]|frontmatter//contributor[not(affiliation)]" mode="repair">
+    <xsl:copy>
+        <!-- Include "personname" first -->
+        <xsl:apply-templates select="personname|@*" mode="repair"/>
+        <!-- If there are bare deparmtment/institution/address, wrap them in affailiation -->
+        <xsl:if test="department or institution or location">
+            <affiliation>
+                <xsl:apply-templates select="department|institution|location" mode="repair"/>
+            </affiliation>
+        </xsl:if>
+        <!-- Include all additional elements as they are -->
+        <xsl:apply-templates select="*[not(self::personname or self::department or self::institution or self::location)]" mode="repair"/>
+    </xsl:copy>
+</xsl:template>
+
 
 <!-- ############################## -->
 <!-- Killed, in Chronological Order -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1019,15 +1019,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:if>
         </div>
         <div class="author-info">
-            <xsl:if test="department">
-                <xsl:apply-templates select="department" />
-                <xsl:if test="department/following-sibling::*">
-                    <br />
-                </xsl:if>
-            </xsl:if>
-            <xsl:if test="institution">
-                <xsl:apply-templates select="institution" />
-                <xsl:if test="institution/following-sibling::*">
+            <xsl:if test="affiliation">
+                <xsl:apply-templates select="affiliation"/>
+                <xsl:if test="affiliation/following-sibling::*">
                     <br />
                 </xsl:if>
             </xsl:if>
@@ -1041,12 +1035,33 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </xsl:template>
 
+<xsl:template match="affiliation">
+    <xsl:if test="department">
+        <xsl:apply-templates select="department" />
+        <xsl:if test="department/following-sibling::*">
+            <br />
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="institution">
+        <xsl:apply-templates select="institution" />
+        <xsl:if test="institution/following-sibling::*">
+            <br />
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="location">
+        <xsl:apply-templates select="location" />
+        <xsl:if test="location/following-sibling::*">
+            <br />
+        </xsl:if>
+    </xsl:if>
+</xsl:template>
+
 <!-- Departments and Institutions are free-form, or sequences of lines -->
-<xsl:template match="department|institution">
+<xsl:template match="department|institution|location">
     <xsl:apply-templates/>
 </xsl:template>
 
-<xsl:template match="department[line]|institution[line]">
+<xsl:template match="department[line]|institution[line]|location[line]">
     <xsl:apply-templates select="line" />
 </xsl:template>
 
@@ -4611,22 +4626,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="personname" />
     </div>
     <div class="contributor-info">
-        <xsl:if test="department">
-            <xsl:apply-templates select="department" />
-            <xsl:if test="department/following-sibling::*">
-                <br />
-            </xsl:if>
-        </xsl:if>
-        <xsl:if test="institution">
-            <xsl:apply-templates select="institution" />
-            <xsl:if test="institution/following-sibling::*">
-                <br />
-            </xsl:if>
-        </xsl:if>
-        <xsl:if test="location">
-            <xsl:apply-templates select="location" />
-            <xsl:if test="location/following-sibling::*">
-                <br />
+        <xsl:if test="affiliation">
+            <xsl:apply-templates select="affiliation"/>
+            <xsl:if test="affiliation/following-sibling::*">
+                <br/>
             </xsl:if>
         </xsl:if>
         <xsl:if test="email">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -4101,10 +4101,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="type-name"/>
     </xsl:if>
     <xsl:text>}\\</xsl:text>
-    <xsl:if test="institution">
+    <xsl:if test="affiliation/institution">
         <xsl:text>[0.5\baselineskip]&#xa;</xsl:text>
         <xsl:text>{\Large </xsl:text>
-        <xsl:apply-templates select="institution" />
+        <xsl:apply-templates select="affiliation/institution" />
         <xsl:text>}\\</xsl:text>
     </xsl:if>
 </xsl:template>
@@ -4119,9 +4119,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>{\normalsize </xsl:text>
         <xsl:apply-templates select="personname" />
         <xsl:text>}\\</xsl:text>
-        <xsl:if test="institution">
+        <xsl:if test="affiliation/institution">
             <xsl:text>[0.25\baselineskip]&#xa;</xsl:text>
-            <xsl:apply-templates select="institution" />
+            <xsl:apply-templates select="affiliation/institution" />
             <xsl:text>\\</xsl:text>
         </xsl:if>
         <xsl:if test="following-sibling::author">
@@ -4250,13 +4250,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- http://stackoverflow.com/questions/2817664/xsl-how-to-tell-if-element-is-last-in-series -->
 <xsl:template match="author" mode="article-info">
     <xsl:apply-templates select="personname" />
-    <xsl:if test="department">
-        <xsl:text>\\&#xa;</xsl:text>
-        <xsl:apply-templates select="department" />
-    </xsl:if>
-    <xsl:if test="institution">
-        <xsl:text>\\&#xa;</xsl:text>
-        <xsl:apply-templates select="institution" />
+    <xsl:if test="affiliation">
+        <xsl:apply-templates select="affiliation" />
     </xsl:if>
     <xsl:if test="email">
         <xsl:text>\\&#xa;</xsl:text>
@@ -4272,6 +4267,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="personname" />
     <xsl:text>, </xsl:text>
     <xsl:apply-templates select="." mode="type-name"/>
+    <xsl:if test="affiliation">
+        <xsl:apply-templates select="affiliation"/>
+    </xsl:if>
+    <xsl:if test="email">
+        <xsl:text>\\&#xa;</xsl:text>
+        <xsl:apply-templates select="email" />
+    </xsl:if>
+    <xsl:if test="following-sibling::editor" >
+        <xsl:text>&#xa;\and</xsl:text>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Preprocessor always puts Department, Institution, and Address          -->
+<!-- inside Affiliation. This just adds line breaks between them as needed. -->
+<xsl:template match="affiliation">
     <xsl:if test="department">
         <xsl:text>\\&#xa;</xsl:text>
         <xsl:apply-templates select="department" />
@@ -4280,25 +4291,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\\&#xa;</xsl:text>
         <xsl:apply-templates select="institution" />
     </xsl:if>
-    <xsl:if test="email">
+    <xsl:if test="location">
         <xsl:text>\\&#xa;</xsl:text>
-        <xsl:apply-templates select="email" />
+        <xsl:apply-templates select="location" />
     </xsl:if>
-    <xsl:if test="following-sibling::author" >
-        <xsl:text>&#xa;\and</xsl:text>
-    </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-
-<!-- Departments and Institutions are free-form, or sequences of lines -->
-<!-- Line breaks are inserted above, due to \and, etc,                 -->
-<!-- so do not end last line here                                      -->
-<xsl:template match="department|institution">
+<!-- Departments, Institutions, and Addresses are free-form, or sequences of lines  -->
+<!-- Line breaks are inserted above, due to \and, etc, so do not end last line here -->
+<xsl:template match="department|institution|location">
     <xsl:apply-templates/>
 </xsl:template>
 
-<xsl:template match="department[line]|institution[line]">
+<xsl:template match="department[line]|institution[line]|location[line]">
     <xsl:apply-templates select="line" />
 </xsl:template>
 
@@ -5056,25 +5061,28 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\contributorname{</xsl:text>
     <xsl:apply-templates select="personname" />
     <xsl:text>}%&#xa;</xsl:text>
-    <xsl:if test="department|institution|email">
+    <xsl:if test="affiliation|email">
         <xsl:text>\contributorinfo{</xsl:text>
-        <xsl:if test="department">
-            <xsl:apply-templates select="department" />
-            <xsl:if test="department/following-sibling::*">
+        <xsl:if test="affiliation/department">
+            <xsl:apply-templates select="affiliation/department" />
+            <xsl:if test="affiliation/department/following-sibling::*">
                 <xsl:text>\\&#xa;</xsl:text>
             </xsl:if>
         </xsl:if>
-        <xsl:if test="institution">
-            <xsl:apply-templates select="institution" />
-            <xsl:if test="institution/following-sibling::*">
+        <xsl:if test="affiliation/institution">
+            <xsl:apply-templates select="affiliation/institution" />
+            <xsl:if test="affiliation/institution/following-sibling::*">
                 <xsl:text>\\&#xa;</xsl:text>
             </xsl:if>
         </xsl:if>
-        <xsl:if test="location">
-            <xsl:apply-templates select="location" />
-            <xsl:if test="location/following-sibling::*">
+        <xsl:if test="affiliation/location">
+            <xsl:apply-templates select="affiliation/location" />
+            <xsl:if test="affiliation/location/following-sibling::*">
                 <xsl:text>\\&#xa;</xsl:text>
             </xsl:if>
+        </xsl:if>
+        <xsl:if test="affiliation/following-sibling::*">
+            <xsl:text>\\&#xa;</xsl:text>
         </xsl:if>
         <xsl:if test="email">
             <!-- switch to node-set with "c" if characters need escaping -->


### PR DESCRIPTION
As a step toward better frontmatter, this allows for an author (or editor or contributor) to have their `<department>`, `<institution>` and `<location>` wrapped in an `<affiliation>` element.  This will allow for multiple affiliations and referencing common affiliations later.

The current PR results in no changes to the latex output of either the sample article or sample book.  HTML output looks unchanged as well.

`<location>` was already a valid child of `<author>` for `<contributor>`, so I moved that to also be allowed for `<author>` and `<editor>` rather than introducing a `<address>`.  

The first commit is just schema.  It duplicates some of the changes in #2306, so either this or that might create a conflict depending on which is merged first.  I'm happy to resolve that if it occurs.