### PR TITLE
CSS: limit statement/feedback width in wide hparsons for salem/denver

### DIFF
--- a/css/targets/html/denver/_rs-widen.scss
+++ b/css/targets/html/denver/_rs-widen.scss
@@ -62,6 +62,14 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
   margin-right: auto;
 }
 
+/* limit width of statement and success/error message inside hparson */
+.hparsons_section .hp_question,
+.hparsons_section .hp_feedback {
+  max-width: $content-width;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* limit width of content inside parsons except for actual parsons */
 .runestone.parsons_section > .parsons {
   width: 100%;

--- a/css/targets/html/salem/_rs-widen.scss
+++ b/css/targets/html/salem/_rs-widen.scss
@@ -79,6 +79,14 @@ $grouping-elements: ".theorem-like, .definition-like, .example-like, .exercise-l
   margin-right: auto;
 }
 
+/* limit width of statement and success/error message inside hparson */
+.hparsons_section .hp_question,
+.hparsons_section .hp_feedback {
+  max-width: $content-width;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* limit width of content inside parsons except for actual parsons */
 .runestone.parsons_section > .parsons {
   width: 100%;


### PR DESCRIPTION
Just submitted a RS PR that removes a hard-coded cap on hparson width: https://github.com/RunestoneInteractive/rs/pull/706

This adds some limiting to the statement and feedback after Denver/Salem stretch out the container.

@oscarlevin should bless change to Denver.

Oscar - it might be worth breaking refactoring `_rs_widen` to be something that we each `@use` after defining different values for the variables. Do you think it is likely that we will continue to want exactly the same modifications just with different numbers?

![image](https://github.com/user-attachments/assets/7cc12214-2be3-498e-af74-6eabe0713de7)
