### PR TITLE
Title colon cleanup

### DIFF
--- a/css/components/page-parts/_banner.scss
+++ b/css/components/page-parts/_banner.scss
@@ -39,11 +39,15 @@ $centered-content: false !default;
     padding-left: 9.68px;
     overflow: hidden;
     flex: 1;
-  
+
     .heading {
       font-weight: 700;
       font-size: 100%;
       line-height: 1.25em;
+    }
+
+    .title:has(+ .subtitle)::after {
+      content: ":";
     }
 
     .subtitle {
@@ -103,7 +107,7 @@ $centered-content: false !default;
       flex: unset;
       .heading {
         line-height: 1em;
-        
+
         .subtitle {
           /* Force the subtitle onto a separate line */
           display: block;

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1028,12 +1028,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <h2 class="heading">
         <span class="title">
             <xsl:apply-templates select="$document-root" mode="title-full" />
-            <xsl:if test="$b-has-subtitle">
-                <xsl:text>:</xsl:text>
-            </xsl:if>
         </span>
         <xsl:if test="$b-has-subtitle">
-            <xsl:text> </xsl:text>
             <span class="subtitle">
                 <xsl:apply-templates select="$document-root" mode="subtitle" />
             </span>
@@ -6919,9 +6915,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                         <!-- Do not use shorttitle in masthead,  -->
                                         <!-- which is much like cover of a book  -->
                                         <xsl:apply-templates select="$document-root" mode="title-simple" />
-                                        <xsl:if test="$b-has-subtitle">
-                                            <xsl:text>:</xsl:text>
-                                        </xsl:if>
                                     </span>
                                     <xsl:if test="$b-has-subtitle">
                                         <xsl:text> </xsl:text>
@@ -10952,9 +10945,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <!-- Do not use shorttitle in masthead,  -->
                                     <!-- which is much like cover of a book  -->
                                     <xsl:apply-templates select="$document-root" mode="title-simple" />
-                                    <xsl:if test="$b-has-subtitle">
-                                        <xsl:text>:</xsl:text>
-                                    </xsl:if>
                                 </span>
                                 <xsl:if test="$b-has-subtitle">
                                     <xsl:text> </xsl:text>


### PR DESCRIPTION
As discussed on -dev (https://groups.google.com/g/pretext-dev/c/oUMo42G3Vq0), this removes the colon separating a title from a subtitle (in the three places in the `pretext-html`, and puts it back as CSS just in the masthead.  Expected results are that nothing looks any different in the masthead, but the titlepage, which has the subtitle on the next line, does not have a colon following it.  

Tested successfully both with and without a subtitle.