### PR TITLE
CSS: ensure .hidden doesn't display

### DIFF
--- a/css/components/elements/_misc-content.scss
+++ b/css/components/elements/_misc-content.scss
@@ -133,7 +133,7 @@ article.theorem-like .emphasis {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 /* genus and species in italics */


### PR DESCRIPTION
@mitchkeller discovered that using the `?embed` query string for embedding a ptx page doesn't always hide the outer page elements on all themes.  For example, in `greeley`, other css display commands were overriding the `.hidden {display: none}`.  

This adds `!important` to the `.hidden` selector's display.  @ascholerChemeketa, any reason you can think of that this would be a bad idea?  It seems like if we have put `hidden` in the class, that should always take precedence.

Tested with all the themes and I didn't notice any problems (and the `?embed` is working as expected now).  