### PR TITLE
Speedup xml-to-json indent

### DIFF
--- a/xsl/xml-to-json.xsl
+++ b/xsl/xml-to-json.xsl
@@ -212,9 +212,7 @@ done`
 
     <xsl:template name="indent">
         <xsl:param name="depth" select="'0'" />
-        <xsl:for-each select="//*[position() &lt;= $depth]">
-            <xsl:if test="position() &lt;= $depth"><xsl:text>  </xsl:text></xsl:if>
-        </xsl:for-each>
+        <xsl:value-of select="substring('                                                ', 1, $depth * 2)" />
     </xsl:template>
 
     <!-- Escape strings for JSON. This process first escapes backslashes,


### PR DESCRIPTION
The `"indent"` template in xml-json appears to have time complexity that is exponential in the height it is called from. And it gets called many times in the production of a blob of json. It accounts for ~5% of the xsltproc build time of the sample book. In documents with lots of short pages, it can account for 25+% of the build time.

The template is only used to make the indentation for the JS that gets added to pages for sage cells and mathjax.

This patch turns it into a non-entity in terms of build time and generates clean diffs on sample book.