### PR TITLE
HTML: Hide toc-toggle and ptx-sidebar when toc-level is 0

### DIFF
--- a/css/components/helpers/_buttons-default.scss
+++ b/css/components/helpers/_buttons-default.scss
@@ -39,6 +39,10 @@ $border-radius: 0 !default;
     cursor: not-allowed;
   }
 
+  &.hidden {
+    display: none;
+  }
+
   &.open {
     color: var(--button-hover-text-color);
     background-color: var(--button-hover-background);

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11759,6 +11759,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="primary-navigation-toc">
     <button class="toc-toggle button">
+        <xsl:if test="not($toc-level)">
+            <xsl:attribute name="class">
+                toc-toggle button hidden
+            </xsl:attribute>
+        </xsl:if>
         <xsl:attribute name="title">
             <xsl:apply-templates select="." mode="type-name">
                 <xsl:with-param name="string-id" select="'toc'"/>
@@ -11778,6 +11783,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ToC sidebar                                                -->
 <xsl:template match="*" mode="sidebars">
     <div id="ptx-sidebar" class="ptx-sidebar">
+        <xsl:if test="not($toc-level)">
+            <xsl:attribute name="class">
+                ptx-sidebar hidden
+            </xsl:attribute>
+        </xsl:if>
         <nav id="ptx-toc">
             <xsl:attribute name="class">
                 <xsl:text>ptx-toc</xsl:text>


### PR DESCRIPTION
Working to fulfill the promise in the Guide's page on Single Page HTML that if you set `tableofcontents/@level` to 0, then "there will be no sidebar Table of Contents at all".