### PR TITLE
Runestone: change placement of True or False in static

### DIFF
--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -87,8 +87,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:copy-of select="statement/preceding-sibling::*"/>
     <!-- prompt, followed by ordered list of choices -->
     <statement>
-        <xsl:copy-of select="statement/node()"/>
         <p>True or False?</p>
+        <xsl:copy-of select="statement/node()"/>
     </statement>
     <!-- Hints are authored, not derived from problem formulation -->
     <xsl:copy-of select="hint"/>


### PR DESCRIPTION
A simple swap of two lines of code so that the "True or False?" prompt comes first in static formats.

In PDF, here is the "before" picture:
![image](https://github.com/user-attachments/assets/20c5006d-24b5-44da-8987-c6c80c1c6732)

And here is the "after" picture:
![image](https://github.com/user-attachments/assets/edf4513e-d688-4b35-bd0e-34c1f96e1a3f)
