### PR TITLE
fix revealjs function call

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3870,8 +3870,8 @@ def revealjs(
     # consulted during the XSL run and so need to be placed beforehand
     copy_managed_directories(tmp_dir, external_abs=external_abs, generated_abs=generated_abs)
 
-    # place CSS and JS in scratch directory
-    copy_html_css_js(tmp_dir)
+    # place JS in scratch directory
+    copy_html_js(tmp_dir)
 
     # Write output into temporary directory
     log.info("converting {} to HTML in {}".format(xml, tmp_dir))


### PR DESCRIPTION
This corrects an outdated function call in the revealjs build function of the pretext script.  

Note that there is no CSS being copied at all any more, but this should be fine as the revealjs css appears to be completely hard-coded into the page.