### PR TITLE
Texstyles: fetch and place required files

### DIFF
--- a/journals/texstyles/ams.xml
+++ b/journals/texstyles/ams.xml
@@ -5,7 +5,6 @@
         <code>ams</code>
         <name>AMS journals</name>
         <publisher>American Mathematical Society</publisher>
-        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
         <latex-engine command="pdflatex"/>
         <bibliography-style>spbasic</bibliography-style>
 

--- a/journals/texstyles/dependents/proc-amer-math-soc.xml
+++ b/journals/texstyles/dependents/proc-amer-math-soc.xml
@@ -7,7 +7,7 @@
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
         <required-files>
-            <file href="https://www.ams.org/arc/journals/packages/proc/proc_amslatex/proc-l.cls" compression="none" path="proc-l.cls"/>
+            <file href="https://www.ams.org/arc/journals/packages/proc/proc_amslatex/proc-l.cls" name="proc-l.cls"/>
         </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>

--- a/journals/texstyles/dependents/quart-appl-math.xml
+++ b/journals/texstyles/dependents/quart-appl-math.xml
@@ -7,7 +7,7 @@
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
         <required-files>
-            <file href="https://www.ams.org/arc/journals/packages/qam/qam_amslatex/qam-l.cls" compression="none" path="qam-l.cls"/>
+            <file name="qam-l.cls" href="https://www.ams.org/arc/journals/packages/qam/qam_amslatex/qam-l.cls"/>
         </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>

--- a/journals/texstyles/dependents/represent-theory.xml
+++ b/journals/texstyles/dependents/represent-theory.xml
@@ -7,7 +7,7 @@
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
         <required-files>
-            <file name="ert-l.cls" href="https://www.ams.org/arc/journals/packages/ert/ert_amslatex/ert-l.cls" compression="none"/>
+            <file name="ert-l.cls" href="https://www.ams.org/arc/journals/packages/ert/ert_amslatex/ert-l.cls"/>
         </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>

--- a/journals/texstyles/dependents/theory-probab-math-statist.xml
+++ b/journals/texstyles/dependents/theory-probab-math-statist.xml
@@ -7,7 +7,7 @@
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
         <required-files>
-            <file href="https://probability.knu.ua/tims/tpms_amslatex.zip" compression="zip" path="tpms_amslatex/tpms-l.cls"/>
+            <file name="tpms-l.cls" href="https://probability.knu.ua/tims/tpms_amslatex.zip" path="tpms_amslatex/tpms-l.cls"/>
         </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-03-12</date>

--- a/journals/texstyles/electron-j-combin.xml
+++ b/journals/texstyles/electron-j-combin.xml
@@ -5,10 +5,9 @@
         <code>electron-j-combin</code>
         <name>Electronic Journal of Combinatorics</name>
         <publisher>Electronic Journal of Combinatorics</publisher>
-        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
-        <!--<required-files>
-            <file href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" compression="zip" path="sn-article-template/sn-jnl.cls"/>
-        </required-files>-->
+        <required-files>
+            <file name="e-jc.sty" href="https://www.combinatorics.org/files/e-jc.sty" />
+        </required-files>
         <latex-engine command="pdflatex"/>
         <!--<bibliography-style>spbasic</bibliography-style>-->
 
@@ -24,7 +23,7 @@
 
 <!-- the e-jc.cls provides some theorem environments; we add the pretext ones it misses. -->
 <ptx-preamble>
-    <theoremstyle name="plain" environments="identity"/>
+    <theoremstyle name="plain" environments="identity" define-counter="no"/>
     <theoremstyle name="definition" environments="axiom, principle, heuristic, hypothesis, assumption, openproblem, openquestion, algorithm, activity, exercise, inlineexercise, investigation, exploration, project"/>
     <theoremstyle name="remark" environments="warning, convention, insight, computation, technology, data"/>
 </ptx-preamble>

--- a/journals/texstyles/springer-nature.xml
+++ b/journals/texstyles/springer-nature.xml
@@ -5,9 +5,8 @@
         <code>springer-nature</code>
         <name>Springer Nature journals</name>
         <publisher>Springer Nature</publisher>
-        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
         <required-files>
-            <file href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" compression="zip" path="sn-article-template/sn-jnl.cls"/>
+            <file name="sn-jnl.cls" href="https://resource-cms.springernature.com/springer-cms/rest/v1/content/18782940/data/v13.zip" path="sn-article-template/sn-jnl.cls"/>
         </required-files>
         <latex-engine command="pdflatex"/>
         <bibliography-style>spbasic</bibliography-style>
@@ -42,15 +41,7 @@
     <ptx-preamble>
         <theoremstyle
             name="thmstyleone"
-            environments="
-                theorem,
-                proposition
-                lemma
-                corollary, claim
-                fact
-                identity
-                conjecture
-            "
+            environments="theorem, proposition, lemma, corollary, claim, fact, identity, conjecture"
         />
         <theoremstyle
             name="thmstyletwo"
@@ -63,7 +54,6 @@
                 assumption
                 openproblem
                 openquestion
-                algorithm
                 question
                 activity
                 exercise

--- a/journals/texstyles/taylor-francis.xml
+++ b/journals/texstyles/taylor-francis.xml
@@ -5,7 +5,6 @@
         <code>taylor-francis</code>
         <name>Taylor Francis General - All other Taylor-Francis journals</name>
         <publisher>Taylor-Francis</publisher>
-        <!-- Each file element of required files should have an href to a location where wget can download the file.  @compression describes how the file is compressed (or None).  @path gives the path to the file relative to the extracted resource.  The file at this path will be copied to the build directory before running xelatex/pdflatex -->
         <latex-engine command="pdflatex"/>
         <bibliography-style>spbasic</bibliography-style>
 

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -134,6 +134,7 @@ def get_destination_directory(directory, xml_source, pub_file, component):
         "qrcode": "qrcode",
         "datafile": "datafile",
         "play-button": "play-button",
+        "latex-package": "latex-packages",
     }
     # if specified, check, sanitize, return absolute path
     if directory:
@@ -337,6 +338,7 @@ def get_cli_arguments():
         ("theme", "theme.css file for HTML build. Any theme options which require HTML changes will not be updated."),
         ("trace", "Program trace data for CodeLens"),
         ("datafile", "data files to text representations"),
+        ("latex-package", "LaTeX external packages for journals"),
         (
             "all",
             "Complete document (in various formats) (for pdf, method: [xelatex], pdflatex)",
@@ -727,6 +729,8 @@ def main():
         )
     elif args.component == "theme":
         ptx.update_theme(xml_source, publication_file, stringparams, dest_dir)
+    elif args.component == "latex-package":
+        ptx.latex_package(xml_source, publication_file, stringparams, dest_dir)
     elif args.component == "all":
         if args.format == "html":
             ptx.html(

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -4204,6 +4204,7 @@ def get_latex_style(xml, pub_file, stringparams):
       - Checks the value of the publisher variable 'journal-name'.
       - If it finds a journal name, tries to resolve that using the list of
         journals, returning the corresponding latex-style entry for that journal.
+        Also adds the texstyle file name to the string params
       - If there is no journal-name publisher variable, or the variable is not in the
         list of journals, checks for the publisher variable 'latex-style' and returns this.
     """
@@ -4213,7 +4214,7 @@ def get_latex_style(xml, pub_file, stringparams):
     if len(journal_name) > 0:
         journal_info = get_journal_info(journal_name)
         log.debug(f"Journal Info: {journal_info}")
-        stringparams["journal.code"] = journal_info.get("texstyle", "")
+        stringparams["journal.texstyle.file"] = journal_info.get("texstyle-file", "")
         latex_style = journal_info.get("latex-style", "")
         if len(latex_style) == 0:
             msg = "The journal name {} in your publication file is invalid or does not correspond to a valid latex-style.  Using the default LaTeX style instead."
@@ -4295,6 +4296,8 @@ def pdf(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir, method):
     # (an empty string is impossible due to a slash always being present?)
 
     copy_managed_directories(tmp_dir, external_abs=external_abs, generated_abs=generated_abs)
+
+    #copy_required_build_files(dest=tmp_dir, stringparams=stringparams, cache_dir=external_abs)
 
     # now work in temporary directory since LaTeX is a bit incapable
     # of working outside of the current working directory
@@ -5158,28 +5161,43 @@ def get_journal_info(journal_name):
     log.debug("Reading list of journals in {}".format(journal_xml))
     journals_tree = ET.parse(journal_xml)
     journals_tree.xinclude()
+
     # Find the node with <code> value journal_name:
     try:
         journal = journals_tree.xpath(f"//journal[code='{journal_name.lower()}']")[0]
     except Exception as e:
         log.warning("The journal name {} specified in the publication file is not supported.".format(journal_name))
         return {"latex-style": ""}
+
+    # name, code, and publisher are nodes containing text
     keys = ["name", "code", "publisher"]
     journal_info = {}
     for key in keys:
-        if journal.find(key) is not None:
-            journal_info[key] = journal.find(key).text
-    # Set the latex-style value.  This will either be the value of an attribute of "method", or should be "texstyle"
-    if journal.find("method") is not None and "latex-style" in journal.find("method").attrib:
-        journal_info["latex-style"] = journal.find("method").attrib["latex-style"]
-    else:
-        journal_info["latex-style"] = "texstyle"
-    # Finally, set the "texstyle" value, which will either be the "code" value or the value of the "texstyle" attribute of "method"
-    if journal.find("method") is not None and "texstyle" in journal.find("method").attrib:
-        journal_info["texstyle"] = journal.find("method").attrib["texstyle"]
-    else:
-        journal_info["texstyle"] = journal.find("code").text
-        log.debug("Using the journal code {} as the texstyle value.".format(journal_info["texstyle"]))
+        element = journal.find(key)
+        journal_info[key] = element.text if element is not None else None
+    # get the attribute values of the optional 'method' element.  Possible attributes are @latex-style, @texstyle, and @dependent
+    if journal.find("method") is not None:
+        for attr in ["latex-style", "texstyle", "dependent"]:
+            if attr in journal.find("method").attrib:
+                journal_info[attr] = journal.find("method").attrib[attr]
+
+    # If any of these are not yet set (or are None), set them to the default values
+    journal_info["latex-style"] = journal_info.get("latex-style", "texstyle")
+    journal_info["texstyle"] = journal_info.get("texstyle", journal_info.get("code"))
+    journal_info["dependent"] = journal_info.get("dependent", "no")
+    log.debug("Using the journal code {} as the texstyle value.".format(journal_info.get("texstyle")))
+
+    # If the latex-style is "texstyle", then find a filename for the texstyle file (as a relative path inside journals/texstyles).  What this is depends on whether dependent is "yes"
+    if journal_info["latex-style"] == "texstyle":
+        # If dependent is "yes", then we need to set the texstyle-file to the filename of the texstyle file, which is the code value.
+        if journal_info["dependent"] == "yes":
+            journal_info["texstyle-file"] = "dependents/" + journal_info.get("texstyle") + ".xml"
+            log.debug("Using texstyle-file {}.".format(journal_info["texstyle-file"]))
+        # If dependent is "no", then we need to set the texstyle-file to the filename of the texstyle file, which is the code value.
+        else:
+            journal_info["texstyle-file"] =  journal_info.get("texstyle") + ".xml"
+            log.debug("Using texstyle-file {}.".format(journal_info["texstyle-file"]))
+
     return journal_info
 
 

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -4227,10 +4227,25 @@ def get_latex_style(xml, pub_file, stringparams):
         latex_style = pub_latex_style
     return latex_style
 
+def latex_package(xml, pub_file, stringparams, dest_dir):
+    """
+    Fetch latex packages (.sty/.cls files) required for building a latex document in a particular journal's style (as specified by a texstyle file).  This always downloads a fresh version of the files.
+    """
+    pub_vars = get_publisher_variable_report(xml, pub_file, stringparams)
+    journal_name = get_publisher_variable(pub_vars, "journal-name")
+    if journal_name:
+        tmp_dir = get_temporary_directory()
+        # place_latex_package_files checks if tmp_dir already has the files, which it won't, so new files will always be downloaded.
+        dest_dir = os.path.join(dest_dir, journal_name)
+        place_latex_package_files(dest_dir, journal_name, tmp_dir)
+        log.info("latex package files downloaded to " + dest_dir)
+    else:
+        log.warning("No journal name found in publication file, so no latex package files downloaded.")
+
+
 # This is not a build target, there is no such thing as a "latex build."
 # Instead, this is a conveience for developers who want to compare
 # different versions of this file during development and testing.
-
 def latex(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir):
     """Convert XML source to LaTeX in destination directory"""
 
@@ -4297,7 +4312,11 @@ def pdf(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir, method):
 
     copy_managed_directories(tmp_dir, external_abs=external_abs, generated_abs=generated_abs)
 
-    #copy_required_build_files(dest=tmp_dir, stringparams=stringparams, cache_dir=external_abs)
+    # If we are building for a journal, we might need extra files
+    pub_vars = get_publisher_variable_report(xml, pub_file, stringparams)
+    journal_name = get_publisher_variable(pub_vars, "journal-name")
+    if journal_name:
+        place_latex_package_files(tmp_dir, journal_name, os.path.join(generated_abs, "latex-packages"))
 
     # now work in temporary directory since LaTeX is a bit incapable
     # of working outside of the current working directory
@@ -5199,6 +5218,51 @@ def get_journal_info(journal_name):
             log.debug("Using texstyle-file {}.".format(journal_info["texstyle-file"]))
 
     return journal_info
+
+def place_latex_package_files(dest_dir, journal_name, cache_dir):
+    """
+    Check whether the latex requires additional files specified in a texstyle file.
+    If so, either copy them from cache_dir or download them from the internet (and also store a copy in the cache_dir).
+    """
+    # Get the texstyle file for the journal name
+    texstyle_file = get_journal_info(journal_name).get("texstyle-file")
+    # Double check that there is a texstyle file
+    if texstyle_file is None:
+        return
+    # Otherwise, parse this file and check for any <file> elements.
+    texstyle_tree = ET.parse(os.path.join(get_ptx_path(), "journals", "texstyles", texstyle_file))
+    texstyle_file_elements = texstyle_tree.xpath("//required-files/file")
+    if not texstyle_file_elements:
+        log.debug("No required files found in the texstyle file.")
+        return
+    # Check whether the journal code is present in the metadata element of the texstyle file
+    journal_code = texstyle_tree.xpath("//metadata/code")[0].text
+    cache_dir = os.path.join(cache_dir, journal_code)
+    # Create the cache_dir if it doesn't exist
+    os.makedirs(cache_dir, exist_ok=True)
+
+    for file in texstyle_file_elements:
+        file_path = os.path.join(cache_dir, file.attrib["name"])
+        if not os.path.exists(file_path):
+            # download the file if it is not already in the cache_dir
+            log.debug("Downloading required file {} from {}".format(file.attrib["name"], file.attrib["href"]))
+            url = file.attrib["href"]
+            # The url might be to the file, or to a compressed archive.  We do slightly different things in each case.  TODO: other archive formats.
+            if url.endswith(".zip"):
+                tmp_zip = os.path.join(cache_dir, "tmp.zip")
+                download_file(url, tmp_zip)
+                with zipfile.ZipFile(tmp_zip, 'r') as zip_ref:
+                    with open(file_path, 'wb') as f:
+                        f.write(zip_ref.read(file.attrib["path"]))
+                os.remove(tmp_zip)
+            else:
+                download_file(url, file_path)
+            log.debug("Saved file {} to {}".format(file.attrib["name"], file_path))
+        else:
+            log.debug("File {} already exists in the generated assets directory.".format(file.attrib["name"]))
+        # Copy required resource to the destination directory
+        shutil.copy2(file_path, dest_dir)
+
 
 
 ###########################

--- a/xsl/latex/pretext-latex-texstyle.xsl
+++ b/xsl/latex/pretext-latex-texstyle.xsl
@@ -260,8 +260,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}%&#xa;</xsl:text>
     <!-- In just the first theoremstyle, we use "theorem" as the     -->
     <!-- default theorem for purposes of defining a counter.         -->
+    <!-- Unless we see @define-counter="no", in which case we assume -->
+    <!-- that the package for the journal does this already.         -->
     <!-- Note that "theorem" is not among the $numbered-theorem-envs -->
-    <xsl:if test="not(preceding-sibling::theoremstyle)">
+    <xsl:if test="not(preceding-sibling::theoremstyle) and not(@define-counter='no')">
         <xsl:text>\newtheorem{theorem}{</xsl:text>
         <xsl:apply-templates select="($document-root//theorem)[1]" mode="type-name"/>
         <xsl:text>}[section]&#xa;</xsl:text>

--- a/xsl/latex/pretext-latex-texstyle.xsl
+++ b/xsl/latex/pretext-latex-texstyle.xsl
@@ -45,23 +45,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Import of correct texstyle files -->
 <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
 
-<!-- Set a default parameter value, but this will be overridden by -->
-<!-- pretext.py  using the journal-name variable.                  -->
-<xsl:param name="journal.code" select="''"/>
 
-<!-- Get the journal corresponding to code with value 'journal.name' -->
-<xsl:variable name="journal-listing" select="document('../../journals/journals.xml')/ptx-journals/journal[code=$journal.code]"/>
+<!-- stringparam that pretext.py will override with the texstyle file name -->
+<!-- (including "dependents/" if appropriate and ".xml")                   -->
+<xsl:param name="journal.texstyle.file" select="''"/>
 
-<!-- Get the texstyle file corresponding to the selected journal -->
-<xsl:variable name="texstyle-file-path">
-    <xsl:text>../../journals/texstyles/</xsl:text>
-    <xsl:if test="$journal-listing/method[@dependent='yes']">
-        <xsl:text>dependents/</xsl:text>
-    </xsl:if>
-</xsl:variable>
+<!-- Base texstyle folder -->
+<xsl:variable name="texstyle-file-path" select="'../../journals/texstyles/'"/>
+
 
 <!-- Read in the original texstyle file -->
-<xsl:variable name="orig-texstyle-root" select="document(concat($texstyle-file-path, $journal.code, '.xml'))"/>
+<xsl:variable name="orig-texstyle-root" select="document(concat($texstyle-file-path, $journal.texstyle.file))"/>
 
 <!-- We create a texstyle-root element which is either the root of the     -->
 <!-- original texstyle file, or is the root of a texstyle file that the    -->
@@ -80,7 +74,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <xsl:when test="metadata/extends">
             <xsl:variable name="base-texstyle-file-name" select="metadata/extends"/>
-            <xsl:variable name="base-texstyle-root" select="document(concat($texstyle-file-path,'../', $base-texstyle-file-name, '.xml'))"/>
+            <xsl:variable name="base-texstyle-root" select="document(concat($texstyle-file-path, $base-texstyle-file-name, '.xml'))"/>
             <xsl:copy>
                 <xsl:apply-templates select="$base-texstyle-root/texstyle/*" mode="include-base"/>
             </xsl:copy>


### PR DESCRIPTION
This PR contains three commits.  

First, I refactored the texstyle xsl and python so that the stringparam points directly to the texstyle file instead of just providing a journal name.  I think this is simpler, and we need the texstyle filename for getting extra files anyway.

Commit 2 is just the python.  Added a function that will copy the correct extra files to the tmp build directory, downloading them first if they are missing.   This did introduce a little duplication (the pdf function calls the latex function which gets the journal info, but the pdf function also needs to get the journal info separately), but I don't think this is too time intensive so should be fine.

Finally, the python functions clarified what info we actually need to get the extra files, so I fixed up the texstyle files with the that data formatted correctly.

Interestingly, having these extra files and trying to compile the latex revealed some issues I hadn't thought of (like some environments being already defined).  I'll fix those up on the next pass.