### PR TITLE
CSS: Improve page footer button spacing in Denver on mobile

### DIFF
--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -204,4 +204,9 @@ $sidebar-hide-breakpoint: $content-width + 2 * $content-side-padding-tight + $si
       position: relative;
       justify-content: center;
   }
+
+  .ptx-content-footer {
+    padding-left: $content-side-padding-tight;
+    padding-right: $content-side-padding-tight;
+  }
 }


### PR DESCRIPTION
Third commit mentioned but not provided in https://github.com/PreTeXtBook/pretext/pull/2399

Prevents page footer buttons from getting squashed in Denver/Greeley on mobile

@oscarlevin, do you want to bless this one?