### PR TITLE
Improve display of navbar buttons and footer logos in mobile view

### DIFF
--- a/css/components/page-parts/_footer.scss
+++ b/css/components/page-parts/_footer.scss
@@ -40,8 +40,12 @@ $nav-height: 36px !default;
 @media screen and (max-width: $navbar-breakpoint) {
   .ptx-page-footer {
     // prevent icons from spreading too much
-    gap: 50px;
+    gap: 20px;
     justify-content: center;
     margin-bottom: $nav-height - 2;
+
+    & > a > .logo:first-child {
+      height: 2em;
+    }
   }
 }

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -128,6 +128,11 @@ $center-content: true !default;
     right: 0;
     z-index: 1100;
     background: var(--button-border-color);
+    max-width: 100vw;
+
+    .ptx-navbar-contents {
+      max-width: 100vw;
+    }
 
     .nav-runestone-controls {
       flex: 0;

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -192,3 +192,16 @@ $sidebar-hide-breakpoint: $content-width + 2 * $content-side-padding-tight + $si
     display: none;
   }
 }
+
+//Adjust again when navbar moves to bottom. 
+@media screen and (max-width: $navbar-breakpoint) {
+  // Undo modifications to toc-toggle and margin that held space for it
+  .ptx-navbar .ptx-navbar-contents {
+    margin-left: 0;
+  }
+  .ptx-navbar .toc-toggle {
+      transform: none;
+      position: relative;
+      justify-content: center;
+  }
+}

--- a/css/targets/html/legacy/crc/navbar_crc.css
+++ b/css/targets/html/legacy/crc/navbar_crc.css
@@ -23,6 +23,7 @@
 .ptx-navbar-contents {
   display: flex;
   flex: 1;
+  max-width: 100%;
 }
 
 

--- a/css/targets/html/legacy/default/navbar_default.css
+++ b/css/targets/html/legacy/default/navbar_default.css
@@ -22,6 +22,7 @@ nav.ptx-navbar {
 .ptx-navbar-contents {
   display: flex;
   flex: 1;
+  max-width: 100%;
 }
 
 .ptx-navbar .button {

--- a/css/targets/html/legacy/wide/navbar_wide.scss
+++ b/css/targets/html/legacy/wide/navbar_wide.scss
@@ -18,6 +18,7 @@
 .ptx-navbar-contents {
   display: flex;
   flex: 1;
+  max-width: 100%;
 }
 
 .pretext .ptx-navbar .toc-toggle {


### PR DESCRIPTION
Addresses:
https://groups.google.com/g/pretext-dev/c/NXRWnX2XKkk/m/zwHgdqLzDwAJ?utm_medium=email&utm_source=footer

I have three commits on the branch, but they could be squashed into one "better mobile" commit

@oscarlevin I made an update to parts-paper since they override some of what the basic navbar does - do you want to check it out? Once we hit the navbar/mobile breakpoint, it tries to undo the custom location of the toc-toggle. Third commit turns off the large side padding on the .ptx-content-footer once we reach that size so that those buttons don't end up squashed.