### PR TITLE
CSS: darken keyword prism color to meet accessibility requiremenets.

### DIFF
--- a/css/components/elements/_prism.scss
+++ b/css/components/elements/_prism.scss
@@ -83,7 +83,7 @@ pre[class*="language-"] {
     &:is(.atrule,
     .attr-value,
     .keyword) {
-      color: rgb(18, 137, 201);
+      color: #0679B7;
     }
     
     &.function,


### PR DESCRIPTION
A matching fix is already PR'ed on runestone for active code.