### PR TITLE
CSS: fix SCSS palette variable name

### DIFF
--- a/css/colors/_palette-dual.scss
+++ b/css/colors/_palette-dual.scss
@@ -29,10 +29,10 @@ $schemes: (
   ),
 );
 
-$color-scheme: 'red-blue' !default;
+$palette: 'red-blue' !default;
 
-@if not map.has-key($schemes, $color-scheme) {
-  @error "Unknown color scheme #{$color-scheme} for theme. Valid schemes are: #{map.keys($schemes)}";
+@if not map.has-key($schemes, $palette) {
+  @error "Unknown color scheme #{$palette} for theme. Valid schemes are: #{map.keys($schemes)}";
 }
 
 // if primary-color or secondary-color are not set, use the scheme colors
@@ -40,11 +40,11 @@ $primary-color: null !default;
 $secondary-color: null !default;
 
 @if $primary-color == null {
-  $scheme-primary-color: map.get(map.get($schemes, $color-scheme), "primary-color");
+  $scheme-primary-color: map.get(map.get($schemes, $palette), "primary-color");
   $primary-color: $scheme-primary-color;
 }
 @if $secondary-color == null {
-  $scheme-secondary-color: map.get(map.get($schemes, $color-scheme), "secondary-color");
+  $scheme-secondary-color: map.get(map.get($schemes, $palette), "secondary-color");
   $secondary-color: $scheme-secondary-color;
 }
 

--- a/css/colors/_palette-quad-chunks.scss
+++ b/css/colors/_palette-quad-chunks.scss
@@ -61,10 +61,10 @@ $schemes: (
   ),
 );
 
-$color-scheme: 'bold' !default;
+$palette: 'bold' !default;
 
-@if not map.has-key($schemes, $color-scheme) {
-  @error "Unknown color scheme #{$color-scheme} in theme. Valid schemes are: #{map.keys($schemes)}";
+@if not map.has-key($schemes, $palette) {
+  @error "Unknown color scheme #{$palette} in theme. Valid schemes are: #{map.keys($schemes)}";
 }
 
 // color-main is for basic groupings and knowls
@@ -81,19 +81,19 @@ $color-meta: null !default;
 
 // if a color is not set, use the scheme colors
 @if $color-main == null {
-  $scheme-color: map.get(map.get($schemes, $color-scheme), "color-main");
+  $scheme-color: map.get(map.get($schemes, $palette), "color-main");
   $color-main: $scheme-color;
 }
 @if $color-do == null {
-  $scheme-color: map.get(map.get($schemes, $color-scheme), "color-do");
+  $scheme-color: map.get(map.get($schemes, $palette), "color-do");
   $color-do: $scheme-color;
 }
 @if $color-fact == null {
-  $scheme-color: map.get(map.get($schemes, $color-scheme), "color-fact");
+  $scheme-color: map.get(map.get($schemes, $palette), "color-fact");
   $color-fact: $scheme-color;
 }
 @if $color-meta == null {
-  $scheme-color: map.get(map.get($schemes, $color-scheme), "color-meta");
+  $scheme-color: map.get(map.get($schemes, $palette), "color-meta");
   $color-meta: $scheme-color;
 }
 

--- a/css/targets/html/default-modern/theme-default-modern.scss
+++ b/css/targets/html/default-modern/theme-default-modern.scss
@@ -2,7 +2,7 @@
 // different definitions for these variables to this file before the theme
 // is compiled.
 
-$color-scheme: 'blue-red' !default;
+$palette: 'blue-red' !default;
 $primary-color: null !default;
 $secondary-color: null !default;
 $primary-color-dark: #698aa8 !default;
@@ -24,13 +24,13 @@ $background-color-dark: #23241f !default;
 
 @use "colors/color-helpers" as colorHelpers;
 @use 'colors/palette-dual' as palette-dual with (
-  $color-scheme: $color-scheme,
+  $palette: $palette,
   $primary-color: $primary-color,
   $secondary-color: $secondary-color,
 );
 
 // primary/secondary color defined as determined by palette-dual using
-// $color-scheme, $primary-color, $secondary-color
+// $palette, $primary-color, $secondary-color
 $primary-color: map.get(palette-dual.$colors, 'primary-color');
 $secondary-color: map.get(palette-dual.$colors, 'secondary-color');
 

--- a/css/targets/html/denver/theme-denver.scss
+++ b/css/targets/html/denver/theme-denver.scss
@@ -6,7 +6,7 @@
 // different definitions for these variables to this file before the theme
 // is compiled.
 
-$color-scheme: 'bold' !default;
+$palette: 'bold' !default;
 $color-main: null !default;
 $color-do: null !default;
 $color-fact: null !default;
@@ -37,7 +37,7 @@ $heading-font: 'Noto Sans, Helvetica Neue, Helvetica, Arial, sans-serif' !defaul
 
 // fancy colors for chunks
 @use 'colors/palette-quad-chunks' as palette-chunks with (
-  $color-scheme: $color-scheme,
+  $palette: $palette,
   $color-main: $color-main,
   $color-do: $color-do,
   $color-fact: $color-fact,

--- a/css/targets/html/greeley/theme-greeley.scss
+++ b/css/targets/html/greeley/theme-greeley.scss
@@ -5,7 +5,7 @@
 // Variables used by theme. CSSBuilder overrides these by prepending
 // different definitions for these variables to this file before the theme
 // is compiled.
-$color-scheme: 'grays' !default;
+$palette: 'grays' !default;
 $primary-color: null !default;
 $secondary-color: null !default;
 $primary-color-dark: #829ab1 !default;

--- a/css/targets/html/salem/theme-salem.scss
+++ b/css/targets/html/salem/theme-salem.scss
@@ -7,7 +7,7 @@
 // is compiled.
 
 // light colors
-$color-scheme: 'ice-fire' !default; 
+$palette: 'ice-fire' !default; 
 $color-main: null !default;
 $color-do: null !default;
 $color-fact: null !default;
@@ -38,7 +38,7 @@ $heading-font: 'Noto Sans, Helvetica Neue, Helvetica, Arial, sans-serif' !defaul
 
 // fancy colors for chunks
 @use 'colors/palette-quad-chunks' as palette-chunks with (
-  $color-scheme: $color-scheme,
+  $palette: $palette,
   $color-main: $color-main,
   $color-do: $color-do,
   $color-fact: $color-fact,


### PR DESCRIPTION
Late in the SCSS development process, I started to rename a variable from `$palette` to `$color-scheme`. That never got finished and ended up on an alt branch which got merged in during a late-stage rebase. This is causing attempts to control the palette from PTX to not work.

This restores the original name and fixes the issue.

Tested against multiple themes and color options.