### PR TITLE
Fix unconverted close input tags

### DIFF
--- a/doc/guide/appendices/cli-v1vsv2.xml
+++ b/doc/guide/appendices/cli-v1vsv2.xml
@@ -108,7 +108,7 @@
         </targets>
       </project>
       ]]>
-    </input>
+      </code>
     </program>
     </listing>
 
@@ -143,7 +143,7 @@
         </targets>
       </project>
       ]]>
-    </input>
+      </code>
     </program>
     </listing>
 


### PR DESCRIPTION
This fixes two `</input>` tags that did not become `<\code> tags in 09371e5bfeac67c4d4dbe4d2ab090e4d041e4789.

Apologies for letting those slip through!