### PR TITLE
CSS: add minimalist 'boulder' theme for standalone pages

### DIFF
--- a/css/targets/html/boulder/_customization.scss
+++ b/css/targets/html/boulder/_customization.scss
@@ -1,0 +1,33 @@
+//$color: var(--primary-color) !default;
+//$text-color: white !default;
+
+.hide-type .codenumber:not(:empty)::after {
+    content: ". ";
+}
+
+.ptx-masthead {
+    display: none;
+}
+
+.ptx-navbar {
+    border-top: none;
+}
+
+.ptx-page {
+    margin-top: 36px;
+    margin-bottom: 36px;
+}
+
+.button.disabled {
+    display: none;
+}
+
+//.ptx-toc {
+//    padding-top:unset;
+//}
+
+//// Top heading followed by no content and then a subsection that starts with heading
+//section > .heading + section > .heading {
+//  margin-top: 0.5em;
+//}
+

--- a/css/targets/html/boulder/theme-boulder.scss
+++ b/css/targets/html/boulder/theme-boulder.scss
@@ -1,16 +1,15 @@
-/*! Theme: greeley */
-// Theme designed for short articles (i.e., research papers).
+/*! Theme: boulder */
+// Theme designed for short articles (i.e., research papers) or course documents.
+// Minimal navigation bar; there is likely only one html page per document.
 
 // Current maintainer: Oscar Levin
 
 // Variables used by theme. CSSBuilder overrides these by prepending
 // different definitions for these variables to this file before the theme
 // is compiled.
-$palette: 'grays' !default;
-$primary-color: null !default;
-$secondary-color: null !default;
-$primary-color-dark: #829ab1 !default;
-$background-color-dark: #23241f !default;
+$primary-color: hsl(270, 40%, 15%) !default;
+$primary-color-dark: hsl(270, 40%, 70%) !default;
+$background-color-dark: hsl(270, 5%, 5%) !default;
 
 @use "sass:map";
 
@@ -22,7 +21,7 @@ $background-color-dark: #23241f !default;
 @use '../denver/parts-paper';
 //@use 'shell';
 @use 'customization';
-@use 'chunks-greeley';
+@use '../greeley/chunks-greeley';
 
 //@use 'heading-tweaks';
 

--- a/script/cssbuilder/cssbuilder.mjs
+++ b/script/cssbuilder/cssbuilder.mjs
@@ -116,6 +116,7 @@ function getTargets(options) {
     { out: 'theme-salem', in: path.join(cssRoot, 'targets/html/salem/theme-salem.scss')},
     { out: 'theme-denver', in: path.join(cssRoot, 'targets/html/denver/theme-denver.scss') },
     { out: 'theme-greeley', in: path.join(cssRoot, 'targets/html/greeley/theme-greeley.scss') },
+    { out: 'theme-boulder', in: path.join(cssRoot, 'targets/html/boulder/theme-boulder.scss') },
     { out: 'theme-tacoma', in: path.join(cssRoot, 'targets/html/tacoma/theme-tacoma.scss') },
     // -------------------------------------------------------------------------
     // -------------------------------------------------------------------------

--- a/script/cssbuilder/package-lock.json
+++ b/script/cssbuilder/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pretext",
+  "name": "pretext-cssbuilder",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pretext",
+      "name": "pretext-cssbuilder",
       "version": "1.0.0",
       "dependencies": {
         "command-line-args": "^6.0.0",

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2335,6 +2335,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <option name="primary-color" check-contrast="#fff"/>
         <option name="primary-color-dark" check-contrast="#23241f"/>
     </theme>
+    <theme name="boulder">
+        <option name="provide-dark-mode" default="yes"/>
+        <option name="primary-color" check-contrast="#fff"/>
+        <option name="primary-color-dark" check-contrast="#23241f"/>
+    </theme>
     <theme name="custom">
         <option name="provide-dark-mode" default="yes"/>
         <option name="entry-point" default="custom-theme.scss"/>


### PR DESCRIPTION
This adds a new "colorado" theme; not too different from Greeley, except that it hides the masthead and any deactivated buttons.  Intended for use in a chunk level=0 and portable=yes document.

Changes to greeley theme to keep the color setup consistent between the three colorado themes.

Note that I did not try to move anything around after all; there is a title on the first page anyway, and keeping the navbar made sense in case someone wanted to use search.