### PR TITLE
Script: prevent carriage returns from breaking trace generation

### DIFF
--- a/xsl/extract-trace.xsl
+++ b/xsl/extract-trace.xsl
@@ -58,7 +58,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="text" select="code" />
         </xsl:call-template>
     </xsl:variable>
-    <xsl:value-of select="str:replace($code-with-newlines, '&#xa;', '\n')"/>
+    <xsl:variable name="removed-carriage-returns">
+        <xsl:value-of select="str:replace($code-with-newlines, '&#xd;', '')" />
+    </xsl:variable>
+    <xsl:value-of select="str:replace($removed-carriage-returns, '&#xa;', '\n')"/>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 


### PR DESCRIPTION
codelens trace file depends on stripping out newlines in code. If code is authored in Windows, it will have `\r\n` instead of `\n` and the carriage returns will not be stripped. This breaks `pretext.py`'s `tracer` function which thinks the `\r`s are line breaks.

I encountered the issue with code that was xincluded from a text file authored in Windows.
```
  <program label="structs_operators-on-structures-1" interactive="codelens">
<xi:include href="../../programs/structs/structs-operators-on-structures-1.cpp" parse="text"/>
  </program>
```

If I copy/paste the code into the program, everything works as expected (even when authored in Windows). So there is something about the include mechanism that is affecting newline treatment.

This PR strips any carriage returns during trace generation to make sure they don't break. 

Tested in Windows and Linux using `\r\n` and `\n` line endings.