### PR TITLE
Add theme names as comments; elevate log messages for building css

### DIFF
--- a/css/targets/ebook/epub/epub.scss
+++ b/css/targets/ebook/epub/epub.scss
@@ -1,3 +1,4 @@
+/*! Theme: epub */
 @use '../ebook-common';
 
 // no extra styles

--- a/css/targets/ebook/kindle/kindle.scss
+++ b/css/targets/ebook/kindle/kindle.scss
@@ -1,3 +1,4 @@
+/*! Theme: kindle */
 @use '../ebook-common';
 
 .ptx-content {

--- a/css/targets/html/default-modern/theme-default-modern.scss
+++ b/css/targets/html/default-modern/theme-default-modern.scss
@@ -1,3 +1,5 @@
+/*! Theme: default-modern */
+
 // Variables used by theme. CSSBuilder overrides these by prepending
 // different definitions for these variables to this file before the theme
 // is compiled.

--- a/css/targets/html/denver/theme-denver.scss
+++ b/css/targets/html/denver/theme-denver.scss
@@ -1,3 +1,4 @@
+/*! Theme: denver */
 // Theme that uses bold content blocks with a visible centered "page" of content
 
 // Current maintainer: Oscar Levin

--- a/css/targets/html/greeley/theme-greeley.scss
+++ b/css/targets/html/greeley/theme-greeley.scss
@@ -1,3 +1,4 @@
+/*! Theme: greeley */
 // Theme designed for short articles (i.e., research papers).
 
 // Current maintainer: Oscar Levin

--- a/css/targets/html/legacy/crc/theme-crc.scss
+++ b/css/targets/html/legacy/crc/theme-crc.scss
@@ -1,3 +1,4 @@
+/*! Theme: crc-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';
 @use 'legacy/pretext_add_on.css';

--- a/css/targets/html/legacy/default/theme-default.scss
+++ b/css/targets/html/legacy/default/theme-default.scss
@@ -1,3 +1,4 @@
+/*! Theme: default-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';
 @use 'legacy/pretext_add_on.css';

--- a/css/targets/html/legacy/min/theme-min.scss
+++ b/css/targets/html/legacy/min/theme-min.scss
@@ -1,3 +1,4 @@
+/*! Theme: min-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';
 @use 'legacy/pretext_add_on.css';

--- a/css/targets/html/legacy/oscarlevin/theme-oscarlevin.scss
+++ b/css/targets/html/legacy/oscarlevin/theme-oscarlevin.scss
@@ -1,4 +1,5 @@
-// Designed to support custom styling for https://github.com/UPS-CWLT/soundwriting
+/*! Theme: oscarlevin-legacy */
+// Designed to support custom styling for oscarlevin style
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';
 @use 'legacy/pretext_add_on.css';

--- a/css/targets/html/legacy/soundwriting/theme-soundwriting.scss
+++ b/css/targets/html/legacy/soundwriting/theme-soundwriting.scss
@@ -1,3 +1,4 @@
+/*! Theme: soundwriting-legacy */
 // Designed to support custom styling for https://github.com/UPS-CWLT/soundwriting
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';

--- a/css/targets/html/legacy/wide/theme-wide.scss
+++ b/css/targets/html/legacy/wide/theme-wide.scss
@@ -1,3 +1,4 @@
+/*! Theme: wide-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';
 @use 'legacy/pretext_add_on.css';

--- a/css/targets/html/salem/theme-salem.scss
+++ b/css/targets/html/salem/theme-salem.scss
@@ -1,3 +1,4 @@
+/*! Theme: salem */
 // A theme focused on displaying wide content gracefully
 
 // Current maintainer: Andrew Scholer

--- a/css/targets/html/tacoma/theme-tacoma.scss
+++ b/css/targets/html/tacoma/theme-tacoma.scss
@@ -1,3 +1,4 @@
+/*! Theme: tacoma */
 // A theme focused on a minimal distraction reading environment
 
 // Current maintainer: Andrew Scholer

--- a/css/targets/revealjs/reveal.scss
+++ b/css/targets/revealjs/reveal.scss
@@ -1,3 +1,4 @@
+/*! Theme: reveal */
 @use "components/elements/list-styles";
 
 ul {

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3659,7 +3659,7 @@ def _move_prebuilt_theme(theme_name, theme_opts, tmp_dir):
     if 'secondary-color' not in theme_opts['options'].keys():
         theme_opts['options']['secondary-color'] = color_schemes[scheme]['secondary-color']
 
-    log.debug("Using prebuilt theme: " + theme_name + " with options: " + str(theme_opts))
+    log.info("Using prebuilt css theme: " + theme_name + " with options: " + str(theme_opts))
 
     # copy src -> dest with modifications
     with open(src, 'r') as theme_file:
@@ -3709,7 +3709,7 @@ def _build_custom_theme(xml, theme_name, theme_opts, tmp_dir):
         node_exec_cmd = get_executable_cmd("node")
         # theme name is prefixed with "theme-" in the cssbuilder script output
         full_name = "theme-{}".format(theme_name)
-        log.debug("Building custom theme: " + full_name)
+        log.info("Building custom css theme: " + full_name)
         log.debug("Theme options:" + json.dumps(theme_opts))
         result = subprocess.run(node_exec_cmd + [script, "-t", full_name, "-o", css_dest, "-c", json.dumps(theme_opts)], capture_output=True, timeout=10)
         if result.stdout:


### PR DESCRIPTION
Two minor commits to make debugging css theme issues easier.

1. Elevate a couple `log.debug` messages to `log.info` for the step when either copying or building a css theme.
2. Add a comment to each theme that SASS will put in the minified `theme.css` so it will be clear what theme is being used from the browser inspector.

These should help with an issue I'm running into with building on runestone where it doesn't seem to be using the requested theme.