### PR TITLE
Runestone: Allow horizontal-parsons in containers other than exercise

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1211,7 +1211,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Parsons Problem (Horizontal)-->
 
-<xsl:template  match="exercise[@exercise-interactive = 'parson-horizontal']" mode="runestone-to-interactive">
+<xsl:template  match="*[@exercise-interactive = 'parson-horizontal']" mode="runestone-to-interactive">
     <!-- determine these options before context switches -->
     <xsl:variable name="active-language">
       <xsl:apply-templates select="." mode="active-language"/>


### PR DESCRIPTION
Currently most RS interactives have a template like this that places the component:
```xsl
<xsl:template match="*[@exercise-interactive = 'parson']" mode="runestone-to-interactive">
```

But horizontal parsons have `exercise[...` instead of `*[...` and thus only can appear in exercises and not activities, etc...

This was reported as a bug in RS discord.

This template already limits which elements can get the `@exercise-interactive` https://github.com/PreTeXtBook/pretext/blob/5ed521fd3f5fafadb989e07c2b8637c3523bf3fa/xsl/pretext-html.xsl#L4226

So this PR removes the exercise restriction on the `"runestone-to-interactive"` template