### PR TITLE
TOC customizable icons

### DIFF
--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -101,6 +101,16 @@ $nav-height: 36px !default;
     text-align: left;
     flex-grow: 0;
   }
+
+
+  /* ---------------icon customization----------------- */
+  .toc-item > .toc-title-box > .toc-expander > .icon:before {
+    content: "add";
+  }
+
+  .toc-item.expanded > .toc-title-box > .toc-expander > .icon:before {
+    content: "remove";
+  }
 }
 
 

--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -259,7 +259,7 @@ and then clear indent if there is a codenumber */
     align-items: center;
 
     .icon {
-      font-size: 30px;
+      font-size: 1.25em;
       line-height: 18px;
       font-variation-settings: 'wght' 200;
     }
@@ -272,9 +272,5 @@ and then clear indent if there is a codenumber */
         fill: var(--tocitem-highlight-text-color);
       }
     }
-  }
-
-  .toc-item.expanded > .toc-title-box > .toc-expander > .icon {
-    transform: rotate(-90deg);
   }
 }

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -88,6 +88,8 @@ function toggleTOCItem(expander) {
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
 
+    expander.querySelector('span').innerText = expanded ? "remove" : "add";
+
     let itemType = getTOCItemType(listItem);
     if(expanded) {
         expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
@@ -155,7 +157,7 @@ window.addEventListener("DOMContentLoaded", function(event) {
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
-            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">chevron_left</span>';
+            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">add</span>';
             tocItem.querySelector(".toc-title-box").append(expander);
             expander.addEventListener('click', () => {
                 toggleTOCItem(expander);

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -88,8 +88,6 @@ function toggleTOCItem(expander) {
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
 
-    expander.querySelector('span').innerText = expanded ? "remove" : "add";
-
     let itemType = getTOCItemType(listItem);
     if(expanded) {
         expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
@@ -157,7 +155,8 @@ window.addEventListener("DOMContentLoaded", function(event) {
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
-            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">add</span>';
+            // content of span is set by CSS :before rule.
+            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true"></span>';
             tocItem.querySelector(".toc-title-box").append(expander);
             expander.addEventListener('click', () => {
                 toggleTOCItem(expander);


### PR DESCRIPTION
This is a variation of my earlier PR that allows some customization of the TOC icons via CSS. It is limited to the icons that can be specified in the content of a `<span class="icon material-symbols-outlined" aria-hidden="true"></span>` but that at least accounts for the chevrons of before and the +/- that I'd like to see.

Note. I haven't been able to figure out how to do a full end-to-end test of building the whole pretext CLI, etc. to test these changes but I've tested the JS and CSS by hacking it in my built book. So this should work but apologies if I've misunderstood something about how the scss works.