### PR TITLE
Fix dark/light mode syncing for interactive iframes

### DIFF
--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -978,17 +978,25 @@ function setDarkMode(isDark) {
     if(document.documentElement.dataset.darkmode === 'disabled')
         return;
 
-    if (isDark) {
-      document.documentElement.classList.add("dark-mode");
+    const parentHtml = document.documentElement;
+    const iframes = document.querySelectorAll("iframe[data-dark-mode-enabled]");
 
-      // Apply to local iframes that want dark mode
-      const iframes = document.querySelectorAll("iframe[data-dark-mode-enabled]");
-      for (const iframe of iframes) {
-          iframe.contentWindow.document.documentElement.classList.add("dark-mode");
-      }
-  } else {
-      document.documentElement.classList.remove("dark-mode");
-  }
+    // Update the parent document
+    if (isDark) {
+        parentHtml.classList.add("dark-mode");
+    } else {
+        parentHtml.classList.remove("dark-mode");
+    }
+
+    // Sync each iframe's <html> class with the parent
+    for (const iframe of iframes) {
+        try {
+            const iframeHtml = iframe.contentWindow.document.documentElement;
+            iframeHtml.className = parentHtml.className;
+        } catch (err) {
+            console.warn("Dark mode sync to iframe failed:", err);
+        }
+    }
 
     const modeButton = document.getElementById("light-dark-button");
     if (modeButton) {

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -992,7 +992,11 @@ function setDarkMode(isDark) {
     for (const iframe of iframes) {
         try {
             const iframeHtml = iframe.contentWindow.document.documentElement;
-            iframeHtml.className = parentHtml.className;
+            if (isDark) {
+              iframeHtml.classList.add("dark-mode")
+            } else {
+              iframeHtml.classList.remove("dark-mode")
+            }
         } catch (err) {
             console.warn("Dark mode sync to iframe failed:", err);
         }


### PR DESCRIPTION
This PR attempts to fix an issue where interactive iframes do not correctly toggle between light and dark mode after the first switch. The problem appears to be that the loop propogating the mode only scans through the iFrames when dark mode is true and does not update them when dark mode is turned off.