### PR TITLE
Workbooks: fix workspace in exercisegroups

### DIFF
--- a/examples/workbook/workbook-article.xml
+++ b/examples/workbook/workbook-article.xml
@@ -164,6 +164,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xi:include href="ws-geometric-prelude.xml" />
         <xi:include href="ws-networks.xml" />
         <xi:include href="ws-testing.xml" />
+        <xi:include href="ws-exercisegroup.xml" />
         <xi:include href="ws-dot-products.xml" />
         <xi:include href="ws-activity-with-task.xml" />
       </article>

--- a/examples/workbook/workbook-book.xml
+++ b/examples/workbook/workbook-book.xml
@@ -159,10 +159,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </frontmatter>
 
         <chapter xml:id="ch-triplet">
-          <title>Three Worksheets</title>
+          <title>Four Worksheets</title>
             <xi:include href="ws-geometric-prelude.xml" />
             <xi:include href="ws-networks.xml" />
             <xi:include href="ws-testing.xml" />
+            <xi:include href="ws-exercisegroup.xml" />
           </chapter>
           <chapter xml:id="ch-duo">
             <title>Two Worksheet Chapter</title>

--- a/examples/workbook/ws-exercisegroup.xml
+++ b/examples/workbook/ws-exercisegroup.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--********************************************************************
+Copyright 2024 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<worksheet label="worksheet-exercisegroup" margin="1cm">
+  <introduction>
+      <p>
+        This is a mock worksheet for testing workspace in exercises within an exercisegrou.
+    </p>
+  </introduction>
+
+  <page>
+    <exercisegroup cols="2" workspace="1in">
+        <introduction>
+            <p>
+                Do things to the following.
+            </p>
+        </introduction>
+        <exercise>
+            <statement>
+                <p>
+                    Apple
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Banana
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Cherry
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Durian
+                </p>
+            </statement>
+        </exercise>
+        <exercise workspace="2in">
+            <statement>
+                <p>
+                    Elderberry (with workspace override)
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Fig
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Guava
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Habanero
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    I can't think of an <q>I</q> fruit.
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Jackfruit
+                </p>
+            </statement>
+        </exercise>
+    </exercisegroup>
+  </page>
+  <page>
+    <exercisegroup workspace="0.25in">
+        <introduction>
+            <p>
+                Now with one column, do things to the following.
+            </p>
+        </introduction>
+        <exercise>
+            <statement>
+                <p>
+                    Apple
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Banana
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Cherry
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Durian
+                </p>
+            </statement>
+        </exercise>
+        <exercise workspace="2in">
+            <statement>
+                <p>
+                    Elderberry (with workspace override)
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Fig
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Guava
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Habanero
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    I can't think of an <q>I</q> fruit.
+                </p>
+            </statement>
+        </exercise>
+        <exercise>
+            <statement>
+                <p>
+                    Jackfruit
+                </p>
+            </statement>
+        </exercise>
+    </exercisegroup>
+  </page>
+</worksheet>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1291,7 +1291,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="$b-pageref">
             <xsl:text>\label{#4}</xsl:text>
         </xsl:if>
-        <xsl:text>\hypertarget{#4}{}}, after={\notblank{#3}{\newline\rule{\workspacestrutwidth}{#3}\newline\vfill}{\par}}}&#xa;</xsl:text>
+        <xsl:text>\hypertarget{#4}{}}, after upper={\notblank{#3}{\newline\rule{\workspacestrutwidth}{#3}\newline\vfill}{\par}}}&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="$document-root//@workspace">
         <xsl:text>%% Worksheet exercises may have workspaces&#xa;</xsl:text>


### PR DESCRIPTION
At least with my 2023 version of texlive, worksheets with an exercisegroup are coming out with the workspace attribute ignored. This was also reported in -support. Hard to say if it is an issue for all LaTeX distributions. The change here to `pretext-latex-common.xsl` fixes that.