### PR TITLE
FITB: input width changed to size

### DIFF
--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -57,7 +57,7 @@
             <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
         </xsl:if>
         <xsl:if test="@width">
-            <xsl:attribute name="width"><xsl:value-of select="@width"/></xsl:attribute>
+            <xsl:attribute name="size"><xsl:value-of select="@width"/></xsl:attribute>
         </xsl:if>
     </xsl:element>
 </xsl:template>


### PR DESCRIPTION
The attribute `width` on an HTML text input does not do anything. It should be `size`.