### PR TITLE
HTML: Don't include pretext_search.css

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12808,7 +12808,7 @@ TODO:
         <script src="{$lunr-search-file}" async=""/>
         <!-- PreTeXt Javascript and CSS to form and render results of a search -->
         <script src="{$html.js.dir}/pretext_search.js"/>
-        <link href="{$html.css.dir}/pretext_search.css" rel="stylesheet" type="text/css"/>
+        <!-- CSS for search is bundled into theme.css -->
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
CSS for native-serach is now baked into theme.css for all themes. An include for `pretext_search.css` is no longer needed/wanted. At best it 404s, at worst it picks up files left over from older builds.