### PR TITLE
Retire WW 215

### DIFF
--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -18,7 +18,7 @@
   <introduction>
     <p>
       With a <webwork/> server
-      (version 2.14 or higher, or <url href="https://webwork-ptx.aimath.org" visual="webwork-ptx.aimath.org"/>)
+      (version 2.16 or higher, or <url href="https://webwork-ptx.aimath.org" visual="webwork-ptx.aimath.org"/>)
       and a little setup work, you can embed <webwork/> exercises in your <pretext/> project.
       HTML output can have interactive problem cells or print problems in <q>static</q> form.
       PDF output will print static versions.
@@ -26,7 +26,7 @@
       for use in the <q>traditional</q> way.
     </p>
     <p>
-      Although we expect that version 2.14 and above are supported,
+      Although we expect that version 2.16 and above are supported,
       we recommend that you use the <url href="https://github.com/openwebwork/webwork2/blob/main/VERSION">current</url>
       (or one previous) version of <webwork/> whenever possible.
       Should bugs be discovered, it may be difficult to address them with older versions of <webwork/>.

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -987,7 +987,7 @@
                     <cline>/publication/webwork/@server</cline>
                 </cd>
                 should include the protocol (e.g.<nbsp/><c>http</c> or <c>https</c>) and not include a trailing slash.
-                The server should be version 2.14 or later.
+                The server should be version 2.16 or later.
             </p>
         </subsection>
 

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -18,7 +18,7 @@
   <introduction>
     <p>
       With a <webwork/> server
-      (version 2.14 or higher, or <url href="https://webwork-ptx.aimath.org" visual="webwork-ptx.aimath.org"/>)
+      (version 2.16 or higher, or <url href="https://webwork-ptx.aimath.org" visual="webwork-ptx.aimath.org"/>)
       and a little setup work, you can embed <webwork/> exercises in your <pretext/> project.
       HTML output can have interactive problem cells or print problems in <q>static</q> form.
       PDF output will print static versions.
@@ -42,7 +42,7 @@
     <p>
       If you are configuring your own <webwork/> server to use with <pretext/>,
       we assume a mild familiarity with administrating a <webwork/> server.
-      The version of <webwork/> needs to be 2.14 or later for use with <pretext/>.
+      The version of <webwork/> needs to be 2.16 or later for use with <pretext/>.
     </p>
     <p>
       The only thing you need to do at this level is set the web server to use certain headers on content that is fetched.
@@ -94,7 +94,7 @@
     <p>
       If you are configuring your own <webwork/> server to use with <pretext/>,
       we assume a mild familiarity with administrating a <webwork/> server.
-      The version of <webwork/> needs to be 2.14 or later for use with <pretext/>.
+      The version of <webwork/> needs to be 2.16 or later for use with <pretext/>.
     </p>
     <p>
       Using the <c>admin</c> course, create a course named <c>anonymous</c>.
@@ -250,7 +250,7 @@
         <attr>course</attr>, <attr>coursepassword</attr>, <attr>user</attr>, and <attr>userpassword</attr>.
         If absent, these default to <c>https://webwork-ptx.aimath.org</c>, <c>anonymous</c>, <c>anonymous</c>,
         <c>anonymous</c>, and <c>anonymous</c> respectively. If you specify a server, you must correctly
-        specify the protocol (<c>http</c> versus <c>https</c>). And it must be version 2.14 or later.
+        specify the protocol (<c>http</c> versus <c>https</c>). And it must be version 2.16 or later.
         Do not include a trailing slash.
       </p>
     </subsection>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -176,39 +176,12 @@
         <!-- 4. human readable PG (for PTX-authored)                               -->
         <pghuman>
             <xsl:apply-templates select=".">
-                <xsl:with-param name="b-hint" select="true()" />
-                <xsl:with-param name="b-solution" select="true()" />
                 <xsl:with-param name="b-human-readable" select="true()" />
             </xsl:apply-templates>
         </pghuman>
         <!-- 5. PG optimized (and less human-readable) for use in PTX output modes -->
-        <pgdense hint="yes" solution="yes">
+        <pgdense>
             <xsl:apply-templates select=".">
-                <xsl:with-param name="b-hint" select="true()" />
-                <xsl:with-param name="b-solution" select="true()" />
-                <xsl:with-param name="b-human-readable" select="false()" />
-            </xsl:apply-templates>
-        </pgdense>
-        <!-- Below are only needed for WeBWorK 2.15 and earlier, -->
-        <!-- where we use an iframe for the embedding. Otherwise -->
-        <pgdense hint="no" solution="no">
-            <xsl:apply-templates select=".">
-                <xsl:with-param name="b-hint" select="false()" />
-                <xsl:with-param name="b-solution" select="false()" />
-                <xsl:with-param name="b-human-readable" select="false()" />
-            </xsl:apply-templates>
-        </pgdense>
-        <pgdense hint="no" solution="yes">
-            <xsl:apply-templates select=".">
-                <xsl:with-param name="b-hint" select="false()" />
-                <xsl:with-param name="b-solution" select="true()" />
-                <xsl:with-param name="b-human-readable" select="false()" />
-            </xsl:apply-templates>
-        </pgdense>
-        <pgdense hint="yes" solution="no">
-            <xsl:apply-templates select=".">
-                <xsl:with-param name="b-hint" select="false()" />
-                <xsl:with-param name="b-solution" select="true()" />
                 <xsl:with-param name="b-human-readable" select="false()" />
             </xsl:apply-templates>
         </pgdense>
@@ -290,8 +263,6 @@
 
 
 <xsl:template match="webwork[statement]">
-    <xsl:param name="b-hint" />
-    <xsl:param name="b-solution" />
     <xsl:param name="b-human-readable" />
     <xsl:if test="$b-human-readable">
         <xsl:call-template name="converter-blurb-webwork" />
@@ -318,24 +289,18 @@
     <xsl:apply-templates select="statement">
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
-    <xsl:if test="$b-hint">
-        <xsl:apply-templates select="hint">
-            <xsl:with-param name="b-human-readable" select="$b-human-readable" />
-        </xsl:apply-templates>
-    </xsl:if>
-    <xsl:if test="$b-solution">
-        <xsl:apply-templates select="solution">
-            <xsl:with-param name="b-human-readable" select="$b-human-readable" />
-        </xsl:apply-templates>
-    </xsl:if>
+    <xsl:apply-templates select="hint">
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="solution">
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
     <xsl:call-template name="end-problem">
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="webwork[task]">
-    <xsl:param name="b-hint" />
-    <xsl:param name="b-solution" />
     <xsl:param name="b-human-readable" />
     <xsl:if test="$b-human-readable">
         <xsl:call-template name="converter-blurb-webwork" />
@@ -397,8 +362,6 @@
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="task">
-        <xsl:with-param name="b-hint" select="$b-hint" />
-        <xsl:with-param name="b-solution" select="$b-solution" />
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
     <xsl:if test="$b-human-readable">
@@ -421,8 +384,6 @@
 </xsl:template>
 
 <xsl:template match="task[statement]">
-    <xsl:param name="b-hint" />
-    <xsl:param name="b-solution" />
     <xsl:param name="b-human-readable" />
     <xsl:call-template name="begin-block">
         <xsl:with-param name="block-title">Section</xsl:with-param>
@@ -439,16 +400,12 @@
     <xsl:apply-templates select="statement">
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
-    <xsl:if test="$b-hint">
-        <xsl:apply-templates select="hint">
-            <xsl:with-param name="b-human-readable" select="$b-human-readable" />
-        </xsl:apply-templates>
-    </xsl:if>
-    <xsl:if test="$b-solution">
-        <xsl:apply-templates select="solution">
-            <xsl:with-param name="b-human-readable" select="$b-human-readable" />
-        </xsl:apply-templates>
-    </xsl:if>
+    <xsl:apply-templates select="hint">
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="solution">
+        <xsl:with-param name="b-human-readable" select="$b-human-readable" />
+    </xsl:apply-templates>
     <xsl:if test="$b-human-readable">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
@@ -459,8 +416,6 @@
 </xsl:template>
 
 <xsl:template match="task[task]">
-    <xsl:param name="b-hint" />
-    <xsl:param name="b-solution" />
     <xsl:param name="b-human-readable" />
     <xsl:call-template name="begin-block">
         <xsl:with-param name="block-title">Section</xsl:with-param>
@@ -490,8 +445,6 @@
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="task">
-        <xsl:with-param name="b-hint" select="$b-hint" />
-        <xsl:with-param name="b-solution" select="$b-solution" />
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
     <xsl:if test="$b-human-readable">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -262,20 +262,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- inserted into the source by the pre-processor ("assembly") when     -->
 <!-- making dynamic exercises.                                           -->
 
-<xsl:variable name="webwork-reps-version" select="$document-root//webwork-reps[1]/@version"/>
 <xsl:variable name="webwork-major-version" select="$document-root//webwork-reps[1]/@ww_major_version"/>
 <xsl:variable name="webwork-minor-version" select="$document-root//webwork-reps[1]/@ww_minor_version"/>
 
-<xsl:variable name="webwork-domain">
-    <xsl:choose>
-        <xsl:when test="$webwork-reps-version = 1">
-            <xsl:value-of select="$document-root//webwork-reps[1]/server-url[1]/@domain" />
-        </xsl:when>
-        <xsl:when test="$webwork-reps-version = 2">
-            <xsl:value-of select="$document-root//webwork-reps[1]/server-data/@domain" />
-        </xsl:when>
-    </xsl:choose>
-</xsl:variable>
+<xsl:variable name="webwork-domain" select="$document-root//webwork-reps[1]/server-data/@domain" />
 
 <!-- #### EXPERIMENTAL #### -->
 <!-- We allow for the HTML conversion to chunk output, starting  -->
@@ -10483,15 +10473,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- WeBWorK Javascript header -->
 <xsl:template name="webwork-js">
     <xsl:if test="$b-has-webwork-reps">
-        <xsl:choose>
-            <xsl:when test="$webwork-reps-version = 1">
-                <script src="{$webwork-domain}/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.min.js"></script>
-            </xsl:when>
-            <xsl:when test="$webwork-reps-version = 2">
-                <script src="{$html.js.dir}/pretext-webwork/2.{$webwork-minor-version}/pretext-webwork.js"></script>
-                <script src="{$webwork-domain}/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.min.js"></script>
-            </xsl:when>
-        </xsl:choose>
+        <script src="{$html.js.dir}/pretext-webwork/2.{$webwork-minor-version}/pretext-webwork.js"></script>
+        <script src="{$webwork-domain}/webwork2_files/node_modules/iframe-resizer/js/iframeResizer.min.js"></script>
     </xsl:if>
 </xsl:template>
 
@@ -10546,23 +10529,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
             </xsl:apply-templates>
         </xsl:when>
-        <xsl:when test="$webwork-reps-version = 1">
-            <xsl:if test="$b-webwork-inline-randomize">
-                <xsl:apply-templates select="." mode="webwork-randomize-buttons"/>
-            </xsl:if>
-            <xsl:apply-templates select="." mode="webwork-iframe">
-                <xsl:with-param name="b-has-hint"     select="$b-has-hint"/>
-                <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-            </xsl:apply-templates>
-        </xsl:when>
-        <xsl:when test="$webwork-reps-version = 2">
+        <xsl:otherwise>
             <xsl:apply-templates select="." mode="webwork-interactive-div">
                 <xsl:with-param name="b-original"     select="$b-original"/>
                 <xsl:with-param name="b-has-hint"     select="$b-has-hint"/>
                 <xsl:with-param name="b-has-answer"   select="$b-has-answer"/>
                 <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
             </xsl:apply-templates>
-        </xsl:when>
+        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -10722,15 +10696,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="$webwork-domain" />
         <xsl:text>"]})</xsl:text>
     </script>
-</xsl:template>
-
-<!-- Buttons for randomizing the seed of a live WeBWorK problem            -->
-<!-- Undocumented. Only designed to work with 2.15 and earlier WW servers. -->
-<xsl:template match="webwork-reps" mode="webwork-randomize-buttons">
-    <div class="WW-randomize-buttons">
-        <button class="WW-randomize" type="button" onclick="WWiframeReseed('{@ww-id}')">Randomize</button>
-        <button class="WW-randomize" type="button" onclick="WWiframeReseed('{@ww-id}',{static/@seed})">Reset</button>
-    </div>
 </xsl:template>
 
 <!-- ############################# -->


### PR DESCRIPTION
This should simplify many things for the larger Tacoma PR. Net 165 deletions here.

This removes all of the special case handling if the WW server version is 2.15 (or 2.14). So such old WW servers can no longer be used to generate output. I announced on pretext-announce on June 18, 2024, that this would happen "soon". If this is merged I can announce again that it has actually happened.

In my testing with the webwork minimal and webwork sample-chapter examples, there is no change in either:

- webwork representations file and 
- html output files

between this branch and "master" branch. The only changes are

- timestamps
- binary image files register a diff but are the same size and appear the same to me visually (so maybe a timestamp buried in the binary)

If one does try to use a WW server 2.15 or earlier, there will be an error about that, and a suggestion to use the AIM WW server.