### PR TITLE
Portable html: the css and javascript parts

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -647,14 +647,31 @@
         <subsection xml:id="online-platform-options">
             <title>HTML Platforms</title>
             <idx><h>platform</h><h>HTML</h></idx>
+            <idx><h>host</h><h>HTML</h></idx>
             <idx>online platforms</idx>
 
             <p>The<cd>
-                <cline>/publication/html</cline>
-            </cd>element can have an attribute <attr>platform</attr> with values:<ul>
+                <cline>/publication/html/platform</cline>
+            </cd>element can have an attribute <attr>host</attr> with values:<ul>
                 <li><c>web</c>: the default, meant for self-hosting with no server configuration, features, or assumptions</li>
                 <li><c>runestone</c>: output meant for hosting on a Runestone server (<xref ref="runestone"/>)</li>
             </ul>Here <term>platform</term> refers to the server where the <init>HTML</init> output will eventually be hosted.  The effect is to create minor variations in the output to take advantage of extra features of the indicated platform.</p>
+        </subsection>
+
+        <subsection xml:id="online-portable-options">
+            <title>Portable HTML</title>
+            <idx><h>platform</h><h>HTML</h></idx>
+            <idx><h>portable</h><h>HTML</h></idx>
+            <idx><h>portable html</h></idx>
+
+            <p>To limit the number of files and directories created by the HTML conversion,
+            you can set the
+            <cd>
+                <cline>/publication/html/platform/@portable</cline>
+            </cd>
+            attribute to the value <c>"yes"</c>. 
+            This will result in the HTML using hosted CSS and Javascript files, rather than including them adjacent to the rest of your output.
+            This is especially useful in conjunction with setting the <xref ref="common-chunking-options">chunking variable</xref> to 0 to get a single html file.</p>
         </subsection>
 
         <subsection xml:id="online-style-options">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -318,10 +318,26 @@
             <code>
             Html =
                 element html {
-                    attribute platform { "web" | "runestone" }?,
                     attribute favicon { "none" | "simple" }?,
                     attribute short-answer-responses { "graded" | "always" }?,
-                    (Analytics? &amp; Baseurl? &amp; Calculator? &amp; WebworkDynamism? &amp; Indexpage? &amp; Knowls? &amp; Exercises? &amp; Css? &amp; Search? &amp; Video? &amp; Asymptote? &amp; Feedback? &amp; NavigationHTML? &amp; Tableofcontents? &amp; Crossreferences?)
+                    (
+                        Analytics? &amp;
+                        Asymptote? &amp;
+                        Baseurl? &amp;
+                        Calculator? &amp;
+                        Css? &amp;
+                        Crossreferences?
+                        Exercises? &amp;
+                        Feedback? &amp;
+                        Indexpage? &amp;
+                        Knowls? &amp;
+                        NavigationHTML? &amp;
+                        Platform? &amp;
+                        Search? &amp;
+                        Tableofcontents? &amp;
+                        Video? &amp;
+                        WebworkDynamism? &amp;
+                    )
                 }
 
             Analytics =
@@ -399,6 +415,11 @@
                 element navigation {
                     attribute logic { "linear" | "tree" }?,
                     attribute upbutton { "yes" | "no" }?
+                }
+            Platform =
+                element platform {
+                    attribute host { "web" | "runestone" }
+                    attribute portable { "yes" | "no" }
                 }
             Search =
                 element search {

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -110,9 +110,35 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- So the name says "dir", but effectively it is "location". -->
 <!-- But this is not the intent, nor supported, and thus can   -->
 <!-- change without warning.                                   -->
-<xsl:variable name="html.css.dir" select="'_static/pretext/css'"/>
-<xsl:variable name="html.js.dir" select="'_static/pretext/js'"/>
-<xsl:variable name="html.jslib.dir" select="'_static/pretext/js/lib'"/>
+<xsl:variable name="html.css.dir" select="concat($cdn-prefix, '_static/pretext/css')"/>
+<xsl:variable name="html.js.dir" select="concat($cdn-prefix, '_static/pretext/js')"/>
+<xsl:variable name="html.jslib.dir" select="concat($cdn-prefix, '_static/pretext/js/lib')"/>
+
+<!-- Add a prefix for the cdn url, which is empty unless the portable html variable is true -->
+<!-- We use version "latest" unless the CLI provides a version -->
+<xsl:param name="cli.version" select="'latest'"/>
+<xsl:variable name="cdn-prefix">
+    <xsl:if test="$b-portable-html">
+        <xsl:text>https://cdn.jsdelivr.net/gh/PreTeXtBook/html-static@</xsl:text>
+        <xsl:value-of select="$cli.version"/>
+        <xsl:text>/dist/</xsl:text>
+    </xsl:if>
+</xsl:variable>
+
+<!-- The css file name is usually "theme.css", but if portable html is selected, -->
+<!-- then we use a minified version and need to give the full theme name.        -->
+<xsl:variable name="html-css-theme-file">
+    <xsl:choose>
+        <xsl:when test="$b-portable-html">
+            <xsl:text>theme-</xsl:text>
+            <xsl:value-of select="$html-theme-name"/>
+            <xsl:text>.min.css</xsl:text> 
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>theme.css</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
 
 <!-- Annotation -->
 <xsl:param name="html.annotation" select="''" />
@@ -13057,7 +13083,7 @@ TODO:
 <!-- Diagcess header library -->
 <xsl:template name="diagcess-header">
     <xsl:if test="$b-has-prefigure-annotations">
-        <script src="_static/pretext/js/diagcess/diagcess.js"></script>
+        <script src="{$html.js.dir}/diagcess/diagcess.js"></script>
     </xsl:if>
 </xsl:template>
 
@@ -13071,7 +13097,7 @@ TODO:
 <!-- CSS header -->
 <xsl:template name="css">
     <xsl:if test="not($b-debug-react)">
-        <link href="{$html.css.dir}/theme.css" rel="stylesheet" type="text/css"/>
+        <link href="{$html.css.dir}/{$html-css-theme-file}" rel="stylesheet" type="text/css"/>
     </xsl:if>
     <!-- Temporary until css handling overhaul by ascholer complete -->
     <link href="{$html.css.dir}/ol-markers.css" rel="stylesheet" type="text/css"/>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -225,6 +225,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:for-each select="$rs-js-tokens">
         <script>
             <xsl:attribute name="src">
+                <xsl:value-of select="$cdn-prefix"/>
                 <xsl:text>_static/</xsl:text>
                 <xsl:value-of select="."/>
             </xsl:attribute>
@@ -233,6 +234,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:for-each select="$rs-css-tokens">
         <link rel="stylesheet" type="text/css">
             <xsl:attribute name="href">
+                <xsl:value-of select="$cdn-prefix"/>
                 <xsl:text>_static/</xsl:text>
                 <xsl:value-of select="."/>
             </xsl:attribute>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2584,6 +2584,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-host-web"       select="$host-platform = 'web'"/>
 <xsl:variable name="b-host-runestone" select="$host-platform = 'runestone'"/>
 
+<!-- To create a standalone html document with all css and js served by CDN -->
+<!-- we can select platform/@portable to "yes"                              -->
+<xsl:variable name="portable-html">
+    <xsl:apply-templates select="$publisher-attribute-options/html/platform/pi:pub-attribute[@name='portable']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-portable-html" select="$portable-html = 'yes'"/>
+
 <!--                            -->
 <!-- HTML Favicon Specification -->
 <!--                            -->
@@ -3136,6 +3143,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </video>
         <platform>
             <pi:pub-attribute name="host" default="web" options="runestone" legacy-options="aim"/>
+            <pi:pub-attribute name="portable" default="no" options="yes"/>
         </platform>
     </html>
     <epub>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -102,6 +102,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$journal-name"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2025-03-10 portable html switch -->
+    <xsl:text>portable-html</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$portable-html"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- -->
 
     <!--


### PR DESCRIPTION
This adds a new publication variable at `/publication/html/platform/@portable`, which when set to "yes" will result in the HTML using a CDN for all css and javascript, and not copy those files to the output.

This is set up to allow the CLI to set a string-param for `cli.version`, which will be added to the URL for the CDN (since we will keep the versions of the css and javascript versioned identically to the cli).

The documentation and schema for the publication file had outdated information about `platform`: they said that `@platform` was an attribute of `/publication/html`, rather than `platform` being a child element of `/publication/html`.  That is fixed in the guide and publication schema, adjacent to the new `@portable` attribute.

Happy to rename things as needed, but this does seem functional now.