### PR TITLE
Sample Chapter: don't use special characters in description

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -1267,7 +1267,7 @@
                             </p>
                             <image width="50%">
                                 <description>
-                                    this image has pictures of text with special characters like $, %, and @
+                                    this image has pictures of text with special perl characters
                                 </description>
                                 <latex-image>
                                     \begin{tikzpicture}


### PR DESCRIPTION
Special perl characters are used in a description. Under the new code in the Tacoma project branch, this causes problems. Eventually those problems should be worked on, so that it can be OK to use characters like this in a description. But it's a project for some other day. For now I just want to sidestep this.