### PR TITLE
Schema: program/@interactive can be "activecode"

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1455,7 +1455,7 @@
                     attribute hidecode {"yes"|"no"}?,
                     attribute highlight-lines {text}?,
                     attribute include {text}?,
-                    attribute interactive {"codelens"}?,
+                    attribute interactive {"codelens"|"activecode"}?,
                     attribute interpreter-args {text}?,
                     attribute language {text}?,
                     attribute line-numbers {"yes"|"no"}?,


### PR DESCRIPTION
I noticed the schema currently only allows for program/@interactive to be "codelens". It should also allow "activecode".