### PR TITLE
Documentation update relating to Interactive Exercises

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2067,7 +2067,7 @@ displayed line, and there are no <c>\\</c>s.  Use <c>\amp</c> to mark the alignm
 
             <p>A True/False exercise <em>must</em> have a <tag>statement</tag> element, and this element <em>must</em> have a <attr>correct</attr> attribute, whose value is <c>yes</c> or <c>no</c> (there is no default value).  That's it.  The presence of the <attr>correct</attr> attribute is the signal that this is a True/False exercise.</p>
 
-            <p>The text of the statement is the assertion the reader must determine is true or not.  The <attr>correct</attr> attribute is how an author describes if the statment is true (<c>yes</c>) or false (<c>no</c>).  This is enough information for a conversion to formulate a version of the question.  An optional <tag>feedback</tag> element may follow the <tag>statement</tag>, and should provide more thatn a binary explanation of the exercise.</p>
+            <p>The text of the statement is the assertion the reader must determine is true or not.  The <attr>correct</attr> attribute is how an author describes if the statment is true (<c>yes</c>) or false (<c>no</c>).  This is enough information for a conversion to formulate a version of the question.  An optional <tag>feedback</tag> element may follow the <tag>statement</tag>, and should provide more than a binary explanation of the exercise.</p>
 
             <p>Presentation as an interactive element will vary cosmetically, according to the output type targeted.</p>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -9591,7 +9591,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <exercise label="dynamic-fitb-simple-formula">
                     <title>Fill-In Formula (Dynamic)</title>
                     <statement>
-                        <p>Find a formula for a cubic function <m>f(x)</m> that roots at <m>x=<eval obj="x1"/></m>,  <m>x=<eval obj="x2"/></m>, and <m>x=<eval obj="x3"/></m> and so that <m>f(0)=<eval obj="y0"/></m>.</p>
+                        <p>Find a formula for a cubic function <m>f(x)</m> that has roots at <m>x=<eval obj="x1"/></m>,  <m>x=<eval obj="x2"/></m>, and <m>x=<eval obj="x3"/></m> and so that <m>f(0)=<eval obj="y0"/></m>.</p>
                         <p><m>f(x)=</m> <fillin name="st_cubic" mode="math" ansobj="cubic"/></p>
                     </statement>
                     <solution>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -9541,6 +9541,53 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </evaluation>
                 </exercise>
 
+                <exercise label="fillin-multi-answer-jscmp">
+                    <title>Fill-In, Multiple Strings, Custom Checker</title>
+
+                    <statement>
+                        <p>
+                            In order to apply the Integral Test to a sequence <m>\{a_n\}</m>,
+                            the function <m>a(n) = a_n</m> must be
+                            <fillin mode="string" answer="continuous"/>, <fillin mode="string" answer="positive"/><nbsp/>and <fillin mode="string" answer="decreasing"/>.
+                        </p>
+                    </statement>
+                    <evaluation>
+                        <evaluate>
+                            <test correct="yes">
+                                <jscmp><![CDATA[
+                                ["continuous","positive","decreasing"].includes(ans)
+                                ]]></jscmp>
+                            </test>
+                        </evaluate>
+                        <evaluate>
+                            <test correct="yes">
+                                <jscmp><![CDATA[
+                                ["continuous","positive","decreasing"].includes(ans) && !ans_array.slice(0,1).includes(ans)
+                                ]]></jscmp>
+                            </test>
+                            <test>
+                                <jscmp><![CDATA[
+                                ans_array.slice(0,1).includes(ans)
+                                ]]></jscmp>
+                                <feedback>You already gave that answer.</feedback>
+                            </test>
+                        </evaluate>
+                        <evaluate>
+                            <test correct="yes">
+                                <jscmp><![CDATA[
+                                ["continuous","positive","decreasing"].includes(ans) && !ans_array.slice(0,2).includes(ans)
+                                ]]></jscmp>
+                            </test>
+                            <test>
+                                <jscmp><![CDATA[
+                                ans_array.slice(0,2).includes(ans)
+                                ]]></jscmp>
+                                <feedback>You already gave that answer.</feedback>
+                            </test>
+                        </evaluate>
+                     </evaluation>
+                </exercise>
+
                 <exercise label="dynamic-fitb-simple-formula">
                     <title>Fill-In Formula (Dynamic)</title>
                     <statement>


### PR DESCRIPTION
Three small updates to documentation:

- sample-article: Add an example for Dynamic Fill-In Exercises illustrating the use of a javascript test using jscmp to facilitate checking multiple blanks so that the order a student answers does not matter.
- sample-article: Correct grammar in a different fill-in exercise that was missing a verb
- guide: Spelling error correction from "thatn" to "than"