### PR TITLE
Generate correct runestone-id for fillin exercises in manifest

### DIFF
--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -81,9 +81,7 @@
     <div class="ptx-runestone-container">
         <div class="runestone">
             <div data-component="fillintheblank" class="fillintheblank" style="visibility: hidden;">
-                <xsl:attribute name="id">
-                    <xsl:value-of select="$the-id"/>
-                </xsl:attribute>
+                <xsl:apply-templates select="." mode="runestone-id-attribute"/>
                 <script type="application/json">
                     <xsl:text>{&#xa;</xsl:text>
                     <!-- A seed is provided to generate consistent static content -->


### PR DESCRIPTION
The new fillins do not currently generate the decorated unique id (including book title) needed within the RS manifest. This fixes that issue.