### PR TITLE
Sample Chapter: move chunking to publisher file

### DIFF
--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -199,13 +199,13 @@ sample-chapter-problem-sets:
 	install -d $(PGOUT)
 	cd $(PGOUT); \
 	rm -r Integrating_WeBWorK_into_Textbooks; \
-	$(PTX)/pretext/pretext -v -c all -f webwork-sets -x chunk.level 1 debug.datedfiles no -p $(SMPCPUB) $(SMPC)
+	$(PTX)/pretext/pretext -v -c all -f webwork-sets -x debug.datedfiles no -p $(SMPCPUB) $(SMPC)
 
 mini-problem-sets:
 	install -d $(PGOUT)
 	cd $(PGOUT); \
 	rm -r WeBWorK_Minimal_Example; \
-	$(PTX)/pretext/pretext -v -c all -f webwork-sets -x chunk.level 1 debug.datedfiles no -p $(MINIPUB) $(MINI)
+	$(PTX)/pretext/pretext -v -c all -f webwork-sets -x debug.datedfiles no -p $(MINIPUB) $(MINI)
 
 
 #########################################################################

--- a/examples/webwork/sample-chapter/publisher/publication-academy.xml
+++ b/examples/webwork/sample-chapter/publisher/publication-academy.xml
@@ -20,6 +20,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <publication>
+    <common>
+        <chunking level="2"/>
+    </common>
 
     <source>
         <directories generated="generated" external="external"/>

--- a/examples/webwork/sample-chapter/publisher/publication.xml
+++ b/examples/webwork/sample-chapter/publisher/publication.xml
@@ -20,6 +20,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <publication>
+    <common>
+        <chunking level="2"/>
+    </common>
 
     <source>
       <directories generated="generated" external="external"/>


### PR DESCRIPTION
This just moves the chunking specification for the sample chapter problem set archive from the Makefile to the publisher file.