### PR TITLE
Script: report ImportError during latex image conversion

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -589,6 +589,8 @@ def latex_image_conversion(
                     ext_converter(latex_image, outformat, dest_dir, method)
                 else:
                     individual_latex_image_conversion(latex_image, outformat, dest_dir, method)
+            except ImportError:
+                raise
             except Exception as e:
                 failed_images.append(latex_image)
 


### PR DESCRIPTION
If `ImportError` is raised during `individual_latex_image_conversion` then the current latex image file is thrown on the `failed_images` pile and conversion moves on to the next file. After processing (and failing on) all files, the script reports that conversion failed for all files but doesn't say why. (It says to refer to the log files, but in this case no log files will have been generated.)

If a required module was not available for the first file it will certainly not be available for all subsequent files, so we might as well bail out on the first `ImportError` and report it to the user.