### PR TITLE
Guide: remove webwork from publihser files

### DIFF
--- a/doc/guide/publication-styled.xml
+++ b/doc/guide/publication-styled.xml
@@ -40,7 +40,4 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <directories external="external" generated="generated"/>
     </source>
 
-    <!-- These are the defaults but written explicitly here to serve as a model. -->
-    <webwork server="https://webwork-ptx.aimath.org" course="anonymous" coursepassword="anonymous" user="anonymous" userpassword="anonymous" />
-
 </publication>

--- a/doc/guide/publication.xml
+++ b/doc/guide/publication.xml
@@ -46,7 +46,4 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <directories external="external" generated="generated"/>
     </source>
 
-    <!-- These are the defaults but written explicitly here to serve as a model. -->
-    <webwork server="https://webwork-ptx.aimath.org" course="anonymous" coursepassword="anonymous" user="anonymous" userpassword="anonymous" />
-
 </publication>


### PR DESCRIPTION
The Guide's publisher file has webwork settings, which are unnecessary because there are no live WeBWorK exercises in the guide. (IIRC there was one once, but because it complicated building the guide, we removed it.)

So this removes all that fro the publisher files. It helps reduce clutter when searching for webwork things that need updating.