### PR TITLE
CSS: Bugfix MathJax top pixel clipping in Chrome

### DIFF
--- a/css/components/elements/_math.scss
+++ b/css/components/elements/_math.scss
@@ -7,6 +7,7 @@
 
 .displaymath mjx-container[jax="CHTML"][display="true"] {
   margin: 0 0 0 0;  // container is going to apply margin, so remove it from mjx-container
+  padding-top: 2px; // Chrome sometimes clips the top 1-2 pixels of math after it has been scaled - provide room for that content
 }
 
 // ?

--- a/css/dist/epub.css
+++ b/css/dist/epub.css
@@ -1181,6 +1181,7 @@ pre[class*=language-] .line-highlight {
 }
 .displaymath mjx-container[jax=CHTML][display=true] {
   margin: 0 0 0 0;
+  padding-top: 2px;
 }
 [data-knowl] > mjx-mrow .TEX-I {
   font-family: MJXZERO !important;

--- a/css/dist/kindle.css
+++ b/css/dist/kindle.css
@@ -1181,6 +1181,7 @@ pre[class*=language-] .line-highlight {
 }
 .displaymath mjx-container[jax=CHTML][display=true] {
   margin: 0 0 0 0;
+  padding-top: 2px;
 }
 [data-knowl] > mjx-mrow .TEX-I {
   font-family: MJXZERO !important;

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -2502,6 +2502,7 @@ pre[class*=language-] .line-highlight {
 }
 .displaymath mjx-container[jax=CHTML][display=true] {
   margin: 0 0 0 0;
+  padding-top: 2px;
 }
 [data-knowl] > mjx-mrow .TEX-I {
   font-family: MJXZERO !important;


### PR DESCRIPTION
Fix for issue described here:
https://groups.google.com/d/msgid/pretext-support/348ae3aa-bc5a-4273-ab58-03b1f985fbe3n%40googlegroups.com?utm_medium=email&utm_source=footer

Root issue appears to be Chrome doesn't always reserve enough space for the rescaled text that MathJax produces. This adds a few pixels of fudge to account for that.