### PR TITLE
Keywords refactor

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7155,8 +7155,13 @@ Book (with parts), "section" at level 3
 <!-- No conversion will create content directly from bibinfo -->
 <xsl:template match="bibinfo"/>
 
-<!-- Keywords: create a comma-separated list.  No punctuation after final keyword -->
+<!-- Keywords: create a comma-separated list of each keyword -->
+<!-- (the comma can be overridden by a passed param).        -->
+<!-- Include "Primary" or "Secondary" appropriately, ";" to  -->
+<!-- separate the list of primary and secondary keywords.    -->
+<!-- No ending period (some styles don't include it).        -->
 <xsl:template match="keywords/keyword">
+    <xsl:param name="sep" select="', '"/>
     <xsl:if test="@primary='yes'">
         <xsl:text>Primary </xsl:text>
     </xsl:if>
@@ -7164,9 +7169,15 @@ Book (with parts), "section" at level 3
         <xsl:text>Secondary </xsl:text>
     </xsl:if>
     <xsl:value-of select="."/>
-    <xsl:if test="following-sibling::keyword">
-        <xsl:text>, </xsl:text>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="following-sibling::keyword[1][@primary='no' or @secondary='yes']">
+            <xsl:text>; </xsl:text>
+        </xsl:when>
+        <xsl:when test="following-sibling::keyword">
+            <xsl:value-of select="$sep"/>
+        </xsl:when>
+        <xsl:otherwise/>
+    </xsl:choose>
 </xsl:template>
 
 


### PR DESCRIPTION
This is a minor refactor of the keywords xsl template.  It puts a semicolon after the last "primary" keyword, otherwise separates keywords with a comma.

However, to support the texstyle work on #2433, the comma separator is now stored in a param that the texstyle xsl template will be able to override.