### PR TITLE
Scorm: implement building scorm archives

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -367,6 +367,7 @@ def get_cli_arguments():
         ("latex", "LaTeX source file (only, an intermediate format for developers)"),
         ("html", "HyperText Markup Language (online/web pages)"),
         ("html-zip", "HyperText Markup Language (single zip file)"),
+        ("html-scorm", "HyperText Markup Language (single zip file including SCORM manifest)"),
         ("revealjs", "PreTeXt slideshow to reveal.js HTML format"),
         ("epub-svg", "EPUB container, math as SVG"),
         ("epub-mml", "EPUB container, math as MathML"),
@@ -752,6 +753,19 @@ def main():
                 stringparams,
                 None,
                 "zip",
+                extra_stylesheet,
+                out_file,
+                dest_dir,
+                None
+            )
+        elif args.format == "html-scorm":
+            # same as html-zip, but with SCORM manifest
+            ptx.html(
+                xml_source,
+                publication_file,
+                stringparams,
+                None,
+                "scorm",
                 extra_stylesheet,
                 out_file,
                 dest_dir,

--- a/pretext/pretext.py
+++ b/pretext/pretext.py
@@ -4032,6 +4032,9 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
         stringparams["publisher"] = pub_file
     if xmlid_root:
         stringparams["subtree"] = xmlid_root
+    # Build SCORM manifest if requested
+    if file_format == "scorm":
+        stringparams["html.scorm"] = "yes"
     # Optional extra XSL could be None, or sanitized full filename
     if extra_xsl:
         extraction_xslt = extra_xsl
@@ -4066,7 +4069,7 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
         # see comments at  copy_build_directory()
         # before replacing with  shutil.copytree()
         copy_build_directory(tmp_dir, dest_dir)
-    elif file_format == "zip":
+    elif file_format == "zip" or file_format == "scorm":
         # working in temporary directory gets simple paths in zip file
         with working_directory(tmp_dir):
             zip_file = "html-output.zip"

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -145,6 +145,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.annotation" select="''" />
 <xsl:variable name="b-activate-hypothesis" select="boolean($html.annotation='hypothesis')" />
 
+<!-- Should we build the SCORM manifest file? -->
+<xsl:param name="html.scorm" select="'no'" />
+<xsl:variable name="b-build-scorm-manifest" select="$html.scorm = 'yes'" />
+
 <!-- ######### -->
 <!-- Variables -->
 <!-- ######### -->
@@ -308,6 +312,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- build a search page (in development) -->
     <xsl:if test="$has-native-search">
         <xsl:call-template name="search-page-construction"/>
+    </xsl:if>
+    <!-- Optionally, build a SCORM manifest -->
+    <xsl:if test="$b-build-scorm-manifest">
+        <xsl:call-template name="scorm-manifest"/>
     </xsl:if>
     <!-- The main event                          -->
     <!-- We process the enhanced source pointed  -->
@@ -13625,5 +13633,51 @@ TODO:
     </xsl:if>
 </xsl:template>
 
+
+<!-- SCORM manifest -->
+<!-- Generate a simple xml file describing a minimal SCORM "course". -->
+<!-- Besides some boiler plate, we include the title of the course   -->
+<!-- (under the main organization), a single item (since the entire  -->
+<!-- document is a single iframe), and the entry point for that item -->
+<!-- (the resource with its file).  It appears that while other files-->
+<!-- can be listed as files for that resource, this is not required. -->
+
+<!-- The only customization we do here is setting the main title to  -->
+<!-- the title of the document.  We could easily expand this.        -->
+<xsl:template name="scorm-manifest">
+    <xsl:variable name="root-filename">
+        <xsl:apply-templates select="$document-root" mode="containing-filename" />
+    </xsl:variable>
+    <exsl:document href="imsmanifest.xml" method="xml" omit-xml-declaration="no" indent="yes">
+        <manifest identifier="ptx-scorm-test" version="1" xmlns="http://www.imsglobal.org/xsd/imscp_v1p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_v1p3" xmlns:adlseq="http://www.adlnet.org/xsd/adlseq_v1p3" xmlns:adlnav="http://www.adlnet.org/xsd/adlnav_v1p3" xmlns:imsss="http://www.imsglobal.org/xsd/imsss" xsi:schemaLocation="http://www.imsglobal.org/xsd/imscp_v1p1 imscp_v1p1.xsd http://www.adlnet.org/xsd/adlcp_v1p3 adlcp_v1p3.xsd http://www.adlnet.org/xsd/adlseq_v1p3 adlseq_v1p3.xsd http://www.adlnet.org/xsd/adlnav_v1p3 adlnav_v1p3.xsd http://www.imsglobal.org/xsd/imsss imsss_v1p0.xsd">
+            <!--The metadata node simply declares which SCORM version this course operates under.-->
+            <metadata>
+                <schema>ADL SCORM</schema>
+                <schemaversion>2004 3rd Edition</schemaversion>
+            </metadata>
+            <!-- There is just one organization. The organization contains just one item.-->
+            <organizations default="main">
+                <organization identifier="main">
+                    <title>
+                        <xsl:apply-templates select="$document-root" mode="title-full"/>
+                    </title>
+                    <item identifier="item_1" identifierref="main-resource">
+                        <!-- "Main" here is a generic name.  Only visible when importing a into LMS -->
+                        <!-- (at least in Canvas), sort of a sole entry in the table of contents.   -->
+                        <title>Main</title>
+                    </item>
+                </organization>
+            </organizations>
+            <!-- There is just one resource that represents the single SCO that comprises the entirety of this course. The href attribute points to the launch URL for the course and all of the files required by the course are listed. -->
+            <resources>
+                <!-- We use the index.html file pretext produces, as this always points to the right place.  -->
+                <!-- NB we could point to any entry filename, as long as it is in the resulting zip          -->
+                <resource identifier="main-resource" type="webcontent" adlcp:scormType="sco" href="index.html">
+                <file href="index.html"/>
+                </resource>
+            </resources>
+        </manifest>
+    </exsl:document>
+</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
For the record: a SCORM archive is a zip folder containing a number of files (in our case html) and a manifest file.  This archive can be uploaded to an LMS (or other hosting platform), which will allow an instructor to build a PreTeXt document so that the result can only be seen by students in their course.

While more advanced features might be added in the future, this accomplishes the generation of the archive in the simplest way possible.  One additional template in `pretext-html.xsl` generates the manifest file.  The only customization is to the title of the scorm object (we just include `index.html` as the entry point).  The template is only "called" when the stringparam `html.scorm = "'yes'"`.  

On the python side, this is achieved by letting the `file_format` for an html build be 'scorm'.  Besides setting the stringparam, this then behaves exactly like when `file_format = "zip"`.  Added `html-scorm` as a format for the pretext script.

Happy to discuss other implementations, but did test this and its working.  Assuming we move forward, I will follow up with documentation in a later PR.