### PR TITLE
Add copy-element functionality for program code chunks

### DIFF
--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -50,5 +50,58 @@
   width: 3.0em;
 }
 
+.clipboardable {
+  position: relative;  // To anchor the code-copy button
+  display: flow-root;
 
+  .console + .code-copy {
+    top: 1em;
+  }
 
+  .program + .code-copy {
+    top: 0.5em;
+  }
+
+  .code-copy {
+    position: absolute;
+    right: 0;
+    top: 0;
+    opacity: 0.25;
+    border-width: 0;
+    background: none;
+    cursor: pointer;
+    z-index: 1;
+    white-space-collapse: collapse;
+    padding: 1px;
+    scale: 0.85;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    .checkmark {
+      display: none;
+    }
+
+    &.copied {
+      opacity: 1;
+      color: mediumseagreen;
+      cursor: not-allowed;
+      pointer-events: none;
+
+      .copyicon {
+        display: none;
+      }
+
+      .checkmark {
+        display: inline;
+      }
+    }
+  }
+}
+
+@media print {
+  .code-copy {
+    display: none;
+  }
+}

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1087,3 +1087,33 @@ window.addEventListener("DOMContentLoaded", function(event) {
         }
     }
 });
+
+// START Support for code-copy button functionality
+document.addEventListener("click", (ev) => {
+    const codeBox = ev.target.closest(".clipboardable");
+    if (!navigator.clipboard || !codeBox) return;
+    const button = ev.target.closest(".code-copy");
+    const preContent = codeBox.querySelector("pre").textContent;
+    navigator.clipboard.writeText(preContent);
+    button.classList.toggle("copied")
+    setTimeout(() => button.classList.toggle("copied"), 1000);
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    const elements = document.querySelectorAll(".clipboardable");
+    for (el of elements) {
+        const div = document.createElement("div");
+        div.classList.add("clipboardable");
+        el.classList.remove("clipboardable");
+        el.replaceWith(div);
+        div.insertAdjacentElement("afterbegin", el);
+        div.insertAdjacentHTML("beforeend", `
+    <button class="code-copy" title="Copy code" role="button" aria-label="Copy code" >
+        <span class="copyicon material-symbols-outlined">content_copy</span>
+        <span class="checkmark material-symbols-outlined">check</span>
+    </button>
+            `.trim());
+    }
+});
+// END Support for code-copy button functionality
+

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8709,7 +8709,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original" select="true()" />
     <xsl:element name="pre">
         <xsl:attribute name="class">
-            <xsl:text>code-display tex2jax_ignore</xsl:text>
+            <xsl:text>code-display tex2jax_ignore clipboardable</xsl:text>
         </xsl:attribute>
         <xsl:choose>
             <xsl:when test="not(@showspaces) or (@showspaces = 'none')">
@@ -8727,7 +8727,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original" select="true()" />
     <xsl:element name="pre">
         <xsl:attribute name="class">
-            <xsl:text>code-display tex2jax_ignore</xsl:text>
+            <xsl:text>code-display tex2jax_ignore clipboardable</xsl:text>
         </xsl:attribute>
         <xsl:apply-templates select="cline" />
     </xsl:element>
@@ -9409,7 +9409,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <pre>
             <!-- always identify as coming from "program" -->
             <xsl:attribute name="class">
-                <xsl:text>program</xsl:text>
+                <xsl:text>program clipboardable</xsl:text>
                 <!-- conditionally request line numbers -->
                 <xsl:if test="@line-numbers = 'yes'">
                     <xsl:text> line-numbers</xsl:text>
@@ -9504,7 +9504,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- An interactive command-line session with a prompt, input and output -->
 <xsl:template match="console" mode="code-inclusion">
     <!-- ignore prompt, and pick it up in trailing input -->
-    <pre class="console">
+    <pre class="console clipboardable">
         <xsl:apply-templates select="input|output"/>
     </pre>
 </xsl:template>


### PR DESCRIPTION
This PR adds a copy-to-clipboard button to the top right of program code chunks, similar to the functionality on GitHub Markdown code chunks. Still to do:

- [x] Check how this behaves with activecode and codelens. They should not be affected at all as they are not using class="code-box"
- [x] Should this also work for `<cd>` elements? They only produce a pre element without a surrounding tag, so adding a button would be challenging at the moment, unless we modify it.
- [x] Test different themes
- [x] Test side-by-sides (looks like button not present at all)
- [x] Should this be toggleable somehow at various levels? Or just always on?
- [x] While this sort-of works for console, it would need some adjustment. And there is also the question of what text should be copied in the console case. Currently everything, including prompts etc as well as all of the input and output, is copied.
- [x] The button visually disappears when `@line-numbers` is used