### PR TITLE
LaTeX: first pass at texstyle infrastructure

### DIFF
--- a/doc/guide/appendices/journals-table.xml
+++ b/doc/guide/appendices/journals-table.xml
@@ -7,12 +7,40 @@
       <cell>Code</cell>
     </row>
     <row bottom="minor">
+      <cell>AMS journals</cell>
+      <cell>ams</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Elsevier journals</cell>
+      <cell>elsevier</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Springer Nature journals</cell>
+      <cell>springer-nature</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Taylor Francis journals</cell>
+      <cell>taylor-francis</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Annals of Pure and Applied Logic</cell>
+      <cell>ann-pure-appl-logic</cell>
+    </row>
+    <row bottom="minor">
       <cell>Bulletin (New Series) of the American Mathematical Society</cell>
       <cell>bull-amer-math-soc</cell>
     </row>
     <row bottom="minor">
       <cell>Conformal Geometry and Dynamics</cell>
       <cell>conform-geom-dyn</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Electronic Journal of Combinatorics</cell>
+      <cell>electron-j-combin</cell>
+    </row>
+    <row bottom="minor">
+      <cell>Experimental Mathematics</cell>
+      <cell>exp-math</cell>
     </row>
     <row bottom="minor">
       <cell>Journal of Algebraic Geometry</cell>
@@ -32,19 +60,11 @@
     </row>
     <row bottom="minor">
       <cell>Proceedings of the American Mathematical Society</cell>
-      <cell>Proc-Amer-Math-Soc</cell>
+      <cell>proc-amer-math-soc</cell>
     </row>
     <row bottom="minor">
       <cell>Representation Theory</cell>
       <cell>represent-theory</cell>
-    </row>
-    <row bottom="minor">
-      <cell>St. Petersburg Mathematical Journal</cell>
-      <cell>st-petersburg-math-j</cell>
-    </row>
-    <row bottom="minor">
-      <cell>Sugaku Expositions</cell>
-      <cell>sugaku-expositions</cell>
     </row>
     <row bottom="minor">
       <cell>Theory of Probability and Mathematical Statistics</cell>
@@ -53,26 +73,6 @@
     <row bottom="minor">
       <cell>Transactions of the American Mathematical Society</cell>
       <cell>trans-ams</cell>
-    </row>
-    <row bottom="minor">
-      <cell>Transactions of the Moscow Mathematical Society</cell>
-      <cell>trans-moscow-math-soc</cell>
-    </row>
-    <row bottom="minor">
-      <cell>General - All other AMS journals</cell>
-      <cell>ams-general</cell>
-    </row>
-    <row bottom="minor">
-      <cell>Electronic Journal of Combinatorics</cell>
-      <cell>electron-j-combin</cell>
-    </row>
-    <row bottom="minor">
-      <cell>Experimental Mathematics</cell>
-      <cell>exp-math</cell>
-    </row>
-    <row bottom="minor">
-      <cell>Annals of Pure and Applied Logic</cell>
-      <cell>ann-pure-appl-logic</cell>
     </row>
   </tabular>
 </table>

--- a/journals/build.sh
+++ b/journals/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# When journals.xml is updated, run this script to create a pretext table in the guide's appendices folder which "journals.xml" will import.
+# When journals.xml is updated, run this script from the journals directory to create a pretext table in the guide's appendices folder which "journals.xml" will import.
 
 # Build the journals-table for the documentation
 xsltproc journals-to-table.xsl journals.xml > ../doc/guide/appendices/journals-table.xml

--- a/journals/journals.xml
+++ b/journals/journals.xml
@@ -1,124 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ptx-journals>
-<!-- We might want some categories or other way to break these up?  More likely just use tags -->
+  <!-- We might want some categories or other way to break these up?  More likely just use tags -->
 
   <journal>
-    <code>bull-amer-math-soc</code>
-    <name>Bulletin (New Series) of the American Mathematical Society</name>
+    <code>ams</code>
+    <name>AMS journals</name>
     <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
   </journal>
 
   <journal>
-    <code>conform-geom-dyn</code>
-    <name>Conformal Geometry and Dynamics</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
+    <code>elsevier</code>
+    <name>Elsevier journals</name>
+    <publisher>Elsevier</publisher>
   </journal>
 
   <journal>
-    <code>j-algebraic-geom</code>
-    <name>Journal of Algebraic Geometry</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
+    <code>springer-nature</code>
+    <name>Springer Nature journals</name>
+    <publisher>Springer Nature</publisher>
   </journal>
 
   <journal>
-    <code>j-amer-math-soc</code>
-    <name>Journal of the American Mathematical Society</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>math-comp</code>
-    <name>Mathematics of Computation</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>quart-appl-math</code>
-    <name>Quarterly of Applied Mathematics</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>Proc-Amer-Math-Soc</code>
-    <name>Proceedings of the American Mathematical Society</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>represent-theory</code>
-    <name>Representation Theory</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>st-petersburg-math-j</code>
-    <name>St. Petersburg Mathematical Journal</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>sugaku-expositions</code>
-    <name>Sugaku Expositions</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>theory-probab-math-statist</code>
-    <name>Theory of Probability and Mathematical Statistics</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>trans-ams</code>
-    <name>Transactions of the American Mathematical Society</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>trans-moscow-math-soc</code>
-    <name>Transactions of the Moscow Mathematical Society</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>ams-general</code>
-    <name>General - All other AMS journals</name>
-    <publisher>American Mathematical Society</publisher>
-    <latex-style>amsart</latex-style>
-  </journal>
-
-  <journal>
-    <code>electron-j-combin</code>
-    <name>Electronic Journal of Combinatorics</name>
-    <publisher>Electronic Journal of Combinatorics</publisher>
-    <latex-style>ejc</latex-style>
-  </journal>
-
-  <journal>
-    <code>exp-math</code>
-    <name>Experimental Mathematics</name>
+    <code>taylor-francis</code>
+    <name>Taylor Francis journals</name>
     <publisher>Taylor &amp; Francis</publisher>
-    <latex-style>tf</latex-style>
   </journal>
 
   <journal>
     <code>ann-pure-appl-logic</code>
     <name>Annals of Pure and Applied Logic</name>
     <publisher>Elsevier</publisher>
-    <latex-style>elsart</latex-style>
+    <method texstyle="elsevier"/>
   </journal>
+
+  <journal>
+    <code>bull-amer-math-soc</code>
+    <name>Bulletin (New Series) of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>conform-geom-dyn</code>
+    <name>Conformal Geometry and Dynamics</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>electron-j-combin</code>
+    <name>Electronic Journal of Combinatorics</name>
+    <publisher>Electronic Journal of Combinatorics</publisher>
+  </journal>
+
+  <journal>
+    <code>exp-math</code>
+    <name>Experimental Mathematics</name>
+    <publisher>Taylor &amp; Francis</publisher>
+    <method texstyle="taylor-francis"/>
+  </journal>
+
+  <journal>
+    <code>j-algebraic-geom</code>
+    <name>Journal of Algebraic Geometry</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+
+  <journal>
+    <code>j-amer-math-soc</code>
+    <name>Journal of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>math-comp</code>
+    <name>Mathematics of Computation</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>quart-appl-math</code>
+    <name>Quarterly of Applied Mathematics</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>proc-amer-math-soc</code>
+    <name>Proceedings of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>represent-theory</code>
+    <name>Representation Theory</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>theory-probab-math-statist</code>
+    <name>Theory of Probability and Mathematical Statistics</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
+  <journal>
+    <code>trans-ams</code>
+    <name>Transactions of the American Mathematical Society</name>
+    <publisher>American Mathematical Society</publisher>
+    <method dependent="yes"/>
+  </journal>
+
 </ptx-journals>

--- a/journals/texstyles/ams.xml
+++ b/journals/texstyles/ams.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>ams</code>
+        <name>AMS journals</name>
+        <publisher>American Mathematical Society</publisher>
+        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
+        <latex-engine command="pdflatex"/>
+        <bibliography-style>spbasic</bibliography-style>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-12</date>
+    </metadata>
+
+    <documentclass name="amsart"/>
+
+
+    <ptx-preamble>
+        <theoremstyle name="plain" environments="theorem, proposition, lemma, corollary, claim, fact, identity, conjecture"/>
+        <theoremstyle name="definition" environments=", definition, axiom,, principle, heuristic, hypothesis, assumption, openproblem, openquestion, algorithm, question, activity, exercise, inlineexercise, investigation, exploration, problem, example, project"/>
+        <theoremstyle name="remark" environments="remark, warning, convention, insight, note, observation, computation, technology, data"/>
+    </ptx-preamble>
+
+    <begin-document/>
+
+    <title cmd="title">
+        <opt><ptx-short-title/></opt>
+        <arg><ptx-title/></arg>
+    </title>
+
+    <author-list>
+        <author cmd="author" corresponding="author*">
+            <arg><ptx-personname/></arg>
+        </author>
+        <affiliation cmd="address">
+            <arg><ptx-affiliation/></arg>
+        </affiliation>
+        <email cmd="email">
+            <arg><ptx-email/></arg>
+        </email>
+        <support cmd="thanks">
+            <arg><ptx-support/></arg>
+        </support>
+    </author-list>
+
+    <keywords authority="msc" cmd="subjclass" variant-style="opt" sep=", "/>
+
+    <date cmd="date">
+        <arg><ptx-date/></arg>    
+    </date>
+
+    <dedication cmd="dedicatory">
+        <arg><ptx-dedication/></arg>
+    </dedication>
+
+
+    <keywords authority="author" cmd="keywords" sep=", "/>
+
+    <abstract env="abstract">
+        <ptx-abstract/>
+    </abstract>
+
+    <maketitle/>
+
+
+    <mainmatter/>
+
+
+    <acknowledgments heading="\section*{Acknowledgments}"/>
+
+
+
+    <appendices env="appendices" />
+
+
+    <bibliography cmd="bibliography">
+        <arg><bib-file/></arg>
+    </bibliography>
+
+
+    <end-document/>
+</texstyle>

--- a/journals/texstyles/dependents/bull-amer-math-soc.xml
+++ b/journals/texstyles/dependents/bull-amer-math-soc.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>bull-amer-math-soc</code>
+        <name>Bulletin (New Series) of the American Mathematical Society</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="bull"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/conform-geom-dyn.xml
+++ b/journals/texstyles/dependents/conform-geom-dyn.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>conform-geom-dyn</code>
+        <name>Conformal Geometry and Dynamics</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="ecgd-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/j-algebraic-geom.xml
+++ b/journals/texstyles/dependents/j-algebraic-geom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>j-algebraic-geom</code>
+        <name>Journal of Algebraic Geometry</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="jag-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/j-amer-math-soc.xml
+++ b/journals/texstyles/dependents/j-amer-math-soc.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>j-amer-math-soc</code>
+        <name>Journal of the American Mathematical Society</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="jams-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/math-comp.xml
+++ b/journals/texstyles/dependents/math-comp.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>math-comp</code>
+        <name>Mathematics of Computation</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="mcom-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/proc-amer-math-soc.xml
+++ b/journals/texstyles/dependents/proc-amer-math-soc.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>proc-amer-math-soc</code>
+        <name>Proceedings of the American Mathematical Society</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+        <required-files>
+            <file href="https://www.ams.org/arc/journals/packages/proc/proc_amslatex/proc-l.cls" compression="none" path="proc-l.cls"/>
+        </required-files>
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="proc-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/quart-appl-math.xml
+++ b/journals/texstyles/dependents/quart-appl-math.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>quart-appl-math</code>
+        <name>Quarterly of Applied Mathematics</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+        <required-files>
+            <file href="https://www.ams.org/arc/journals/packages/qam/qam_amslatex/qam-l.cls" compression="none" path="qam-l.cls"/>
+        </required-files>
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="qam-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/represent-theory.xml
+++ b/journals/texstyles/dependents/represent-theory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>represent-theory</code>
+        <name>Representation Theory</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+        <required-files>
+            <file name="ert-l.cls" href="https://www.ams.org/arc/journals/packages/ert/ert_amslatex/ert-l.cls" compression="none"/>
+        </required-files>
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="ert-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/theory-probab-math-statist.xml
+++ b/journals/texstyles/dependents/theory-probab-math-statist.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>theory-probab-math-statist</code>
+        <name>Theory of Probability and Mathematical Statistics</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+        <required-files>
+            <file href="https://probability.knu.ua/tims/tpms_amslatex.zip" compression="zip" path="tpms_amslatex/tpms-l.cls"/>
+        </required-files>
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-12</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="tpms-l"/>
+
+</texstyle>

--- a/journals/texstyles/dependents/trans-ams.xml
+++ b/journals/texstyles/dependents/trans-ams.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>trans-ams</code>
+        <name>Transactions of the American Mathematical Society</name>
+        <publisher>American Mathematical Society</publisher>
+        <extends>ams</extends>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-12</date>
+    </metadata>
+
+<!-- Override the document class.  Everything else is the same. -->
+    <documentclass name="trans"/>
+
+</texstyle>

--- a/journals/texstyles/electron-j-combin.xml
+++ b/journals/texstyles/electron-j-combin.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>electron-j-combin</code>
+        <name>Electronic Journal of Combinatorics</name>
+        <publisher>Electronic Journal of Combinatorics</publisher>
+        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
+        <!--<required-files>
+            <file href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" compression="zip" path="sn-article-template/sn-jnl.cls"/>
+        </required-files>-->
+        <latex-engine command="pdflatex"/>
+        <!--<bibliography-style>spbasic</bibliography-style>-->
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-23</date>
+    </metadata>
+
+<documentclass name="article"/>
+
+<packages>
+    \usepackage[amsmath]{e-jc}
+</packages>
+
+<!-- the e-jc.cls provides some theorem environments; we add the pretext ones it misses. -->
+<ptx-preamble>
+    <theoremstyle name="plain" environments="identity"/>
+    <theoremstyle name="definition" environments="axiom, principle, heuristic, hypothesis, assumption, openproblem, openquestion, algorithm, activity, exercise, inlineexercise, investigation, exploration, project"/>
+    <theoremstyle name="remark" environments="warning, convention, insight, computation, technology, data"/>
+</ptx-preamble>
+
+    <date cmd="dateline">
+        <arg><ptx-date/></arg>
+        <arg><text>TBD</text></arg>
+        <arg><text>TBD</text></arg>
+    </date>
+
+    <keywords authority="msc" cmd="MSC" sep=", "/>
+
+    <copyright cmd="Copyright">
+        <arg>The author.</arg>
+    </copyright>
+
+    <title cmd="title">
+        <arg><ptx-title/></arg>
+    </title>
+
+    <author cmd="author">
+        <arg>
+            <author-list sep="&#xa;\and&#xa;">
+                <ptx-personname/>
+                <fnmark cmd="authornote" arg="ordinal"/>
+            </author-list>
+        </arg>
+    </author>
+
+    <author-list>
+        <fntext cmd="authortext" arg="ordinal">
+            <arg>
+                <ptx-affiliation after="\\"/>
+                <ptx-email/>
+            </arg>
+        </fntext>
+    </author-list>
+
+
+    <begin-document/>
+
+    <maketitle/>
+
+    <abstract env="abstract">
+        <ptx-abstract/>
+        <keywords authority="author" style="bf-heading" sep=", " before="\par\medskip"/>
+    </abstract>
+
+
+
+
+    <mainmatter/>
+
+
+    <acknowledgments heading="\section*{Acknowledgments}"/>
+
+
+    <appendices cmd="appendix"/>
+
+
+    <bibliography cmd="bibliography">
+        <arg><bib-file/></arg>
+    </bibliography>
+
+
+    <end-document/>
+</texstyle>

--- a/journals/texstyles/elsevier.xml
+++ b/journals/texstyles/elsevier.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>elsevier</code>
+        <name>Eslevier journals</name>
+        <publisher>Elsevier</publisher>
+        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
+        <!--<required-files>
+            <file href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" compression="zip" path="sn-article-template/sn-jnl.cls"/>
+        </required-files>-->
+        <latex-engine command="pdflatex"/>
+        <!--<bibliography-style>spbasic</bibliography-style>-->
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-21</date>
+    </metadata>
+
+<documentclass name="elsarticle"/>
+
+
+
+    <ptx-preamble/>
+
+
+    <begin-document/>
+
+    <frontmatter env="frontmatter">
+
+        <title cmd="title">
+            <arg><ptx-title/></arg>
+        </title>
+
+
+        <author-list>
+            <author cmd="author">
+                <arg>
+                    <ptx-personname/>
+                    <fnmark cmd="fnref" arg="unique-id"/>
+                </arg>
+            </author>
+            <fntext cmd="fntext" opt="unique-id">
+                <arg><ptx-support/></arg>
+            </fntext>
+            <affiliation cmd="affiliation">
+                <arg><ptx-affiliation sep=", "/></arg>
+            </affiliation>
+            <email cmd="ead">
+                <arg><ptx-email/></arg>
+            </email>
+        </author-list>
+
+
+        <abstract env="abstract">
+            <arg><ptx-abstract/></arg>
+        </abstract>
+
+        <keywords env="keyword">
+            <keywords authority="author" sep=" \sep "/>
+
+            <keywords authority="msc" cmd="MSC" variant-style="opt" sep=" \sep "/>
+        </keywords>
+
+    <!--<maketitle/>-->
+    </frontmatter>
+
+    <mainmatter/>
+
+
+    <acknowledgments heading="\section*{Acknowledgments}"/>
+
+
+    <appendices cmd="appendix"/>
+
+
+    <bibliography cmd="bibliography">
+        <arg><bib-file/></arg>
+    </bibliography>
+
+
+    <end-document/>
+</texstyle>

--- a/journals/texstyles/springer-nature.xml
+++ b/journals/texstyles/springer-nature.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>springer-nature</code>
+        <name>Springer Nature journals</name>
+        <publisher>Springer Nature</publisher>
+        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
+        <required-files>
+            <file href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" compression="zip" path="sn-article-template/sn-jnl.cls"/>
+        </required-files>
+        <latex-engine command="pdflatex"/>
+        <bibliography-style>spbasic</bibliography-style>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-04-01</date>
+    </metadata>
+
+<documentclass name="sn-jnl"/>
+
+
+    <packages>
+        \usepackage{multirow}%
+        \usepackage{amsmath,amssymb,amsfonts}%
+        \usepackage{amsthm}%
+        \usepackage{mathrsfs}%
+        \usepackage[title]{appendix}%
+        \usepackage{xcolor}%
+        \usepackage{textcomp}%
+        \usepackage{manyfoot}%
+        \usepackage{booktabs}%
+        \usepackage{algorithm}%
+        \usepackage{algorithmicx}%
+        \usepackage{algpseudocode}%
+        \usepackage{listings}%
+    </packages>
+
+
+
+
+
+    <ptx-preamble>
+        <theoremstyle
+            name="thmstyleone"
+            environments="
+                theorem,
+                proposition
+                lemma
+                corollary, claim
+                fact
+                identity
+                conjecture
+            "
+        />
+        <theoremstyle
+            name="thmstyletwo"
+            environments="
+                definition,
+                axiom,
+                principle
+                heuristic
+                hypothesis
+                assumption
+                openproblem
+                openquestion
+                algorithm
+                question
+                activity
+                exercise
+                inlineexercise
+                investigation
+                exploration
+                problem
+                example
+                project
+            "
+        />
+        <theoremstyle
+            name="thmstylethree"
+            environments="
+                remark
+                warning
+                convention
+                insight
+                note
+                observation
+                computation
+                technology
+                data
+            "
+        />
+    </ptx-preamble>
+
+
+    <begin-document/>
+
+    <title cmd="title">
+        <opt><ptx-short-title/></opt>
+        <arg><ptx-title/></arg>
+    </title>
+
+
+    <author-list>
+        <author cmd="author" corresponding="author*">
+            <opt><affiliation-ordinal/></opt>
+            <arg><ptx-personname/></arg>
+        </author>
+        <email cmd="email">
+            <arg><ptx-email/></arg>
+        </email>
+    </author-list>
+
+    <affiliation-list>
+        <affiliation cmd="affil" current="affil*">
+            <opt><affiliation-ordinal/></opt>
+            <arg><ptx-affiliation/></arg>
+        </affiliation>
+    </affiliation-list>
+
+
+
+
+    <abstract cmd="abstract">
+        <arg><ptx-abstract/></arg>
+    </abstract>
+
+    <keywords authority="author" cmd="keywords" sep=", "/>
+
+    <keywords authority="msc" cmd="pacs" variant-style="opt" sep=", "/>
+
+    <maketitle/>
+
+
+    <mainmatter>
+        <content/>
+    </mainmatter>
+
+
+    <backmatter cmd="backmatter"/>
+
+    <supplement heading="\bmhead{Supplementary information}">
+        <content/>
+    </supplement>
+
+    <acknowledgments heading="\bmhead{Acknowledgments}">
+        <content/>
+    </acknowledgments>
+
+    <declarations heading="\section*{Declarations}" required="yes">
+        <content/>
+    </declarations>
+
+    <appendices env="appendices">
+        <content/>
+    </appendices>
+
+
+    <bibliography cmd="bibliography">
+        <arg><bib-file/></arg>
+    </bibliography>
+
+
+    <end-document/>
+</texstyle>

--- a/journals/texstyles/taylor-francis.xml
+++ b/journals/texstyles/taylor-francis.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<texstyle>
+    <metadata>
+        <code>taylor-francis</code>
+        <name>Taylor Francis General - All other Taylor-Francis journals</name>
+        <publisher>Taylor-Francis</publisher>
+        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
+        <latex-engine command="pdflatex"/>
+        <bibliography-style>spbasic</bibliography-style>
+
+        <style-author>Oscar Levin</style-author>
+        <date>2025-03-17</date>
+    </metadata>
+
+    <documentclass name="article"/>
+
+
+    <ptx-preamble/>
+
+
+    <title cmd="title">
+        <arg>
+            <ptx-title/>
+            <support cmd="support">
+                <arg><ptx-bibinfo-support/></arg>
+            </support>
+        </arg>
+    </title>
+
+    <author cmd="author">
+        <arg>
+            <author-list sep="\and">
+                <ptx-personname/>
+                <support cmd="thanks" after="\\">
+                    <arg><ptx-support/></arg>
+                </support>
+                <ptx-affiliation sep="\\&#xa;" after="\\"/>
+                <ptx-email/>
+            </author-list>
+        </arg>
+    </author>
+
+    <date cmd="date">
+        <arg><ptx-date/></arg>
+    </date>
+
+    <begin-document/>
+
+    <maketitle/>
+
+    <abstract env="abstract">
+        <ptx-abstract/>
+         <!--  heading="\noindent{\bfseries Keywords}." -->
+        <keywords authority="author" style="bf-heading" sep=", " before="\par\medskip" />
+        <keywords authority="msc" style="bf-heading" variant-style="before" sep=", " before="\par\medskip"/>
+        <!--<subj-class heading="\noindent{\bfseries {@variant} Mathematics Subject Classification}."/>-->
+    </abstract>
+
+    <mainmatter/>
+
+
+
+    <acknowledgments heading="\section*{Acknowledgments}"/>
+
+
+    <appendices/>
+
+
+    <bibliography cmd="bibliography">
+        <arg><bib-file/></arg>
+    </bibliography>
+
+
+    <end-document/>
+</texstyle>

--- a/xsl/latex/pretext-latex-texstyle.xsl
+++ b/xsl/latex/pretext-latex-texstyle.xsl
@@ -1,0 +1,846 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2025 Oscar Levin
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Conveniences for classes of similar elements -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../entities.ent">
+    %entities;
+]>
+
+<!-- Identify as a stylesheet -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:date="http://exslt.org/dates-and-times"
+    xmlns:str="http://exslt.org/strings"
+    xmlns:pi="http://pretextbook.org/2020/pretext/internal"
+    xmlns:pf="https://prefigure.org"
+    extension-element-prefixes="exsl date str"
+>
+
+<!-- Build off of latex-classic, overriding as needed. -->
+<xsl:import href="../pretext-latex-classic.xsl" />
+
+
+
+<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<!-- Import of correct texstyle files -->
+<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+
+<!-- Set a default parameter value, but this will be overridden by -->
+<!-- pretext.py  using the journal-name variable.                  -->
+<xsl:param name="journal.code" select="''"/>
+
+<!-- Get the journal corresponding to code with value 'journal.name' -->
+<xsl:variable name="journal-listing" select="document('../../journals/journals.xml')/ptx-journals/journal[code=$journal.code]"/>
+
+<!-- Get the texstyle file corresponding to the selected journal -->
+<xsl:variable name="texstyle-file-path">
+    <xsl:text>../../journals/texstyles/</xsl:text>
+    <xsl:if test="$journal-listing/method[@dependent='yes']">
+        <xsl:text>dependents/</xsl:text>
+    </xsl:if>
+</xsl:variable>
+
+<!-- Read in the original texstyle file -->
+<xsl:variable name="orig-texstyle-root" select="document(concat($texstyle-file-path, $journal.code, '.xml'))"/>
+
+<!-- We create a texstyle-root element which is either the root of the     -->
+<!-- original texstyle file, or is the root of a texstyle file that the    -->
+<!-- original texstyle file extends.  This is done similar to how assembly -->
+<!-- works.                                                                -->
+<xsl:variable name="texstyle-root-rtf">
+    <xsl:apply-templates select="$orig-texstyle-root" mode="include-base" />
+</xsl:variable>
+<xsl:variable name="texstyle-root" select="exsl:node-set($texstyle-root-rtf)"/>
+
+<!-- Entry point to the include-base modal templates.  Looks for the /texstyle/medatadata/extends -->
+<!-- element.  If it's there, gets the file it extends (assumed to be in the parent directory of  -->
+<!-- the original texstyle file) and dives into that base file to copy everything there unless    -->
+<!-- there is a version of that element in the extending/original texstyle file.                  -->
+<xsl:template match="texstyle" mode="include-base">
+    <xsl:choose>
+        <xsl:when test="metadata/extends">
+            <xsl:variable name="base-texstyle-file-name" select="metadata/extends"/>
+            <xsl:variable name="base-texstyle-root" select="document(concat($texstyle-file-path,'../', $base-texstyle-file-name, '.xml'))"/>
+            <xsl:copy>
+                <xsl:apply-templates select="$base-texstyle-root/texstyle/*" mode="include-base"/>
+            </xsl:copy>
+        </xsl:when>
+        <xsl:otherwise>
+            <!-- If not extending, then we just take a copy of the original texstyle file -->
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Modal template that tests each node of base to see if it is in the  -->
+<!-- original texstyle file, in which case it copies the node from the   -->
+<!-- original, or else copies the node from the base texstyle file.      -->
+<!-- Note that we only look at children of the texstyle element.         -->
+<xsl:template match="node()|@*" mode="include-base">
+    <xsl:variable name="base-node-name" select="string(name())"/>
+    <xsl:variable name="orig-node-name" select="$orig-texstyle-root/texstyle/*[name()=$base-node-name]"/>
+    <xsl:choose>
+        <xsl:when test="$orig-node-name">
+            <xsl:copy-of select="$orig-node-name"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- end of texstyle file import logic -->
+
+
+<!--%%%%%%%%%%%%%%%%%%%%%%%%-->
+<!-- Main "entry" templates -->
+<!--%%%%%%%%%%%%%%%%%%%%%%%%-->
+
+<!-- The main template that will be controlled by the texstyle file -->
+<xsl:template match="article">
+    <!-- Some boiler plate at the top of the file -->
+    <xsl:call-template name="converter-blurb-latex"/>
+    <!-- Now hand over control of the document order to the texstyle file -->
+    <xsl:apply-templates select="$texstyle-root/texstyle"/>
+    <!-- Each of the elements of the texstyle file will have its own template below -->
+    <!-- So that's it! -->
+</xsl:template>
+
+
+<!-- Catch-all for elements not yet implemented, to be overridden below -->
+<xsl:template match="texstyle/*">
+    <xsl:message>PTX:WARNING: Unhandled texstyle element: <xsl:value-of select="name()"/></xsl:message>
+</xsl:template>
+
+
+<!-- Sort of an entry template, which get's called as part of -->
+<!-- the match on the pretext source's article.               -->
+<xsl:template match="texstyle">
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+
+<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<!-- texstyle templates               -->
+<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+
+<!-- Include comments describing the texstyle file used -->
+<xsl:template match="texstyle/metadata">
+    <xsl:text>% This document was created with the texstyle file "</xsl:text>
+    <xsl:apply-templates select="code"/>
+    <xsl:text>.xml" to satisfy the requirements of the journal "</xsl:text>
+    <xsl:apply-templates select="name"/>
+    <xsl:text>."&#xa;%&#xa;%&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- - - - - - - - - -->
+<!-- Preamble stuff  -->
+<!-- - - - - - - - - -->
+
+<!-- For the document class -->
+<!-- TODO: respond to options with correct options -->
+<xsl:template match="texstyle/documentclass">
+    <xsl:text>\documentclass{</xsl:text>
+    <xsl:value-of select="@name"/>
+    <xsl:text>}&#xa;%&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Sometimes journals require specific packages -->
+<xsl:template match="texstyle/packages">
+<xsl:text>% Required packages:&#xa;</xsl:text>
+    <xsl:call-template name="sanitize-text">
+        <xsl:with-param name="text" select="." />
+    </xsl:call-template>
+</xsl:template>
+
+
+<!-- Here we build the "standard" (classic) latex preamble,       -->
+<!-- with some minor modifications suggested by the texstyle file -->
+<xsl:template match="texstyle/ptx-preamble">
+    <xsl:call-template name="frontmatter-helpers"/>
+    <xsl:call-template name="preamble-early"/>
+    <xsl:call-template name="cleardoublepage"/>
+    <xsl:call-template name="standard-packages"/>
+    <xsl:choose>
+        <xsl:when test="theoremstyle">
+            <xsl:apply-templates select="theoremstyle"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <!-- The latex-theorem-environments template from -classic:  -->
+            <xsl:call-template name="latex-theorem-environments"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:call-template name="tcolorbox-init"/>
+    <xsl:call-template name="numberless-environments"/>
+    <xsl:call-template name="page-setup"/>
+    <xsl:call-template name="latex-engine-support"/>
+    <xsl:call-template name="font-support"/>
+    <xsl:call-template name="math-packages"/>
+    <xsl:call-template name="pdfpages-package"/>
+    <xsl:call-template name="semantic-macros"/>
+    <xsl:call-template name="exercises-and-solutions"/>
+    <xsl:call-template name="chapter-start-number"/>
+    <xsl:call-template name="equation-numbering"/>
+    <xsl:call-template name="image-tcolorbox"/>
+    <xsl:call-template name="tables"/>
+    <xsl:call-template name="font-awesome"/>
+    <xsl:call-template name="poetry-support"/>
+    <xsl:call-template name="music-support"/>
+    <xsl:call-template name="code-support"/>
+    <xsl:call-template name="list-layout"/>
+    <xsl:call-template name="load-configure-hyperref"/>
+    <xsl:call-template name="create-numbered-tcolorbox"/>
+    <xsl:call-template name="watermark"/>
+    <xsl:call-template name="showkeys"/>
+    <xsl:call-template name="latex-image-support"/>
+    <xsl:call-template name="sidebyside-environment"/>
+    <xsl:call-template name="kbd-keys"/>
+    <xsl:call-template name="late-preamble-adjustments"/>
+</xsl:template>
+
+<!-- A list of all the elements that could need \newtheorem environments -->
+<xsl:variable name="numbered-theorem-envs" select="
+        ($document-root//lemma)[1]|
+        ($document-root//proposition)[1]|
+        ($document-root//corollary)[1]|
+        ($document-root//claim)[1]|
+        ($document-root//fact)[1]|
+        ($document-root//identity)[1]|
+        ($document-root//conjecture)[1]|
+        ($document-root//definition)[1]|
+        ($document-root//axiom)[1]|
+        ($document-root//principle)[1]|
+        ($document-root//heuristic)[1]|
+        ($document-root//hypothesis)[1]|
+        ($document-root//assumption)[1]|
+        ($document-root//openproblem)[1]|
+        ($document-root//openquestion)[1]|
+        ($document-root//algorithm)[1]|
+        ($document-root//question)[1]|
+        ($document-root//activity)[1]|
+        ($document-root//exercise)[1]|
+        ($document-root//inlineexercise)[1]|
+        ($document-root//investigation)[1]|
+        ($document-root//exploration)[1]|
+        ($document-root//problem)[1]|
+        ($document-root//example)[1]|
+        ($document-root//project)[1]|
+        ($document-root//convention)[1]|
+        ($document-root//warning)[1]|
+        ($document-root//remark)[1]|
+        ($document-root//insight)[1]|
+        ($document-root//note)[1]|
+        ($document-root//observation)[1]|
+        ($document-root//computation)[1]|
+        ($document-root//technology)[1]|
+        ($document-root//data)[1]
+"/>
+
+<!-- Determine which \newtheorem environments to create based on what is in the texstyle file -->
+<xsl:template match="theoremstyle">
+    <xsl:text>%&#xa;</xsl:text>
+    <xsl:text>\theoremstyle{</xsl:text>
+    <xsl:value-of select="@name"/>
+    <xsl:text>}%&#xa;</xsl:text>
+    <!-- In just the first theoremstyle, we use "theorem" as the     -->
+    <!-- default theorem for purposes of defining a counter.         -->
+    <!-- Note that "theorem" is not among the $numbered-theorem-envs -->
+    <xsl:if test="not(preceding-sibling::theoremstyle)">
+        <xsl:text>\newtheorem{theorem}{</xsl:text>
+        <xsl:apply-templates select="($document-root//theorem)[1]" mode="type-name"/>
+        <xsl:text>}[section]&#xa;</xsl:text>
+    </xsl:if>
+    <!-- Read in all the names of theorems in the @environments attribute -->
+    <xsl:variable name="thm-envs" select="str:tokenize(@environments, ', ')"/>
+    <!-- Apply the modal newtheorem template to each environment if it belongs in this group -->
+    <xsl:for-each select="$thm-envs">
+        <xsl:variable name="env">
+            <xsl:value-of select="."/>
+        </xsl:variable>
+        <xsl:for-each select="$numbered-theorem-envs">
+            <xsl:if test="name() = $env">
+                <xsl:apply-templates select="." mode="newtheorem"/>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:for-each>
+</xsl:template>
+
+<!-- End preamble stuff -->
+
+
+
+<!-- - - - - - - - - - - - - - - - -->
+<!-- Frontmatter and bibinfo stuff -->
+<!-- - - - - - - - - - - - - - - - -->
+
+<!-- Note: for the rest of the template commands, we will use a couple      -->
+<!-- utility templates, located at the end of this file, to consistently    -->
+<!-- wrap the pretext content in environments, command options and          -->
+<!-- arguments, or below headings. Each of the following templates will     -->
+<!-- pass the appropriate pretext node as needed to these utility templates.-->
+
+<!-- Some journals wrap some of the bibinfo in a `frontmatter` environment -->
+<!-- NB only environment supported as of 2025-03-23 -->
+<xsl:template match="texstyle/frontmatter">
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap"/>
+</xsl:template>
+
+<!-- A title texstyle element.  Currently assumes @cmd structured with opt and arg -->
+<xsl:template match="texstyle//title">
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+        <xsl:with-param name="ptx-node" select="$document-root"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="texstyle//title//ptx-short-title">
+    <xsl:apply-templates select="$document-root" mode="title-short"/>
+</xsl:template>
+
+<xsl:template match="texstyle//title//ptx-title">
+    <xsl:apply-templates select="$document-root" mode="title-full"/>
+    <xsl:if test="$document-root/subtitle">
+        <xsl:text>\\&#xa;</xsl:text>
+        <!-- Trying to match author fontsize -->
+        <xsl:text>{\small </xsl:text>
+        <xsl:apply-templates select="$document-root" mode="subtitle"/>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- Article-level support statement.  Assumes @cmd as of 2025-03-23 -->
+<!-- NB careful that this does not conflict with author-level support. -->
+<!-- That is, don't allow <support> in author, use <ptx-support> always. -->
+<xsl:template match="texstyle//support">
+    <xsl:if test="$bibinfo/support">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+            <xsl:with-param name="ptx-node" select="$bibinfo"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="ptx-bibinfo-support">
+    <xsl:apply-templates select="$bibinfo/support"/>
+</xsl:template>
+
+<xsl:template match="texstyle//date">
+    <xsl:if test="$bibinfo/date">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+            <xsl:with-param name="ptx-node" select="$bibinfo"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+
+<!-- Author listings -->
+
+<!-- We provide two basic frameworks for listing authors.                                   -->
+<!-- 1. Each author is listed with its own command, possibly tied to an affiliation with    -->
+<!--    some sort of reference or number.  The texstyle file wraps all author information   -->
+<!--    in an <author-list> environment.                                                    -->
+<!-- 2. All authors are listed inside a single command, separated by \and or similar.       -->
+<!--    In the texstyle, this is indicated by having a top-level <author> element which     -->
+<!--    encloses an <author-list>.                                                          -->
+
+
+<!-- An author-list means we should cycle through the list of authors. -->
+<!-- So we apply templates for $bibinfo/author, but pass the context -->
+<!-- of the texstyle node, so we can keep looking around there. -->
+<!-- NB this works for either framework, either as a direct child of texstyle -->
+<!-- or as a child of author -->
+<xsl:template match="texstyle//author-list">
+    <xsl:apply-templates select="$bibinfo/author" mode="author-list">
+        <xsl:with-param name="ts-node" select="."/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- Here our context is on the author node of the ptx source, but we want to -->
+<!-- now apply each template of the texstyle author-list node in the order of -->
+<!-- the textstyle file.  So we apply templates, and pass the context of the  -->
+<!-- author node from pretext source.                                         -->
+<xsl:template match="*" mode="author-list">
+    <xsl:param name="ts-node"/>
+    <xsl:apply-templates select="$ts-node/*">
+        <xsl:with-param name="ptx-node" select="."/>
+    </xsl:apply-templates>
+    <!-- If we are separating authors, add the separator between each group of texstyle nodes -->
+    <xsl:if test="following-sibling::author and $ts-node/@sep">
+        <xsl:value-of select="$ts-node/@sep"/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- Context: texstyle nodes, Param: ptx-source node (for the author)-->
+<xsl:template match="texstyle//author-list/author">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+        <xsl:with-param name="ptx-node" select="$ptx-node"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="texstyle//author-list/affiliation">
+    <xsl:param name="ptx-node"/>
+    <xsl:if test="$ptx-node/affiliation">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+            <xsl:with-param name="ptx-node" select="$ptx-node"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+
+<xsl:template match="texstyle//author-list/support">
+    <xsl:param name="ptx-node"/>
+    <xsl:if test="$ptx-node/support">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+            <xsl:with-param name="ptx-node" select="$ptx-node"/>
+            <xsl:with-param name="after" select="@after"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="texstyle//author-list/email">
+    <xsl:param name="ptx-node"/>
+    <xsl:if test="$ptx-node/email">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+            <xsl:with-param name="ptx-node" select="$ptx-node"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+<!-- We do the same thing for affiliation-list -->
+<xsl:template match="texstyle//affiliation-list">
+    <xsl:apply-templates select="$bibinfo/author" mode="affiliation-list">
+        <xsl:with-param name="ts-node" select="."/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- Context: ptx-source (likely an author element) -->
+<!-- NB this is currently assuming only one structure of the ts-node.            -->
+<!-- In particular, we do not pass back to the ts-node as we did for author-list -->
+<!-- TODO: should this just be author-list in the ts file? -->
+<xsl:template match="*" mode="affiliation-list">
+    <xsl:param name="ts-node"/>
+    <xsl:if test="$ts-node/affiliation">
+        <xsl:text>\</xsl:text>
+        <xsl:value-of select="$ts-node/affiliation/@cmd"/>
+        <xsl:if test="$ts-node/affiliation/opt">
+            <xsl:text>[</xsl:text>
+            <xsl:apply-templates select="$ts-node/affiliation/opt/*">
+                <xsl:with-param name="ptx-node" select="."/>
+            </xsl:apply-templates>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
+        <xsl:text>{</xsl:text>
+        <!-- This could be the contents of the <arg> element, but hardcoded for now. -->
+        <xsl:apply-templates select="affiliation"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- The next two templates are a little strange: it gives a way to -->
+<!-- get the number of "ptx-source node", when called from a different  -->
+<!-- node.  NB we use mode="texstyle-number" to avoid a conflict    -->
+<!-- with the default number modal template.                        -->
+<xsl:template match="affiliation-ordinal">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="$ptx-node" mode="texstyle-number"/>
+</xsl:template>
+
+<xsl:template match="*" mode="texstyle-number">
+    <xsl:number/>
+</xsl:template>
+
+<!-- Some journals put footnote commands with their contents elsewhere, linked by an id -->
+<xsl:template match="fnmark">
+    <xsl:param name="ptx-node"/>
+    <xsl:text>\</xsl:text>
+    <xsl:value-of select="@cmd"/>
+    <xsl:text>{</xsl:text>
+    <xsl:choose>
+        <xsl:when test="@arg = 'unique-id'">
+            <xsl:value-of select="$ptx-node/@unique-id"/>
+        </xsl:when>
+        <xsl:when test="@arg = 'ordinal'">
+            <xsl:apply-templates select="$ptx-node" mode="texstyle-number"/>
+        </xsl:when>
+        <!-- Todo: add other options here -->
+    </xsl:choose>
+    <xsl:text>}</xsl:text>
+</xsl:template>
+
+<xsl:template match="fntext">
+    <xsl:param name="ptx-node"/>
+    <xsl:text>\</xsl:text>
+    <xsl:value-of select="@cmd"/>
+    <xsl:if test="@opt">
+        <xsl:text>[</xsl:text>
+        <xsl:choose>
+            <xsl:when test="@opt = 'unique-id'">
+                <xsl:value-of select="$ptx-node/@unique-id"/>
+            </xsl:when>
+            <xsl:when test="@arg = 'ordinal'">
+                <xsl:apply-templates select="$ptx-node" mode="texstyle-number"/>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:text>]</xsl:text>
+    </xsl:if>
+    <xsl:if test="@arg">
+        <xsl:text>{</xsl:text>
+        <xsl:choose>
+            <xsl:when test="@arg = 'unique-id'">
+                <xsl:value-of select="$ptx-node/@unique-id"/>
+            </xsl:when>
+            <xsl:when test="@arg = 'ordinal'">
+                <xsl:apply-templates select="$ptx-node" mode="texstyle-number"/>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:text>}</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="*">
+        <xsl:with-param name="ptx-node" select="$ptx-node"/>
+    </xsl:apply-templates>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Now for the second option for listing authors.        -->
+<!-- We only need the top level template here; everything  -->
+<!-- else will be handled by the general author-list above -->
+<!-- NB we can't use texstyle//author because that conflicts with texstyle//authorlist/author -->
+<xsl:template match="texstyle/author|/texstyle/frontmatter/author">
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap">
+        <xsl:with-param name="ptx-node" select="$bibinfo"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+
+<xsl:template match="ptx-support">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="$ptx-node/support"/>
+</xsl:template>
+
+<xsl:template match="ptx-personname">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="$ptx-node/personname"/>
+</xsl:template>
+
+<xsl:template match="ptx-affiliation">
+    <xsl:param name="ptx-node"/>
+    <!-- Variable for sep param; use value of attribute or '\\&#xa;' for default. -->
+    <xsl:variable name="sep">
+        <xsl:choose>
+            <xsl:when test="@sep">
+                <xsl:value-of select="@sep"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>\\&#xa;</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:apply-templates select="$ptx-node/affiliation">
+        <xsl:with-param name="sep" select="$sep"/>
+        <xsl:with-param name="after" select="@after"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="ptx-email">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="$ptx-node/email" mode="article-info"/>
+</xsl:template>
+
+<xsl:template match="ptx-date">
+    <xsl:param name="ptx-node"/>
+    <xsl:apply-templates select="$ptx-node/date"/>
+</xsl:template>
+
+<!-- End of author information -->
+
+
+
+<!-- Abstract, keywords, etc. -->
+
+<xsl:template match="texstyle//abstract">
+    <xsl:if test="$document-root/frontmatter/abstract">
+        <xsl:apply-templates select="." mode="env-cmd-header-wrap" />
+    </xsl:if>
+</xsl:template>
+
+
+<xsl:template match="texstyle//keywords[keywords]">
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap"/>
+</xsl:template>
+
+
+<!-- First we select which source keyword element to use for a particular texstyle -->
+<!-- keyword element by matching up their "authority" (with authority="author" the -->
+<!-- default for source). In either case, we jump to a modal template with context -->
+<!-- on the source node, passing the texstyle node as a param.                     -->
+<!-- NB we can group keywords inside a parent keywords element, but that's not what we want here. -->
+<xsl:template match="texstyle//keywords[not(keywords)]">
+    <xsl:choose>
+        <xsl:when test="@authority = 'author'">
+            <xsl:apply-templates select="$bibinfo/keywords[@authority='author' or not(@authority)]" mode="keywords">
+                <xsl:with-param name="ts-node" select="."/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <xsl:when test="@authority = 'msc'">
+            <xsl:apply-templates select="$bibinfo/keywords[@authority='msc']" mode="keywords">
+                <xsl:with-param name="ts-node" select="."/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:WARNING: The @authority attribute on a keyword element (in a texstyle file) is required and must be "author" or "msc".  Found "@authority="<xsl:value-of select="@authority"/>". </xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Here we insert the correct text for a keywords element based on the ts-node param -->
+<xsl:template match="*" mode="keywords">
+    <xsl:param name="ts-node"/>
+    <xsl:choose>
+        <!-- Case when keywords are in the argument of a command: -->
+        <xsl:when test="$ts-node/@cmd">
+            <xsl:text>\</xsl:text>
+            <xsl:value-of select="$ts-node/@cmd"/>
+            <xsl:if test="$ts-node/@variant-style='opt'">
+                <xsl:text>[</xsl:text>
+                <xsl:apply-templates select="@variant"/>
+                <xsl:text>]</xsl:text>
+            </xsl:if>
+            <xsl:text>{</xsl:text>
+            <xsl:apply-templates select="keyword">
+                <xsl:with-param name="sep" select="$ts-node/@sep"/>
+            </xsl:apply-templates>
+            <xsl:text>}&#xa;</xsl:text>
+        </xsl:when>
+        <!-- Case when keywords have a boldface heading -->
+        <xsl:when test="$ts-node/@style='bf-heading'">
+            <xsl:if test="$ts-node/@before">
+                <xsl:value-of select="$ts-node/@before"/>
+                <xsl:text>&#xa;</xsl:text>
+            </xsl:if>
+            <xsl:text>\noindent\textbf{</xsl:text>
+            <xsl:choose>
+                <xsl:when test="$ts-node/@authority='author'">
+                    <xsl:text>Keywords</xsl:text>
+                </xsl:when>
+                <xsl:when test="$ts-node/@authority='msc'">
+                    <xsl:if test="$ts-node/@variant-style='before'">
+                        <xsl:value-of select="@variant"/>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                    <xsl:text>Math Subject Classification</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:text>}. </xsl:text>
+            <xsl:apply-templates select="keyword">
+                <xsl:with-param name="sep" select="$ts-node/@sep"/>
+            </xsl:apply-templates>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="keyword">
+                <xsl:with-param name="sep" select="$ts-node/@sep"/>
+            </xsl:apply-templates>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+
+<xsl:template match="ptx-abstract">
+    <xsl:apply-templates select="$document-root/frontmatter/abstract/*"/>
+</xsl:template>
+
+<xsl:template match="texstyle/maketitle">
+    <xsl:text>\maketitle&#xa;</xsl:text>
+</xsl:template>
+<!-- End frontmatter stuff -->
+
+
+
+<!-- Mainmatter -->
+<xsl:template match="texstyle/mainmatter">
+    <xsl:apply-templates select="$document-root/*[not(backmatter|references)]"/>
+</xsl:template>
+
+
+<!-- Backmatter -->
+<xsl:template match="texstyle/backmatter">
+    <xsl:apply-templates select="." mode="env-cmd-header-wrap" />
+</xsl:template>
+
+<!-- Todo: fix these -->
+<xsl:template match="texstyle/supplement">
+    <xsl:message>PTX:WARNING: Supplements are not yet available in PreTeXt so this feature is not available currently.</xsl:message>
+    <xsl:if test="$document-root//supplement">
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>% Supplement sections&#xa;</xsl:text>
+        <xsl:value-of select="@heading"/>
+        <xsl:text>%&#xa;%&#xa;</xsl:text>
+        <xsl:apply-templates select="$document-root//supplement"/>
+    </xsl:if>
+</xsl:template>
+<xsl:template match="texstyle/acknowledgments">
+    <xsl:if test="$document-root//acknowledgement">
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>% acknowledgement section&#xa;</xsl:text>
+        <xsl:value-of select="@heading"/>
+        <xsl:text>%&#xa;%&#xa;</xsl:text>
+        <xsl:apply-templates select="$document-root//acknowledgement"/>
+    </xsl:if>
+</xsl:template>
+<xsl:template match="texstyle/declarations">
+    <xsl:message>PTX:WARNING: Declarations are not yet available in PreTeXt so this feature is not available currently.</xsl:message>
+    <xsl:if test="$document-root//declaration">
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>% Declarations sections&#xa;</xsl:text>
+        <xsl:value-of select="@heading"/>
+        <xsl:text>%&#xa;%&#xa;</xsl:text>
+        <xsl:apply-templates select="$document-root//declaration"/>
+    </xsl:if>
+</xsl:template>
+
+
+<xsl:template match="texstyle/appendices">
+    <xsl:if test="$document-root//appendix">
+        <xsl:text>%&#xa;</xsl:text>
+        <xsl:text>% Appendices&#xa;</xsl:text>
+        <xsl:if test="@env">
+            <xsl:text>\begin{</xsl:text>
+            <xsl:value-of select="@env"/>
+            <xsl:text>}</xsl:text>
+            <xsl:text>%&#xa;%&#xa;</xsl:text>
+        </xsl:if>
+        <xsl:apply-templates select="$document-root//appendix"/>
+        <xsl:if test="@env">
+            <xsl:text>\end{</xsl:text>
+            <xsl:value-of select="@env"/>
+            <xsl:text>}%&#xa;</xsl:text>
+        </xsl:if>
+    </xsl:if>
+</xsl:template>
+
+
+<xsl:template match="texstyle/bibliography">
+    <xsl:message>PTX:WARNING: Bibliographies are not implemented correctly yet.</xsl:message>
+    <xsl:apply-templates select="$document-root/references"/>
+</xsl:template>
+
+
+<!-- Begin/End document -->
+<xsl:template match="texstyle/begin-document">
+    <xsl:text>%&#xa;%&#xa;</xsl:text>
+    <xsl:text>%*********************************%&#xa;</xsl:text>
+    <xsl:text>%*      Begin Main Document      *%&#xa;</xsl:text>
+    <xsl:text>%*********************************%&#xa;</xsl:text>
+    <xsl:text>%&#xa;</xsl:text>
+    <xsl:text>\begin{document}&#xa;</xsl:text>
+    <xsl:text>%&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="texstyle/end-document">
+    <xsl:text>%&#xa;\end{document}&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- LaTeX spacing commands -->
+
+<xsl:template match="medskip">
+    <xsl:text>\par\medskip&#xa;</xsl:text>
+</xsl:template>
+
+<!-- For cases when the texstyle file should include raw text -->
+<xsl:template match="text">
+    <xsl:value-of select="."/>
+</xsl:template>
+
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  -->
+<!-- Utility templates for wrapping pretext content in environments, -->
+<!-- command options and arguments, or below headings.               -->
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  -->
+
+
+<!-- First we have a template that will put in the \begin{env}...\end{env}, -->
+<!-- or \cmd or heading depending on what the current ts-node has as an     -->
+<!-- attribute.  We might pass a ptx-node depending on the originating      -->
+<!-- template as well.                                                      -->
+<!-- The `after` param is for templates that need to put a linebreak or     -->
+<!-- or similar text after the end of the command.                          -->
+<xsl:template match="*" mode="env-cmd-header-wrap">
+    <xsl:param name="ptx-node"/>
+    <xsl:param name="after"/>
+    <xsl:choose>
+        <xsl:when test="@env">
+            <xsl:text>\begin{</xsl:text>
+            <xsl:value-of select="@env"/>
+            <xsl:text>}&#xa;</xsl:text>
+            <xsl:apply-templates select="*">
+                <xsl:with-param name="ptx-node" select="$ptx-node"/>
+            </xsl:apply-templates>
+            <xsl:text>\end{</xsl:text>
+            <xsl:value-of select="@env"/>
+            <xsl:text>}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="@cmd">
+            <xsl:text>\</xsl:text>
+            <xsl:value-of select="@cmd"/>
+            <xsl:apply-templates select="*">
+                <xsl:with-param name="ptx-node" select="$ptx-node"/>
+            </xsl:apply-templates>
+            <xsl:value-of select="$after"/>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="@heading">
+            <xsl:value-of select="@heading"/>
+            <xsl:apply-templates select="*">
+                <xsl:with-param name="ptx-node" select="$ptx-node"/>
+            </xsl:apply-templates>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Wrappers for opts and args -->
+<!-- These are applied inside commands.  Context is a ts-node -->
+<!-- we always pass the ptx-node parent of any element we will apply using a ptx-element -->
+<xsl:template match="opt">
+    <xsl:param name="ptx-node"/>
+    <xsl:text>[</xsl:text>
+        <xsl:apply-templates select="*">
+            <xsl:with-param name="ptx-node" select="$ptx-node"/>
+        </xsl:apply-templates>
+    <xsl:text>]</xsl:text>
+</xsl:template>
+
+<xsl:template match="arg">
+    <xsl:param name="ptx-node"/>
+    <xsl:text>{</xsl:text>
+        <xsl:apply-templates select="*">
+            <xsl:with-param name="ptx-node" select="$ptx-node"/>
+        </xsl:apply-templates>
+    <xsl:text>}</xsl:text>
+</xsl:template>
+
+
+</xsl:stylesheet>

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -296,7 +296,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:if test="email">
         <xsl:text>\\&#xa;</xsl:text>
-        <xsl:apply-templates select="email" />
+        <xsl:apply-templates select="email" mode="article-info"/>
     </xsl:if>
     <xsl:if test="following-sibling::author" >
         <xsl:text>&#xa;\and</xsl:text>
@@ -308,20 +308,48 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Preprocessor always puts Department, Institution, and Address          -->
 <!-- inside Affiliation. This just adds line breaks between them as needed. -->
 <xsl:template match="affiliation">
+    <xsl:param name="sep" select="'\\&#xa;'"/>
+    <xsl:param name="after"/>
     <xsl:if test="department">
-        <xsl:apply-templates select="department" />
+        <xsl:apply-templates select="department">
+            <xsl:with-param name="sep" select="$sep"/>
+        </xsl:apply-templates>
         <xsl:if test="department/following-sibling::*">
-            <xsl:text>\\&#xa;</xsl:text>
+            <xsl:value-of select="$sep"/>
         </xsl:if>
     </xsl:if>
     <xsl:if test="institution">
-        <xsl:apply-templates select="institution" />
+        <xsl:apply-templates select="institution">
+            <xsl:with-param name="sep" select="$sep"/>
+        </xsl:apply-templates>
         <xsl:if test="institution/following-sibling::*">
-            <xsl:text>\\&#xa;</xsl:text>
+            <xsl:value-of select="$sep"/>
         </xsl:if>
     </xsl:if>
     <xsl:if test="location">
-        <xsl:apply-templates select="location" />
+        <xsl:apply-templates select="location">
+            <xsl:with-param name="sep" select="$sep"/>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- always end with a new line, after the `after` param if passed -->
+    <xsl:value-of select="$after"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+
+<!-- override the default department[line] etc and line templates to use sep param -->
+<xsl:template match="department[line]|institution[line]|location[line]">
+    <xsl:param name="sep" select="'\\&#xa;'"/>
+    <xsl:apply-templates select="line">
+        <xsl:with-param name="sep" select="$sep"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="line">
+    <xsl:param name="sep" select="'\\&#xa;'"/>
+    <xsl:apply-templates/>
+    <xsl:if test="following-sibling::line">
+        <xsl:value-of select="$sep"/>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3160,7 +3160,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <pi:pub-attribute name="pageref" options="yes no" legacy-stringparam="latex.pageref"/>
         <pi:pub-attribute name="draft" default="no" options="yes" legacy-stringparam="latex.draft"/>
         <pi:pub-attribute name="open-odd" default="no" options="add-blanks skip-pages"/>
-        <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide amsart tf elsevier ejc"/>
+        <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide amsart tf elsevier ejc texstyle"/>
         <page>
             <pi:pub-attribute name="bottom-alignment" default="ragged" options="flush"/>
         </page>


### PR DESCRIPTION
There is a LOT going on here, and there will be more to come.  Right now:

- Inside `journals` a folder of `texstyles` contains two different texstyle files describing the latex layout for ams journals and springer nature journals.  A third dependent style is in `dependents`, with only the documentclass changed.
- The xsl that manages all this is `xsl/latex/pretext-latex-texstyle.xsl`.  The goal is that this will replace all the recent journal-specific xsl files.  It reads in the correct texstyle file and does all the processing. 
- A very small change to the python script is merely cosmetic (name of stringparam).

The xsl file really pushed me to understand how xsl works.  There will absolutely be better ways to do some of these things I think.  The merging of a dependent and base texstyle, using techniques from assembly, was particularly fun.  Also the processing of authors: we bounce back and forth between the source pretext and texstyle file a couple times so we can "loop over" the authors and the author data in the correct order.  Fun fun fun.

My plan:
- Fix a few things that are broken (keywords and their separators)
- Implement the other journal styles as texstyles
- Redo most of it when I get feedback and see the more obvious and better way to do the xsl.

So no rush, but it's here if you are currious.