### PR TITLE
More portable

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -605,7 +605,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- to generate standalone printable and editable   -->
     <!-- versions. $paper becomes HTML class names, e.g. -->
     <!-- LOWER CASE "a4" and "letter"                    -->
-    <xsl:if test="self::worksheet">
+    <!-- NB we don't produce these for portable html     -->
+    <xsl:if test="self::worksheet and not($b-portable-html)">
         <xsl:apply-templates select="." mode="standalone-worksheet">
             <xsl:with-param name="paper" select="'letter'"/>
             <xsl:with-param name="heading-level" select="$heading-level"/>
@@ -948,7 +949,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Links to the "printable" version(s), meant only for "viewable" -->
     <!-- worksheet, so CSS can kill on the "printable" versions         -->
     <!-- $paper is LOWER CASE "a4" and "letter"                         -->
-    <xsl:if test="self::worksheet">
+    <!-- NB until worksheet printing can be done without extra files,   -->
+    <!-- we omit this for portable html.                                -->
+    <xsl:if test="self::worksheet and not($b-portable-html)">
         <xsl:apply-templates select="." mode="standalone-worksheet-links"/>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -180,6 +180,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- We generally want to chunk longer HTML output -->
 <xsl:variable name="chunk-level">
     <xsl:choose>
+        <!-- portable html always gets chunk level 0, even something else is entered -->
+        <xsl:when test="$b-portable-html">0</xsl:when>
         <xsl:when test="$chunk-level-entered != ''">
             <xsl:value-of select="$chunk-level-entered" />
         </xsl:when>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -378,7 +378,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="make-xref-knowls"/>
     </xsl:if>
     <!-- custom ol marker css production -->
-    <xsl:if test="not($b-subsetting)">
+    <xsl:if test="not($b-subsetting) and not($b-portable-html)">
         <xsl:call-template name="ol-marker-styles"/>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6743,7 +6743,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </div>
     <!-- Always build a standalone page, PDF links to these -->
-    <xsl:apply-templates select="." mode="media-standalone-page" />
+    <!-- The only exception is when building portable html  -->
+    <xsl:if test="not($b-portable-html)">
+        <xsl:apply-templates select="." mode="media-standalone-page" />
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="audio">
@@ -6773,7 +6776,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="media-embed"/>
     </div>
     <!-- Always build a standalone page, PDF links to these -->
-    <xsl:apply-templates select="." mode="media-standalone-page" />
+    <!-- (except when building portable html)               -->
+    <xsl:if test="not($b-portable-html)">
+        <xsl:apply-templates select="." mode="media-standalone-page" />
+    </xsl:if>
 </xsl:template>
 
 <!-- Formerly a "pop-out" page, now a "standalone" page     -->
@@ -9544,12 +9550,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- (1) Build, display full content on the page, where born -->
     <xsl:apply-templates select="." mode="interactive-core" />
     <!-- (2) Identical content, but now isolated on a reader-friendly page -->
-    <xsl:apply-templates select="." mode="standalone-page" >
-        <xsl:with-param name="content">
-            <xsl:apply-templates select="." mode="interactive-core" />
-        </xsl:with-param>
-    </xsl:apply-templates>
+    <!-- (we skip this for portable html)                                  -->
+    <xsl:if test="not($b-portable-html)">
+        <xsl:apply-templates select="." mode="standalone-page" >
+            <xsl:with-param name="content">
+                <xsl:apply-templates select="." mode="interactive-core" />
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
     <!-- (3) A simple page that can be used in an iframe construction -->
+    <!-- (portable html still needs these, since they contain the     -->
+    <!-- the content for the interactive                              -->
     <xsl:apply-templates select="." mode="create-iframe-page" />
 </xsl:template>
 


### PR DESCRIPTION
A bunch of small fixes to reduce the number of extra files that get built for a portable build.  Included is an override of chunking level (without warning), removal of standalone pages where possible, removal of worksheet pages and their buttons, and removal of the ol-markers.css (which I understand will soon be obsolete anyway).