### PR TITLE
New: project.ptx for sample book

### DIFF
--- a/examples/sample-book/project.ptx
+++ b/examples/sample-book/project.ptx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file provides the overall configuration for your PreTeXt
+    project. To edit the content of your document, open `source/main.ptx`
+    (default location).
+-->
+<project ptx-version="2" source="." publication=".">
+  <targets>
+    <target name="html"
+      format="html"
+      source="sample-book.xml"
+      publication="publication-noparts.xml" />
+    <target name="runestone"
+      format="html"
+      source="sample-book.xml"
+      publication="publication-runestone-academy.xml">
+      <!-- <stringparams debug.rs.dev="yes" /> -->
+    </target>
+    <target name="pdf" format="pdf" source="sample-book-noparts.xml" />
+    <target name="latex" format="latex" source="sample-book-noparts.xml" />
+
+  </targets>
+</project>

--- a/examples/sample-book/project.ptx
+++ b/examples/sample-book/project.ptx
@@ -16,8 +16,14 @@
       publication="publication-runestone-academy.xml">
       <!-- <stringparams debug.rs.dev="yes" /> -->
     </target>
-    <target name="pdf" format="pdf" source="sample-book-noparts.xml" />
-    <target name="latex" format="latex" source="sample-book-noparts.xml" />
+    <target name="pdf"
+      format="pdf"
+      source="sample-book.xml"
+      publication="publication-noparts.xml" />
+    <target name="latex"
+      format="latex"
+      source="sample-book.xml"
+      publication="publication-noparts.xml" />
 
   </targets>
 </project>


### PR DESCRIPTION
This adds an updated project.ptx for the sample book.

A runestone build can use this and the html will be placed in the correct place where the runestone server can find it.