### PR TITLE
CSS: Custom theme lets pub file control focused TOC

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2237,8 +2237,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Whether or not to tag TOC as focused -->
 <xsl:variable name="html-toc-focused_value">
     <xsl:choose>
-        <xsl:when test="contains($html-theme-name, '-legacy')">
-            <!-- legacy themes can pick whether to use a focused toc or not -->
+        <xsl:when test="$html-theme-name = 'custom' or contains($html-theme-name, '-legacy')">
+            <!-- legacy/custom themes can pick whether to use a focused toc or not -->
             <xsl:apply-templates select="$publisher-attribute-options/html/tableofcontents/pi:pub-attribute[@name='focused']" mode="set-pubfile-variable"/>
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
Legacy themes allow the pub file to control whether the ToC is "focused". In modern themes that is controlled by the theme. 

This allows the pubfile to control the ToC "focused" mode when `theme="custom"` is specified.