### PR TITLE
Webwork CSS hidden-content fix

### DIFF
--- a/css/components/interactives/_webwork.scss
+++ b/css/components/interactives/_webwork.scss
@@ -115,3 +115,10 @@ label.incorrect .feedback {
 .ptx-content .webwork-button {
   @include buttons.ptx-button;
 }
+
+//.hidden-content used to be used for knowls and got repurposed for hiding webwork contents
+// now just used by webwork
+.problem-buttons.hidden-content,
+.problem-contents.hidden-content {
+  display: none;
+}

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -3342,6 +3342,9 @@ label.incorrect .feedback {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
+.problem-buttons.hidden-content,
+.problem-contents.hidden-content {
+  display: none;
 }
 .sagecell_sessionOutput pre {
   font-family: var(--font-monospace);


### PR DESCRIPTION
Webwork had repurposed a `.hidden-content` rule that was part of the old knowl code to hide items that should not be displayed.

That rule got phased out. This adds new rules so that class has the intended effect when applied to the div's that WW tries ot hide.