### PR TITLE
WeBWorK Minimal: include an OPL problem

### DIFF
--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -38,6 +38,7 @@
     </frontmatter>
     <section>
       <title><webwork /> Minimal Section</title>
+      <!-- An exercise "generated" from PTX source -->
       <exercise>
         <webwork>
           <pg-code>
@@ -64,6 +65,11 @@
             </p>
           </solution>
         </webwork>
+      </exercise>
+      <!-- An exercise with source from a "webwork2" server           -->
+      <!-- The path is relative to the host course's templates folder -->
+      <exercise>
+        <webwork source="Library/PCC/BasicAlgebra/Geometry/CylinderVolume10.pg"/>
       </exercise>
     </section>
   </article>


### PR DESCRIPTION
My plan is that the WW minimal example end up with one example each of:

- PTX authored exercise (that it already has)
- Problem from a host course on a webwork2 server (that this PR adds)
- Local problem file (that will come later as the larger Tacoma PR is chipped away at)

Adding this one now will make some future diff smaller.