### PR TITLE
Sbsgroup spacing

### DIFF
--- a/css/components/chunks/_sidebyside.scss
+++ b/css/components/chunks/_sidebyside.scss
@@ -1,9 +1,10 @@
-.sidebyside {
-  width: 100%;
+// Space all rows in a sbsgroup, no other styling
+.sbsgroup > *:not(:first-child)
+{
+    margin-top: 1.5em;
+}
 
-  .sbsgroup {
-    width: 100%;
-  }
+.sidebyside {
 
   .sbsrow {
     display: flex;

--- a/css/components/elements/_figures.scss
+++ b/css/components/elements/_figures.scss
@@ -10,7 +10,7 @@ figure {
 figcaption {
   margin-left: auto;
   margin-right: auto;
-  margin-top: 2px;
+  margin-top: 0.5em;
 
   code.code-inline {
     white-space: pre;

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6035,9 +6035,21 @@ Book (with parts), "section" at level 3
 <!-- it is the layout template for each sidebyside     -->
 <!-- that goes out to the enclosing group to get them  -->
 
+<!-- default wrapper does nothing, output modes may    -->
+<!-- optionally provide some containing structure      -->
+<xsl:template name="sbsgroup-wrapper">
+    <xsl:param name="sbsgroup-content"/>
+    <xsl:copy-of select="$sbsgroup-content"/>
+</xsl:template>
+
 <xsl:template match="sbsgroup">
-    <xsl:apply-templates select="sidebyside" />
-    <xsl:apply-templates select="." mode="post-sbsgroup"/>
+    <xsl:variable name="data">
+        <xsl:apply-templates select="sidebyside" />
+        <xsl:apply-templates select="." mode="post-sbsgroup"/>
+    </xsl:variable>
+    <xsl:call-template name="sbsgroup-wrapper">
+        <xsl:with-param name="sbsgroup-content" select="$data"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- Since stackable items do not carry titles or captions,   -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6329,6 +6329,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The main templates for "sidebyside" and "sbsgroup"   -->
 <!-- are in xsl/pretext-common.xsl, as befits containers -->
 
+
+<xsl:template name="sbsgroup-wrapper">
+    <xsl:param name="sbsgroup-content"/>
+    <xsl:element name="div">
+        <xsl:attribute name="class">
+            <xsl:text>sbsgroup</xsl:text>
+        </xsl:attribute>
+        <xsl:copy-of select="$sbsgroup-content"/>
+    </xsl:element>
+</xsl:template>
+
 <!-- When we use CSS margins (or padding), then percentage        -->
 <!-- widths are relative to the remaining space.  This utility    -->
 <!-- takes in a width relative to full-text-width and the margins -->


### PR DESCRIPTION
Fixes sbsgroup in figure spacing issue identified here:
https://groups.google.com/g/pretext-dev/c/calPA-mk1c0/m/lOUWhcxFBQAJ?utm_medium=email&utm_source=footer

Here is the sample Vlerio provided if you want to test against it in Hello World or something:
https://github.com/valelav/sbstest/blob/ee0e03d2b6a089165a1fd311219443dc5f7e4ca6/source/sec-section-name.ptx#L8

Will also see effect of the change at this sample in SA:
[Figure 14.4](https://pretextbook.org/examples/sample-article/html/section-interactive-authored.html#figure-animation) 
https://pretextbook.org/examples/sample-article/html/section-interactive-authored.html#figure-animation

Clean against latex build of SA
HTML build shows expected changes, no impact to legacy styles