### PR TITLE
WeBWorK: fix new HTML production with an old representations file

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10640,7 +10640,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="server-data/@user-id"/>
         </xsl:attribute>
         <xsl:attribute name="data-coursePassword">
-            <xsl:value-of select="server-data/@password"/>
+            <xsl:choose>
+                <xsl:when test="server-data/@password">
+                    <xsl:value-of select="server-data/@password"/>
+                </xsl:when>
+                <!-- Old representations files will have @course-password instead of @password -->
+                <xsl:otherwise>
+                    <xsl:value-of select="server-data/@course-password"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:attribute>
         <xsl:attribute name="aria-live">
             <xsl:value-of select="'polite'"/>


### PR DESCRIPTION
In #2499, I overlooked something that this fixes. Note: @bnmnetp would like this in soon, so that it can get to the CLI soon, so that some Runestone books with WeBworK will work again.

A project might have built a representations file in the past that it retained. Perhaps it is cached by the CLI, perhaps it is committed to a repository because there is no expectation that it will change.

With #2499, one detail of the structure of the representation file changed, where the attribute `course-password` became `password`. (This was actually part of recognizing that `user-password` and `course-password` at a deeper level were not both needed, and merging them.) So this means that HTML built *after* #2499 using a representations file from *before* #2499 will not work. The change here makes that scenario work again.

Note to self: for the Tacoma work, much more changes happen to the representations file. I have to decide if more backward compatibility code is appropriate, or if we should just compel people to rebuild their representations files and make an announcement.

