### PR TITLE
Speedup and fix serialize-namespace

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1875,8 +1875,10 @@ Book (with parts), "section" at level 3
 <!-- original element declaration. And then serialize what is left.                      -->
 <xsl:template match="*" mode="serialize-namespace">
     <xsl:for-each select="./namespace::*">
-        <!-- test taken from http://lenzconsulting.com/namespace-normalizer/normalize-namespaces.xsl -->
-        <xsl:if test="name()!='xml' and not(.=../preceding::*/namespace::* or .=ancestor::*[position()>1]/namespace::*)">
+        <!-- Comment test taken from http://lenzconsulting.com/namespace-normalizer/normalize-namespaces.xsl -->
+        <!-- scanning all ancestors is too time consuming... it they leak through, so be it                  -->
+        <!-- <xsl:if test="name()!='xml' and not(.=../preceding::*/namespace::* or .=ancestor::*[position()>1]/namespace::*)"> -->
+        <xsl:if test="name()!='xml' and name()!='xi'">
             <xsl:text> xmlns</xsl:text>
             <xsl:if test="not(name(current())='')">
                 <xsl:text>:</xsl:text>


### PR DESCRIPTION
After other speedups, `serialize-namespace` now accounts for ~30% of the time reported by xsltproc.

The offender appears to be the ancestor scanning. This replaces it with a list of known offenders that tend to leak into HTML output.

This produces clean diffs in the sample-book, but it clearly could change behavior... but I'm not sure what the original intent was. 

I can also get clean diffs by just never calling `serialize-namespace` from `serialize`. 

This was added as part of "Watermarks in HTML and LaTeX (PR #1018)" but I can't see what it 

@Alex-Jordan can you provide insight?

