### PR TITLE
Add @randomize for cardsort

### DIFF
--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3285,12 +3285,12 @@ TEST_CASE( "Test the add function" ) {
             <title>Matching Problem, Dates</title>
             <idx>matching US dates</idx>
             <statement>
-                <p>Match each event in United States history with the year it happened.</p>
+                <p>Match each event in United States history with the year it happened. Hint: this one isn't randomized.</p>
             </statement>
             <feedback>
                 <p>Review <url href="https://www.britannica.com/list/25-decade-defining-events-in-us-history" visual="www.britannica.com/list/25-decade-defining-events-in-us-history">Encyclopedia Brittania, 25 Decade-Defining Events in U.S. History</url>url.</p>
             </feedback>
-            <cardsort>
+            <cardsort randomize="no">
                 <match>
                     <premise order="4">Monroe Doctrine</premise>
                     <response>1823</response>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1455,6 +1455,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <div class="runestone cardsort_section">
             <ul data-component="dragndrop" data-question_label="" style="visibility: hidden;">
                 <xsl:apply-templates select="." mode="runestone-id-attribute"/>
+                <xsl:if test="cardsort/@randomize = 'no'">
+                    <xsl:attribute name="data-random">
+                        <xsl:value-of select="cardsort/@randomize"/>
+                    </xsl:attribute>
+                </xsl:if>
                 <span data-subcomponent="question">
                     <xsl:apply-templates select="statement"/>
                 </span>


### PR DESCRIPTION
At Andrew's request, I added @randomize to cardsort.  The default is to randomize so if you don't want the premises shuffled set it to 'no'
