### PR TITLE
CSS: add min node and cleanup cssbuilder/package.json

### DIFF
--- a/script/cssbuilder/package.json
+++ b/script/cssbuilder/package.json
@@ -1,22 +1,19 @@
 {
-  "name": "pretext",
+  "name": "pretext-cssbuilder",
   "version": "1.0.0",
-  "description": "PreTeXt\r =======",
+  "description": "PreTeXt CSS Builder",
   "main": "bundleEntry.js",
-  "directories": {
-    "doc": "doc",
-    "example": "examples"
-  },
   "scripts": {
     "build": "node ./cssbuilder.mjs",
     "watch": "node ./cssbuilder.mjs --watch"
   },
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "command-line-args": "^6.0.0",
     "command-line-usage": "^7.0.3",
     "esbuild": "^0.23.0",
     "esbuild-sass-plugin": "^3.3.1"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Adds a min node version to the package.json for CSSBuilder and removes some default cruft from the file.