### PR TITLE
HTML: display ToC on root page

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11639,6 +11639,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$toc-contents" mode="customized-toc-item">
         <xsl:with-param name="this-page" select="$this-page-node"/>
         <xsl:with-param name="this-page-ancestors" select="$this-page-ancestors"/>
+        <xsl:with-param name="is-root-ul" select="true()"/>
     </xsl:apply-templates>
 </xsl:template>
 
@@ -11659,8 +11660,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="ul|li" mode="customized-toc-item">
     <xsl:param name="this-page"/>
     <xsl:param name="this-page-ancestors"/>
+    <xsl:param name="is-root-ul" select="false()"/>
 
-    <xsl:variable name="is-ancestor" select="count($this-page-ancestors|.) = count($this-page-ancestors)"/>
+    <!-- root ul in toc should always be considered "contains-active" -->
+    <!-- even if there is no active page (e.g. index.html)            -->
+    <xsl:variable name="is-ancestor" select="$is-root-ul or count($this-page-ancestors|.) = count($this-page-ancestors)"/>
     <xsl:variable name="is-page" select="count($this-page|.) = count($this-page)"/>
     <xsl:choose>
         <!-- ToC item contains or is active page -->


### PR DESCRIPTION
On the root page of a document (e.g. sample-book.html) there is no ToC entry that corresponds to the current page. Thus nothing is considered active and the entire ToC is hidden.

Solution here is to force the root ToC item to always think it "contains-active". That way the root level of the ToC is forced to display.

Clean diffs on sample-book other than sample-book.html which has the desired extra class on the top ul in ToC.