### PR TITLE
WeBWorK: multiple choice repair for 2.19

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2697,12 +2697,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This may only be needed as support for older servers' generated PreTeXt. -->
 <xsl:template match="statement//var[@form = 'checkboxes']/li[(p[. = '?']) or (normalize-space(.) = '?')]" mode="webwork-rep-to-static"/>
 
-<!-- "var/@form" come back from the server as a result of authored -->
+<!-- @form comes back from the server as a result of authored      -->
 <!-- "answer forms" and should be rendered as lists in static      -->
 <!-- representations.                                              -->
 <!-- NB: this does not preclude the match below (scrubbing default -->
 <!-- items) from functioning.                                      -->
-<xsl:template match="statement//var[@form]" mode="webwork-rep-to-static">
+<xsl:template match="statement//ul[@form]|statement//var[@form]" mode="webwork-rep-to-static">
     <ul>
         <!-- duplicate attributes, but for @form -->
         <xsl:apply-templates select="@*[not(name() = 'form')]" mode="repair"/>
@@ -2726,6 +2726,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:attribute>
         <xsl:apply-templates select="node()" mode="webwork-rep-to-static"/>
     </ul>
+</xsl:template>
+
+<xsl:template match="statement//ol[@form]" mode="webwork-rep-to-static">
+    <ol>
+        <!-- duplicate attributes, but for @form -->
+        <xsl:apply-templates select="@*[not(name() = 'form')]" mode="repair"/>
+        <!-- internal attribute to indicate WW origins -->
+        <xsl:attribute name="pi:ww-form">
+            <xsl:value-of select="@form"/>
+        </xsl:attribute>
+        <xsl:apply-templates select="node()" mode="webwork-rep-to-static"/>
+    </ol>
+</xsl:template>
+
+<xsl:template match="statement//dl[@form]" mode="webwork-rep-to-static">
+    <dl>
+        <!-- duplicate attributes, but for @form -->
+        <xsl:apply-templates select="@*[not(name() = 'form')]" mode="repair"/>
+        <!-- internal attribute to indicate WW origins -->
+        <xsl:attribute name="pi:ww-form">
+            <xsl:value-of select="@form"/>
+        </xsl:attribute>
+        <xsl:apply-templates select="node()" mode="webwork-rep-to-static"/>
+    </dl>
 </xsl:template>
 
 <!-- Default xeroxing template -->


### PR DESCRIPTION
After this PR and #2541 are processed, I have a branch ready to submit that covers local PG processing for making representations. (It speeds up representation-making by a lot.) That only works when the local PG repository is 2.19 (or later) though. PG 2.19 sends static PTX back where a few things are slightly differently compared with 2.17, most notably in the multiple choice family of questions. Multiple choice were redesigned somewhere along the way with 2.19.

So for the sake of the local PG pull request that is coming up, this PR adds a bit of the 2.19 support needed so the local PG 2.19 can work. (There will be larger changes on the `webwork2` side when I get to supporting 2.19 all the way.)

I could include these changes with the local PG processing PR, but this feels logically separate. It happens to be needed for local PG processing, but it is really about supporting PG 2.19 in general.