### PR TITLE
Script: Custom themes can set arbitrary options in pub/html/css

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2376,8 +2376,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="get-theme-option">
     <xsl:param name="optname"/>
     <xsl:choose>
-        <!-- Must be an option in the theme -->
-        <xsl:when test="$html-theme/option[@name = $optname]">
+        <!-- Must be an option in the theme or a custom theme -->
+        <xsl:when test="$html-theme/option[@name = $optname] or $html-theme[@name = 'custom']">
             <xsl:choose>
                 <xsl:when test="$publication/html/css/options/@*[name() = $optname]">
                     <!-- Exists in pub file, use that -->
@@ -2414,8 +2414,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:variable name="options-string">
             <xsl:for-each select="$publication/html/css/@*">
                 <xsl:variable name="optname" select="name(.)"/>
-                <!-- only pass on values that match theme options -->
-                <xsl:if test="$html-theme/option[@name = $optname]">
+                <!-- only pass on values that match theme options unless custom -->
+                <xsl:if test="$html-theme/option[@name = $optname] or $html-theme[@name = 'custom']">
                     <xsl:value-of select="concat('&quot;', name(.), '&quot;:')"/>
                     <xsl:value-of select="concat('&quot;', ., '&quot;')"/>
                     <xsl:text>,</xsl:text>


### PR DESCRIPTION
Currently only known options are passed on from pub/html/css to the cssbuilder script. So in a theme that does not make use of `secondary-color`, any attempt to set a value in the pubfile will never be seen by the builder.

This loosens that for `theme="custom"` as we don't know what options make sense for it.

Example need: 
Soundwriting project wants a custom theme (their own scss file), but wants to be able to set different `secondary-color` values from different pub files.

Without this change, there would need to be 2 different scss files and each pub file would point to a different scss file.