### PR TITLE
HTML: only create brandlogo link if @url is present

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13167,28 +13167,32 @@ TODO:
 
 <!-- Brand Logo -->
 <!-- Place image in masthead -->
+<!-- We either create a link with an image, or just an image. -->
+<!-- NB: This template does nothing unless $docinfo/brandlogo -->
+<!-- exists, in which case we assume @source exists, as       -->
+<!-- required by the schema.                                  -->
 <xsl:template name="brand-logo">
-    <a id="logo-link" class="logo-link" target="_blank" >
-        <xsl:attribute name="href">
-            <xsl:choose>
-                <xsl:when test="not($docinfo/brandlogo/@url = '')">
-                    <xsl:value-of select="$docinfo/brandlogo/@url"/>
-                </xsl:when>
-                <xsl:when test="$b-has-baseurl">
-                    <xsl:value-of select="$baseurl"/>
-                </xsl:when>
-                <xsl:otherwise/>
-            </xsl:choose>
-        </xsl:attribute>
-        <xsl:if test="$docinfo/brandlogo/@source">
-            <xsl:variable name="location">
-                <!-- empty when not using managed directories -->
-                <xsl:value-of select="$external-directory"/>
-                <xsl:value-of select="$docinfo/brandlogo/@source"/>
-            </xsl:variable>
-            <img src="{$location}" alt="Logo image"/>
-        </xsl:if>
-    </a>
+    <xsl:if test="$docinfo/brandlogo">
+        <xsl:variable name="location">
+            <!-- empty when not using managed directories -->
+            <xsl:value-of select="$external-directory"/>
+            <xsl:value-of select="$docinfo/brandlogo/@source"/>
+        </xsl:variable>
+
+        <xsl:choose>
+            <xsl:when test="$docinfo/brandlogo/@url">
+                <a id="logo-link" class="logo-link" target="_blank" >
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="$docinfo/brandlogo/@url"/>
+                    </xsl:attribute>
+                    <img src="{$location}" alt="Logo image"/>
+                </a>
+            </xsl:when>
+            <xsl:otherwise>
+                    <img src="{$location}" alt="Logo image"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
 </xsl:template>
 
 <!-- Analytics Footers -->


### PR DESCRIPTION
This refactors the `brand-logo` template to only create a link around the brandlogo image if there is a `brandlogo/@url` present.  If `brandlogo` is in source without a `@url`, this just puts the image located at `brandlogo/@source` (this is a required attribute of `brandlogo` according to the schema.

Why the change?  Currently, if no brandlogo is in source, we create an empty link which gives an error according to the WAVE accessibility tester.

Previously, there was a CSS "Sigma" in the location of the brand-logo which linked to the current page or `baseurl` or something like that.  But this didn't make much sense, as the link opened in a new tab anyway.