### PR TITLE
add optional external runestone methods for the CLI to hook into

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -719,7 +719,7 @@ def main():
         ptx.datafiles_to_xml(xml_source, publication_file, stringparams, args.xmlid, dest_dir)
     elif args.component == "dynamic":
         ptx.dynamic_substitutions(
-            xml_source, publication_file, stringparams, args.xmlid, dest_dir
+            xml_source, publication_file, stringparams, args.xmlid, dest_dir, None
         )
     elif args.component == "theme":
         ptx.update_theme(xml_source, publication_file, stringparams, dest_dir)
@@ -734,6 +734,7 @@ def main():
                 extra_stylesheet,
                 out_file,
                 dest_dir,
+                None
             )
         elif args.format == "html-zip":
             # no "subtree root" build is possible
@@ -746,6 +747,7 @@ def main():
                 extra_stylesheet,
                 out_file,
                 dest_dir,
+                None
             )
         elif args.format == "revealjs":
             ptx.revealjs(


### PR DESCRIPTION
This slightly refactors the runestone services logic, creating a new function that does the downloading of the services xml file, and adding hooks to the `html` and `dynamic_substitutions` functions.  PreTeXt expects this function to either be `None` or to have keyword arguments, including a `format` that can be either "xml" or "tgz" to distinguish whether it should just do the services query (xml) or get the entire tgz file.

Behavior of the pretext script should be unchanged when `ext_rs_methods` is `None`.

Happy to rename variables if you have a better suggestion.  