### PR TITLE
WeBWorK: consolidate course-password and user-password

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1001,16 +1001,6 @@
             </p>
         </subsection>
 
-        <subsection xml:id="publication-file-webwork-course-password">
-            <title>Course Password</title>
-            <p>
-                A course password (distinct from a user password) is in the attribute
-                <cd>
-                    <cline>/publication/webwork/@coursepassword</cline>
-                </cd>
-            </p>
-        </subsection>
-
         <subsection xml:id="publication-file-webwork-user">
             <title>User</title>
             <p>
@@ -1021,12 +1011,12 @@
             </p>
         </subsection>
 
-        <subsection xml:id="publication-file-webwork-user-password">
-            <title>User Password</title>
+        <subsection xml:id="publication-file-webwork-password">
+            <title>Password</title>
             <p>
-                That user's password is in the attribute
+                A password (for the host user in the host course) is in the attribute
                 <cd>
-                    <cline>/publication/webwork/@userpassword</cline>
+                    <cline>/publication/webwork/@password</cline>
                 </cd>
             </p>
         </subsection>

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -247,7 +247,7 @@
       <p>
         <c>-p</c> specifies the publication file, as described in <xref ref="publication-file-reference"/>.
         In the publication file, the element <tag>webwork</tag> may have attributes <attr>server</attr>,
-        <attr>course</attr>, <attr>coursepassword</attr>, <attr>user</attr>, and <attr>userpassword</attr>.
+        <attr>course</attr>, <attr>user</attr>, and <attr>password</attr>.
         If absent, these default to <c>https://webwork-ptx.aimath.org</c>, <c>anonymous</c>, <c>anonymous</c>,
         <c>anonymous</c>, and <c>anonymous</c> respectively. If you specify a server, you must correctly
         specify the protocol (<c>http</c> versus <c>https</c>). And it must be version 2.16 or later.

--- a/examples/showcase/publisher/publication.xml
+++ b/examples/showcase/publisher/publication.xml
@@ -36,9 +36,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <webwork
         server="https://webwork-ptx.aimath.org"
         course="anonymous"
-        coursepassword="anonymous"
         user="anonymous"
-        userpassword="anonymous"
+        password="anonymous"
         />
 
 </publication>

--- a/examples/webwork/sample-chapter/publisher/publication-academy.xml
+++ b/examples/webwork/sample-chapter/publisher/publication-academy.xml
@@ -26,7 +26,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->
-    <webwork server="https://webwork-ptx.aimath.org" course="anonymous" coursepassword="anonymous" user="anonymous" userpassword="anonymous" task-reveal="preceding-correct" />
+    <webwork server="https://webwork-ptx.aimath.org" course="anonymous" user="anonymous" password="anonymous" task-reveal="preceding-correct" />
 
     <html>
         <platform host="runestone"/>

--- a/examples/webwork/sample-chapter/publisher/publication.xml
+++ b/examples/webwork/sample-chapter/publisher/publication.xml
@@ -29,9 +29,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <webwork
         server="https://webwork-ptx.aimath.org"
         course="anonymous"
-        coursepassword="anonymous"
         user="anonymous"
-        userpassword="anonymous"
+        password="anonymous"
         task-reveal="preceding-correct"
         />
 

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1261,7 +1261,6 @@ def webwork_to_xml(
             "courseID": ww_xml.find("server-params-pub").find("course-id").text,
             "userID": ww_xml.find("server-params-pub").find("user-id").text,
             "password": ww_xml.find("server-params-pub").find("password").text,
-            "course_password": ww_xml.find("server-params-pub").find("course-password").text,
         }
     else:
         server_params_pub = {}
@@ -1300,14 +1299,12 @@ def webwork_to_xml(
             ww_domain = sanitize_url(split_server_params[0])
             courseID = sanitize_alpha_num_underscore(split_server_params[1])
             userID = sanitize_alpha_num_underscore(split_server_params[2])
-            password = sanitize_alpha_num_underscore(split_server_params[3])
-            course_password = sanitize_alpha_num_underscore(split_server_params[4])
+            password = sanitize_alpha_num_underscore(split_server_params[4])
         else:
-            ww_domain       = sanitize_url(server_params)
-            courseID        = "anonymous"
-            userID          = "anonymous"
-            password        = "anonymous"
-            course_password = "anonymous"
+            ww_domain = sanitize_url(server_params)
+            courseID  = "anonymous"
+            userID    = "anonymous"
+            password  = "anonymous"
     else:
         # Now we know server_params_pub is nonepty
         # Use it, and warn if server_params argument is also present
@@ -1315,11 +1312,10 @@ def webwork_to_xml(
             log.warning("Publication file in use and -s argument passed for WeBWorK server.\n"
                   + "              -s argument will be ignored.\n"
                   + "              Using publication/webwork values (or defaults) instead.")
-        ww_domain       = sanitize_url(server_params_pub["ww_domain"])
-        courseID        = server_params_pub["courseID"]
-        userID          = server_params_pub["userID"]
-        password        = server_params_pub["password"]
-        course_password = server_params_pub["course_password"]
+        ww_domain = sanitize_url(server_params_pub["ww_domain"])
+        courseID  = server_params_pub["courseID"]
+        userID    = server_params_pub["userID"]
+        password  = server_params_pub["password"]
 
     ww_domain_ww2 = ww_domain + "/webwork2/"
     ww_domain_path = ww_domain_ww2 + "html2xml"
@@ -1334,7 +1330,7 @@ def webwork_to_xml(
             displayMode='PTX',
             courseID=courseID,
             userID=userID,
-            course_password=course_password,
+            course_password=password,
             outputformat='raw'
         )
         version_determination_json = requests.get(url=ww_domain_path, params=params_for_version_determination, timeout=10).json()
@@ -1469,8 +1465,7 @@ def webwork_to_xml(
             ("displayMode", "PTX"),
             ("courseID", courseID),
             ("userID", userID),
-            ("password", password),
-            ("course_password", course_password),
+            ("course_password", password),
             ("outputformat", "ptx"),
             server_params_source,
             ("problemSeed", seed[problem]),
@@ -1866,7 +1861,7 @@ def webwork_to_xml(
         server_data.set("domain", ww_domain)
         server_data.set("course-id", courseID)
         server_data.set("user-id", userID)
-        server_data.set("course-password", course_password)
+        server_data.set("password", password)
         server_data.set("language", localization)
 
         # Add PG for PTX-authored problems

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -530,9 +530,8 @@
                 element webwork {
                     attribute server { text },
                     attribute course { text }?,
-                    attribute coursepassord { text }?,
                     attribute user { text }?,
-                    attribute userpassword { text }?,
+                    attribute password { text }?,
                     attribute task-reveal { "preceding-correct" | "all" }?
                 }
             </code>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -115,11 +115,8 @@
                     <xsl:value-of select="$webwork-user"/>
                 </user-id>
                 <password>
-                    <xsl:value-of select="$webwork-userpassword"/>
+                    <xsl:value-of select="$webwork-password"/>
                 </password>
-                <course-password>
-                    <xsl:value-of select="$webwork-coursepassword"/>
-                </course-password>
             </xsl:if>
         </server-params-pub>
         <xsl:apply-imports/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10642,7 +10642,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="server-data/@user-id"/>
         </xsl:attribute>
         <xsl:attribute name="data-coursePassword">
-            <xsl:value-of select="server-data/@course-password"/>
+            <xsl:value-of select="server-data/@password"/>
         </xsl:attribute>
         <xsl:attribute name="aria-live">
             <xsl:value-of select="'polite'"/>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1226,16 +1226,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/webwork/pi:pub-attribute[@name='course']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
-<xsl:variable name="webwork-coursepassword">
-    <xsl:apply-templates select="$publisher-attribute-options/webwork/pi:pub-attribute[@name='coursepassword']" mode="set-pubfile-variable"/>
-</xsl:variable>
-
 <xsl:variable name="webwork-user">
     <xsl:apply-templates select="$publisher-attribute-options/webwork/pi:pub-attribute[@name='user']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
-<xsl:variable name="webwork-userpassword">
-    <xsl:apply-templates select="$publisher-attribute-options/webwork/pi:pub-attribute[@name='userpassword']" mode="set-pubfile-variable"/>
+<xsl:variable name="webwork-password">
+    <xsl:choose>
+        <!-- For backwards compatibility -->
+        <xsl:when test="$publication/webwork/@coursepassword">
+            <xsl:value-of select="$publication/webwork/@coursepassword"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="$publisher-attribute-options/webwork/pi:pub-attribute[@name='password']" mode="set-pubfile-variable"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:variable>
 
 <!-- WeBWorK tasks can be revealed incrementally or all at once -->
@@ -3196,9 +3200,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <webwork>
         <pi:pub-attribute name="server" default="https://webwork-ptx.aimath.org" freeform="yes"/>
         <pi:pub-attribute name="course" default="anonymous" freeform="yes"/>
-        <pi:pub-attribute name="coursepassword" default="anonymous" freeform="yes"/>
         <pi:pub-attribute name="user" default="anonymous" freeform="yes"/>
-        <pi:pub-attribute name="userpassword" default="anonymous" freeform="yes"/>
+        <pi:pub-attribute name="password" default="anonymous" freeform="yes"/>
         <pi:pub-attribute name="task-reveal" default="all" options="preceding-correct"/>
     </webwork>
     <revealjs>
@@ -4206,6 +4209,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="date-string" select="'2024-07-12'" />
         <xsl:with-param name="message" select="'the html/css/@toc, @navbar, @shell, @knowls, and @banner publication entries have been deprecated. Use @theme to control html appearance. See the Guide for theme options.'" />
         <xsl:with-param name="incorrect-use" select="($publication/html/css/@toc != '' or $publication/html/css/@navbar != '' or $publication/html/css/@shell != '' or $publication/html/css/@knowls != '' or $publication/html/css/@banner != '')" />
+    </xsl:call-template>
+    <!--  -->
+    <xsl:call-template name="parameter-deprecation-message">
+        <xsl:with-param name="date-string" select="'2025-05-09'" />
+        <xsl:with-param name="message" select="'the webwork/@coursepassword and @userpassword publication entries have been deprecated. Use @password instead.'" />
+        <xsl:with-param name="incorrect-use" select="($publication/webwork/@coursepassword != '' or $publication/webwork/@userpassword != '')" />
     </xsl:call-template>
     <!--  -->
 </xsl:template>


### PR DESCRIPTION
Once upon a time, I think that Mike Gage had a scheme in mind for authenticating into a WeBWorK course for a remote procedure call where two passwords would be necessary. Their names are misnomers, I think, but were called `coursePassword` and `userPassword`. We set things up so that PreTeXt would be ready to work with both. But all that was ever needed was `coursePassword`. The other one has never been needed or had an effect.

So this PR:

- mostly scrubs away both of them, and puts a simple `password` in place instead
- except out in the wild, publisher files and stringparams might still use `coursePassword`, and that is still supported for backwards compatibility (but with a deprecation warning)
- also versions of WW 2.18 and earlier are expecting to hear a param named `coursePassword`, so that is still used in two places by `pretext.py` when it needs to talk to a webwork2 server
- and also I do not want to edit the `pretext-webwork.js` files here that go with old versions of WeBWorK. Copies of those are hosted in places like the utmost server and even with individual projects that are hosted up on the internet somewhere, since we started using local js files. So those files still look for `coursePassword` as a data attribute on a certain div in PTX HTML output. And so that div keeps a data attribute with name `coursePassword` too.

All of this should set things up to simplify the big Tacoma PR with 2.19 support. 