### PR TITLE
WeBWorK: better control over blank lines

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1883,10 +1883,6 @@ def webwork_to_xml(
                 )
             else:
                 formatted_pg = pghuman[problem]
-            # opportunity to cut out extra blank lines
-            formatted_pg = re.sub(
-                re.compile(r"(\n *\n)( *\n)*", re.MULTILINE), r"\n\n", formatted_pg
-            )
             pg.text = ET.CDATA("\n" + formatted_pg)
         elif origin[problem] == "server":
             pg.set("source", source[problem])

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -172,9 +172,14 @@
         </xsl:attribute>
         <!-- 4. human readable PG (for PTX-authored)                               -->
         <pghuman>
-            <xsl:apply-templates select=".">
-                <xsl:with-param name="b-human-readable" select="true()" />
-            </xsl:apply-templates>
+            <xsl:variable name="pg">
+                <xsl:apply-templates select=".">
+                    <xsl:with-param name="b-human-readable" select="true()" />
+                </xsl:apply-templates>
+            </xsl:variable>
+            <xsl:call-template name="consolidate-empty-lines">
+                <xsl:with-param name="text" select="$pg"/>
+            </xsl:call-template>
         </pghuman>
         <!-- 5. PG optimized (and less human-readable) for use in PTX output modes -->
         <pgdense>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -487,9 +487,11 @@
         </xsl:if>
     </xsl:if>
     <!-- pg-code verbatim, but trim indentation -->
-    <xsl:call-template name="sanitize-text">
-        <xsl:with-param name="text" select=".//pg-code" />
-    </xsl:call-template>
+    <xsl:if test=".//pg-code">
+        <xsl:call-template name="sanitize-text">
+            <xsl:with-param name="text" select=".//pg-code" />
+        </xsl:call-template>
+    </xsl:if>
     <!-- if there are latex-image in the problem, put their code here -->
     <!-- introduction images are not needed except for human readable code -->
     <xsl:if test="$b-human-readable">
@@ -560,6 +562,9 @@
     <xsl:apply-templates select="*">
         <xsl:with-param name="b-human-readable" select="$b-human-readable"/>
     </xsl:apply-templates>
+    <xsl:if test="parent::exercisegroup">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="webwork/description">
@@ -1519,6 +1524,7 @@
 </xsl:template>
 
 <xsl:template match="image[latex-image]" mode="latex-image-code">
+    <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="." mode="pg-name"/>
     <xsl:text> = createLaTeXImage();&#xa;</xsl:text>
     <xsl:if test="$docinfo/latex-image-preamble">
@@ -2363,6 +2369,7 @@
     <xsl:apply-templates select="li">
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
+    <xsl:text>&#xa;</xsl:text>
     <!-- When a list ends, there may be more content before the p ends. This  -->
     <!-- content needs to be indented the proper amount when the list was a   -->
     <!-- nested list.                                                         -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -525,6 +525,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- Merge consecutive empty lines -->
+<!-- In other words, if there are three or more consecutive newline -->
+<!-- characters, replace them with just two newline characters.     -->
+<xsl:template name="consolidate-empty-lines">
+    <xsl:param name="text" />
+    <xsl:choose>
+        <xsl:when test="not(contains($text, '&#xa;&#xa;&#xa;'))">
+            <xsl:value-of select="$text" />
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="consolidate-empty-lines">
+                <xsl:with-param name="text" select="str:replace($text,'&#xa;&#xa;&#xa;','&#xa;&#xa;')" />
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- Gobble leading whitespace -->
 <!-- Drop consecutive leading spaces and tabs, only     -->
 <!-- Designed for a single line as input                -->


### PR DESCRIPTION
Over in #2462 I want to refactor so that problem set archives (pg files, set definition files, etc) are generated directly from source. This means `pretext.py` would no longer be part of the process.

Currently, either through laziness or technical limitations, `extract-pg.xsl` produces PG content with excess blank lines in places. And `pretext.py` condenses all such instances into a single blank line. But that will not happen once archiving bypasses `pretext.py`.

So this commit:

- preemptively removes that trimming code from `pretext.py`
- refines `extract-pg.xsl` to produce fewer blank lines in the first place

The net effect is that in some places, the PG output has a blank line where there wasn't one before.

- Sometimes this is actually an improvement: now there is a blank line preceding a block of latex-image code.
- Sometimes this is turning what was a single blank line into a double or triple blank line. This is OK. It happens following lists or list items. I don't think I'll ever work out how to actually suppress the excess blank lines, because of the complications from list items being structured or unstructured. And other complications like if the `p` surrounding the list has test nodes following the list. And is the list the last element in the `p`. And more.

The diff in the problem set archive for the sample chapter only shows these things I just mentioned. I see no diff at all in the latex file output. For HTML, the only diff is in the base64 encoding of the problems. This is the same base64 encoding used to fetch the static versions, which are then written into that latex file. So I am confident that all the problems render in the live HTML.