### PR TITLE
Implement journal publisher variable

### DIFF
--- a/doc/guide/appendices/journals-table.xml
+++ b/doc/guide/appendices/journals-table.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+  <title>Journals supported by PreTeXt</title>
+  <tabular>
+    <row header="yes">
+      <cell>Full Journal Name</cell>
+      <cell>Code</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Bulletin (New Series) of the American Mathematical Society</cell>
+      <cell>bull-amer-math-soc</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Conformal Geometry and Dynamics</cell>
+      <cell>conform-geom-dyn</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Journal of Algebraic Geometry</cell>
+      <cell>j-algebraic-geom</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Journal of the American Mathematical Society</cell>
+      <cell>j-amer-math-soc</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Mathematics of Computation</cell>
+      <cell>math-comp</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Quarterly of Applied Mathematics</cell>
+      <cell>quart-appl-math</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Proceedings of the American Mathematical Society</cell>
+      <cell>Proc-Amer-Math-Soc</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Representation Theory</cell>
+      <cell>represent-theory</cell>
+    </row>
+    <row bottom="minor">
+      <cell>St. Petersburg Mathematical Journal</cell>
+      <cell>st-petersburg-math-j</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Sugaku Expositions</cell>
+      <cell>sugaku-expositions</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Theory of Probability and Mathematical Statistics</cell>
+      <cell>theory-probab-math-statist</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Transactions of the American Mathematical Society</cell>
+      <cell>trans-ams</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Transactions of the Moscow Mathematical Society</cell>
+      <cell>trans-moscow-math-soc</cell>
+    </row>
+    <row bottom="minor">
+      <cell>General - All other AMS journals</cell>
+      <cell>ams-general</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Electronic Journal of Combinatorics</cell>
+      <cell>electron-j-combin</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Experimental Mathematics</cell>
+      <cell>exp-math</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Annals of Pure and Applied Logic</cell>
+      <cell>ann-pure-appl-logic</cell>
+    </row>
+  </tabular>
+</table>

--- a/doc/guide/appendices/journals.xml
+++ b/doc/guide/appendices/journals.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--      PreTeXt Author's Guide                              -->
+<!--                                                          -->
+<!-- Copyright (C) 2013-2019  Robert A. Beezer                -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<appendix xml:id="appendix-journals" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+    <title>List of Supported Journal Styles</title>
+
+        <p>
+            This appendix contains the list of supported journals and their short name codes.  To specify
+            one of these journals, use the publication file.  See <xref ref="common-journal"/>.
+        </p>
+
+        <p>
+            The code for a journal is taken from the list of abbreviations used by MathSciNet available at <url href="https://mathscinet.ams.org/msnhtml/serials.pdf">https://mathscinet.ams.org/msnhtml/serials.pdf</url>.
+        </p>
+
+        <xi:include href="journals-table.xml"/>
+
+</appendix>

--- a/doc/guide/backmatter.xml
+++ b/doc/guide/backmatter.xml
@@ -31,6 +31,7 @@
     <xi:include href="appendices/windows-wsl.xml"/>
     <xi:include href="appendices/cli-transition.xml"/>
     <xi:include href="appendices/cli-v1vsv2.xml"/>
+    <xi:include href="appendices/journals.xml"/>
     <appendix>
         <title>Example List of Notation</title>
         <notation-list />

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -169,6 +169,27 @@
                 QR code pixels.
             </p>
         </subsection>
+
+        <subsection xml:id="common-journal">
+            <title>Journal name</title>
+            <idx><h>common option</h><h>journal name</h></idx>
+            <idx><h>journal name</h><h>common option</h></idx>
+
+            <p>
+                When an article is intended for publication in a particular journal, the name of the
+                journal can be specified with
+                <cd>
+                    <cline>/publication/common/journal/@name</cline>
+                </cd>
+                with a value being one of a list of supported journal short name codes.  Setting this option
+                will control the format of bibliography entries and the format of latex that can be produced.
+            </p>
+
+            <p>
+                A complete list of the supported journals, together with their short name codes, will
+                be available in <xref ref="appendix-journals"/>.
+            </p>
+        </subsection>
     </section>
 
     <section xml:id="publication-file-numbering">

--- a/journals/README.md
+++ b/journals/README.md
@@ -1,0 +1,9 @@
+# Journals supported by PreTeXt
+
+This folder contains a single `journals.xml` file which holds all relevant data about the journals currently supported by PreTeXt.
+
+This file is the one source of truth for data about these journals.  It is used in the following ways:
+
+- By running the `build.sh` file, the `journals.xml` file will be transformed into a pretext table (via the `journals-to-table.xsl` file) that is placed in the correct location for when the pretext guide is built.
+- The pretext script parses `journals.xml` to find the correct latex-style to apply based on the journal code provided in the authors publication file.
+

--- a/journals/build.sh
+++ b/journals/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# When journals.xml is updated, run this script to create a pretext table in the guide's appendices folder which "journals.xml" will import.
+
+# Build the journals-table for the documentation
+xsltproc journals-to-table.xsl journals.xml > ../doc/guide/appendices/journals-table.xml

--- a/journals/journals-to-table.xsl
+++ b/journals/journals-to-table.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+
+<xsl:template match="/ptx-journals">
+    <table>
+        <title>Journals supported by PreTeXt</title>
+        <tabular>
+            <row header="yes">
+                <cell>Full Journal Name</cell><cell>Code</cell>
+            </row>
+            <xsl:apply-templates select="journal"/>
+        </tabular>
+    </table>
+
+</xsl:template>
+
+
+<xsl:template match="journal">
+    <row bottom="minor">
+        <cell><xsl:value-of select="name"/></cell>
+        <cell><xsl:value-of select="code"/></cell>
+    </row>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/journals/journals.xml
+++ b/journals/journals.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ptx-journals>
+<!-- We might want some categories or other way to break these up?  More likely just use tags -->
+
+  <journal>
+    <code>bull-amer-math-soc</code>
+    <name>Bulletin (New Series) of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>conform-geom-dyn</code>
+    <name>Conformal Geometry and Dynamics</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>j-algebraic-geom</code>
+    <name>Journal of Algebraic Geometry</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>j-amer-math-soc</code>
+    <name>Journal of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>math-comp</code>
+    <name>Mathematics of Computation</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>quart-appl-math</code>
+    <name>Quarterly of Applied Mathematics</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>Proc-Amer-Math-Soc</code>
+    <name>Proceedings of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>represent-theory</code>
+    <name>Representation Theory</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>st-petersburg-math-j</code>
+    <name>St. Petersburg Mathematical Journal</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>sugaku-expositions</code>
+    <name>Sugaku Expositions</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>theory-probab-math-statist</code>
+    <name>Theory of Probability and Mathematical Statistics</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>trans-ams</code>
+    <name>Transactions of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>trans-moscow-math-soc</code>
+    <name>Transactions of the Moscow Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>ams-general</code>
+    <name>General - All other AMS journals</name>
+    <publisher>American Mathematical Society</publisher>
+    <latex-style>amsart</latex-style>
+  </journal>
+
+  <journal>
+    <code>electron-j-combin</code>
+    <name>Electronic Journal of Combinatorics</name>
+    <publisher>Electronic Journal of Combinatorics</publisher>
+    <latex-style>ejc</latex-style>
+  </journal>
+
+  <journal>
+    <code>exp-math</code>
+    <name>Experimental Mathematics</name>
+    <publisher>Taylor &amp; Francis</publisher>
+    <latex-style>tf</latex-style>
+  </journal>
+
+  <journal>
+    <code>ann-pure-appl-logic</code>
+    <name>Annals of Pure and Applied Logic</name>
+    <publisher>Elsevier</publisher>
+    <latex-style>elsart</latex-style>
+  </journal>
+</ptx-journals>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -157,6 +157,9 @@
                     element qrcode {
                         attribute image { text }
                     }
+                    element journal {
+                        attribute name {text}
+                    }
                 }
 
             ExerciseAttributes =

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -227,6 +227,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-watermark" select="$publication/common/watermark or ($watermark.text != '')"/>
 <xsl:variable name="b-latex-watermark" select="$b-watermark or ($latex.watermark != '')"/>
 
+<!-- Journal name for bibliography formatting and latex style selection -->
+<xsl:variable name="journal-name">
+    <xsl:apply-templates select="$publisher-attribute-options/common/journal/pi:pub-attribute[@name='name']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
+
 <!-- ########################### -->
 <!-- Exercise component switches -->
 <!-- ########################### -->
@@ -3145,6 +3151,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <mermaid>
             <pi:pub-attribute name="theme" default="default" options="dark forest light"/>
         </mermaid>
+        <journal>
+            <pi:pub-attribute name="name" default="" freeform="yes"/>
+        </journal>
     </common>
     <html>
         <pi:pub-attribute name="short-answer-responses" default="graded" options="always"/>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -97,6 +97,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$latex-style"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2025-02-25 journal name -->
+    <xsl:text>journal-name</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$journal-name"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- -->
 
     <!--


### PR DESCRIPTION
Once you feel caught up on other PRs, I'd appreciate your feedback on this, @rbeezer. 

There will be a many-one mapping from journals to latex-style options.  Example: the Bulletin of the AMS will use `latex-style="amsart"`, but will need to change the `documentclass` .  The "publisher" will be able to set `publication/common/journal/@name="bull-amer-math-soc"` and everything should be set for them.

So far, this PR has the following:
- New publisher variable "journal-name"
- Pretext script for latex gets this name, checks it against a "database" of journals (in `journals/journals.xml`) and sets the `latex-style` accordingly. 
- Start of updates to documentation and publication schema.

Still needed:
- [ ] script that will transform the `journals/journals.xml` file into a pretext table that can be xi:included in the documentation.
- [ ] Decide how to represent additional information about a journal that will be needed for the conversion, including separate documentclass, additional .sty or .cls files that might need to be downloaded, etc.
- [ ] XSL and python code that utilizes that additional information.