### PR TITLE
CSS: Darkmode improvement for WW controls

### DIFF
--- a/css/components/interactives/_webwork.scss
+++ b/css/components/interactives/_webwork.scss
@@ -1,5 +1,7 @@
 // TODO - needs refactoring and dark mode update
 
+@use 'components/helpers/buttons-default' as buttons;
+
 /*  WW problems */
 .ptx-content .wwprob table.attemptResults {
   margin-left: 2em;
@@ -95,44 +97,28 @@ label.incorrect .feedback {
   color: #e07070;
 }
 
-
-.ptx-content .webwork-button {
-  border-radius: 3px;
-  padding: 0px 3px 0px 3px;
-  border: 1px solid #999;
-  background-color: #ffffff;
-}
-
-.ptx-content .webwork-button:hover {
-  cursor: pointer;
-  background-color: #e0e0ff;
-  border: 1px solid #000;
-}
-
-.ptx-content .webwork-button:active {
-  cursor: pointer;
-  background-color: #a0a0a0;
-  border: 1px solid #999;
-}
-
 .webwork img,
 .webwork + .knowl-output img {
   max-width: 100%;
 }
 
-.ptx-content .exercise-wrapper form button {
-  border-radius: 3px;
-  padding: 0px 3px 0px 3px;
-  border: 1px solid #999;
-  color: black;
-  background-color: #ffffff;
+// Make the default margin for items inside the exercise-wrapper similar to
+// default for items in a section
+.exercise-wrapper > *:not(:first-child) {
+  margin-top: 1.5em;
 }
 
-.ptx-content .webwork-button.activate {
-  width: 22px;
-  height: 22px;
-  background-image: url('https://raw.githubusercontent.com/openwebwork/webwork2/main/htdocs/images/favicon.ico');
-  background-size: contain;
-  position: absolute;
-  right: -35px;
+.ptx-content .problem-buttons {
+  display: flex;
+}
+
+.ptx-content .webwork-button {
+  @include buttons.ptx-button;
+}
+
+//.hidden-content used to be used for knowls and got repurposed for hiding webwork contents
+// now just used by webwork
+.problem-buttons.hidden-content,
+.problem-contents.hidden-content {
+  display: none;
 }

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -3326,6 +3326,10 @@ label.incorrect .feedback {
   position: absolute;
   right: -35px;
 }
+.problem-buttons.hidden-content,
+.problem-contents.hidden-content {
+  display: none;
+}
 .sagecell_sessionOutput pre {
   font-family: var(--font-monospace);
 }


### PR DESCRIPTION
Removes hardcoded colors (and background image) for WW controls to make them handle dark mode better.

Does NOT fix the contents returned by the WW server. That will need more significant changes to respect dark mode.

What I know about WW is limited to building the sample chapter to bug check PRs. Someone more knowledgable than me should sign off on this. @Alex-Jordan ?