### PR TITLE
Switch TOC expand/collapse icons to +/-

### DIFF
--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -259,7 +259,7 @@ and then clear indent if there is a codenumber */
     align-items: center;
 
     .icon {
-      font-size: 30px;
+      font-size: 1.25em;
       line-height: 18px;
       font-variation-settings: 'wght' 200;
     }
@@ -272,9 +272,5 @@ and then clear indent if there is a codenumber */
         fill: var(--tocitem-highlight-text-color);
       }
     }
-  }
-
-  .toc-item.expanded > .toc-title-box > .toc-expander > .icon {
-    transform: rotate(-90deg);
   }
 }

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -88,6 +88,8 @@ function toggleTOCItem(expander) {
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
 
+    expander.querySelector('span').innerText = expanded ? "remove" : "add";
+
     let itemType = getTOCItemType(listItem);
     if(expanded) {
         expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
@@ -155,7 +157,7 @@ window.addEventListener("DOMContentLoaded", function(event) {
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
-            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">chevron_left</span>';
+            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">add</span>';
             tocItem.querySelector(".toc-title-box").append(expander);
             expander.addEventListener('click', () => {
                 toggleTOCItem(expander);


### PR DESCRIPTION
Hi, I find the icons currently used for expanding and collapsing sections of the table of contents slightly counter intuitive. I kind of get it in that when the expanders are on the left side of the thing being expanded we use a right-facing triangle so over on the right side it kind of makes sense to use a left facing triangle. But it still bends my brain. Can I interest you in this change?

Before:

<img width="358" alt="image" src="https://github.com/user-attachments/assets/258db788-e92b-46be-b636-3ad1b7cff2bc" />

After:

<img width="353" alt="image" src="https://github.com/user-attachments/assets/b4449ae9-5796-444e-8399-7129ffdcab78" />
