### PR TITLE
Print css for standalone worksheet 

### DIFF
--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -1,14 +1,9 @@
-// TODO - refactor 
+// Basic rules for printing a standard PreTeXt page
 
+// Get rid of UI elements.
+// Leave margin fiddling for system print dialog.
 
-.print-button {
-  position: relative;
-  right: 2px;
-  background-color: LightGreen;
-  z-index: 1;
-  float: right;
-}
-
+// Worksheet printing is handled in print-worksheet.scss
 
 @media print {
   .pretext .ptx-masthead,
@@ -18,97 +13,12 @@
   .pretext  .ptx-page-footer,
   .pretext .ptx-main > div.ptx-content-footer {
     display:none;
-    border:none;
   }
-  .pretext .ptx-page main.ptx-main {
-    margin-left:0;
-    left:auto;
-    border:none;
-    box-shadow:none;
-    padding: 0;
-  }
-  .pretext .ptx-page .ptx-main { margin-top:0 }
-  .pretext .ptx-page .ptx-main .ptx-contentsection { margin-top:1em }
-  .pretext .ptx-page .ptx-main .ptx-contentsection .heading { margin-top:0 }
-  
-  /* over-ride print.less */
-  .pretext a[href]::after {
-    content: "";
-  }
-  
-  /* don't print the print-button */
-  .print-button {
-    display: none;
-  }
-}
 
-/* printing for one-page worksheets */
-
-@media print {
-  body.standalone.worksheet .ptx-page > .ptx-main {
-    width: 820px;
-    max-width: 820px;
-    font-size: 12.5px;
-  }
-  body.standalone.worksheet {
-    margin: 0;
-  }
-  body.standalone section.worksheet {
-    border: none;
-  }
-  body.standalone.worksheet .ptx-masthead,
-  body.standalone.worksheet .ptx-page-footer {
-    display: none;
-  }
-  
-  body.standalone.worksheet.has-sidebar-left.mathbook-loaded .ptx-page .ptx-main {
-    margin: 0;
-  }
-  
-  body.standalone.worksheet .ptx-page > .ptx-main {
-    margin: 0;
-  }
-  body.standalone.worksheet section.onepage {
-    max-height: 100%;
-    max-width: 100%;
-    overflow: hidden;
-    page-break-after: always;
-    /*
-    height: 1243px;
-    */
-    border: none;
-    page-break-inside: avoid;
-  }
-  body.standalone.worksheet .onepage.lastpage {
-    margin-bottom: -2em;  /* to avoid blank space overflow causing an extra blank page */
-    page-break-after: auto;
-  }
-  body.standalone.worksheet.a4 .onepage {
-    /*
-    height: 1320px;
-    */
-  }
-  body.standalone.worksheet .onepage div.workspace,
-  body.standalone.worksheet .onepage div.workspace.squashed.tight {
-    border: none;
-    padding: 0;
-    background: none !important;
-  }
-  body.standalone.worksheet a {
-    color: black;
-  }
-  
-  body.standalone.worksheet .ptx-page  .ptx-main {
+  .pretext .ptx-main .ptx-content {
+    margin-left: auto;
+    margin-right: auto;
+    border:none;
     padding: 0;
   }
-  
-  body.standalone.worksheet.mathbook-loaded .ptx-page .ptx-main .ptx-contentsection.onepage {
-    padding-bottom: 20px;  /* to help prevent flow onto the next page, particularly in Safari */
-    /* the page is not full length, but what is missing was blank anyway */
-    /*
-    margin: 0;
-    */
-  }
-  
-  @page { margin: 0 }
 }

--- a/css/components/_worksheet.scss
+++ b/css/components/_worksheet.scss
@@ -1,72 +1,54 @@
 // TODO refactor
 
-/* should be the default
-section.worksheet > .heading,
-section section.worksheet > .heading,
-section section section.worksheet > .heading {
-  display: block;
-}
-*/
-section.worksheet > .heading > .codenumber {
-  display: inline-block;
-  vertical-align: top;
-}
-section.worksheet > .heading > .title {
-  display: inline-block;
-  max-width: 70%;
-}
+// Rules in this file apply to both screen and print
+// Print specific rules should go in a file in targets/print-worksheet stylesheet
+
+
 .heading .print-links {
   display: inline-block;
   float: right;
   vertical-align: top;
   width: 19%;
   text-align: right;
+
+  & > a {
+    font-family: var(--font-body);
+    font-size: 0.6em;
+    font-weight: bold;
+    padding: 0.1em 0.2em;
+    background: #ffa;
+    border: 2px solid green;
+    
+    &.us {
+      background: #eef;
+      color: #9b1c2c;
+      border-color: #041E42;
+    }
+    
+  }
+  & > a + a {
+    margin-left: 0.25em;
+  }
 }
-.standalone .heading .print-links {
-  display: none;
-}
-.standalone.worksheet .previous-button,
-.standalone.worksheet .up-button,
-.standalone.worksheet .next-button {
-  display: none;
-}
-.standalone.worksheet .ptx-navbar .toc-toggle {
-  display: none;
-}
-.standalone.worksheet [data-knowl]:hover,
-.standalone.worksheet [data-knowl]:active,
-.standalone.worksheet [data-knowl].active {
-  background: none;
-  color: black;
-}
-.standalone.worksheet [data-knowl]::after {
-  border: none;
+
+.print-button {
+  position: relative;
+  right: 2px;
+  background-color: LightGreen;
+  z-index: 1;
+  float: right;
 }
 
 
-
-.heading .print-links > a {
-  font-family: var(--font-body);
-  font-size: 0.6em;
-  font-weight: bold;
-  padding: 0.1em 0.2em;
-  background: #ffa;
-  border: 2px solid green;
-}
-.heading .print-links > a.us {
-  background: #eef;
-  color: #9b1c2c;
-  border-color: #041E42;
-}
-.heading .print-links > a + a {
-  margin-left: 0.25em;
+.standalone.worksheet {
+  .print-links{
+    display: none;
+  }
 }
 
+// Todo, refactor below into nested rules
 
-
-/* also see section > heading for worksheets, maybe around line 1200 */
 /* one-page documents in the browser */
-
 body.standalone.worksheet .onepage > .heading {
   margin-top: 0;
   font-size: 1.3em;
@@ -82,28 +64,17 @@ body.standalone.worksheet .onepage .instructions {
   display: none;
 }
 body.standalone .worksheet {
-/*
-  padding: 40px 45px 45px 55px;
-*/
   padding: 40px 0 45px 0;
   border: 2px solid grey;
   margin: 0;
-/* height: 1243px; */
 }
 
 body.standalone .onepage {
-/*    padding: 40px 45px 45px 55px;
-  padding: 0 0 45px 0;
-*/
   padding: 40px 45px 45px 55px;
   border-bottom: 2px solid grey;
   margin: 0;
-/* height: 1243px; */
 }
 body.standalone .onepage + .onepage {
-/*
-  padding-top: 40px;
-*/
   border-top: 2px solid grey;
 }
 /* there may be worksheet content before the first page
@@ -271,4 +242,14 @@ body.standalone.worksheet section.worksheet > .conclusion {
 }
 body.standalone.worksheet section.worksheet > .heading + .para {
   display: inline;
+}
+
+.standalone.worksheet [data-knowl]:hover,
+.standalone.worksheet [data-knowl]:active,
+.standalone.worksheet [data-knowl].active {
+  background: none;
+  color: black;
+}
+.standalone.worksheet [data-knowl]::after {
+  border: none;
 }

--- a/css/targets/print-worksheet/_chunks-worksheet.scss
+++ b/css/targets/print-worksheet/_chunks-worksheet.scss
@@ -1,0 +1,90 @@
+// Standard collection of chunks. This file should only be modified
+// to fix bugs or improve the default-modern theme. If you want to
+// make changes for use in some other theme, create a _chunks-XXX file
+// in that theme's directory.
+
+$border-radius: 8px !default;
+
+// One stop include for default style content blocks
+@use 'components/chunks/asides-floating';
+@use 'components/chunks/codelike';
+@use 'components/chunks/exercises';
+@use 'components/chunks/solutions';
+@use 'components/chunks/sidebyside';
+@use 'components/chunks/discussion-inline';
+@use 'components/chunks/knowls' with ($border-radius: $border-radius);
+
+@use 'components/chunks/helpers/L-mixin';
+@use 'components/chunks/helpers/box-mixin' with ($border-radius: $border-radius);
+@use 'components/chunks/helpers/heading-box-mixin';
+@use 'components/chunks/helpers/sidebar-mixin';
+@use 'components/chunks/helpers/inline-heading-mixin';
+
+// rounded box
+.assemblage-like {
+  @include box-mixin.box($border-color: var(--assemblage-like-border-color), $background-color: var(--assemblage-like-body-background));
+}
+
+// box with title inset on top
+.goal-like {
+  @include heading-box-mixin.box(
+    $background-color: var(--goal-like-body-background),
+    $border-color: var(--goal-like-border-color)
+  );
+}
+
+// L-border
+.theorem-like,
+.definition-like,
+.example-like,
+.project-like,
+.remark-like,
+.openproblem-like,
+.computation-like {
+  @include L-mixin.border;
+}
+
+// projects get a dotted L
+.project-like:not(.knowl__content, .born-hidden-knowl) {
+  @include L-mixin.border($style: dotted);
+}
+
+/* proof gets a backwards facing L */
+.proof {
+  @include L-mixin.border(1px, $L-side: right);
+}
+
+/* No decorations/borders in knowls, to save space */
+.knowl__content {
+  .theorem-like,
+  .definition-like,
+  .example-like,
+  .project-like,
+  .remark-like,
+  .openproblem-like,
+  .computation-like,
+  .project-like {
+    padding-left: 0;
+    margin-left: 0;
+    border-left: none;
+
+    &::after {
+      border-bottom: none;
+      display: none;
+    }
+  }
+}
+
+// wide sidebar on an entire section of solutions
+section.solutions:not(:is(:first-child)) {
+  @include sidebar-mixin.box(
+    $border-width: 10px,
+
+    $border-color: var(--page-border-color),
+  );
+}
+
+.paragraphs,
+article {
+  @include inline-heading-mixin.heading;
+}

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -1,0 +1,117 @@
+/*! Theme: print-worksheet */
+
+// Used for printing versions of worksheets for all themes
+
+// File is included into page with @media="print", so no need to use media query around rules
+
+// Also see: 
+// components/_printing.scss : base rules for printing a standard PreTeXt page - removes UI
+// components/_worksheet.scss : worksheet specific rules to apply to screen AND print
+
+// Current maintainer: ???
+
+// ---------------------------------------------
+// Grouping containers - based off of those in default-modern
+@use 'chunks-worksheet' with ($border-radius: 0);
+
+// Bring in the standard PreTeXt styles for components
+@use 'components/pretext';
+
+// Use underline style headings
+@use 'components/elements/extras/heading-underlines';
+
+// Make sure fonts are available
+@use 'fonts/fonts-google';
+
+
+// ---------------------------------------------
+// concrete rules / includes that generate CSS
+
+
+
+// Todo - review/refactor below
+
+.standalone.worksheet .print-button {
+  display: none;
+}
+
+
+.standalone.worksheet [data-knowl]:hover,
+.standalone.worksheet [data-knowl]:active,
+.standalone.worksheet [data-knowl].active {
+  background: none;
+  color: black;
+}
+.standalone.worksheet [data-knowl]::after {
+  border: none;
+}
+
+
+
+body.standalone.worksheet .ptx-page > .ptx-main {
+  width: 820px;
+  max-width: 820px;
+  font-size: 12.5px;
+}
+body.standalone.worksheet {
+  margin: 0;
+}
+body.standalone section.worksheet {
+  border: none;
+}
+body.standalone.worksheet .ptx-masthead,
+body.standalone.worksheet .ptx-page-footer {
+  display: none;
+}
+
+body.standalone.worksheet.has-sidebar-left.mathbook-loaded .ptx-page .ptx-main {
+  margin: 0;
+}
+
+body.standalone.worksheet .ptx-page > .ptx-main {
+  margin: 0;
+}
+body.standalone.worksheet section.onepage {
+  max-height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  page-break-after: always;
+  /*
+  height: 1243px;
+  */
+  border: none;
+  page-break-inside: avoid;
+}
+body.standalone.worksheet .onepage.lastpage {
+  margin-bottom: -2em;  /* to avoid blank space overflow causing an extra blank page */
+  page-break-after: auto;
+}
+body.standalone.worksheet.a4 .onepage {
+  /*
+  height: 1320px;
+  */
+}
+body.standalone.worksheet .onepage div.workspace,
+body.standalone.worksheet .onepage div.workspace.squashed.tight {
+  border: none;
+  padding: 0;
+  background: none !important;
+}
+body.standalone.worksheet a {
+  color: black;
+}
+
+body.standalone.worksheet .ptx-page  .ptx-main {
+  padding: 0;
+}
+
+body.standalone.worksheet.mathbook-loaded .ptx-page .ptx-main .ptx-contentsection.onepage {
+  padding-bottom: 20px;  /* to help prevent flow onto the next page, particularly in Safari */
+  /* the page is not full length, but what is missing was blank anyway */
+  /*
+  margin: 0;
+  */
+}
+
+@page { margin: 0 }
+ 

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -3873,9 +3873,17 @@ def _move_prebuilt_theme(theme_name, theme_opts, tmp_dir):
         with open(dest, 'w+') as file:
             file.write(filedata)
 
-    # map file copied as is if it exists
+    # map file copied to theme.css.map
     if os.path.exists(src + ".map"):
         shutil.copy(src + ".map", dest + ".map")
+
+    # print-worksheet
+    for file in ["print-worksheet.css", "print-worksheet.css.map"]:
+        src = os.path.join(css_src, file)
+        dest = os.path.join(css_dest, file)
+        if os.path.exists(src):
+            shutil.copy(src, dest)
+
 
 # Helper to build a custom version of a theme
 def _build_custom_theme(xml, theme_name, theme_opts, tmp_dir):

--- a/script/cssbuilder/cssbuilder.mjs
+++ b/script/cssbuilder/cssbuilder.mjs
@@ -112,13 +112,11 @@ function getTargets(options) {
     // -------------------------------------------------------------------------
     // Modern web targets
     { out: 'theme-default-modern', in: path.join(cssRoot, 'targets/html/default-modern/theme-default-modern.scss')},
-    // only default is prebuilt
     { out: 'theme-salem', in: path.join(cssRoot, 'targets/html/salem/theme-salem.scss')},
     { out: 'theme-denver', in: path.join(cssRoot, 'targets/html/denver/theme-denver.scss') },
     { out: 'theme-greeley', in: path.join(cssRoot, 'targets/html/greeley/theme-greeley.scss') },
     { out: 'theme-boulder', in: path.join(cssRoot, 'targets/html/boulder/theme-boulder.scss') },
     { out: 'theme-tacoma', in: path.join(cssRoot, 'targets/html/tacoma/theme-tacoma.scss') },
-    // -------------------------------------------------------------------------
     // -------------------------------------------------------------------------
     // Non-web targets
     { out: 'reveal', in: path.join(cssRoot, 'targets/revealjs/reveal.scss')},
@@ -169,8 +167,30 @@ function getTargets(options) {
   return targets;
 }
 
+// Secondary files that are never the primary target but may need to be built with the theme
+function getModules(options) {
+  let webModules = [
+    // -------------------------------------------------------------------------
+    // Modules - these are secondary files 
+    { out: 'print-worksheet', in: path.join(cssRoot, 'targets/print-worksheet/print-worksheet.scss')}
+  ];
+  // Could be other types of modules here...
+
+  if (!options['selected-target']) {
+    // No particular target, build all
+    return webModules;
+  }
+  else if (options['selected-target'].indexOf('theme-') !== -1) {
+    // Building a web theme, build the web modules
+    return webModules;
+  }
+
+  return [];
+}
+
 async function getESBuildConfig(options) {
   const targets = getTargets(options);
+  const modules = getModules(options);
   const outDir = getOutDir(options);
   // Only minify if there is only one target
   // when building all the prebuilt themes to dist, we want to preserve new lines
@@ -178,7 +198,7 @@ async function getESBuildConfig(options) {
   const minifyCSS = targets.length === 1;
   const ctx = await esbuild
     .context({
-      entryPoints: targets,
+      entryPoints: targets.concat(modules),
       bundle: true,
       sourcemap: true,
       minify: minifyCSS,

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13015,7 +13015,7 @@ TODO:
         <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/autoloader/prism-autoloader.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-numbers/prism-line-numbers.min.js" integrity="sha512-dubtf8xMHSQlExGRQ5R7toxHLgSDZ0K7AunqPWHXmJQ8XyVIG19S1T95gBxlAeGOK02P4Da2RTnQz0Za0H0ebQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/plugins/line-highlight/prism-line-highlight.min.js" integrity="sha512-93uCmm0q+qO5Lb1huDqr7tywS8A2TFA+1/WHvyiWaK6/pvsFl6USnILagntBx8JnVbQH5s3n0vQZY6xNthNfKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <xsl:if test="contains($html-theme-name, '-legacy')">
+        <xsl:if test="$b-html-theme-legacy">
             <!-- Legacy themes rely on external css for prism, but newer ones have it built in -->
             <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.26.0/themes/prism.css" rel="stylesheet"/>
             <!-- We could conditionally load the following based on line number -->
@@ -13205,7 +13205,7 @@ TODO:
     <!-- Material Symbols font used for symbols -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
     <!-- Legacy themes need these fonts, modern ones load them on their own -->
-    <xsl:if test="contains($html-theme-name, '-legacy')">
+    <xsl:if test="$b-html-theme-legacy">
             <!-- DejaVu Serif from an alternate CDN -->
             <link href="https://fonts.cdnfonts.com/css/dejavu-serif" rel="stylesheet"/>
             <!-- A variable font from Google, with serifs -->
@@ -13313,7 +13313,7 @@ TODO:
 <!-- legacy styles - handles old css@colors and dark-mode disabling  -->
 <xsl:template name="html-theme-attributes">
     <!-- check for use of old css color sheets -->
-    <xsl:if test="contains($html-theme-name, '-legacy')">
+    <xsl:if test="$b-html-theme-legacy">
         <xsl:attribute name="data-legacy-colorscheme">
             <xsl:choose>
                 <xsl:when test="not($debug.colors = '')">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10762,6 +10762,37 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:call-template name="native-search-box-js" />
 </xsl:variable>
 
+<!-- Generate a version of file-wrap-full-head-cache customized for  -->
+<!-- use in printable worksheets. There does not seem to be a better -->
+<!-- (and straightforward) method other than duplicating above work. -->
+<xsl:variable name="file-wrap-full-head-cache-printable">
+    <!-- file-wrap-iframe-head-cache -->
+    <xsl:call-template name="fonts"/>
+    <xsl:call-template name="font-awesome"/>
+    <xsl:call-template name="css-printable"/>
+    <xsl:call-template name="mathjax"/>
+    <!-- file-wrap-basic-head-cache -->
+    <xsl:call-template name="keywords-meta-element"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <xsl:call-template name="open-graph-info"/>
+    <xsl:call-template name="pretext-js"/>
+    <xsl:call-template name="runestone-header"/>
+    <xsl:call-template name="diagcess-header"/>
+    <!-- file-wrap-simple-head-cache -->
+    <xsl:call-template name="sagecell-code" />
+    <xsl:call-template name="favicon"/>
+    <xsl:call-template name="webwork-js"/>
+    <xsl:call-template name="lti-iframe-resizer"/>
+    <xsl:call-template name="syntax-highlight"/>
+    <xsl:call-template name="hypothesis-annotation" />
+    <xsl:call-template name="geogebra" />
+    <xsl:call-template name="jsxgraph" />
+    <xsl:call-template name="mermaid-header" />
+    <!-- file-wrap-full-head-cache -->
+    <xsl:call-template name="google-search-box-js" />
+    <xsl:call-template name="native-search-box-js" />
+</xsl:variable>
+
 <!-- Now build end of body caches in the same manner          -->
 <!-- Again, start with univeral content and build from there  -->
 
@@ -10849,7 +10880,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="filename" select="$the-filename"/>
             </xsl:call-template>
             <!-- grab the contents every page gets -->
-            <xsl:copy-of select="$file-wrap-full-head-cache"/>
+            <xsl:choose>
+                <xsl:when test="$b-printable">
+                    <xsl:copy-of select="$file-wrap-full-head-cache-printable"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="$file-wrap-full-head-cache"/>
+                </xsl:otherwise>
+            </xsl:choose>
             <!-- now do anything that is or could be page-specific and comes after cache -->
             <xsl:apply-templates select="." mode="knowl" />
             <!-- webwork's iframeResizer needs to come before sagecell template -->
@@ -13279,10 +13317,7 @@ TODO:
 </xsl:template>
 
 <!-- CSS header -->
-<xsl:template name="css">
-    <xsl:if test="not($b-debug-react)">
-        <link href="{$html.css.dir}/{$html-css-theme-file}" rel="stylesheet" type="text/css"/>
-    </xsl:if>
+<xsl:template name="css-common">
     <!-- Temporary until css handling overhaul by ascholer complete -->
     <link href="{$html.css.dir}/ol-markers.css" rel="stylesheet" type="text/css"/>
     <!-- If extra CSS is specified, then unpack multiple CSS files -->
@@ -13307,6 +13342,21 @@ TODO:
         <xsl:comment> must supply it.                                             </xsl:comment>
         <link href="developer.css" rel="stylesheet" type="text/css" />
     </xsl:if>
+</xsl:template>
+
+<xsl:template name="css-printable">
+    <xsl:if test="not($b-debug-react)">
+        <link href="{$html.css.dir}/{$html-css-theme-file}" media="screen" rel="stylesheet" type="text/css"/>
+        <link href="{$html.css.dir}/print-worksheet.css" media="print" rel="stylesheet" type="text/css"/>
+    </xsl:if>
+    <xsl:call-template name="css-common"/>
+</xsl:template>
+
+<xsl:template name="css">
+    <xsl:if test="not($b-debug-react)">
+        <link href="{$html.css.dir}/{$html-css-theme-file}" rel="stylesheet" type="text/css"/>
+    </xsl:if>
+    <xsl:call-template name="css-common"/>
 </xsl:template>
 
 <!-- Inject classes into the root div of a book. Only for used for   -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2218,7 +2218,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Whether or not to tag TOC as focused -->
 <xsl:variable name="html-toc-focused_value">
     <xsl:choose>
-        <xsl:when test="$html-theme-name = 'custom' or contains($html-theme-name, '-legacy')">
+        <xsl:when test="$html-theme-name = 'custom' or $b-html-theme-legacy">
             <!-- legacy/custom themes can pick whether to use a focused toc or not -->
             <xsl:apply-templates select="$publisher-attribute-options/html/tableofcontents/pi:pub-attribute[@name='focused']" mode="set-pubfile-variable"/>
         </xsl:when>
@@ -2297,6 +2297,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
+
+<xsl:variable name="b-html-theme-legacy" select="contains($html-theme-name, '-legacy')"/>
 
 <xsl:variable name="html-palette-name">
     <xsl:apply-templates select="$publisher-attribute-options/html/css/pi:pub-attribute[@name='palette']" mode="set-pubfile-variable"/>


### PR DESCRIPTION
This sets up a separate stylesheet for `media="print"` on printable standalone worksheet pages. 

It could be this is the wrong direction - especially if we end up wanting theme styling (boxes/headings) to "leak through" to print worksheets. But I think this is the best approach if we want a single print style.

Maybe merge as a branch that David/Mitch can work on next week?

They would be doing work in `css/components/_worksheet.scss` and `css/targets/print-worksheet/print-worksheet.scss`.
