### PR TITLE
Styling fixes for RS timedAssesments

### DIFF
--- a/css/components/interactives/_runestone.scss
+++ b/css/components/interactives/_runestone.scss
@@ -73,6 +73,13 @@
   margin-top: 0;
 }
 
+// RS does not care what kind of element is used
+// PTX chooses to use a ul, so we will fix margins for it here instead of RS
+ul[data-component="timedAssessment"] {
+  margin: 0;
+  padding: 0;
+}
+
 :root.dark-mode {
   // Darker styling to match Runesone's code mirror theme
   .ptx-runestone-container code[class*="language-"],

--- a/css/targets/html/denver/_rs-widen.scss
+++ b/css/targets/html/denver/_rs-widen.scss
@@ -12,7 +12,7 @@ $rs-wide-elements: ".ac_section, .codelens, .parsons_section, .hparsons_section,
 
 // grouping elements that may have wide elements and require different margins
 // need to make sure those elements have a consistent amount of (padding+border)
-$grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
+$grouping-elements: ".timedAssessment, .theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
 
 
 // widen all runestone elements that should be wide

--- a/css/targets/html/salem/_rs-widen.scss
+++ b/css/targets/html/salem/_rs-widen.scss
@@ -12,7 +12,7 @@ $rs-wide-elements: ".ac_section, .codelens, .parsons_section, .hparsons_section,
 
 // grouping elements that may have wide elements and require different margins
 // need to make sure those elements have a consistent amount of (padding+border)
-$grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
+$grouping-elements: ".timedAssessment, .theorem-like, .definition-like, .example-like, .exercise-like, .project-like, .remark-like, .openproblem-like, .openproblems-like, .computation-like, .knowl__content";
 
 
 // widen all runestone elements that should be wide


### PR DESCRIPTION
Fixes styling issue for timedAssessment - they were not growing when they contained wide elements.

Also fixes unwanted padding from ul used for timedAssessment.

In as a draft until @oscarlevin signs off on updating Denver along with Salem.