### PR TITLE
EPUB: add css.map file to the manifest

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3137,10 +3137,12 @@ def epub(xml_source, pub_file, out_file, dest_dir, math_format, stringparams):
     # All styles are baked into one of these two files
     if math_format == "kindle":
         css = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "kindle.css")
-        shutil.copy2(css, css_dir)
+        css_map = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "kindle.css.map")
     if math_format == "svg":
         css = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "epub.css")
-        shutil.copy2(css, css_dir)
+        css_map = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "epub.css.map")
+    shutil.copy2(css, css_dir)
+    shutil.copy2(css_map, css_dir)
 
     # EPUB Cover File
 

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -442,9 +442,11 @@
         <xsl:choose>
             <xsl:when test="$b-kindle">
                 <item id="css-kindle" href="{$css-dir}/kindle.css"            media-type="text/css"/>
+                <item id="css-kindle-map" href="{$css-dir}/kindle.css.map"            media-type="text/css"/>
             </xsl:when>
             <xsl:otherwise>
                 <item id="css-epub" href="{$css-dir}/epub.css"            media-type="text/css"/>
+                <item id="css-epub-map" href="{$css-dir}/epub.css.map"            media-type="text/css"/>
             </xsl:otherwise>
         </xsl:choose>
         <item id="cover-page" href="{$xhtml-dir}/cover-page.xhtml" media-type="application/xhtml+xml"/>


### PR DESCRIPTION
@rbeezer - this adds the epub.css.map file to the epub and its manifest. 

I've opened up the epub file and confirmed that it is in the right place. Calibre still reports not being able to find the file. epubcheck says it can't parse it. I *think* that epubs just can't deal with sourcemap file.

Sharing in case you want to test more. If not, feel free to close the PR - recreating the work will be trivial when someone is ready to do an EPUB deep dive.