### PR TITLE
CSS: fix inline headings for tasks in Denver theme

### DIFF
--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -184,7 +184,7 @@ $chunk-heading-font-size: 1.125em !default;
   }
 }
 
-// Keep heading inline for divisional exercises (the parent of the .exercise-like will have class .exercises).
-.exercises .exercise-like {
+// Keep heading inline for divisional exercises and all tasks (the parent of the .exercise-like will have class .exercises).
+.exercises .exercise-like, .task {
   @include inline-heading-mixin.heading;
 }


### PR DESCRIPTION
When fixing checkpoint exercises so they do NOT have inline headings, I broke tasks.  This fixes the tasks, and should not break the previous change.