### PR TITLE
Runestone: add exercise-statement class to ac_question

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -2091,7 +2091,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         </xsl:if>
                         <!-- add some lead-in text to the window -->
                         <xsl:if test="$exercise-statement">
-                            <div class="ac_question">
+                            <div class="ac_question exercise-statement">
                                 <xsl:attribute name="id">
                                     <xsl:value-of select="$rsid"/>
                                     <xsl:text>_question</xsl:text>


### PR DESCRIPTION
Adds a class `exercise-statement` to activecodes. Trying to use that style across all RS items that suck in exercise statements.