### PR TITLE
CSS: Remove ptx-logo from sidebar; refactor colorado themes

### DIFF
--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -3,22 +3,6 @@
 $sidebar-width: 240px !default;
 $nav-height: 36px !default;
 
-@mixin ptx-logo {  // need space to disappear behind footer - pretext logo fills that space
-  &::after {
-    // Apply logo as a mask so background-color can change it. It is a separate document
-    // so no other way to have styles on page affect it.
-    content: "";
-    mask: url("data:image/svg+xml; utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25' viewBox='338 3000 8772 6866'%3E%3Cg style='stroke-width:.025in; stroke:black; fill:none'%3E%3Cpolyline points='472,3590 472,9732 ' style='stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpath style='stroke-width:126;stroke-linecap:butt;' d='M 4724,9448 A 4660 4660 0 0 1 8598 9259 '%3E%3C/path%3E%3Cpath style='stroke-width:174;stroke-linecap:butt;' d='M 4488,9685 A 4228 4228 0 0 0 472 9732 '%3E%3C/path%3E%3Cpath style='stroke-width:126;stroke-linecap:butt;' d='M 4724,3590 A 4241 4241 0 0 1 8598 3496 '%3E%3C/path%3E%3Cpath style='stroke-width:126;stroke-linecap:round;' d='M 850,3496 A 4241 4241 0 0 1 4724 3590 '%3E%3C/path%3E%3Cpath style='stroke-width:126;stroke-linecap:round;' d='M 850,9259 A 4507 4507 0 0 1 4724 9448 '%3E%3C/path%3E%3Cpolyline points='5385,4299 4062,8125 ' style='stroke-width:300; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='8598,3496 8598,9259 ' style='stroke-width:126; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='850,3496 850,9259 ' style='stroke-width:126; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='4960,9685 4488,9685 ' style='stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='3070,4582 1889,6141 3070,7700 ' style='stroke-width:300; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='6418,4582 7600,6141 6418,7700 ' style='stroke-width:300; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpolyline points='8976,3590 8976,9732 ' style='stroke-width:174; stroke-linejoin:miter; stroke-linecap:round; '%3E%3C/polyline%3E%3Cpath style='stroke-width:174;stroke-linecap:butt;' d='M 4960,9685 A 4228 4228 0 0 1 8976 9732 '%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
-    mask-position: center;
-    mask-repeat: no-repeat;
-    display: block;
-    height: 13em;
-    margin: 1em 2em;
-    background-color: var(--page-border-color);
-    border-right: 1px solid var(--page-border-color);
-    border-left: 1px solid var(--page-border-color);
-  }
-}
 
 
 .ptx-sidebar {

--- a/css/components/page-parts/_toc-default.scss
+++ b/css/components/page-parts/_toc-default.scss
@@ -70,9 +70,18 @@ $navbar-breakpoint: 800px !default;
 @media screen and (max-width: min($sidebar-breakpoint, $navbar-breakpoint)) {
   .ptx-sidebar {
     position: fixed;
+    z-index: 1000;
     top: unset;
+    height: auto;
+    max-height: 80vh;
+    max-width: 80vw;
     bottom: $nav-height;
+    border-right: 2px solid var(--toc-border-color);
+    border-top: 2px solid var(--toc-border-color);
+  }
+  .ptx-toc {
     border-top: 2px solid var(--toc-border-color);
     border-bottom: 0;
+    max-height: 80vh;
   }
 }

--- a/css/components/page-parts/_toc-default.scss
+++ b/css/components/page-parts/_toc-default.scss
@@ -27,9 +27,6 @@ $navbar-breakpoint: 800px !default;
     height: calc(100vh - $nav-height);
     margin-top: -1px; // partially hide top border of first toc item
 
-    // need space to disappear behind footer - pretext logo fills that space
-    @include toc-basics.ptx-logo;
-
     // border under the last item before the pretext icon
     & > .toc-item-list:first-child > .toc-item:last-child {
       border-bottom: 3px solid var(--toc-border-color);
@@ -50,10 +47,8 @@ $navbar-breakpoint: 800px !default;
     display: none;
     position: sticky;
     top: $nav-height;
-    z-index: 1000;
     background: var(--content-background);
     min-height: 30vh;
-    max-height: 80vh;
     border-right: 2px solid var(--toc-border-color);
     border-bottom: 2px solid var(--toc-border-color);
     width: $sidebar-width;

--- a/css/components/page-parts/_toc-overlay.scss
+++ b/css/components/page-parts/_toc-overlay.scss
@@ -31,10 +31,6 @@ $initially-visible: false !default;
   background: var(--page-color);
   width: $sidebar-width;
 
-  // need space to disappear behind footer - pretext logo fills that space
-  @include toc-basics.ptx-logo;
-
-
   // border under the last item before the pretext icon
   & > .toc-item-list:first-child > .toc-item:last-child {
     border-bottom: 3px solid var(--toc-border-color);

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -15,7 +15,6 @@ $sidebar-total-width: $sidebar-width + $sidebar-right-margin;
 $content-width: 600px !default;
 $content-side-padding: 120px !default;
 $content-side-padding-tight: 20px !default;
-$content-with-padding-width: $content-width + 2 * $content-side-padding;
 
 $sidebar-breakpoint: $content-width + $sidebar-total-width + 24px; // a little extra for padding
 
@@ -28,34 +27,44 @@ $main-right-margin: $sidebar-total-width;
 $page-width: $sidebar-total-width + $main-width + $main-right-margin;
 
 @use 'components/page-parts/body' with (
-  $max-width: $content-with-padding-width,
+  $max-width: $page-width,
   $content-width: $content-width,
   $content-side-padding: $content-side-padding,
   $centered-content: $centered-content,
 );
 
 @use 'components/page-parts/banner' with (
-  $max-width: $content-with-padding-width,
+  $max-width: $main-width,
   $navbar-breakpoint: $navbar-breakpoint,
 );
 
 @use 'components/page-parts/navbar' with (
-  $max-width: $content-with-padding-width,
+  $max-width: $main-width,
   $nav-height: $nav-height,
   $navbar-breakpoint: $navbar-breakpoint,
 );
 
-@use 'components/page-parts/toc-overlay' with (
+@use 'components/page-parts/toc-default' with (
+  $scrolling: $scrolling-toc,
   $sidebar-width: $sidebar-width,
+  $sidebar-breakpoint: $sidebar-breakpoint,
   $navbar-breakpoint: $navbar-breakpoint,
-  $initially-visible: true,
 );
+
 @use 'components/page-parts/extras/toc-hidden-scrollbar';
 
 //@use 'summary-links';
 @use 'components/page-parts/footer' with (
   $navbar-breakpoint: $navbar-breakpoint,
 );
+
+.ptx-main {
+  margin-right: $sidebar-total-width;
+}
+
+.ptx-sidebar.hidden + .ptx-main {
+  margin-left: $sidebar-total-width;
+}
 
 // Oscar - note - you might consider how to handle nested RS containers
 // see "Projects and Friends" in sample book
@@ -82,7 +91,8 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
 
 // visually shift the sidebar off the page
 .ptx-sidebar {
-  transform: translateX(-$sidebar-total-width);
+  //transform: translateX(-$sidebar-right-margin);
+  margin-right: $sidebar-right-margin;
 }
 
 // move contents button out of navbar-contents and align with sidebar
@@ -94,7 +104,7 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
 }
 
 .ptx-toc {
-  margin-top: 36px;
+  padding-top: 36px;
   border: none;
   position: sticky;
   top: $nav-height;
@@ -106,16 +116,22 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
   padding-left: 8px;
 }
 
-.ptx-page-footer{
-  z-index: 1000;
-}
 
 // Sidebar hits the left side of page - need to lock it in place
-$sidebar-lock-breakpoint: $content-with-padding-width + 2 * $sidebar-total-width;
+$sidebar-lock-breakpoint: $main-width + 2 * $sidebar-total-width;
 // @debug "$sidebar-lock-breakpoint: #{$sidebar-lock-breakpoint}";
 @media screen and (width <= $sidebar-lock-breakpoint) {
   .ptx-page {
-    margin-left: $sidebar-total-width;
+    margin-left: 0;
+    max-width: 100%;
+  }
+  .ptx-main {
+    margin-right: calc(100% - $main-width - $sidebar-total-width);
+    max-width: $main-width;
+  }
+  .ptx-sidebar.hidden + .ptx-main {
+    margin-right: auto;
+    margin-left: auto;
   }
   .ptx-navbar .ptx-navbar-contents {
     margin-left: $sidebar-total-width;
@@ -125,25 +141,13 @@ $sidebar-lock-breakpoint: $content-with-padding-width + 2 * $sidebar-total-width
 // When the the main content is almost to the edge of the screen, we remove the drop-shadow
 // and change the layout strategy to center the content in what space is available
 // Sidebar no only consumes minimum required space as whitespace on left/right of main should be equal
-$page-border-breakpoint: $content-with-padding-width + $sidebar-width + 2 * $sidebar-right-margin;
+$page-border-breakpoint: $main-width + $sidebar-width + 2 * $sidebar-right-margin;
 // @debug "page-border-breakpoint: #{$page-border-breakpoint}";
 @media screen and (width <= $page-border-breakpoint) {
-  // page now extends to fill all extra space
-  .ptx-page {
-    margin-left: $sidebar-width;
-    width: calc(100% - $sidebar-width);
-    max-width: unset;
-  }
-
-  // if sidebar is hidden, no need for margin
-  .ptx-page:has(.ptx-sidebar.hidden) {
-    margin-left: 0;
-    width: 100%;
-  }
-
   // main is centered in page
   .ptx-main {
     box-shadow: unset;
+    margin-right: auto;
 
     // shrink content padding
     .ptx-content {
@@ -153,15 +157,10 @@ $page-border-breakpoint: $content-with-padding-width + $sidebar-width + 2 * $sid
     }
   }
 
-  // adjust root variable to match new padding
-  :root {
-    --content-padding: #{$content-side-padding-tight};
+  .ptx-sidebar {
+    margin-right: 0;
   }
 
-  // adjust sidebar position to match just its dimensions
-  .ptx-sidebar {
-    transform: translateX(-$sidebar-width);
-  }
   // align toc-toggle with right edge of sidebar
   .ptx-navbar .ptx-navbar-contents {
     margin-left: $sidebar-width;
@@ -185,39 +184,11 @@ $page-border-breakpoint: $content-with-padding-width + $sidebar-width + 2 * $sid
 }
 
 
-// Now it is time to hide the sidebar unless requested, at which point it overlays
+// Now it is time to hide the sidebar unless requested
 $sidebar-hide-breakpoint: $content-width + 2 * $content-side-padding-tight + $sidebar-width;
 // @debug "sidebar-hide-breakpoint: #{$sidebar-hide-breakpoint}";
 @media screen and (width <= $sidebar-hide-breakpoint) {
   .ptx-sidebar {
     display: none;
-    transform: translate(0px);
-  }
-
-  .ptx-toc {
-    margin-top: 0;  //no longer need/want gap
-  }
-
-  // no longer need to move the page over or control size
-  .ptx-page {
-    margin: 0;
-    width: unset;
-  }
-}
-
-// Nav to bottom breakpoint. Assumes that sidebar is already hidden
-@media screen and (width <= #{$navbar-breakpoint}){
-  .ptx-masthead .ptx-banner {
-    width: 100%;
-    padding: 10px 10px;
-  }
-
-  // restore toc-toggle and navbar-contents to normal
-  .ptx-navbar .ptx-navbar-contents {
-    margin-left: 0;
-  }
-  .ptx-navbar .toc-toggle {
-    transform: unset;
-    position: relative;
   }
 }


### PR DESCRIPTION
This eliminates the pretext logo from the sidebar.  A few related tweaks improve the TOC for default-modern, and a refactoring of the TOC for denver and greeley were needed, both of which look better now.

Tested with all themes and all widths on chrome, firefox, and epiphany (webkit) on linux.  

Note, only committed the SCSS files; you will need to `npm run build` from `scripts/cssbuilder` to try out `default-modern`.