### PR TITLE
CSS: improve denver theme

### DIFF
--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -184,7 +184,7 @@ $chunk-heading-font-size: 1.125em !default;
   }
 }
 
-.paragraphs,
-article {
+
+.exercise-like {
   @include inline-heading-mixin.heading;
 }

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -102,9 +102,8 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
 
 // Make expanded parts of TOC look more like subsections
 .toc-item.visible {
-  border-left: 3px solid var(--primary-color-white-95);
   font-size: .95em;
-  padding-left: 10px;
+  padding-left: 8px;
 }
 
 .ptx-page-footer{


### PR DESCRIPTION
Fixes two annoyances with the denver theme:
1. first paragraph of examples was inline
2. ugly border in dark mode in toc.

Tested on the sample article and looks much better.