### PR TITLE
CSS: Fix Safari svg sizing issues in banner/footer

### DIFF
--- a/css/components/page-parts/_banner.scss
+++ b/css/components/page-parts/_banner.scss
@@ -56,7 +56,11 @@ $centered-content: false !default;
     display: flex;
 
     img {
-      max-height:100%; //fix rendering bug on safari with large images
+      max-height: 100%; //fix rendering bug on safari with large images
+    }
+    img[src$=".svg"] {
+      height: 100%; //svg's in safari don't get a correct width with max-height
+      // don't use this for all images as we wouldn't want to stretch raster images
     }
   }
 

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -159,6 +159,9 @@ body.pretext > a.assistive:focus {
 .ptx-masthead .logo-link img {
   max-height: 100%;
 }
+.ptx-masthead .logo-link img[src$=".svg"] {
+  height: 100%;
+}
 .ptx-masthead .byline {
   color: var(--byline-color);
   font-weight: normal;

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12178,7 +12178,8 @@ TODO:
 <xsl:template name="pretext-link">
     <a class="pretext-link" href="https://pretextbook.org" title="PreTeXt">
         <div class="logo">
-            <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="338 3000 8772 6866">
+            <!-- explicitly only have a height here to prevent rendering issue in Safari -->
+            <svg xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="338 3000 8772 6866">
                 <g style="stroke-width:.025in; stroke:currentColor; fill:none">
                     <polyline points="472,3590 472,9732 " style="stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; "/>
                     <path style="stroke-width:126;stroke-linecap:butt;"  d="M 4724,9448 A 4660 4660  0  0  1  8598  9259"/>


### PR DESCRIPTION
Fixes issues reported on -dev by William

[https://groups.google.com/d/msgid/pretext-dev/ae51986d-60e7-4c69-9aa5-8b501a9baef4n%40googlegroups.com](https://groups.google.com/d/msgid/pretext-dev/ae51986d-60e7-4c69-9aa5-8b501a9baef4n%40googlegroups.com?utm_medium=email&utm_source=footer)