### PR TITLE
Javascript: fix permalinks for tasks

### DIFF
--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -98,7 +98,7 @@ function permalinkDescription(elem) {
         if ((nodeName == 'ARTICLE') && (elem.classList.contains('exercise')) ) {
             typeStr = "Exercise";
         } else if ((nodeName == 'ARTICLE') && (elem.classList.contains('task')) ) {
-            typeStr = elem.parentElement.firstElementChild.getAttribute('data-description');
+            typeStr = elem.parentElement.querySelector(':scope > .autopermalink').getAttribute('data-description');
             numberSep = "";
         } else {
             resultNodes = headerNode.getElementsByClassName("type");


### PR DESCRIPTION
Permalink code for `task` made an assumption about HTML structure that was no longer true. Changed to be a little more robust.