### PR TITLE
Portable HTML: svg embedding

### DIFF
--- a/css/components/elements/_media.scss
+++ b/css/components/elements/_media.scss
@@ -22,7 +22,7 @@ img.contained {
 
 // ---------------------------------------------
 // images
-.ptx-content img {
+.ptx-content img, .ptx-content svg {
   // for body images in dark mode, we want to be able to force a light colored background
   // as most transparent images will assume that the background is white
   background: var(--ptx-image-bg);

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3980,6 +3980,9 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     if include_static_files:
         # extra css for custom ol markers
         move_ol_marker_css(tmp_dir)
+    if not(include_static_files):
+        # remove latex-image generated directories for portable builds
+        shutil.rmtree(os.path.join(tmp_dir, "generated", "latex-image"), ignore_errors=True)
 
     if file_format  == "html":
         # with multiple files, we need to copy a tree

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6176,6 +6176,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <svg xmlns="http://www.w3.org/2000/svg">
         <xsl:copy-of select="$image-svg-xml/svg:svg/namespace::*"/>
         <xsl:copy-of select="$image-svg-xml/svg:svg/@version"/>
+        <!-- Keep the viewbox, or create one based on the height and width -->
+        <xsl:choose>
+            <xsl:when test="$image-svg-xml/svg:svg/@viewBox">
+                <xsl:attribute name="viewBox">
+                    <xsl:value-of select="$image-svg-xml/svg:svg/@viewBox"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:attribute name="viewBox">
+                    <xsl:text>0 0 </xsl:text>
+                    <xsl:value-of select="$image-svg-xml/svg:svg/@width"/>
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="$image-svg-xml/svg:svg/@height"/>
+                </xsl:attribute>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:copy-of select="$image-svg-xml/svg:svg/@viewBox"/>
         <xsl:attribute name="role">
             <xsl:text>img</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5926,8 +5926,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- object to hold the image.  For an annotated PreFigure diagram     -->
     <!-- we need a custom embedding for the diagcess JS to act on.  The    -->
     <!-- two files (SVG image, XML annotations) are products of PreFigure. -->
+
     <xsl:choose>
-        <xsl:when test="latex-image|pf:prefigure[not(pf:diagram/pf:annotations)]">
+        <xsl:when test="$b-portable-html and (latex-image|pf:prefigure[not(pf:diagram/pf:annotations)])">
+            <xsl:apply-templates select="." mode="svg-embedded"/>
+        </xsl:when>
+        <xsl:when test="latex-image|pf:prefigure[not(pf:diagram/pf:annotations  )]">
             <xsl:apply-templates select="." mode="svg-png-wrapper">
                 <xsl:with-param name="image-filename" select="concat($base-pathname, '.svg')" />
             </xsl:apply-templates>
@@ -6144,6 +6148,71 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
         </xsl:choose>
     </img>
+</xsl:template>
+
+<!-- Instead of linking to an svg file as in the modal svg-png-wrapper above  -->
+<!-- we can include the svg directly in the html document, which is what      -->
+<!-- this does.  Used with b-portable-html is true, at least now (2025-03-04) -->
+<xsl:template match="image" mode="svg-embedded">
+    <!-- Get the filename of the generated svg file -->
+    <xsl:variable name="svg-source-filename">
+        <xsl:value-of select="$generated-directory-source" />
+        <xsl:if test="$b-managed-directories">
+            <xsl:choose>
+                <xsl:when test="latex-image">
+                    <xsl:text>latex-image/</xsl:text>
+                </xsl:when>
+                <xsl:when test="pf:prefigure">
+                    <xsl:text>prefigure/</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:if>
+        <xsl:apply-templates select="latex-image|pf:prefigure" mode="image-source-basename"/>
+        <xsl:text>.svg</xsl:text>
+    </xsl:variable>
+    <!-- Get the SVG file as an XML document -->
+    <xsl:variable name="image-svg-xml" select="document($svg-source-filename, $original)" />
+    <!-- Create an SVG element with the contents of the SVG file -->
+    <svg xmlns="http://www.w3.org/2000/svg">
+        <xsl:copy-of select="$image-svg-xml/svg:svg/namespace::*"/>
+        <xsl:copy-of select="$image-svg-xml/svg:svg/@version"/>
+        <xsl:copy-of select="$image-svg-xml/svg:svg/@viewBox"/>
+        <xsl:attribute name="role">
+            <xsl:text>img</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="class">
+            <xsl:text>contained</xsl:text>
+        </xsl:attribute>
+        <xsl:choose>
+            <xsl:when test="@decorative = 'yes'">
+                <xsl:attribute name="aria-hidden">
+                    <xsl:text>true</xsl:text>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="shortdescription">
+                <xsl:attribute name="aria-label">
+                    <xsl:apply-templates select="shortdescription"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise/>
+        </xsl:choose>
+        <xsl:if test="shortdescription">
+            <title>
+                <xsl:apply-templates select="shortdescription"/>
+            </title>
+        </xsl:if>
+        <xsl:if test="description">
+            <desc>
+                <xsl:apply-templates select="description"/>
+            </desc>
+        </xsl:if>
+        <xsl:copy-of select="$image-svg-xml/svg:svg/*" />
+    </svg>
 </xsl:template>
 
 <xsl:template match="image" mode="description">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -45,6 +45,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
     xmlns:svg="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:pi="http://pretextbook.org/2020/pretext/internal"
     xmlns:exsl="http://exslt.org/common"
     xmlns:date="http://exslt.org/dates-and-times"
@@ -6227,9 +6228,36 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="description"/>
             </desc>
         </xsl:if>
-        <xsl:copy-of select="$image-svg-xml/svg:svg/*" />
+        <xsl:apply-templates select="$image-svg-xml/svg:svg/*" mode="svg-unique-ids">
+            <xsl:with-param name="svg-unique-id">
+                <xsl:value-of select="@unique-id"/>
+            </xsl:with-param>
+        </xsl:apply-templates>
     </svg>
 </xsl:template>
+
+<!-- When embedding multiple svgs in a single page, the ids used     -->
+<!-- to refer to svg elements can colide.  This recursively adds     -->
+<!-- a unique id (per svg) suffix to all id and xlink:href elements. -->
+
+<xsl:template match="node()|@*" mode="svg-unique-ids">
+    <xsl:param name="svg-unique-id"/>
+    <xsl:copy>
+        <xsl:apply-templates select="node()|@*" mode="svg-unique-ids">
+            <xsl:with-param name="svg-unique-id" select="$svg-unique-id"/>
+        </xsl:apply-templates>
+    </xsl:copy>
+</xsl:template>
+
+<xsl:template match="@id|@xlink:href" mode="svg-unique-ids">
+    <xsl:param name="svg-unique-id"/>
+    <xsl:attribute name="{local-name()}">
+        <xsl:value-of select="."/>
+        <xsl:text>_</xsl:text>
+        <xsl:value-of select="$svg-unique-id"/>
+    </xsl:attribute>
+</xsl:template>
+
 
 <xsl:template match="image" mode="description">
     <xsl:if test="description">


### PR DESCRIPTION
Adds a template for embedding a latex-image- or prefigure-generated svg directly in the html.  The template is called based on the `$b-portable-html` variable (note, since #2429 is not yet merged, a commented line at 5911 of `pretext-html.xsl` allows for testing; this and the previous line should be removed prior to merging).

I am not sure if I have the namespace stuff right.  I was able to copy the `xmlns:...` "attributes" of the original svg, but had to hard code in the `xmlns="..../svg"` directly (which might be bad, I have no idea).  See lines 6158-6159.

Finally, a small tweak to the css to put a white background behind svg's like images get, needed for dark mode.

I have NOT refrained from copying the generated latex-image folder to output; that would require testing on a pubvar, and I need to think about the right way to do this with the very recent pub-var-report that got moved in.  So it's on my radar.