### PR TITLE
HTML: Refactor permalinks

### DIFF
--- a/css/components/elements/_description-lists.scss
+++ b/css/components/elements/_description-lists.scss
@@ -18,7 +18,7 @@ dl:is(.description-list, .glossary) {
   margin-top: 1em;
   margin-left: 0;
   margin-bottom: 0;
-  overflow: hidden;
+  //overflow: hidden; // Removed to show permalinks
 
   dt {
     font-weight: bold;

--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -1,11 +1,20 @@
 // TODO - refactor
 $opacity: 0.0 !default;
 
-/* so that we can position things (like .autopermalink) absolutely wrt these items */
+/*
+So that we can position things (like .autopermalink) absolutely wrt these items.
+Any element whose permalink should be positioned directly to the left of it
+should be in this list.
+*/
 section,
 article,
+li,
+blockquote,
+figcaption,
+dt,
 .exercisegroup,
 .discussion-like,
+.solution-like,
 .para {
   position: relative;
 }
@@ -22,9 +31,8 @@ article,
   margin-top: 0 !important;
 }
 
-li > .para > .autopermalink {
-  left: -3.4em;
-  top: 0;
+li > .autopermalink {
+  left: -3.5em;
 }
 
 .autopermalink > * {
@@ -32,53 +40,45 @@ li > .para > .autopermalink {
   padding-right: 0.2em;
 }
 
-/* when jumping to a permalink, push down so sticky navbar does not cover */
-:target {
-  scroll-margin-top: 45px;
-}
 
-.para > .autopermalink {
-  margin-top: 0.2em;
-}
-
-.exercises > .autopermalink,
-.introduction > .autopermalink,
-.glossary > .autopermalink {
-  margin-top: 0.3em;
-  /*
-  margin-top: 1em;
-*/
-}
-
+// Move permalink for division titles etc a little bit lower
 .appendix > .autopermalink,
 .chapter > .autopermalink,
 .index > .autopermalink,
-.section > .autopermalink {
-  margin-top: 0.3em;
-  /*
-  margin-top: 2.7em;
-*/
-}
-
+.section > .autopermalink,
 .subsection > .autopermalink,
 .references > .autopermalink,
 .exercises > .autopermalink {
-  margin-top: 0.3em;
-  /*
-  margin-top: 2.0em;
-*/
+  top: 1.5ex;
 }
 
-.subsubsection > .autopermalink {
-  margin-top: 0;
+// In some styles, the autopermalink for paras land right on the border line.
+// This is an attempt to fix that.  TODO: find a more robust solution, maybe
+// using a variable for the left offset of paras inside blocks.
+.assemblage-like > .para > .autopermalink,
+.example-like > .para > .autopermalink,
+.example-like > .exercise-like > .autopermalink,
+.project-like > .para > .autopermalink,
+.project-like > .exercise-like > .autopermalink,
+.project-like > .exercise-like > .introduction > .para > .autopermalink,
+.project-like > .exercise-like > .conclusion > .para > .autopermalink,
+.remark-like > .para > .autopermalink {
+  left: -2.9em;
 }
 
-.exercisegroup > .autopermalink {
-  /*
-  margin-top: 0.3em;
-*/
-  margin-top: 1.4em;
+
+.axiom-like, .example-like, .exercise-like, .solution-like, .assemblage-like, .definition-like, .remark-like, .project-like, .openproblem-like, .computation-like, .theorem-like, .proof, .case, li, dd {
+  > .para:first-of-type > .autopermalink {
+    display:none;
+  }
+
+  > .introduction > .para:first-of-type > .autopermalink {
+    display:none;
+  }
 }
+
+
+// Hover effects
 
 .ptx-content:has(.autopermalink:hover) .autopermalink {
   opacity: 0.2;
@@ -92,7 +92,7 @@ li > .para > .autopermalink {
   opacity: 1;
 }
 
-.permalink-alert { 
+.permalink-alert {
   position: absolute;
   top: -3em;
   left: 5em;
@@ -102,14 +102,18 @@ li > .para > .autopermalink {
   z-index: 2001;
 }
 
-/* the "pink flash" when navigating to a target
-*/
+
+/* when jumping to a permalink, push down so sticky navbar does not cover */
 :target {
-    animation: target-fade 10s 1;
+  scroll-margin-top: 45px;
+  // the "pink flash" when navigating to a target
+  animation: target-fade 10s 1;
 }
 
 @keyframes target-fade {
     0% { background-color: var(--activated-content-bg) }
-    100% { background-color: inherit;
-           opacity: 1; }
+    100% {
+      background-color: inherit;
+      opacity: 1;
+    }
 }

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4576,6 +4576,9 @@ Book (with parts), "section" at level 3
     <xsl:apply-templates select="parent::*" mode="number"/>
 </xsl:template>
 
+<!-- No numbers on pages of worksheets -->
+<xsl:template match="page" mode="serial-number"/>
+
 <!-- Should not drop in here.  Ever. -->
 <xsl:template match="*" mode="serial-number">
     <xsl:text>[NUM]</xsl:text>
@@ -4923,6 +4926,9 @@ Book (with parts), "section" at level 3
 <!-- Structure Numbers: Fragment -->
 <!-- We number serially, see below -->
 <xsl:template match="fragment" mode="structure-number"/>
+
+<!-- worksheet pages are unnumbered -->
+<xsl:template match="page" mode="structure-number"/>
 
 <!-- Should not drop in here.  Ever. -->
 <xsl:template match="*" mode="structure-number">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -696,6 +696,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="$b-is-groupwork">
             <xsl:apply-templates select="." mode="runestone-groupwork"/>
         </xsl:if>
+
+        <!-- Include permalink for the section as last child -->
+        <xsl:apply-templates select="." mode="permalink"/>
     </section>
 </xsl:template>
 
@@ -2094,6 +2097,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="." mode="title-full"/>
             </xsl:when>
         </xsl:choose>
+        <!-- Insert permalink directly below the title or caption -->
+        <xsl:apply-templates select="." mode="permalink"/>
     </figcaption>
 </xsl:template>
 
@@ -4779,6 +4784,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="*">
                     <xsl:with-param name="b-original" select="$b-original" />
                 </xsl:apply-templates>
+                <!-- Insert permalink -->
+                <xsl:apply-templates select="." mode="permalink"/>
             </article>
         </xsl:when>
         <xsl:otherwise>
@@ -4788,6 +4795,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:apply-templates select="." mode="html-id-attribute"/>
                 </xsl:if>
                 <xsl:apply-templates select="." mode="title-full" />
+                <!-- Insert permalink -->
+                <xsl:apply-templates select="." mode="permalink"/>
             </dt>
             <dd>
                 <xsl:apply-templates select="*">
@@ -5026,6 +5035,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="b-original" select="$b-original" />
             <xsl:with-param name="block-type" select="$block-type" />
         </xsl:apply-templates>
+        <!-- Insert a permalink as the last child of the block, but only   -->
+        <!-- if not FIGURE-LIKE (these get their permalink on the caption) -->
+        <xsl:if test="not(&FIGURE-FILTER;)">
+            <xsl:apply-templates select="." mode="permalink"/>
+        </xsl:if>
     </xsl:element>
     <!-- Extraordinary: PROOF-LIKE are not displayed within their-->
     <!-- parent theorem, but as a sibling, following.  It might  -->
@@ -5095,6 +5109,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates>
             <xsl:with-param name="b-original" select="$b-original" />
         </xsl:apply-templates>
+        <!-- Insert permalink -->
+        <xsl:apply-templates select="." mode="permalink"/>
     </div>
 </xsl:template>
 
@@ -5186,6 +5202,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:for-each>
         <!-- INDENT ABOVE ON A WHITESPACE COMMIT -->
+    <!-- Insert permalink -->
+    <xsl:apply-templates select="." mode="permalink"/>
     </div>
 </xsl:template>
 
@@ -5287,6 +5305,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
                     </xsl:otherwise>
                 </xsl:choose>
+                <!-- Insert permalink -->
+                <xsl:apply-templates select="." mode="permalink"/>
             </xsl:element>
         </xsl:otherwise>
     </xsl:choose>
@@ -5315,6 +5335,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:apply-templates select="." mode="html-id-attribute"/>
                 </xsl:if>
                 <xsl:apply-templates select="." mode="title-full" />
+                <!-- Insert permalink -->
+                <xsl:apply-templates select="." mode="permalink"/>
             </xsl:element>
             <xsl:element name="dd">
                 <xsl:apply-templates>
@@ -11421,6 +11443,33 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
+
+
+<!-- ########## -->
+<!-- Permalinks -->
+<!-- ########## -->
+
+<xsl:template match="*" mode="permalink">
+    <div class="autopermalink">
+        <xsl:attribute name="data-description">
+            <xsl:apply-templates select="." mode="tooltip-text"/>
+        </xsl:attribute>
+        <a>
+            <xsl:attribute name="href">
+                <xsl:text>#</xsl:text>
+                <xsl:apply-templates select="." mode="unique-id"/>
+            </xsl:attribute>
+            <xsl:attribute name="title">
+                <xsl:text>Copy permalink for </xsl:text>
+                <xsl:apply-templates select="." mode="tooltip-text"/>
+            </xsl:attribute>
+            <xsl:text>🔗</xsl:text>
+        </a>
+    </div>
+</xsl:template>
+
+<!-- Asides and footnotes don't get permalinks -->
+<xsl:template match="fn|&ASIDE-LIKE;" mode="permalink"/>
 
 
 <!--                     -->


### PR DESCRIPTION
This cleans up permalinks by moving their production to build time rather than using javascript to insert them.  Should make page loads faster, and we have finer control over what gets a permalink.  Took the opportunity to also clean up the CSS a bit (in particular, I want some bonus points since permalinks for figures now show up just to the left of the figure caption).

To test this, I recommend first checking out the first commit and building.  You will see two sets of permalinks: the old ones with the slanted link chain, and new ones with google's material UI horizontal link chain.  That way you can verify that everything that was getting a permalink still is.

In the second commit, I revert the link icon for the new permalinks to the unicode sideways link.  I suggest squashing this commit in with the first one.

Next two commits are for the JS and CSS respectively.  Javascript is much simpler, and we use event listeners rather than hard coding `onclick` into the html.  

As for the XSL, I had to do some Inclusion/Exclusion to get permalinks on what I want but not on the first paragraph of named blocks (which get their own permalink).  Added an entity to handle this.  Also added to pretext-common to explicitly make the `<page>` element non-numbered since this was throwing errors.