### PR TITLE
Texstyles: fix appendices and add required files for ams journals

### DIFF
--- a/journals/texstyles/ams.xml
+++ b/journals/texstyles/ams.xml
@@ -68,15 +68,11 @@
 
     <acknowledgments heading="\section*{Acknowledgments}"/>
 
-
-
-    <appendices env="appendices" />
-
+    <appendices />
 
     <bibliography cmd="bibliography">
         <arg><bib-file/></arg>
     </bibliography>
-
 
     <end-document/>
 </texstyle>

--- a/journals/texstyles/dependents/bull-amer-math-soc.xml
+++ b/journals/texstyles/dependents/bull-amer-math-soc.xml
@@ -6,12 +6,14 @@
         <name>Bulletin (New Series) of the American Mathematical Society</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="bull-l.cls" href="https://www.ams.org/arc/journals/packages/bull/bull_amslatex/bull-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>
     </metadata>
 
 <!-- Override the document class.  Everything else is the same. -->
-    <documentclass name="bull"/>
+    <documentclass name="bull-l"/>
 
 </texstyle>

--- a/journals/texstyles/dependents/conform-geom-dyn.xml
+++ b/journals/texstyles/dependents/conform-geom-dyn.xml
@@ -6,7 +6,9 @@
         <name>Conformal Geometry and Dynamics</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="ecgd-l.cls" href="https://www.ams.org/arc/journals/packages/ecgd/ecgd_amslatex/ecgd-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>
     </metadata>

--- a/journals/texstyles/dependents/j-algebraic-geom.xml
+++ b/journals/texstyles/dependents/j-algebraic-geom.xml
@@ -6,7 +6,9 @@
         <name>Journal of Algebraic Geometry</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="jag-l.cls" href="https://www.ams.org/arc/journals/packages/jag/jag_amslatex/jag-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>
     </metadata>

--- a/journals/texstyles/dependents/j-amer-math-soc.xml
+++ b/journals/texstyles/dependents/j-amer-math-soc.xml
@@ -6,7 +6,9 @@
         <name>Journal of the American Mathematical Society</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="jams-l.cls" href="https://www.ams.org/arc/journals/packages/jams/jams_amslatex/jams-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>
     </metadata>

--- a/journals/texstyles/dependents/math-comp.xml
+++ b/journals/texstyles/dependents/math-comp.xml
@@ -6,7 +6,9 @@
         <name>Mathematics of Computation</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="mcom-l.cls" href="https://www.ams.org/arc/journals/packages/mcom/mcom_amslatex/mcom-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-04-01</date>
     </metadata>

--- a/journals/texstyles/dependents/trans-ams.xml
+++ b/journals/texstyles/dependents/trans-ams.xml
@@ -6,12 +6,14 @@
         <name>Transactions of the American Mathematical Society</name>
         <publisher>American Mathematical Society</publisher>
         <extends>ams</extends>
-
+        <required-files>
+            <file name="tran-l.cls" href="https://www.ams.org/arc/journals/packages/tran/tran_amslatex/tran-l.cls" />
+        </required-files>
         <style-author>Oscar Levin</style-author>
         <date>2025-03-12</date>
     </metadata>
 
 <!-- Override the document class.  Everything else is the same. -->
-    <documentclass name="trans"/>
+    <documentclass name="tran-l"/>
 
 </texstyle>


### PR DESCRIPTION
This fixes the ams journals' texstyles by adding missing required files and removing the appendices environment (which is not used for these styles).