### PR TITLE
Generate better stack traces for XML errors in included files

### DIFF
--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -4070,7 +4070,25 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
     # lxml.etree.XMLSyntaxError: Excessive depth in document: 256 use XML_PARSE_HUGE option
     huge_parser = ET.XMLParser(huge_tree=True)
     src_tree = ET.parse(xml, parser=huge_parser)
-    src_tree.xinclude()
+    try:
+        src_tree.xinclude()
+    except ET.XIncludeError as e:
+        # xinclude() does not show what file a parsing error occured in
+        # So if there was an error, build a custom loader and redo with ElementInclude
+        # which will include the file name in the stack dump.
+        # ElementInclude is a limited version of xinclude(), so can't rely
+        # on it for the real include process.
+
+        # Generate custom loader
+        from lxml import ElementInclude
+        def my_loader(href, parse, encoding=None, parser=None):
+            ret = ElementInclude._lxml_default_loader(href, parse, encoding, parser)
+            return ret
+
+        # Reparse the tree (was modified in try clause) and run ElementInclude
+        # This should also fail, but will give a better error message
+        src_tree = ET.parse(xml, parser=huge_parser)
+        ElementInclude.include(src_tree, loader=my_loader, max_depth=100)
 
     # parse xsl, and build a transformation object
     # allow writing if an output directory is given


### PR DESCRIPTION
Currently, if there is a syntax error (e.g. tag mismatch) in an included file, no information is provided about what file has the issue.

Authors writing a book page by page can figure out the location, but it can be maddening after using a tool to do a batch conversion of edit. 

This makes sure the trace ends with a pointer directly to the offending file:
```
  ...
  File "/mnt/f/Programming/thinkcpp-rs/pretext/Chapter1/program.ptx", line 20
lxml.etree.XMLSyntaxError: Opening and ending tag mismatch: p line 17 and li, line 20, column 10
```
