### PR TITLE
CSS: Link styling updates

### DIFF
--- a/css/colors/_palette-dual.scss
+++ b/css/colors/_palette-dual.scss
@@ -75,9 +75,10 @@ $colors: map.merge(
     "link-text-color": var(--primary-color),
     "link-active-text-color": var(--primary-color-black-20),
     "link-background": var(--primary-color-white-97),
+    "link-active-background": var(--link-background),
 
     "link-alt-text-color": var(--secondary-color-black-10),
-    "link-alt-active-background": var(--secondary-color),
+    "link-alt-active-background": var(--secondary-color-white-97),
     "link-alt-background": var(--secondary-color-white-97),
 
     "toc-border-color": var(--primary-color-white-30),

--- a/css/components/elements/_summary-links.scss
+++ b/css/components/elements/_summary-links.scss
@@ -48,6 +48,9 @@
         color: var(--summary-link-hover-text-color);
         background: var(--summary-link-hover-background);
       }
+      .title {
+        font-weight: normal;
+      }
 
       &::after {
         border-left: 0.4em solid var(--summary-link-hover-text-color);


### PR DESCRIPTION
Fixes two issues with links:

- Bolding of summary link on hover possibly rewrapping text. Now no bolding, but plenty else is going on to indicate hover.
- Background colors of links in dual color themes (e.g. default modern) was getting colors that were too dark. See: https://pretextbook.org/examples/sample-article/html/section-cross-referencing.html