### PR TITLE
ToC expander styling differentiation

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -67,3 +67,13 @@ Files in the `target` folder are considered "owned" by the folder they are in. W
 Files in `components` are "shared". Changes to them should consider (and test) all targets that @use the component.
 
 There is a balancing act between the complexity of the include tree for targets and avoiding duplication of effort. Avoid coping/pasting large numbers of rules from one target to another. If you want to reuse some of the rules from another target, consider factoring out those rules into a `component` that the old file and your new one can both @use. But doing so to reuse a small number of CSS rules likely creates more complexity than simply duplicating those rules in your target.
+
+## Tips on differentiating theme code
+
+1) In cases of significantly different CSS, we try to provide different scss files that themes can choose to import (see `_toc-default` vs `_toc-overlay`). As any given theme will only (hopefully) import one of the options, we don't have to worry about cross talk between the CSS. Common features of the two can be factored out into a sheet they both import (`_toc-basics`).
+
+2) In cases of more minor variations, especially those that end up affecting multiple rules (e.g. how much margin to apply, whether or not to round off border corners) we try to pass in a variable to the scss file to control that aspect. Those variables can have defaults that are applied if a theme does not specify a default. The downside here is that variables need to be passed all the way down through any stylesheets that are between the theme and the target sheet. So in this case a theme file like `theme-default-modern` would have to pass $toc-expander-style to  `_toc-default` as it imports that and `_to-default` would then have to pass it to `_toc-basics` where it is applied.
+
+3) Differences that are only value differences in CSS properties can be set as cssvaraibles. We use that for lots of the colors. A low level file can set `border-right: 1px solid var(--toc-border-color);`. Then a theme can change --toc-border-color` and the new color is used.
+
+4) The last approach is to just define CSS in the theme SCSS file that adds to or overrides what is produced in the import. This works well if the change only makes sense in the context of a particular theme AND if they are extending what is already there instead of undoing all of the defaults to replace them with something new.  We do this for things like Salem making a bunch of the RS elements wider. If the same logic needs to be applied to multiple themes, consider making a mixin file that they can opt into (see `toc-expand-chevrons`).

--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -101,6 +101,16 @@ $nav-height: 36px !default;
     text-align: left;
     flex-grow: 0;
   }
+
+
+  /* ---------------icon customization----------------- */
+  .toc-item > .toc-title-box > .toc-expander > .icon:before {
+    content: "add";
+  }
+
+  .toc-item.expanded > .toc-title-box > .toc-expander > .icon:before {
+    content: "remove";
+  }
 }
 
 

--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -259,7 +259,7 @@ and then clear indent if there is a codenumber */
     align-items: center;
 
     .icon {
-      font-size: 30px;
+      font-size: 1.25em;
       line-height: 18px;
       font-variation-settings: 'wght' 200;
     }
@@ -272,9 +272,5 @@ and then clear indent if there is a codenumber */
         fill: var(--tocitem-highlight-text-color);
       }
     }
-  }
-
-  .toc-item.expanded > .toc-title-box > .toc-expander > .icon {
-    transform: rotate(-90deg);
   }
 }

--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -101,16 +101,6 @@ $nav-height: 36px !default;
     text-align: left;
     flex-grow: 0;
   }
-
-
-  /* ---------------icon customization----------------- */
-  .toc-item > .toc-title-box > .toc-expander > .icon:before {
-    content: "add";
-  }
-
-  .toc-item.expanded > .toc-title-box > .toc-expander > .icon:before {
-    content: "remove";
-  }
 }
 
 
@@ -282,5 +272,14 @@ and then clear indent if there is a codenumber */
         fill: var(--tocitem-highlight-text-color);
       }
     }
+  }
+
+  /* ---------------icon customization----------------- */
+  .toc-item > .toc-title-box > .toc-expander > .icon:before {
+    content: "add";
+  }
+
+  .toc-item.expanded > .toc-title-box > .toc-expander > .icon:before {
+    content: "remove";
   }
 }

--- a/css/components/page-parts/extras/_toc-expand-chevrons.scss
+++ b/css/components/page-parts/extras/_toc-expand-chevrons.scss
@@ -1,0 +1,17 @@
+// Use chevrons instead of +/- in ToC expander control
+
+.ptx-toc {
+  .toc-item > .toc-title-box > .toc-expander > .icon {
+    font-size: 30px;
+    &:before {
+      content: "chevron_left";
+    }
+  }
+
+  .toc-item.expanded > .toc-title-box > .toc-expander > .icon {
+    transform: rotate(-90deg);
+    &:before {
+      content: "chevron_left";
+    }
+  }
+}

--- a/css/targets/html/boulder/_customization.scss
+++ b/css/targets/html/boulder/_customization.scss
@@ -1,6 +1,8 @@
 //$color: var(--primary-color) !default;
 //$text-color: white !default;
 
+@use 'components/page-parts/extras/toc-expand-chevrons';
+
 .hide-type .codenumber:not(:empty)::after {
     content: ". ";
 }

--- a/css/targets/html/default-modern/_customization.scss
+++ b/css/targets/html/default-modern/_customization.scss
@@ -2,6 +2,7 @@
 @use 'components/page-parts/extras/navbar-btn-borders';
 @use 'components/page-parts/extras/toc-last-level-plain';
 @use 'components/page-parts/extras/toc-borders';
+@use 'components/page-parts/extras/toc-expand-chevrons';
 
 // used to expand math and RS blocks
 @use 'components/helpers/expandable';

--- a/css/targets/html/denver/_customizations.scss
+++ b/css/targets/html/denver/_customizations.scss
@@ -1,6 +1,9 @@
 $color: var(--primary-color) !default;
 $text-color: white !default;
 
+@use 'components/page-parts/extras/toc-expand-chevrons';
+
+
 .hide-type .codenumber:not(:empty)::after {
     content: " ";
 }

--- a/css/targets/html/greeley/_customization.scss
+++ b/css/targets/html/greeley/_customization.scss
@@ -1,6 +1,9 @@
 //$color: var(--primary-color) !default;
 //$text-color: white !default;
 
+@use 'components/page-parts/extras/toc-expand-chevrons';
+
+
 .hide-type .codenumber:not(:empty)::after {
     content: ". ";
 }

--- a/css/targets/html/tacoma/_customization.scss
+++ b/css/targets/html/tacoma/_customization.scss
@@ -1,4 +1,7 @@
 // more generous spacing for sections/articles
+
+@use 'components/page-parts/extras/toc-expand-chevrons';
+
 section>*:not(:first-child) {
   margin-top: 1.5em;
 }

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -88,6 +88,8 @@ function toggleTOCItem(expander) {
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
 
+    expander.querySelector('span').innerText = expanded ? "remove" : "add";
+
     let itemType = getTOCItemType(listItem);
     if(expanded) {
         expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
@@ -155,7 +157,7 @@ window.addEventListener("DOMContentLoaded", function(event) {
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
-            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">chevron_left</span>';
+            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">add</span>';
             tocItem.querySelector(".toc-title-box").append(expander);
             expander.addEventListener('click', () => {
                 toggleTOCItem(expander);

--- a/js/pretext.js
+++ b/js/pretext.js
@@ -88,8 +88,6 @@ function toggleTOCItem(expander) {
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
 
-    expander.querySelector('span').innerText = expanded ? "remove" : "add";
-
     let itemType = getTOCItemType(listItem);
     if(expanded) {
         expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
@@ -157,7 +155,8 @@ window.addEventListener("DOMContentLoaded", function(event) {
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
-            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true">add</span>';
+            // content of span is set by CSS :before rule.
+            expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true"></span>';
             tocItem.querySelector(".toc-title-box").append(expander);
             expander.addEventListener('click', () => {
                 toggleTOCItem(expander);


### PR DESCRIPTION
Builds on https://github.com/PreTeXtBook/pretext/pull/2527 to restore chevrons to non-Salem themes.

Adds notes to the CSS README about options for projects like this.

First commit should just be squashed into Peter's and credited to him. The expander rules are only needed in the "focused" section.
