### PR TITLE
Add xmlid_root option for braille conversion

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -781,9 +781,9 @@ def main():
                 dest_dir,
             )
         elif args.format == "braille-emboss":
-            ptx.braille(xml_source, publication_file, stringparams, out_file, dest_dir, "emboss")
+            ptx.braille(xml_source, publication_file, stringparams, args.xmlid, out_file, dest_dir, "emboss")
         elif args.format == "braille-electronic":
-            ptx.braille(xml_source, publication_file, stringparams, out_file, dest_dir, "electronic")
+            ptx.braille(xml_source, publication_file, stringparams, args.xmlid, out_file, dest_dir, "electronic")
         elif args.format == "epub-svg":
             ptx.epub(
                 xml_source, publication_file, out_file, dest_dir, "svg", stringparams

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -2600,7 +2600,7 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
 #######################
 
 
-def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format):
+def braille(xml_source, pub_file, stringparams, xmlid_root, out_file, dest_dir, page_format):
     """Produce a complete document in BRF format ( = Braille ASCII, plus formatting control)"""
 
     # to ensure provided stringparams aren't mutated unintentionally
@@ -2672,6 +2672,8 @@ def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format)
     stringparams["page-format"] = page_format
     if pub_file:
         stringparams["publisher"] = pub_file
+    if xmlid_root:
+        stringparams["subtree"] = xmlid_root
     preprint = os.path.join(tmp_dir, "preprint.xml")
     braille_xslt = os.path.join(get_ptx_xsl_path(), "pretext-braille-preprint.xsl")
     xsltproc(braille_xslt, xml_source, preprint, tmp_dir, stringparams)


### PR DESCRIPTION
@davidaustinm noted that building a braille book especially could benefit from restricting to just a chapter.  This adds that option in the same way that the xmlid_root is done in the other conversions.

Note, I have not tested that this actually works with the rest of the braille conversion.  Understand it might take a while to get this merged.