### PR TITLE
Texstyles: add backmatter references to bibliographies

### DIFF
--- a/xsl/latex/pretext-latex-texstyle.xsl
+++ b/xsl/latex/pretext-latex-texstyle.xsl
@@ -744,7 +744,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="texstyle/bibliography">
     <xsl:message>PTX:WARNING: Bibliographies are not implemented correctly yet.</xsl:message>
-    <xsl:apply-templates select="$document-root/references"/>
+    <xsl:apply-templates select="$document-root/references|$document-root/backmatter/references"/>
 </xsl:template>
 
 


### PR DESCRIPTION
This adds references that are inside `backmatter`.  Previously, only references that were inside an appendix or child of article were included.

I'm sure that bibliographies need a lot more work for texstyle files, since they are not getting any journal-specific styling.  But I'm going to wait for that until we can tackle bibliographies proper anyway.