### PR TITLE
Use toggle to select printable worksheet paper size

### DIFF
--- a/css/components/_worksheet.scss
+++ b/css/components/_worksheet.scss
@@ -2,43 +2,37 @@
 
 // Rules in this file apply to both screen and print
 // Print specific rules should go in a file in targets/print-worksheet stylesheet
-
+@use 'components/helpers/buttons-default' as buttons;
 
 .heading .print-links {
-  display: inline-block;
   float: right;
-  vertical-align: top;
-  width: 19%;
-  text-align: right;
-
-  & > a {
+  vertical-align: bottom;
+  .print-link {
     font-family: var(--font-body);
-    font-size: 0.6em;
-    font-weight: bold;
     padding: 0.1em 0.2em;
-    background: #ffa;
-    border: 2px solid green;
-
-    &.us {
-      background: #eef;
-      color: #9b1c2c;
-      border-color: #041E42;
-    }
-
   }
-  & > a + a {
-    margin-left: 0.25em;
+  .material-symbols-outlined {
+    margin-top:5pt;
   }
 }
 
 .print-button {
-  position: relative;
-  right: 2px;
-  background-color: LightGreen;
-  z-index: 1;
-  float: right;
+  @include buttons.ptx-button;
 }
 
+.papersize-select {
+  z-index: 1;
+  .name::after {
+    content: ": ";
+  }
+}
+
+.ws-page-controls {
+  display:flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 1em;
+}
 
 .standalone.worksheet {
   .print-links{

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -35,6 +35,10 @@
   display: none;
 }
 
+.standalone.worksheet .papersize-select {
+  display: none;
+}
+
 
 .standalone.worksheet [data-knowl]:hover,
 .standalone.worksheet [data-knowl]:active,

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -774,6 +774,60 @@ function urlattribute() {
 window.addEventListener("load",function(event) {
 
   if (document.body.classList.contains("worksheet")) {
+    const papersize = localStorage.getItem("papersize");
+    if (papersize) {
+      const radio = document.querySelector(`input[name="papersize"][value="${papersize}"]`);
+      if (radio) {
+        radio.checked = true;
+      }
+      // Set the papersize class on body
+      document.body.classList.remove("a4", "letter");
+      document.body.classList.add(papersize);
+    } else {
+      // Try to set papersize based on user's geographic region
+      // Default to 'letter' for North and South America, 'a4' elsewhere
+        try {
+          fetch('https://ipapi.co/json/')
+            .then(response => response.json())
+            .then(data => {
+          let continent = data && data.continent_code ? data.continent_code : "";
+          let papersize = (continent === "NA" || continent === "SA") ? "letter" : "a4";
+          const radio = document.querySelector(`input[name="papersize"][value="${papersize}"]`);
+          if (radio) {
+            radio.checked = true;
+            localStorage.setItem("papersize", papersize);
+          }
+          document.body.classList.remove("a4", "letter");
+          document.body.classList.add(papersize);
+          console.log("Setting papersize to", papersize);
+            })
+            .catch((err) => {
+            // rethrow to be caught by the outer catch
+            throw err;
+            });
+        } catch (e) {
+          // fallback: default to letter
+          const radio = document.querySelector(`input[name="papersize"][value="letter"]`);
+          if (radio) radio.checked = true;
+        }
+      //NB: the default papersize is set to 'letter' in the body class list.
+    }
+    const papersizeRadios = document.querySelectorAll('input[name="papersize"]');
+    papersizeRadios.forEach(radio => {
+      radio.addEventListener('change', function() {
+        if (this.checked) {
+          document.body.classList.remove("a4", "letter");
+          document.body.classList.add(this.value);
+          localStorage.setItem("papersize", this.value);
+          console.log("Setting papersize to", this.value);
+          // reload the page to apply the new papersize
+          // It does not seem to work to just rerun adjustWorkspace
+          // (maybe because some attributes are already set?)
+          window.location.reload();
+        }
+      });
+    });
+
       console.log("begin adjusting workspace");
 
       var born_hidden_knowls = document.querySelectorAll('article > a[data-knowl]');

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -265,6 +265,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -289,6 +289,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -268,6 +268,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -263,6 +263,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Aktivovat</localization>
     <localization string-id='reset'>Reset</localization>
     <localization string-id='array'>pole</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <localization string-id='print'>Tisk</localization>
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Zavřít</localization>
 </locale>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -274,6 +274,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -313,8 +313,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Reset</localization>
     <!-- Describe an array of fill-in-the-blanks, say for a matrix -->
     <localization string-id='array'>array</localization>
-    <!-- Print page button text -->
+    <!-- "paper size" toggle title                                -->
+    <localization string-id="papersize">Paper size</localization>
+    <!-- Print page button text                                   -->
     <localization string-id='print'>Print</localization>
+    <!-- Print preview tooltip text                               -->
+    <localization string-id='print-preview'>Print preview</localization>
     <!-- Close something interactive                              -->
     <localization string-id='close'>Close</localization>
 

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -269,6 +269,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <localization string-id='papersize'>Tamaño del papel</localization>
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -275,6 +275,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -259,6 +259,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Activer</localization>
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <localization string-id='print'>Imprimer</localization>
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Fermer</localization>
 </locale>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -261,6 +261,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Activer</localization>
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <localization string-id='print'>Imprimer</localization>
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Fermer</localization>
 </locale>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -263,6 +263,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -264,6 +264,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Attiva</localization>
     <localization string-id='reset'>Azzera</localization>
     <localization string-id='array'>tabella</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <localization string-id='print'>Stampa</localization>
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Chiudi</localization>
 </locale>

--- a/xsl/localizations/ku-CKB.xml
+++ b/xsl/localizations/ku-CKB.xml
@@ -307,7 +307,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>ڕێکخستنەوە</localization>
     <!-- Describe an array of fill-in-the-blanks, say for a matrix -->
     <localization string-id='array'>ڕیزکراو</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- Print page button text -->
     <localization string-id='print'>پرنت</localization>
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/nl-NL.xml
+++ b/xsl/localizations/nl-NL.xml
@@ -316,6 +316,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Activeren</localization>
     <!-- Reset an interactive to its original state               -->
     <localization string-id='reset'>Resetten</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -272,6 +272,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='activate'>Ativar</localization>
     <localization string-id='reset'>Redefinir</localization>
     <localization string-id='array'>lista</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -275,6 +275,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='activate'>Activate</localization> -->
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
+    <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -591,18 +591,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="heading-level" select="$heading-level"/>
     </xsl:apply-templates>
 
-    <!-- For a "worksheet" (only), we do it again TWICE, -->
-    <!-- to generate standalone printable and editable   -->
-    <!-- versions. $paper becomes HTML class names, e.g. -->
-    <!-- LOWER CASE "a4" and "letter"                    -->
-    <!-- NB we don't produce these for portable html     -->
+    <!-- For a "worksheet" (only), we do it again, to generate -->
+    <!-- a standalone printable and editable version.          -->
+    <!-- NB we don't produce these for portable html.          -->
     <xsl:if test="self::worksheet and not($b-portable-html)">
         <xsl:apply-templates select="." mode="standalone-worksheet">
-            <xsl:with-param name="paper" select="'letter'"/>
-            <xsl:with-param name="heading-level" select="$heading-level"/>
-        </xsl:apply-templates>
-        <xsl:apply-templates select="." mode="standalone-worksheet">
-            <xsl:with-param name="paper" select="'a4'"/>
             <xsl:with-param name="heading-level" select="$heading-level"/>
         </xsl:apply-templates>
     </xsl:if>
@@ -786,25 +779,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="runestone-progress-indicator"/>
 </xsl:template>
 
-<!-- Worksheets generate two additional versions, each -->
-<!-- designed for printing, on US Letter or A4 paper.  -->
+<!-- Worksheets generate one additional version     -->
+<!-- designed for printing, on Letter or A4 paper.  -->
 <xsl:template match="worksheet" mode="standalone-worksheet">
     <xsl:param name="heading-level"/>
-    <xsl:param name="paper"/>
 
     <xsl:variable name="base-filename">
         <xsl:apply-templates select="." mode="visible-id"/>
     </xsl:variable>
     <xsl:apply-templates select="." mode="file-wrap">
         <xsl:with-param name="filename">
-            <xsl:apply-templates select="." mode="standalone-worksheet-filename">
-                <xsl:with-param name="paper" select="$paper"/>
-             </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="standalone-worksheet-filename"/>
         </xsl:with-param>
         <xsl:with-param name="extra-body-classes">
-            <!-- Hack, include necessary spaces -->
-            <xsl:text> standalone worksheet </xsl:text>
-            <xsl:value-of select="$paper"/>
+            <!-- Hack, include necessary spaces; use letter as default -->
+            <xsl:text> standalone worksheet letter</xsl:text>
         </xsl:with-param>
         <xsl:with-param name="content">
             <xsl:apply-templates select="." mode="structural-division-content">
@@ -951,22 +940,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Links to the "printable" version(s), meant only for "viewable" -->
 <!-- worksheet, so CSS can kill on the "printable" versions         -->
-<!-- $paper is LOWER CASE "a4" and "letter".  We isolate link       -->
-<!-- creation, so we can kill it simply in derivative conversions   -->
+<!-- As of 2025-05-31, this is changing to a single print button    -->
+<!-- and will later change to have the button to popout printable   -->
+<!-- worksheet instead of linking to separate file.                 -->
+<!-- We isolate link creation, so we can kill it simply in          -->
+<!-- derivative  conversions                                        -->
 <xsl:template match="worksheet" mode="standalone-worksheet-links">
-    <xsl:variable name="letter-filename">
-        <xsl:apply-templates select="." mode="standalone-worksheet-filename">
-            <xsl:with-param name="paper" select="'letter'"/>
-        </xsl:apply-templates>
+    <xsl:variable name="filename">
+        <xsl:apply-templates select="." mode="standalone-worksheet-filename"/>
     </xsl:variable>
-    <xsl:variable name="a4-filename">
-        <xsl:apply-templates select="." mode="standalone-worksheet-filename">
-            <xsl:with-param name="paper" select="'a4'"/>
+    <xsl:variable name="print-preview-text">
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'print-preview'"/>
         </xsl:apply-templates>
     </xsl:variable>
     <div class="print-links">
-        <a href="{$a4-filename}" class="a4">A4</a>
-        <a href="{$letter-filename}" class="us">US</a>
+        <a href="{$filename}" class="print-link" title="{$print-preview-text}">
+            <xsl:call-template name="insert-symbol">
+                <xsl:with-param name="name" select="'print'"/>
+            </xsl:call-template>
+        </a>
     </div>
 </xsl:template>
 
@@ -11021,8 +11014,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </xsl:if>
                     <div id="ptx-content" class="ptx-content">
                         <xsl:if test="$b-printable">
-                            <xsl:apply-templates select="." mode="print-button"/>
-                        </xsl:if>
+                            <div class="ws-page-controls">
+                                <xsl:apply-templates select="." mode="papersize-toggle"/>
+                                <xsl:apply-templates select="." mode="print-button"/>
+                            </div>
+                            </xsl:if>
                         <!-- Alternative to "copy-of": convert $content to a  -->
                         <!-- node-set, and then hit with an identity template -->
                         <!-- to duplicate.  Experiment indicates no change in -->
@@ -11747,8 +11743,32 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:apply-templates>
     </xsl:variable>
     <button class="print-button" title="{$print-text}" onClick="window.print()">
-        <span class="name"><xsl:value-of select="$print-text"/></span>
+        <xsl:call-template name="insert-symbol">
+            <xsl:with-param name="name" select="'print'"/>
+        </xsl:call-template>
+        <span class="name">
+            <xsl:value-of select="$print-text"/>
+        </span>
     </button>
+</xsl:template>
+
+<xsl:template match="*" mode="papersize-toggle"/>
+
+<xsl:template match="worksheet" mode="papersize-toggle">
+    <xsl:variable name="papersize">
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'papersize'"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+    <form class="papersize-select" id="papersize-select">
+        <span class="name"><xsl:value-of select="$papersize"/></span>
+        <label>
+            <input type="radio" name="papersize" value="a4"/>A4
+        </label>
+        <label>
+            <input type="radio" name="papersize" value="letter"/>Letter
+        </label>
+    </form>
 </xsl:template>
 
 <!-- Primary Navigation Panels -->
@@ -13758,11 +13778,8 @@ TODO:
 <!-- A template ensures standalone page creation, -->
 <!-- and links to same, are consistent            -->
 <xsl:template match="worksheet" mode="standalone-worksheet-filename">
-    <xsl:param name="paper"/>
-
     <xsl:apply-templates select="." mode="visible-id"/>
-    <xsl:text>-</xsl:text>
-    <xsl:value-of select="$paper"/>
+    <xsl:text>-printable</xsl:text>
     <xsl:text>.html</xsl:text>
 </xsl:template>
 


### PR DESCRIPTION
Instead of having two buttons next to every worksheet leading to two extra html pages for printable worksheets, this PR will create just a single `*-printable.html` standalone file for each worksheet.  This file will have radio buttons to pick between A4 and Letter paper sizes (the selection is saved in local storage, but initially set by guessing the user's location).  

I also tidied up the css for the print buttons and used a single icon for the "print preview" on the main pages.  

Next steps: if this gets merged, I plan to add a toggle for previewing workspace, which would be off by default.  And then.