### PR TITLE
WeBWorK: escape dollar signs

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -2145,7 +2145,11 @@
 <!--   think this is a bug and white space should not prevent        -->
 <!--   the action.                                                   -->
 <!--                                                                 -->
-<!-- * &, %, $, ^, ~  No need to escape in PGML                      -->
+<!-- * &, %, ^, ~  No need to escape in PGML                         -->
+<!--                                                                 -->
+<!-- * $  No need to escape dollar in PGML, however this needs to be -->
+<!--      escaped when in image descriptions. And harmless to escape -->
+<!--      in PGML.                                                   -->
 <!--                                                                 -->
 <!-- * _  If there are two of these in a line, the parts in          -->
 <!--      between are italicized.                                    -->
@@ -2227,7 +2231,8 @@
 
     <!-- Backslash first, since more will be introduced in other replacements -->
     <xsl:variable name="backslash-fixed" select="str:replace($text,            '\', '\\')"/>
-    <xsl:variable name="asterisk-fixed"  select="str:replace($backslash-fixed, '*', '\*')"/>
+    <xsl:variable name="dollar-fixed"    select="str:replace($backslash-fixed, '$', '\$')"/>
+    <xsl:variable name="asterisk-fixed"  select="str:replace($dollar-fixed,    '*', '\*')"/>
     <xsl:variable name="hash-fixed"      select="str:replace($asterisk-fixed,  '#', '\#')"/>
     <xsl:variable name="lbrace-fixed"    select="str:replace($hash-fixed,      '{', '\{')"/>
     <xsl:variable name="rbrace-fixed"    select="str:replace($lbrace-fixed,    '}', '\}')"/>


### PR DESCRIPTION
Dollar signs do not need to be escaped when written in PGML. But they can be, and it's harmless.

Meanwhile, dollar signs an author writes will soon (with 2.19 support) show up in a PG file, inside the string used for an image description. They do need to be escaped there as this usage is beyond the scope of PGML. So this tiny PR escapes them now.

There is a diff in PG output from the backslashes that this adds. (But not in LaTeX or PDF.) It will be nice a few PRs later, when 2.19 support really comes in, for the dollar-sign-escaping to already be done and not part of that later large diff.