### PR TITLE
WeBWorK Minimal: put webwork element in pub file

### DIFF
--- a/examples/webwork/minimal/publication.xml
+++ b/examples/webwork/minimal/publication.xml
@@ -25,4 +25,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
       <directories generated="generated" external="external"/>
     </source>
 
+    <!-- These are the defaults but written explicitly here to serve as a model. -->
+    <webwork
+        server="https://webwork-ptx.aimath.org"
+        course="anonymous"
+        coursepassword="anonymous"
+        user="anonymous"
+        userpassword="anonymous"
+        task-reveal="preceding-correct"
+        />
+
 </publication>


### PR DESCRIPTION
This adds the `webwork` element to the WW Minimal example's publisher file. All the settings are just the default settings. But having this here helps with development by making it easier to change a setting and build.