### PR TITLE
Prefig cache prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ doc/guide/webwork-representations.ptx
 script/mjsre/node_modules/
 script/mjsre/package-lock.json
 pretext/__pycache__/**
+pretext/lib/__pycache__/**
 .error_schema.log
 # WW examples
 examples/webwork/Makefile.paths

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -244,8 +244,13 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
 #
 ##############################################
 
-def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_dir, outformat):
+def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_dir, outformat, ext_converter):
     """Extract PreFigure code for diagrams and convert to graphics formats"""
+    # ext_converter: an optinal hook for external libraries to patch
+    #                the conversion of individual images.  The intent is that ext_converter
+    #                attempts to use a cached version of the image, or else calls
+    #                individual_prefigure_conversion() to generate the image (and cache it).
+    #
     # stringparams is a dictionary, best for lxml parsing
     import glob
 
@@ -295,7 +300,10 @@ def prefigure_conversion(xml_source, pub_file, stringparams, xmlid_root, dest_di
 
         # Process each pf_source_file for requested format
         for pfdiagram in pf_source_files:
-            individual_prefigure_conversion(pfdiagram, outformat)
+            if ext_converter:
+                ext_converter(pfdiagram, outformat, tmp_dir)
+            else:
+                individual_prefigure_conversion(pfdiagram, outformat)
 
         # Check to see if we made some diagrams before copying the tree
         if os.path.exists('output'):

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -314,6 +314,15 @@ def individual_prefigure_conversion(pfdiagram, outformat):
     except ImportError:
         raise ImportError(__module_warning.format("prefig"))
 
+    if outformat == "tactile" or outformat == "all":
+        # THe tactile outformat produces a pdf, but is different from the pdf outformat.
+        # After producing the output, it must be moved to the tactile subdirectory.
+        # NB we must do this before the pdf outformat option to avoid overwriting the regular pdf.
+        log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
+        prefig.engine.pdf('tactile', pfdiagram)
+        pdf_name = pfdiagram[:-4] + '.pdf'
+        shutil.move('output/'+pdf_name, 'output/tactile/'+pdf_name)
+
     if outformat == "svg" or outformat == "all":
         log.info("compiling PreFigure source file {} to SVG".format(pfdiagram))
         prefig.engine.build('svg', pfdiagram)
@@ -326,17 +335,6 @@ def individual_prefigure_conversion(pfdiagram, outformat):
         log.info("compiling PreFigure source file {} to PNG".format(pfdiagram))
         prefig.engine.png('svg', pfdiagram)
 
-    if outformat == "tactile":
-        log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
-        prefig.engine.pdf('tactile', pfdiagram)
-
-    if outformat == "all":
-        # We will have already made all but the tactile formats; these need to be
-        # put into a separate directory so this logic is separate.
-        log.info("compiling PreFigure source file {} to tactile PDF".format(pfdiagram))
-        prefig.engine.pdf('tactile', pfdiagram)
-        pdf_name = pfdiagram[:-4] + '.pdf'
-        shutil.move('output/'+pdf_name, 'output/tactile/'+pdf_name)
 
 
 def asymptote_conversion(

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -614,7 +614,7 @@ def main():
         ptx.validate(xml_source, out_file, dest_dir)
     elif args.component == "prefigure":
         if args.format in ["source", "svg", "pdf", "png", "tactile", "all"]:
-            ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format)
+            ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format, None)
         else:
             raise NotImplementedError('cannot make Prefigure graphics in "{}" format'.format(args.format) )
     elif args.component == "asy":


### PR DESCRIPTION
The three commits will allow the CLI to cache prefigure assets, the same as we do for latex, sage, and asymptote.

Note that the middle commit does change the behavior of the script when just tactile outformat is selected.  With the change tactile output will always be put in the `tactile` subfolder.  This way, if someone builds tactile and then pdf, the files won't be overwritten.