### PR TITLE
CSS: Horizontal scroll on console if contents too long

### DIFF
--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -13,6 +13,7 @@
 .program {
   border: 1px solid var(--page-border-color);
   padding: 5px 15px;
+  overflow-x: auto;
   @include code-text();
 }
 
@@ -35,6 +36,7 @@
 .code-block {
   border-left: 1px solid #aaa;
   padding: 0 15px 5px;
+  overflow-x: auto;
   @include code-text();
 }
 


### PR DESCRIPTION
If the contents of a console or code block is too wide (after any box stretching done by theme), the content should scroll instead of overflowing its container.

This will avoid issues like the one seen in the SA at [Figure 27.3](https://pretextbook.org/examples/sample-article/html/section-side-by-side-gallery.html#section-side-by-side-gallery-6) , which would be event worse if the panels were switched.