### PR TITLE
Runestone: remove multiple choice exercise statement from ul

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1001,8 +1001,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="*[@exercise-interactive = 'multiplechoice']" mode="runestone-to-interactive">
     <div class="ptx-runestone-container">
         <div class="runestone multiplechoice_section">
+            <!-- overall statement, not per-choice -->
+            <div class="exercise-statement">
+                <xsl:apply-templates select="statement"/>
+            </div>
             <!-- ul can have multiple answer attribute -->
-            <ul data-component="multiplechoice">
+            <ul data-component="multiplechoice" class="exercise-interactives">
                 <xsl:apply-templates select="." mode="runestone-id-attribute"/>
                 <xsl:variable name="ncorrect" select="count(choices/choice[@correct = 'yes'])"/>
                 <xsl:attribute name="data-multipleanswers">
@@ -1025,9 +1029,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:if test="choices/@randomize = 'yes'">
                     <xsl:attribute name="data-random"/>
                 </xsl:if>
-                <!-- Q: the statement is not a list item, but appears *inside* the list? -->
-                <!-- overall statement, not per-choice -->
-                <xsl:apply-templates select="statement"/>
                 <xsl:apply-templates select="choices/choice">
                     <xsl:with-param name="the-id">
                         <xsl:apply-templates select="." mode="runestone-id"/>


### PR DESCRIPTION
As wondered at in the existing comment, multiplechoice questions are generating invalid HTML by placing the statement inside the `<ul>`. 
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul#technical_summary

I noticed because an attempt to put a mermaid diagram in an exercise did not work correctly.

This moves the statement outside of the `<ul>` and wraps it in a div. The `exercise-statement` and `exercise-interactives` classes can hopefully be slowly added to RS components - currently each component has a largely unique set of styling rules.

This does result in the `Choose one` text being too close to the question. Addressing that in a RS PR to also fix dark mode font color for that text.