### PR TITLE
Script: fix html watermark svg generation

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6839,9 +6839,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 
 <xsl:variable name="watermark-css">
-    <xsl:text>background-image:url('data:image/svg+xml;utf8,</xsl:text>
-    <xsl:apply-templates select="exsl:node-set($watermark-svg)" mode="serialize" />
+    <xsl:text>background-image:url('data:image/svg+xml;charset=utf-8,</xsl:text>
+    <xsl:apply-templates select="exsl:node-set($watermark-svg)" mode="serialize">
+        <!-- as-authored-source to preserve namespace on svg -->
+        <xsl:with-param name="as-authored-source" select="true()"/>
+    </xsl:apply-templates>
     <xsl:text>');</xsl:text>
+    <xsl:text>background-position:center top;background-repeat:repeat-y;</xsl:text>
 </xsl:variable>
 
 <!-- NB: here, and elesewhere, references -->
@@ -10715,14 +10719,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
                 <main class="ptx-main">
+                    <xsl:if test="$b-watermark">
+                        <xsl:attribute name="style">
+                            <xsl:value-of select="$watermark-css"/>
+                        </xsl:attribute>
+                    </xsl:if>
                     <div id="ptx-content" class="ptx-content">
                         <xsl:if test="$b-printable">
                             <xsl:apply-templates select="." mode="print-button"/>
-                        </xsl:if>
-                        <xsl:if test="$b-watermark">
-                            <xsl:attribute name="style">
-                                <xsl:value-of select="$watermark-css" />
-                            </xsl:attribute>
                         </xsl:if>
                         <!-- Alternative to "copy-of": convert $content to a  -->
                         <!-- node-set, and then hit with an identity template -->


### PR DESCRIPTION
Fix for:
https://groups.google.com/g/pretext-support/c/6M-o-Q8Mb64/m/5rl1-edMAAAJ?utm_medium=email&utm_source=footer

SVG was being serialized from XML without its namespace. Also moved placement to ptx-main which covers more of the viewport when there is not much content on a page.