### PR TITLE
WeBWorK: remove use and mentions of source/@webwork-problems

### DIFF
--- a/doc/guide/appendices/cli-transition.xml
+++ b/doc/guide/appendices/cli-transition.xml
@@ -114,7 +114,7 @@
       and the one created by the <c>pretext init</c> command.
       The file created by <c>pretext init</c> will contain some directory management details, such as:
       <cd>
-        <cline>&lt;source webwork-problems="../generated-assets/webwork/webwork-representations.xml"&gt;</cline>
+        <cline>&lt;source&gt;</cline>
         <cline>    &lt;directories external="../assets" generated="../generated-assets"/&gt;</cline>
         <cline>&lt;/source&gt;</cline>
       </cd>

--- a/doc/guide/publication-styled.xml
+++ b/doc/guide/publication-styled.xml
@@ -36,7 +36,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </latex>
 
     <!-- Relative path, relative to "main" source file -->
-    <source webwork-problems="webwork-representations.xml">
+    <source>
         <directories external="external" generated="generated"/>
     </source>
 

--- a/doc/guide/publication.xml
+++ b/doc/guide/publication.xml
@@ -42,7 +42,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </latex>
 
     <!-- Relative path, relative to "main" source file -->
-    <source webwork-problems="webwork-representations.xml">
+    <source>
         <directories external="external" generated="generated"/>
     </source>
 

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -947,7 +947,6 @@
             </cd>element can have the following attributes:<ul>
                 <li><attr>customizations</attr>: A filename for a structured file of <tag>custom</tag> elements, each with a <attr>name</attr> attribute and content meant to be substituted into source.  See <xref ref="publisher-customizations"/> for details about the use of customizations.</li>
                 <li><attr>private-solutions</attr>: A filename for a structured file of <tag>hint</tag>, <tag>answer</tag>, <tag>solution</tag> that will see limited distribution (for example, instructors only).  See <xref ref="private-solutions-file"/> for details about the use of a private solutions file.</li>
-                <li><attr>webwork-problems</attr>: A filename for a structured file of multiple representations of <webwork/> problems.  It is now recommended that when using <webwork/>, that you also use managed directories (see <xref ref="processing-directory-management"/>), in which case this attribute is unsused.</li>
             </ul></p>
         </subsection>
     </section>

--- a/examples/humanities/publication/publication.ptx
+++ b/examples/humanities/publication/publication.ptx
@@ -12,7 +12,7 @@
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->
   <!-- source PreTeXt file                                      -->
-  <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+  <source>
     <directories external="../assets" generated="../generated-assets"/>
   </source>
 

--- a/examples/minimal/publication/publication.ptx
+++ b/examples/minimal/publication/publication.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
-    <source webwork-problems="../generated-assets/webwork/webwork-representations.ptx">
+    <source>
         <directories external="../assets" generated="../generated-assets"/>
     </source>
 </publication>

--- a/examples/webwork/minimal/pub-not-managed.xml
+++ b/examples/webwork/minimal/pub-not-managed.xml
@@ -21,9 +21,4 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <publication>
 
-    <!-- Relative path, relative to "main" source file         -->
-    <!-- This file name *must* be webwork-representations.xml, -->
-    <!-- but you could specify a different path to the file.   -->
-    <source webwork-problems="webwork-representations.xml"/>
-
 </publication>

--- a/examples/webwork/sample-chapter/publisher/pub-not-managed.xml
+++ b/examples/webwork/sample-chapter/publisher/pub-not-managed.xml
@@ -21,9 +21,4 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <publication>
 
-    <!-- Relative path, relative to "main" source file         -->
-    <!-- This file name *must* be webwork-representations.xml, -->
-    <!-- but you could specify a different path to the file.   -->
-    <source webwork-problems="webwork-representations.xml"/>
-
 </publication>


### PR DESCRIPTION
One small thing peeled off from https://github.com/PreTeXtBook/pretext/pull/2336.

We don't use the `webwork-problems` attribute on `source` in a publisher file anymore. Haven't for a while. In `publisher-variables.xsl`, it is recognized and identified as deprecated.