### PR TITLE
FITB: Refactoring dynamic-feedback and defensive JSON creation

### DIFF
--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -1177,7 +1177,7 @@
 
 <xsl:template match="feedback" mode="serialize-feedback">
     <xsl:variable name="feedback-rtf">
-        <xsl:apply-templates select="*" mode="body"/>
+        <xsl:apply-templates select="*" />
     </xsl:variable>
     <!-- serialize HTML as text, then escape as JSON -->
     <xsl:call-template name="escape-json-string">

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -15,17 +15,6 @@
 <!-- Actual rules for substution when generating HTML     -->
 <!-- ==================================================== -->
 
-<!-- These need to be replaced by localization calls.      -->
-<!-- Or maybe push localization strings to Runestone,      -->
-<!-- since this feedback is only useful in an interactive. -->
-<xsl:variable name="defaultCorrectFeedback">
-    <p>Correct!</p>
-</xsl:variable>
-
-<xsl:variable name="defaultIncorrectFeedback">
-    <p>Incorrect.</p>
-</xsl:variable>
-
 <!-- Convert fillin tag to an input element on the page -->
 <xsl:template match="exercise[@exercise-interactive='fillin']//fillin
                      | project[@exercise-interactive='fillin']//fillin
@@ -373,6 +362,25 @@
 <!-- Evaluation and Feedback                                    -->
 <!-- ========================================================== -->
 
+<!-- Default localized feedback strings. -->
+<xsl:template match="*" mode="get-default-feedback">
+    <xsl:param name="b-correct" select="'no'"/>
+    <xsl:choose>
+        <xsl:when test="$b-correct='yes'">
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'correct'"/>
+            </xsl:apply-templates>
+            <xsl:text>!</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'incorrect'"/>
+            </xsl:apply-templates>
+            <xsl:text>.</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- Deal with possibility of global checker for all blanks -->
 <xsl:template match="evaluation" mode="get-multianswer-check">
     <xsl:variable name="responseTree" select="../statement//fillin" />
@@ -493,7 +501,9 @@
                 </xsl:when>
             </xsl:choose>
             <xsl:text>, "feedback": "</xsl:text>
-            <xsl:value-of select="$defaultCorrectFeedback"/>
+            <xsl:apply-templates select="." mode="get-default-feedback">
+                <xsl:with-param name="b-correct" select="'yes'"/>
+            </xsl:apply-templates>
             <xsl:text>"}</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -507,7 +517,9 @@
     </xsl:for-each>
     <!-- Default feedback for the blank. Always evaluates true.   -->
     <xsl:text>, {"feedback": "</xsl:text>
-    <xsl:value-of select="$defaultIncorrectFeedback"/>
+    <xsl:apply-templates select="." mode="get-default-feedback">
+        <xsl:with-param name="b-correct" select="'no'"/>
+    </xsl:apply-templates>
     <xsl:text>"}]</xsl:text>
 </xsl:template>
 
@@ -531,11 +543,10 @@
                 </xsl:with-param>
             </xsl:call-template>
         </xsl:when>
-        <xsl:when test="$b-correct">
-            <xsl:value-of select="$defaultCorrectFeedback"/>
-        </xsl:when>
         <xsl:otherwise>
-            <xsl:value-of select="$defaultIncorrectFeedback"/>
+            <xsl:apply-templates select="." mode="get-default-feedback">
+                <xsl:with-param name="b-correct" select="$b-correct"/>
+            </xsl:apply-templates>
         </xsl:otherwise>
     </xsl:choose>
 <xsl:text>"}</xsl:text>

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -143,7 +143,7 @@
                     <xsl:text>,&#xa;"feedbackArray": [</xsl:text>
                     <!-- In case all answers are based on one test               -->
                     <xsl:variable name="multiAns">
-                        <xsl:apply-templates select="evaluation" mode="get-multianswer-check" />
+                        <xsl:apply-templates select="evaluation" mode="get-multianswer-check"/>
                     </xsl:variable>
                     <!-- Generate test/feedback pair for each fillin             -->
                     <xsl:apply-templates select="statement//fillin" mode="dynamic-feedback">
@@ -386,71 +386,36 @@
     <xsl:variable name="responseTree" select="../statement//fillin" />
     <xsl:if test="count($responseTree) > 1 and evaluate[@all='yes']/test">
         <xsl:apply-templates select="evaluate[@all='yes']/test" mode="create-test-feedback">
+            <xsl:with-param name="b-correct" select="'yes'"/>
             <xsl:with-param name="fillin" select="$responseTree"/>
         </xsl:apply-templates>
     </xsl:if>
 </xsl:template>
 
+<!-- Return the index of an evaluate -->
+<xsl:template match="evaluation/evaluate" mode="get-index">
+    <xsl:value-of select="position()"/>
+</xsl:template>
 
-<!-- Template for answer checking. Actual work done by specialized templates. -->
-<xsl:template match="fillin" mode="dynamic-feedback">
+<!-- Build feedback based on the #evaluate element. -->
+<xsl:template match="evaluate" mode="dynamic-feedback">
     <xsl:param name="multiAns"/>
-    <xsl:variable name="curFillIn" select="."/>
-    <xsl:variable name="fillinName">
-        <xsl:apply-templates select="." mode="blank-name"/>
-    </xsl:variable>
-    <xsl:variable name="blankNum">
-        <xsl:value-of select="position()" />
-    </xsl:variable>
-    <xsl:variable name="check">
-        <xsl:choose>
-            <xsl:when test="ancestor::statement/../evaluation/evaluate[@name = $fillinName]">
-                <xsl:copy-of select="ancestor::statement/../evaluation/evaluate[@name = $fillinName]"/>
-            </xsl:when>
-            <xsl:when test="ancestor::statement/../evaluation/evaluate[position() = $blankNum]">
-                <xsl:copy-of select="ancestor::statement/../evaluation/evaluate[position() = $blankNum]"/>
-            </xsl:when>
-            <!-- No check matches: Make blank default. -->
-            <xsl:otherwise>
-                <evaluate>
-                    <xsl:attribute name="name">
-                        <xsl:value-of select="$fillinName"/>
-                    </xsl:attribute>
-                    <test>
-                        <xsl:attribute name="correct">
-                            <xsl:text>yes</xsl:text>
-                        </xsl:attribute>
-                        <jscmp>
-                            <xsl:text>false</xsl:text>
-                        </jscmp>
-                        <feedback>
-                            <xsl:text>No comparison rule was provided.</xsl:text>
-                        </feedback>
-                    </test>
-                </evaluate>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="checkCorrectTest">
-        <xsl:choose>
-            <xsl:when test="exsl:node-set($check)/evaluate/test[@correct='yes']">
-                <xsl:copy-of select="exsl:node-set($check)/evaluate/test[@correct='yes']"/>
-            </xsl:when>
-            <!-- If no test matches @correct='yes', then use the default answer. Leave blank. -->
-        </xsl:choose>
-    </xsl:variable>
-    <xsl:if test="$blankNum > 1">
-        <xsl:text>, </xsl:text>
+    <xsl:param name="match-fillin"/>
+
+    <!-- Defend against name mismatches -->
+    <xsl:if test="@name and $match-fillin/@name and not(@name = $match-fillin/@name)">
+        <xsl:message>PTX:WARNING:   evaluate element for FITB matched by number has a mismatching blank name.</xsl:message>
     </xsl:if>
+
     <!-- First check is for correctness. -->
     <xsl:text>[</xsl:text>
     <xsl:choose>
-        <xsl:when test="string-length($multiAns)>0">
+        <xsl:when test="string-length($multiAns) > 0">
             <xsl:value-of select="$multiAns"/>
         </xsl:when>
-        <xsl:when test="string-length($checkCorrectTest) > 0">
-            <xsl:apply-templates select="exsl:node-set($checkCorrectTest)/test" mode="create-test-feedback">
-                <xsl:with-param name="fillin" select="$curFillIn" />
+        <xsl:when test="test[@correct='yes']">
+            <xsl:apply-templates select="test[@correct='yes']" mode="create-test-feedback">
+                <xsl:with-param name="fillin" select="$match-fillin" />
                 <xsl:with-param name="b-correct" select="'yes'" />
             </xsl:apply-templates>
         </xsl:when>
@@ -458,46 +423,44 @@
         <xsl:otherwise>
             <xsl:text>{</xsl:text>
             <xsl:choose>
-                <xsl:when test="$curFillIn/@answer">
+                <xsl:when test="$match-fillin/@answer">
                     <xsl:choose>
-                        <xsl:when test="$curFillIn/@mode='number'">
+                        <xsl:when test="$match-fillin/@mode='number'">
                             <xsl:text>"number": [</xsl:text>
-                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                            <xsl:value-of select="$match-fillin/@answer"/>
                             <xsl:text>,</xsl:text>
-                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                            <xsl:value-of select="$match-fillin/@answer"/>
                             <xsl:text>]</xsl:text>
                         </xsl:when>
-                        <xsl:when test="$curFillIn/@mode='string'">
+                        <xsl:when test="$match-fillin/@mode='string'">
                             <xsl:text>"regex": "</xsl:text>
-                            <xsl:value-of select="exsl:node-set($curFillIn)/@answer"/>
+                            <xsl:value-of select="$match-fillin/@answer"/>
                             <xsl:text>"</xsl:text>
                         </xsl:when>
                     </xsl:choose>
                 </xsl:when>
-                <xsl:when test="$curFillIn/@ansobj">
+                <xsl:when test="$match-fillin/@ansobj">
                     <xsl:choose>
-                        <xsl:when test="$curFillIn/@mode='number'">
+                        <xsl:when test="$match-fillin/@mode='number'">
                             <xsl:text>function() {&#xa;</xsl:text>
                             <xsl:text>    return (Math.abs(</xsl:text>
-                            <xsl:value-of select="$curFillIn/@ansobj"/>
+                            <xsl:value-of select="$match-fillin/@ansobj"/>
                             <xsl:text>- ans) &lt; 1e-10);&#xa;}</xsl:text>
                         </xsl:when>
-                        <xsl:when test="$curFillIn/@mode='string'">
+                        <xsl:when test="$match-fillin/@mode='string'">
                             <xsl:text>function() {&#xa;</xsl:text>
                             <xsl:text>    return (</xsl:text>
-                            <xsl:value-of select="$curFillIn/@ansobj"/>
+                            <xsl:value-of select="$match-fillin/@ansobj"/>
                             <xsl:text>== ans);&#xa;}</xsl:text>
                         </xsl:when>
+                        <xsl:when test="$match-fillin/@mode='math'">
+                            <xsl:text>function() {&#xa;</xsl:text>
+                            <xsl:text>    return _mobjs.compareExpressions(</xsl:text>
+                            <xsl:value-of select="$match-fillin/@ansobj"/>
+                            <xsl:text>, ans</xsl:text>
+                            <xsl:text>);&#xa;}</xsl:text>
+                        </xsl:when>
                     </xsl:choose>
-                </xsl:when>
-                <xsl:when test="$curFillIn/@mode='math'">
-                    <xsl:text>function() {&#xa;</xsl:text>
-                    <xsl:text>    return _mobjs.compareExpressions(</xsl:text>
-                    <xsl:value-of select="$curFillIn/@ansobj"/>
-                    <xsl:text>, ans</xsl:text>
-                    <!-- Can we use ans above instead of $curFillIn/@name? -->
-                    <!-- xsl:value-of select="exsl:node-set($curFillIn)/@name"/-->
-                    <xsl:text>);&#xa;}</xsl:text>
                 </xsl:when>
             </xsl:choose>
             <xsl:text>, "feedback": "</xsl:text>
@@ -509,10 +472,10 @@
     </xsl:choose>
 
     <!-- Now add additional checks for feedback. -->
-    <xsl:for-each select="exsl:node-set($check)//test[not(@correct='yes')]">
+    <xsl:for-each select="test[not(@correct='yes')]">
         <xsl:text>, </xsl:text>
         <xsl:apply-templates select="." mode="create-test-feedback">
-            <xsl:with-param name="fillin" select="$curFillIn"/>
+            <xsl:with-param name="fillin" select="$match-fillin"/>
         </xsl:apply-templates>
     </xsl:for-each>
     <!-- Default feedback for the blank. Always evaluates true.   -->
@@ -521,6 +484,73 @@
         <xsl:with-param name="b-correct" select="'no'"/>
     </xsl:apply-templates>
     <xsl:text>"}]</xsl:text>
+</xsl:template>
+
+<!-- Template for answer checking. Actual work done by specialized templates. -->
+<xsl:template match="fillin" mode="dynamic-feedback">
+    <xsl:param name="multiAns"/>
+    <xsl:variable name="curFillIn" select="."/>
+    <xsl:variable name="fillinName">
+        <xsl:apply-templates select="." mode="blank-name"/>
+    </xsl:variable>
+    <xsl:variable name="blankNum">
+        <xsl:value-of select="position()" />
+    </xsl:variable>
+
+    <!-- we need to know which #evaluate matches the #fillin -->
+    <xsl:variable name="evaluate-index">
+        <xsl:choose>
+            <xsl:when test="ancestor::statement/../evaluation/evaluate[@name = $fillinName]">
+                <xsl:apply-templates select="ancestor::statement/../evaluation/evaluate[@name = $fillinName]" mode="get-index"/>
+            </xsl:when>
+            <xsl:when test="ancestor::statement/../evaluation/evaluate[position() = $blankNum]">
+                <xsl:value-of select="$blankNum"/>
+            </xsl:when>
+            <!-- No check matches: Make blank default. -->
+            <xsl:otherwise>
+                <xsl:number value="-1"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+    <xsl:if test="$blankNum > 1">
+        <xsl:text>, </xsl:text>
+    </xsl:if>
+    <xsl:choose>
+        <!-- First look for a matching name. -->
+        <xsl:when test="ancestor::statement/../evaluation/evaluate[@name = $fillinName]">
+            <xsl:apply-templates select="ancestor::statement/../evaluation/evaluate[@name = $fillinName]" mode="dynamic-feedback">
+                <xsl:with-param name="multiAns" select="$multiAns"/>
+                <xsl:with-param name="match-fillin" select="."/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- Otherwise match on order. -->
+        <xsl:when test="ancestor::statement/../evaluation/evaluate[position() = $blankNum]">
+            <xsl:apply-templates select="ancestor::statement/../evaluation/evaluate[position() = $blankNum]" mode="dynamic-feedback">
+                <xsl:with-param name="multiAns" select="$multiAns"/>
+                <xsl:with-param name="match-fillin" select="."/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- No check matches: Make blank default. -->
+        <xsl:otherwise>
+            <evaluate>
+                <xsl:attribute name="name">
+                    <xsl:value-of select="$fillinName"/>
+                </xsl:attribute>
+                <test>
+                    <xsl:attribute name="correct">
+                        <xsl:text>yes</xsl:text>
+                    </xsl:attribute>
+                    <jscmp>
+                        <xsl:text>false</xsl:text>
+                    </jscmp>
+                    <feedback>
+                        <xsl:text>No comparison rule was provided.</xsl:text>
+                    </feedback>
+                </test>
+            </evaluate>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="test" mode="create-test-feedback">


### PR DESCRIPTION
Refactored `mode='dynamic-feedback'` from just matching `#fillin` to reference `#evaluate` so that the feedback evaluation is directly accessed instead of using exsl:node-tree. This allows localization within feedback creation since now the template has access to the language attribute of the original node-tree.

Removed `mode='body'` in template call on feedback element (was missed on an earlier clean-up)

Went through all of the `<xsl:choose>` and ensure that either `<xsl:otherwise>` was present, or not necessary, or flagged an error. This is the underlying cause of #2458. A problem that lacks a mode will now trigger an error, as will using undefined modes or missing or mismatching `#evaluate` elements.