### PR TITLE
Implement embed button

### DIFF
--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -72,6 +72,25 @@ $center-content: true !default;
     height: 34px;
   }
 
+  .embed-popup {
+    padding: 10px;
+    background-color: var(--navbar-background);
+    position: absolute;
+    margin-top: $nav-height;
+    border: 1px solid var(--page-border-color);
+    border-radius: 3px;
+    box-shadow: 0 0 5px var(--primary-color-gray-80);
+    .embed-code-container {
+      width: "100%";
+      padding:5px;
+      .embed-code-textbox {
+        width: 100%;
+        padding: 10px;
+        height: 5em;
+      }
+    }
+  }
+
   .treebuttons > * {
     display: flex;
     align-items: center;
@@ -87,7 +106,7 @@ $center-content: true !default;
     display: none;
   }
 
-  :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button) .name {
+  :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
     display: none;
   }
 
@@ -156,12 +175,17 @@ $center-content: true !default;
       display: none;
     }
 
+    .embed-popup {
+      margin-top: unset;
+      bottom: $nav-height;
+    }
+
     .dropdown-content {
       top: unset;
       bottom: $nav-height;
     }
 
-    :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button) .name {
+    :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button, .embed-button) .name {
       display: none;
     }
   }

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -828,6 +828,18 @@
                 <li><attr>knowled</attr> with values <c>maximum</c> (default), <c>never</c> and <c>cross-page</c>. <c>maximum</c> will render xref's to structural elements as HTML links and xref's to smaller elements as knowls. <c>never</c> forces all xref's to be rendered as traditional HTML links. <c>cross-page</c> bases the rendering decision on if the xref and its target are on the same page. If so, the xref is always rendered as an HTML link. If the link and target are on different pages, the behavior is the same as <c>maximum</c></li>
             </ul>See <xref ref="knowled-content"/> for explanations and details.</p>
         </subsection>
+
+        <subsection xml:id="online-embed-button-options">
+            <title>Embed Page Button</title>
+            <idx><h>embed page button</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/html</cline>
+            </cd>element can have an attribute <attr>embed-button</attr> with values:<ul>
+                <li><c>no</c>: the default, do not display button.</li>
+                <li><c>yes</c>: show a button in the navigation bar, that when clicked, displays a popup allowing the user to copy an iframe code snippet to paste into their website or LMS.</li>
+            </ul></p>
+        </subsection>
     </section>
 
     <section xml:id="publication-file-revealjs">

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1025,3 +1025,65 @@ window.addEventListener("DOMContentLoaded", function(event) {
         localStorage.setItem("theme", wasDark ? "light" : "dark");
     });
 });
+
+// Share button and embed in LMS code
+window.addEventListener("DOMContentLoaded", function(event) {
+    const shareButton = document.getElementById("embed-button");
+    if (shareButton) {
+        const sharePopup = document.getElementById("embed-popup");
+        const embedCode = "<iframe src='" + window.location.href + "?embed' width='100%' height='1000px' frameborder='0'></iframe>";
+        const embedTextbox = document.getElementById("embed-code-textbox");
+        if (embedTextbox) {
+            embedTextbox.value = embedCode;
+        }
+        shareButton.addEventListener("click", function() {
+            sharePopup.classList.toggle("hidden");
+        });
+        const copyButton = document.getElementById("copy-embed-button");
+        if (copyButton) {
+            copyButton.addEventListener("click", function() {
+                const embedTextbox = document.getElementById("embed-code-textbox");
+                if (embedTextbox) {
+                    navigator.clipboard.writeText(embedCode).then(() => {
+                        console.log("Embed code copied to clipboard!");
+                    }).catch(err => {
+                        console.error("Failed to copy embed code: ", err);
+                    });
+                    //copyButton.innerHTML = "✓✓";
+                    // show confirmation for 2 seconds:
+                    copyButton.querySelector('.icon').innerText = "library_add_check";
+                    setTimeout(function() {
+                        copyButton.querySelector('.icon').innerText = "content_copy";
+                        sharePopup.classList.add("hidden");
+                    }, 450);
+                }
+            });
+        }
+    }
+});
+
+// Hide everything except the content when the URL has "embed" in it
+window.addEventListener("DOMContentLoaded", function(event) {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("embed")) {
+        // Set dark mode based on value of param
+        if (urlParams.get("embed") === "dark") {
+            setDarkMode(true);
+        } else {
+            setDarkMode(false);
+        }
+        const elemsToHide = [
+            "ptx-navbar",
+            "ptx-masthead",
+            "ptx-page-footer",
+            "ptx-sidebar",
+            "ptx-content-footer"
+        ];
+        for (let id of elemsToHide) {
+            const elem = document.getElementById(id);
+            if (elem) {
+                elem.classList.add("hidden");
+            }
+        }
+    }
+});

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10906,7 +10906,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <!-- output. (2023-01-11)                             -->
                         <xsl:copy-of select="$content" />
                     </div>
-                    <div class="ptx-content-footer">
+                    <div id="ptx-content-footer" class="ptx-content-footer">
                         <xsl:apply-templates select="." mode="previous-button"/>
                         <a class="top-button button" href="#" title="Top">
                             <xsl:call-template name="insert-symbol">
@@ -11551,6 +11551,30 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </button>
 </xsl:template>
 
+<xsl:template name="embed-button">
+    <button id="embed-button" class="embed-button button" title="Embed this page">
+        <xsl:call-template name="insert-symbol">
+            <xsl:with-param name="name" select="'code'"/>
+        </xsl:call-template>
+        <span class="name">Embed</span>
+
+    </button>
+    <div class="embed-popup hidden" id="embed-popup">
+        <p>Copy the code below to embed this page in your own website or LMS page.</p>
+        <div class="embed-code-container">
+            <textarea class="embed-code-textbox" id="embed-code-textbox" readonly="true" aria-label="textbox">
+                <iframe src="https://example.com/embed" width="100%" height="1000"></iframe>
+            </textarea>
+            <button class="copy-embed-button button" id="copy-embed-button" title="Copy embed code">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'content_copy'"/>
+                </xsl:call-template>
+                <span class="name">Copy</span>
+            </button>
+        </div>
+    </div>
+</xsl:template>
+
 <xsl:template match="*" mode="print-button"/>
 
 <xsl:template match="worksheet" mode="print-button">
@@ -11624,6 +11648,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="$b-has-calculator">
             <xsl:call-template name="calculator-toggle" />
             <xsl:call-template name="calculator" />
+        </xsl:if>
+        <!-- Button to show code for embedding in an LMS or webpage  -->
+         <xsl:if test="$b-has-embed-button">
+             <xsl:call-template name="embed-button" />
         </xsl:if>
         <xsl:if test="$b-theme-has-darkmode">
             <xsl:call-template name="light-dark-button" />

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2606,6 +2606,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/html/pi:pub-attribute[@name='favicon']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!--                            -->
+<!-- HTML Embed Page button     -->
+<!--                            -->
+
+<xsl:variable name="embed-button">
+    <xsl:apply-templates select="$publisher-attribute-options/html/pi:pub-attribute[@name='embed-button']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-has-embed-button" select="$embed-button = 'yes')"/>
+
 
 <!-- ##################### -->
 <!-- EPUB-Specific Options -->
@@ -3108,6 +3117,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <html>
         <pi:pub-attribute name="short-answer-responses" default="graded" options="always"/>
         <pi:pub-attribute name="favicon" default="none" options="simple"/>
+        <pi:pub-attribute name="embed-button" default="no" options="yes"/>
         <calculator>
             <pi:pub-attribute name="model" default="none" options="geogebra-classic geogebra-graphing geogebra-geometry geogebra-3d" legacy-stringparam="html.calculator"/>
         </calculator>


### PR DESCRIPTION
This adds an optional (but default visible) "Embed this page" button to the navigation bar.  Can be turned off with a publication variable.  The embedded page includes only the `ptx-content`, making it appropriate for Canvas or another LMS.

The guide could use some documentation about this and related features for building "small" documents, or collections of them.  Not sure where to put that, but don't want that decision to hold this feature back.