### PR TITLE
CSS: fix wide rs elements overflowing containers in colorado themes

### DIFF
--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -58,28 +58,16 @@ $page-width: $sidebar-total-width + $main-width + $main-right-margin;
   $navbar-breakpoint: $navbar-breakpoint,
 );
 
+@use 'rs-widen' with (
+  $content-width: 600px,
+);
+
 .ptx-main {
   margin-right: $sidebar-total-width;
 }
 
 .ptx-sidebar.hidden + .ptx-main {
   margin-left: $sidebar-total-width;
-}
-
-// Oscar - note - you might consider how to handle nested RS containers
-// see "Projects and Friends" in sample book
-$rs-max-width: $content-width + (1.5 * $content-side-padding);
-// @debug "rs-max-width: #{$rs-max-width}";
-.ptx-runestone-container:has(.parsons_section,.ac_section,.codelens) {
-  width: $rs-max-width;
-  max-width: $rs-max-width;   // never wider than original size
-  margin-left: calc(-0.75 * var(--content-padding));
-}
-
-$grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
-:is(#{$grouping-elements}) .ptx-runestone-container:has(.parsons_section,.ac_section,.codelens) {
-  //fudge for rs elements in grouping elements
-  margin-left: calc(-0.75 * var(--content-padding) - 21px);
 }
 
 
@@ -168,18 +156,6 @@ $page-border-breakpoint: $main-width + $sidebar-width + 2 * $sidebar-right-margi
   .ptx-navbar .toc-toggle {
     transform: translateX(-$sidebar-width);
     justify-content: center;
-  }
-
-  // From here down need to calculate width based on available space in main
-  .ptx-runestone-container:has(.parsons_section,.ac_section,.codelens) {
-    --cur-width: calc(min(100cqw - 2 * #{$content-side-padding-tight}, #{$rs-max-width}));
-    width: var(--cur-width);
-    margin-left: calc(-0.5 * (var(--cur-width) - 100%));
-  }
-
-  :is(#{$grouping-elements}) .ptx-runestone-container:has(.parsons_section,.ac_section,.codelens) {
-    //no more fudge needed
-    margin-left: calc(-0.5 * (var(--cur-width) - 100%));
   }
 }
 

--- a/css/targets/html/denver/_rs-widen.scss
+++ b/css/targets/html/denver/_rs-widen.scss
@@ -1,0 +1,91 @@
+
+// --------------------------------------------------------------------------
+// Flexible / centered widening of rs elements
+
+$content-width: 600px !default;
+$content-side-padding: 20px !default;
+
+$content-with-padding-width: $content-width + 2 * $content-side-padding;
+
+// components that should be wide
+$rs-wide-elements: ".ac_section, .codelens, .parsons_section, .hparsons_section, .datafile, .contains-wide";
+
+// grouping elements that may have wide elements and require different margins
+// need to make sure those elements have a consistent amount of (padding+border)
+$grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
+
+
+// widen all runestone elements that should be wide
+.ptx-runestone-container:has(#{$rs-wide-elements}) {
+  width: calc(100cqw - 2 * $content-side-padding);
+  max-width: unset;
+  margin-left: calc(-0.5 * (100cqw - #{$content-with-padding-width}));
+}
+
+// unless nested in other runestones
+.ptx-runestone-container {
+  .ptx-runestone-container:has(#{$rs-wide-elements})
+  {
+    width: 100%;
+    min-width: 100%;
+    margin-left: auto;
+  }
+}
+
+// also wide grouping elements that have runestone elements
+:is(#{$grouping-elements}):has(#{$rs-wide-elements}) {
+  width: calc(100cqw - 2 * $content-side-padding);
+  max-width: unset;
+  margin-left: calc(-0.5 * (100cqw - $content-with-padding-width));
+}
+// unless nested in other runestones
+:is(#{$grouping-elements}):has(#{$rs-wide-elements}) {
+  :is(#{$grouping-elements}):has(#{$rs-wide-elements}) {
+    width: 100%;
+    margin-left: auto;
+  }
+}
+
+// which simplifies the nested rs elements
+:is(#{$grouping-elements}) .ptx-runestone-container:has(#{$rs-wide-elements}) {
+  width: 100%;
+  margin-left: 0;
+}
+
+/* limit width of content inside ac except for actual activecode */
+.runestone.ac_section
+  > div
+  > div
+  > *:not(.ac_code_div):not(.ac_output):not(.codelens):not(.ac_actions) {
+  max-width: $content-width;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* limit width of content inside parsons except for actual parsons */
+.runestone.parsons_section > .parsons {
+  width: 100%;
+  padding-right: 0;
+  
+  .sortable-code-container {
+    display: flex;
+    flex-flow: wrap;
+    justify-content: center;
+    gap: 15px;
+    margin: 10px auto;
+  }
+
+  .sortable-code {
+    margin: 0;
+  }
+
+  .runestone_caption_text {
+    max-width: unset;
+  }
+  
+  & > div > *:not(.sortable-code-container) {
+    max-width: $content-width;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}


### PR DESCRIPTION
This fixes a bug with the Colorado themes that let rs components that are wide and get extra space spill over the sides of their containing elements.