### PR TITLE
New journal styles and frontmatter improvements

### DIFF
--- a/css/components/elements/_front-matter.scss
+++ b/css/components/elements/_front-matter.scss
@@ -68,26 +68,32 @@
     margin: 4em 2em;
   }
 
-  .abstract > .title {
-    font-size: 1.125em;
-    font-weight: 600;
-    line-height: 1.125em;
-    display: inline;
+  .keywords, .support {
+    margin-top: 2em;
   }
 
-  .abstract > .title::after {
-    content: ".\2009\2009\2009";
-  }
-  
-  .abstract > .title + .para {
-    display: inline;
+  .abstract, .keywords, .support {
+    & > .title {
+      font-size: 1.125em;
+      font-weight: 600;
+      line-height: 1.125em;
+      display: inline;
+    }
+
+    & > .title::after {
+      content: ".\2009\2009\2009";
+    }
+
+    & > .title + .para {
+      display: inline;
+    }
   }
 
   .colophon {
     .copyright {
       margin-top: 2.5em;
     }
-  
+
     .license {
       margin-top: 2.5em;
     }

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4194,7 +4194,60 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
         <subsection>
             <title>Bibliographic Information</title>
 
-            <p>Required. The <tag>bibinfo</tag> <idx><h>bibinfo</h></idx> element may contain metadata about your document, including <tag>author</tag>, <tag>editor</tag>, <tag>credit</tag>, <tag>date</tag>, <tag>edition</tag>, <tag>website</tag> and <tag>copyright</tag>.  Additional elements to capture bibliogrphic information are planned.</p>
+            <p>Required. The <tag>bibinfo</tag> <idx><h>bibinfo</h></idx> element may contain metadata about your document, including <tag>author</tag>, <tag>editor</tag>, <tag>credit</tag>, <tag>date</tag>, <tag>keywords</tag>, <tag>edition</tag>, <tag>website</tag> and <tag>copyright</tag>.  Additional elements to capture bibliogrphic information are planned.</p>
+
+            <paragraphs>
+                <title>Authors and editors</title>
+                <p>
+                    Each author and editor should be described in their own <tag>author</tag> or <tag>editor</tag> element, which are structured identically (in output, authors are listed first, followed by editors, sometimes using less prominent formatting).  An author can be designated as the <term>corresponding author</term> using the <attr>corresponding</attr> attribute.
+                </p>
+
+                <p>
+                    The name of an author or editor should be enclosed in a <tag>personname</tag> element.  Following this, affiliation information can be provided either by using elements <tag>department</tag>, <tag>institution</tag>, and <tag>location</tag> (each of which can be further structured with <tag>line</tag> tags), or by enclosing these in an <tag>affiliation</tag> element.  (Grouping affiliation details is useful when an author might have multiple affiliations.)
+                </p>
+
+                <p>
+                    An author or editor can also have an <tag>email</tag>, <tag>biographcy</tag>, or <tag>support</tag> element.  The <tag>support</tag> element can be used to describe funding sources particular to that author as required by some journals.  Notice that the <tag>support</tag> element could also be a child of <tag>bibinfo</tag> itself, in which case it would appear as applying to the entire document, not just an individual author.
+                </p>
+            </paragraphs>
+
+            <paragraphs>
+                <title>Keywords</title>
+                <p>
+                    Many journals require papers to contain a list of keywords or subject classification codes.  These are both captured by the <tag>keywords</tag> element.  This groups a collection of <tag>keyword</tag> elements, each of which is a single keyword or subject classification code.
+                </p>
+
+                <p>
+                    To distinguish between author-provided keywords and subject classification codes, the <tag>keywords</tag> element can have attributes <attr>authority</attr> and <attr>variant</attr>.  As of 2025-02-18, the values of these attributes that are recognized are given in <xref ref="table-keywords"/>.
+                </p>
+
+                <table xml:id="table-keywords">
+                    <title>Recognized keyword attribute values</title>
+                    <tabular>
+                        <row header="yes" bottom="minor">
+                            <cell>Type</cell><cell><attr>authority</attr></cell><cell>variant</cell>
+                        </row>
+                        <row>
+                            <cell>Author-provided keywords</cell>
+                            <cell><c>author</c> or none</cell>
+                            <cell>none</cell>
+                        </row>
+                        <row>
+                            <cell>Math Subject Classification (MSC) codes</cell>
+                            <cell><c>msc</c></cell>
+                            <cell><c>2020</c> or <c>2010</c> or etc.</cell>
+                        </row>
+                    </tabular>
+                </table>
+
+                <p>
+                    For subject classification codes, to distinguish between primary or secondary codes, the <tag>keyword</tag> element can have the optional attribute <attr>primary</attr> (with value <c>yes</c> or <c>no</c>).  Put <c>primary="yes"</c> on the <em>first</em> primary keyword, and <c>primary="no"</c> on the <em>first</em> secondary keyword.  Alternatively, using <c>secondary="yes"</c> on the first secondary keyword is also acceptable.
+                </p>
+
+                <p>
+                    If you are writing a paper that needs a different classification from those currently available, please submit a request.
+                </p>
+            </paragraphs>
         </subsection>
 
         <subsection>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -225,6 +225,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <line>Tacoma, Washington, USA</line>
                     </institution>
                     <email>beezer@pugetsound.edu</email>
+                    <support>Statement about support received by the first author.</support>
+                </author>
+
+                <author>
+                    <personname>A. Second Author</personname>
+                    <affiliation>
+                        <department>Department of Mathematics</department>
+                        <institution>University of Somewhere</institution>
+                        <location>Anytown, USA</location>
+                    </affiliation>
+                    <email>asauthor@example.edu</email>
+                    <support>Statement about support received by the second author.</support>
                 </author>
 
                 <!-- Can set date manually or use the "today" element -->

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3026,6 +3026,7 @@
                     Date? &amp;
                     Edition? &amp;
                     Keywords* &amp;
+                    Support? &amp;
                     Website? &amp;
                     Copyright?)
                 }
@@ -3044,7 +3045,7 @@
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
             Support = element support {TextParagraph}
-            Location = element address {TextSimple | ShortLine+}
+            Location = element location {TextSimple | ShortLine+}
             Keywords = element keywords {
                 attribute authority {text}?,
                 attribute variant {text}?,

--- a/xsl/latex/pretext-latex-amsart.xsl
+++ b/xsl/latex/pretext-latex-amsart.xsl
@@ -37,5 +37,104 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- TODO: when @journal is specified in publisher file, we will use   -->
 <!-- that to change the documentclass using some sort of lookup table. -->
 <xsl:variable name="documentclass" select="'amsart'"/>
+<xsl:variable name="bibliographystyle" select="'amsplain'"/>
+
+<!-- Order of bibinfo elements before \begin{document} -->
+<xsl:template name="bibinfo-pre-begin-document"/>
+
+
+<!-- Order of bibinfo elements after \begin{document} -->
+<xsl:template name="bibinfo-post-begin-document">
+    <xsl:apply-templates select="$document-root" mode="article-title"/>
+    <xsl:apply-templates select="$bibinfo/author" mode="article-frontmatter"/>
+    <xsl:apply-templates select="$bibinfo/keywords[@authority='msc']" mode="article-frontmatter"/>
+    <xsl:apply-templates select="$bibinfo/date" mode="article-frontmatter"/>
+    <xsl:apply-templates select="$bibinfo/keywords[not(@authority='msc')]" mode="article-frontmatter"/>
+    <xsl:apply-templates select="$bibinfo/support" mode="article-frontmatter"/>
+    <xsl:apply-templates select="$document-root/frontmatter/abstract" mode="article-frontmatter"/>
+
+    <xsl:text>\maketitle&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Contents of bibinfo elements -->
+<xsl:template match="*" mode="article-title">
+    <xsl:text>%% Title page information for article&#xa;</xsl:text>
+    <xsl:text>\title[</xsl:text>
+    <xsl:apply-templates select="." mode="title-short"/>
+    <xsl:text>]{</xsl:text>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:if test="subtitle">
+        <xsl:text>\\&#xa;</xsl:text>
+        <!-- Trying to match author fontsize -->
+        <xsl:text>{\small </xsl:text>
+        <xsl:apply-templates select="." mode="subtitle"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+
+<xsl:template match="bibinfo/author" mode="article-frontmatter">
+    <xsl:text>\author{</xsl:text>
+    <xsl:apply-templates select="personname"/>
+    <xsl:text>}&#xa;</xsl:text>
+    <xsl:if test="affiliation">
+        <xsl:text>\address{</xsl:text>
+        <xsl:apply-templates select="affiliation"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="email">
+        <xsl:text>\email{</xsl:text>
+        <xsl:apply-templates select="email" mode="article-info" />
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="support">
+        <xsl:text>\thanks{</xsl:text>
+        <xsl:apply-templates select="support"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+
+
+<xsl:template match="bibinfo/keywords[@authority='msc']" mode="article-frontmatter">
+    <xsl:text>\subjclass[</xsl:text>
+    <xsl:value-of select="$bibinfo/keywords[@authority='msc']/@variant"/>
+    <xsl:text>]{</xsl:text>
+    <xsl:apply-templates select="*"/>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+
+<xsl:template match="bibinfo/date" mode="article-frontmatter">
+    <xsl:text>\date{</xsl:text>
+    <xsl:apply-templates select="."/>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+
+<xsl:template match="bibinfo/keywords[not(@authority='msc')]" mode="article-frontmatter">
+    <xsl:text>\keywords{</xsl:text>
+    <xsl:apply-templates select="*"/>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+
+<xsl:template match="bibinfo/support" mode="article-frontmatter">
+    <xsl:text>\dedicatory{</xsl:text>
+    <xsl:apply-templates select="$bibinfo/support" mode="article-info"/>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+
+
+<xsl:template match="frontmatter/abstract" mode="article-frontmatter">
+    <xsl:text>\begin{abstract}&#xa;</xsl:text>
+        <xsl:apply-templates select="*"/>
+    <xsl:text>\end{abstract}&#xa;</xsl:text>
+</xsl:template>
+
+
+
 
 </xsl:stylesheet>

--- a/xsl/latex/pretext-latex-ejc.xsl
+++ b/xsl/latex/pretext-latex-ejc.xsl
@@ -1,0 +1,206 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2025 Oscar Levin
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Conveniences for classes of similar elements -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../entities.ent">
+    %entities;
+]>
+
+<!-- Identify as a stylesheet -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+>
+
+<!-- Override specific tenplates of the standard conversion -->
+<xsl:import href="../pretext-latex-classic.xsl" />
+
+<!-- Provide the name of the document class -->
+<!-- TODO: when @journal is specified in publisher file, we will use   -->
+<!-- that to change the documentclass using some sort of lookup table. -->
+<xsl:variable name="documentclass" select="'article'"/>
+
+
+<xsl:template name="journal-packages">
+    <xsl:text>\usepackage[amsmath]{e-jc}&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- By default, no bibinfo is included before the \begin{document}.     -->
+<!-- Other latex styles can override this to put some information there. -->
+<xsl:template name="bibinfo-pre-begin-document">
+    <!-- date -->
+    <xsl:text>\dateline{</xsl:text>
+    <xsl:if test="$bibinfo/date">
+        <xsl:apply-templates select="$bibinfo/date"/>
+    </xsl:if>
+    <xsl:text>}{TBD}{TBD}&#xa;</xsl:text>
+    <!-- msc -->
+    <xsl:if test="$bibinfo/keywords[@authority='msc']">
+        <xsl:apply-templates select="$bibinfo/keywords[@authority='msc']"/>
+    </xsl:if>
+    <!-- TODO: Copyright, from a list of acceptable statements.  See sample. -->
+    <!-- For now, just a default -->
+    <xsl:text>\Copyright{The author.}&#xa;</xsl:text>
+
+    <!-- Title -->
+    <xsl:text>\title{</xsl:text>
+    <xsl:apply-templates select="$document-root" mode="article-title"/>
+    <xsl:text>}&#xa;</xsl:text>
+    <xsl:if test="$bibinfo/author">
+        <xsl:text>\author{</xsl:text>
+        <xsl:apply-templates select="$bibinfo/author" mode="author-names"></xsl:apply-templates>
+        <xsl:text>}%&#xa;</xsl:text>
+        <xsl:apply-templates select="$bibinfo/author" mode="author-info"/>
+    </xsl:if>
+
+    <xsl:if test="$bibinfo/editor">
+        <xsl:message>PTX:WARNING: The journal you are building for does not provide a mechanisms for listing editors.</xsl:message>
+    </xsl:if>
+
+    <!--<xsl:if test="$bibinfo/keywords[not(@authority='msc')]">
+        <xsl:text>\keywords{</xsl:text>
+        <xsl:apply-templates select="$bibinfo/keywords[not(@authority='msc')]"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>-->
+    <!--<xsl:if test="$bibinfo/support">
+        <xsl:text>\dedicatory{</xsl:text>
+        <xsl:apply-templates select="$bibinfo/support" mode="article-info"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>-->
+</xsl:template>
+
+<!-- By default, all bibinfo goes inside (after) \begin{document}.             -->
+<!-- Other latex styles can override this in combination with the pre-version. -->
+<xsl:template name="bibinfo-post-begin-document">
+    <xsl:text>\maketitle&#xa;</xsl:text>
+    <xsl:if test="$document-root/frontmatter/abstract">
+        <xsl:apply-templates select="$document-root/frontmatter/abstract"/>
+    </xsl:if>
+</xsl:template>
+
+
+<!-- Templates for bibinfo contents: -->
+
+<xsl:template match="bibinfo/keywords[@authority='msc']">
+    <xsl:text>\MSC{</xsl:text>
+    <xsl:apply-templates select="keyword"/>
+    <xsl:text>}%&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="keyword">
+    <xsl:value-of select="."/>
+    <xsl:if test="following-sibling::keyword">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="*" mode="article-title">
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:if test="subtitle">
+        <xsl:text>\\&#xa;</xsl:text>
+        <!-- Trying to match author fontsize -->
+        <xsl:text>{\small </xsl:text>
+        <xsl:apply-templates select="." mode="subtitle"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+
+<xsl:template match="bibinfo/author" mode="author-names">
+    <xsl:apply-templates select="personname"/>
+    <xsl:text>\authornote{</xsl:text>
+    <xsl:number/>
+    <xsl:text>}%&#xa;</xsl:text>
+    <xsl:if test="following-sibling::author">
+        <xsl:text>\and&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="bibinfo/author" mode="author-info">
+    <xsl:text>\authortext{</xsl:text>
+    <xsl:number/>
+    <xsl:text>}{</xsl:text>
+    <xsl:apply-templates select="affiliation"/>
+    <xsl:text>(\email{</xsl:text>
+    <xsl:apply-templates select="email"/>
+    <xsl:text>})}%&#xa;</xsl:text>
+</xsl:template>
+
+<!-- e-jc already includes a number of theorem environments.  We remove these and only 
+keep the ones e-jc.sty doesn't have. -->
+<xsl:template name="latex-theorem-environments">
+    <xsl:text>%% Theorem-like environments&#xa;</xsl:text>
+    <xsl:text>%&#xa;% amsthm package: redundant if using amsart documentclass, but required otherwise.&#xa;</xsl:text>
+    <xsl:text>\usepackage{amsthm}%&#xa;%&#xa;</xsl:text>
+    <xsl:text>\theoremstyle{plain}&#xa;</xsl:text>
+    <!-- Now continue with the remaining elements, checking to see if they are present -->
+    <xsl:variable name="theoremstyle-plain" select="
+        ($document-root//identity)[1]
+        "/>
+    <xsl:for-each select="$theoremstyle-plain">
+        <xsl:apply-templates select="." mode="newtheorem"/>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+
+    <xsl:text>\theoremstyle{definition}&#xa;</xsl:text>
+    <xsl:variable name="theoremstyle-definition" select="
+        ($document-root//axiom)[1]|
+        ($document-root//principle)[1]|
+        ($document-root//heuristic)[1]|
+        ($document-root//hypothesis)[1]|
+        ($document-root//assumption)[1]|
+        ($document-root//openproblem)[1]|
+        ($document-root//openquestion)[1]|
+        ($document-root//algorithm)[1]|
+        ($document-root//activity)[1]|
+        ($document-root//exercise)[1]|
+        ($document-root//inlineexercise)[1]|
+        ($document-root//investigation)[1]|
+        ($document-root//exploration)[1]|
+        ($document-root//project)[1]
+    "/>
+    <xsl:for-each select="$theoremstyle-definition">
+        <xsl:apply-templates select="." mode="newtheorem"/>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+
+    <xsl:text>\theoremstyle{remark}&#xa;</xsl:text>
+        <xsl:variable name="theoremstyle-remark" select="
+        ($document-root//convention)[1]|
+        ($document-root//warning)[1]|
+        ($document-root//insight)[1]|
+        ($document-root//computation)[1]|
+        ($document-root//technology)[1]|
+        ($document-root//data)[1]
+    "/>
+    <xsl:for-each select="$theoremstyle-remark">
+        <xsl:apply-templates select="." mode="newtheorem"/>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- Don't do anything special with hyperref -->
+<xsl:template name="load-configure-hyperref"/>
+
+
+</xsl:stylesheet>

--- a/xsl/latex/pretext-latex-elsevier.xsl
+++ b/xsl/latex/pretext-latex-elsevier.xsl
@@ -1,0 +1,157 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2025 Oscar Levin
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Conveniences for classes of similar elements -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../entities.ent">
+    %entities;
+]>
+
+<!-- Identify as a stylesheet -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+>
+
+<!-- Override specific tenplates of the standard conversion -->
+<xsl:import href="../pretext-latex-classic.xsl" />
+
+<!-- Provide the name of the document class -->
+<!-- TODO: when @journal is specified in publisher file, we will use   -->
+<!-- that to change the documentclass using some sort of lookup table. -->
+<xsl:variable name="documentclass" select="'elsarticle'"/>
+
+
+<xsl:template name="bibinfo-pre-begin-document"/>
+
+<xsl:template name="bibinfo-post-begin-document">
+    <xsl:text>\begin{frontmatter}&#xa;</xsl:text>
+    <xsl:apply-templates select="$document-root" mode="article-title"/>
+    <xsl:if test="$bibinfo/author or $bibinfo/editor">
+        <xsl:apply-templates select="$bibinfo/author" mode="article-info"/>
+        <xsl:apply-templates select="$bibinfo/editor" mode="article-info"/>
+    </xsl:if>
+    <xsl:if test="$document-root/frontmatter/abstract">
+        <xsl:apply-templates select="$document-root/frontmatter/abstract" mode="article-frontmatter"/>
+    </xsl:if>
+    <xsl:if test="$bibinfo/keywords">
+        <xsl:text>\begin{keyword}&#xa;</xsl:text>
+        <xsl:apply-templates select="$bibinfo/keywords"/>
+        <xsl:text>\end{keyword}&#xa;</xsl:text>
+    </xsl:if>
+    <!--<xsl:if test="$bibinfo/support">
+        <xsl:text>\dedicatory{</xsl:text>
+        <xsl:apply-templates select="$bibinfo/support" mode="article-info"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>-->
+
+    <xsl:text>\end{frontmatter}&#xa;</xsl:text>
+</xsl:template>
+
+
+<xsl:template match="*" mode="article-title">
+    <xsl:text>%% Title page information for article&#xa;</xsl:text>
+    <xsl:text>\title{</xsl:text>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:if test="subtitle">
+        <xsl:text>\\&#xa;</xsl:text>
+        <!-- Trying to match author fontsize -->
+        <xsl:text>{\small </xsl:text>
+        <xsl:apply-templates select="." mode="subtitle"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <xsl:text>}&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="bibinfo/author" mode="article-info">
+    <xsl:text>\author{</xsl:text>
+    <xsl:apply-templates select="personname"/>
+    <xsl:if test="support">
+        <xsl:text>\fnref{</xsl:text>
+        <xsl:apply-templates select="." mode="unique-id"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <xsl:text>}&#xa;</xsl:text>
+    <xsl:if test="support">
+        <xsl:text>\fntext[</xsl:text>
+        <xsl:apply-templates select="." mode="unique-id"/>
+        <xsl:text>]{</xsl:text>
+        <xsl:apply-templates select="support"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="affiliation">
+        <xsl:text>\affiliation{</xsl:text>
+        <xsl:apply-templates select="affiliation"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="email">
+        <xsl:text>\ead{</xsl:text>
+        <xsl:apply-templates select="email" mode="article-info" />
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+
+
+<xsl:template match="affiliation">
+    <xsl:if test="department">
+        <xsl:apply-templates select="department" />
+        <xsl:if test="department/following-sibling::*">
+            <xsl:text>, </xsl:text>
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="institution">
+        <xsl:apply-templates select="institution" />
+        <xsl:if test="institution/following-sibling::*">
+            <xsl:text>, </xsl:text>
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="location">
+        <xsl:apply-templates select="location" />
+    </xsl:if>
+    <xsl:text>.</xsl:text>
+</xsl:template>
+
+<xsl:template name="line-separator">
+    <xsl:text>, </xsl:text>
+</xsl:template>
+
+
+<xsl:template match="frontmatter/abstract" mode="article-frontmatter">
+    <xsl:text>\begin{abstract}&#xa;</xsl:text>
+        <xsl:apply-templates select="*"/>
+    <xsl:text>\end{abstract}&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="bibinfo/keywords">
+    <xsl:if test="not(@authority='msc')">
+        <xsl:apply-templates select="*"/>
+        <xsl:text>%&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@authority='msc'">
+        <xsl:text>\MSC[</xsl:text>
+        <xsl:value-of select="@variant"/>
+        <xsl:text>] </xsl:text>
+        <xsl:apply-templates select="*"/>
+        <xsl:text>%&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/latex/pretext-latex-tf.xsl
+++ b/xsl/latex/pretext-latex-tf.xsl
@@ -1,0 +1,41 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2025 Oscar Levin
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Conveniences for classes of similar elements -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../entities.ent">
+    %entities;
+]>
+
+<!-- Identify as a stylesheet -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+>
+
+<!-- Override specific tenplates of the standard conversion -->
+<xsl:import href="../pretext-latex-classic.xsl" />
+
+<!-- Provide the name of the document class -->
+<!-- TODO: when @journal is specified in publisher file, we will use   -->
+<!-- that to change the documentclass using some sort of lookup table. -->
+<xsl:variable name="documentclass" select="'article'"/>
+
+</xsl:stylesheet>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1051,6 +1051,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <br />
                 </xsl:if>
             </xsl:if>
+            <xsl:if test="support">
+                <xsl:apply-templates select="support" />
+                <xsl:if test="support/following-sibling::*">
+                    <br />
+                </xsl:if>
+            </xsl:if>
         </div>
     </div>
 </xsl:template>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -4286,6 +4286,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\\&#xa;</xsl:text>
         <xsl:apply-templates select="email" />
     </xsl:if>
+    <xsl:if test="support">
+        <xsl:text>\\&#xa;</xsl:text>
+        <xsl:apply-templates select="support" />
+    </xsl:if>
     <xsl:if test="following-sibling::author" >
         <xsl:text>&#xa;\and</xsl:text>
     </xsl:if>
@@ -4309,7 +4313,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- Preprocessor always puts Department, Institution, and Address          -->
+<!-- Preprocessor always puts Department, Institution, and Location         -->
 <!-- inside Affiliation. This just adds line breaks between them as needed. -->
 <xsl:template match="affiliation">
     <xsl:if test="department">

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3205,7 +3205,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <pi:pub-attribute name="pageref" options="yes no" legacy-stringparam="latex.pageref"/>
         <pi:pub-attribute name="draft" default="no" options="yes" legacy-stringparam="latex.draft"/>
         <pi:pub-attribute name="open-odd" default="no" options="add-blanks skip-pages"/>
-        <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide amsart"/>
+        <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide amsart tf elsevier ejc"/>
         <page>
             <pi:pub-attribute name="bottom-alignment" default="ragged" options="flush"/>
         </page>


### PR DESCRIPTION
The six commits here take care of some frontmatter for articles maintenance (style the html, add author-level support elements consistently, improve the guide, and fix the schema).  Additionally, there are three new journal styles implemented in the final commit (which required some refactoring of the original amsart style and latex-classic).

In particular, most of the remaining issues from PR #2391 have been resolved.

Note that the "ejc" style (for the Electronic Journal of Combinatorics) requires the existence of `e-jc.sty`.  For testing, this can be downloaded from [their website](https://www.combinatorics.org/files/e-jc.sty).  We will need to think about how to ensure such files are available if we want to build pdfs, but that's a question for another day.