### PR TITLE
CSS: two small denver/greeley css fixes

### DIFF
--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -184,7 +184,7 @@ $chunk-heading-font-size: 1.125em !default;
   }
 }
 
-
-.exercise-like {
+// Keep heading inline for divisional exercises (the parent of the .exercise-like will have class .exercises).
+.exercises .exercise-like {
   @include inline-heading-mixin.heading;
 }

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -210,3 +210,11 @@ $sidebar-hide-breakpoint: $content-width + 2 * $content-side-padding-tight + $si
     padding-right: $content-side-padding-tight;
   }
 }
+
+
+// TOC hover spans entire width of TOC item
+.toc-item:is(:hover, :focus) {
+  color: var(--tocitem-highlight-text-color);
+  background-color: var(--tocitem-highlight-background);
+  border-color: var(--tocitem-highlight-border-color);
+}


### PR DESCRIPTION
The denver/greeley styles had a bug with non-knowled checkpoints.  This fixes that.  It also makes the highlighting of toc items look better.