### PR TITLE
CSS: Documentation update for cssbuilder script

### DIFF
--- a/script/cssbuilder/README.md
+++ b/script/cssbuilder/README.md
@@ -14,16 +14,51 @@ To build all targets to `pretext/css/dist`, from the cssbuilder directory do:
 npm run build
 ```
 
-For debugging, you likely want to build one target (`default-modern` in this case) to a specified output directory (generally the `_static/pretext/css` folder of your book), rebuilding with any changes (`-w` for "watch"). That can be done with:
+To view the help, do:
 
 ```bash
-npm run build -- -t default-modern -o yourbookpath/_static/pretext/css -w'
+npm run build -- -h
+```
+
+Note that parameters being passed to the script must come after a `--` or they will be interpreted as parameters for npm itself.
+
+For debugging, you likely want to build one target by using:
+
+* The `-t` flag to specify a target matching one of the output targets listed in cssbuilder (`theme-salem`, `theme-default-modern`, etc...)
+* The `-o` flag to specify an output directory (generally the `_static/pretext/css` folder of your book)
+* The `-w` flag to specify that you want cssbuilder to "watch" the source files and rebuild any time they are changed.
+
+Something like this:
+
+```bash
+npm run build -- -t theme-default-modern -o yourbookpath/_static/pretext/css -w'
 ```
 
 To specify options or variables you can add the `-c` flag followed by a string containing JSON like this:
 
 ```bash
-npm run build -- -w -t theme-default-modern -o ../../examples/sample-article/out/_static/pretext/css -c '{"options":{"assemblages":"oscar-levin"},"variables":{"primary-color":"rgb(80, 30, 80)", "secondary-color":"rgb(20, 160, 30)", "primary-color-dark":"#b88888"}}'
+npm run build -- -t theme-default-modern -o ../../examples/sample-article/out/_static/pretext/css -c '{"options":{"color-scheme":"blues", "primary-color":"rgb(80, 30, 80)"}'
+```
+
+The options that can be set for a given theme correspond to the variables with default values in that that theme's entry file. For example, theme-salem lists:
+
+```sass
+// light colors
+$color-scheme: 'ice-fire' !default; 
+$color-main: null !default;
+$color-do: null !default;
+$color-fact: null !default;
+$color-meta: null !default;
+
+// dark colors
+$primary-color-dark: #9db9d3 !default;
+$background-color-dark: #23241f !default;
+```
+
+So to override the `color-scheme` and `primary-color-dark` while building theme-salem, you could do:
+
+```bash
+npm run build -- -t theme-default-modern -o ../../examples/sample-article/out/_static/pretext/css -c '{"options":{"color-scheme":"leaves", "primary-color-dark":"#549676"}'
 ```
 
 For full help:

--- a/script/cssbuilder/cssbuilder.mjs
+++ b/script/cssbuilder/cssbuilder.mjs
@@ -41,7 +41,7 @@ const helpContents = [
       {
         name: 'config-options',
         typeLabel: '{underline json-text}',
-        description: 'A string containing a JSON blob with configuration options for the build. This includes variables and options for building a customized version of a theme. This might look like {bold \'\\{"options": \\{"assemblages": "oscar-levin"\\}, "variables": \\{"primary-color": "#801811", "primary-color-dark": "#801811", "secondary-color": "#2a5ea4"\\}\\}\'}.',
+        description: 'A string containing a JSON blob with configuration options for the build. This includes variables and options for building a customized version of a theme. This might look like {bold \'\\{"options": \\{"primary-color": "#801811", "primary-color-dark": "#801811", "secondary-color": "#2a5ea4"\\}\\}\'}.',
       },
       {
         name: 'help',
@@ -196,6 +196,10 @@ async function getESBuildConfig(options) {
         sassPlugin({
           'loadPaths': [cssRoot],
           precompile(source, pathname, isRoot) {
+            // If this is root file, add custom variables. Anything else is just passed through
+            if(!isRoot)
+              return source;
+
             // Tack on any config variables to the top of the file
             let prefix = '';
             if (options['selected-target'] && options['config-options']) {
@@ -203,7 +207,7 @@ async function getESBuildConfig(options) {
                 prefix += `$${key}: ${value};\n`;
               }
             }
-            return isRoot ? prefix + source : source;
+            return prefix + source;
           }
         }),
       ],


### PR DESCRIPTION
I noticed that I had let some of the docs get out of date. This updates the samples for invoking `cssbuilder` by hand with a JSON blob to customize the results. This technique might be handy for you @rbeezer when you go to update the website build script to show more design variants.

No functional changes. One small change to the actual source to make code intent clearer but it produces exactly the same result.