### PR TITLE
HTML: Bump mermaid to v11

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13001,7 +13001,7 @@ TODO:
 <xsl:template name="mermaid-header">
     <xsl:if test="$b-has-mermaid">
         <script type="module">
-            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
             let theme = '<xsl:value-of select="$mermaid-theme"/>';
             if (isDarkMode())
                 theme = 'dark';


### PR DESCRIPTION
Bumps version number of mermaid to 11. v11 has some new options and diagram types as well as lots of bug fixes.

No true breaking changes in 10->11. (A few defaults for diagrams changed but they aren't actually breaking.)

All the samples in SB still work. 
https://github.com/mermaid-js/mermaid/releases/tag/v11.0.0