### PR TITLE
Normalize and fix rendering of authored whitespace in programs for HTML

### DIFF
--- a/examples/hello-world/hello-world.xml
+++ b/examples/hello-world/hello-world.xml
@@ -38,7 +38,119 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- 6.  Experiment with other available conversions                                    -->
 
 <pretext>
-    <article xml:id="hello-world">
-       <p>Hello, World!</p>
-    </article>
+  <article xml:id="hello-world">
+    
+    <p>No whitespace at all - inline elements/content</p>
+    <program>
+      <preamble>AAAAAAAAAAAAAAAAA</preamble>
+      <code>BBBBBBBBBBBBBBB</code>
+      <postamble>CCCCCCCCCCCCCCCC</postamble>
+    </program>
+
+    <p>Only formatting newlines... no authored blank lines</p>
+    <program>
+      <preamble>
+AAAAAAAAAAAAAAAAA
+      </preamble>
+      <code>
+BBBBBBBBBBBBBBB
+      </code>
+      <postamble>
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+    <p>Spacing in code - 2 authored blank lines</p>
+    <program>
+      <preamble>
+AAAAAAAAAAAAAAAAA
+      </preamble>
+      <code>
+
+
+BBBBBBBBBBBBBBB
+
+
+      </code>
+      <postamble>
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+    <p>Spacing in pre/postamble - 2 authored blank lines</p>
+    <program>
+      <preamble>
+AAAAAAAAAAAAAAAAA
+
+
+      </preamble>
+      <code>
+BBBBBBBBBBBBBBB
+      </code>
+      <postamble>
+
+
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+
+    <p>No whitespace at all - inline elements/content</p>
+    <program interactive="activecode" language="python">
+      <preamble>AAAAAAAAAAAAAAAAA</preamble>
+      <code>BBBBBBBBBBBBBBB</code>
+      <postamble>CCCCCCCCCCCCCCCC</postamble>
+    </program>
+
+    <p>Only formatting newlines... no authored blank lines</p>
+    <program interactive="activecode" language="python">
+      <preamble>
+AAAAAAAAAAAAAAAAA
+      </preamble>
+      <code>
+BBBBBBBBBBBBBBB
+      </code>
+      <postamble>
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+
+    <p>Spacing in code - 2 authored blank lines</p>
+    <program interactive="activecode" language="python">
+      <preamble>
+AAAAAAAAAAAAAAAAA
+      </preamble>
+      <code>
+
+
+BBBBBBBBBBBBBBB
+
+
+      </code>
+      <postamble>
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+    <p>Spacing in pre/postamble - 2 authored blank lines</p>
+    <program interactive="activecode" language="python">
+      <preamble>
+AAAAAAAAAAAAAAAAA
+
+
+      </preamble>
+      <code>
+BBBBBBBBBBBBBBB
+      </code>
+      <postamble>
+
+
+CCCCCCCCCCCCCCCC
+      </postamble>
+    </program>
+
+    
+
+  </article>
 </pretext>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9470,22 +9470,36 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- build up full program text so we can apply sanitize-text to entire blob -->
                 <!-- and thus allow relative indentation for preamble/code/postamble         -->
                 <xsl:variable name="program-text">
+                    <!-- each section MUST end in a newline and author might not have provided one -->
+                    <!-- so first, remove up to one newline from front/back as appropriate         -->
+                    <!-- then add newline to end                                                   -->
+                    <!-- preamble - clean up end                                                   -->
                     <xsl:if test="preamble[not(@visible = 'no')]">
-                        <xsl:call-template name="substring-before-last">
-                            <xsl:with-param name="input" select="preamble" />
-                            <xsl:with-param name="substr" select="'&#xA;'" />
+                        <xsl:call-template name="trim-end">
+                            <xsl:with-param name="text" select="preamble" />
+                            <xsl:with-param name="preserve-intentional" select="true()" />
                         </xsl:call-template>
                     </xsl:if>
-                    <!-- code section MUST end with newline, which author may or may not have included      -->
-                    <!-- so remove up to one newline and trailing space from end of code then add a newline -->
-                    <xsl:call-template name="strip-trailing-whitespace-line">
-                        <xsl:with-param name="text" select="code" />
+                    <!-- code - clean up start and end                                             -->
+                    <xsl:variable name="code-clean">
+                      <xsl:call-template name="trim-start-lines">
+                          <xsl:with-param name="text" select="code" />
+                          <xsl:with-param name="preserve-intentional" select="true()" />
+                      </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:call-template name="trim-end">
+                        <xsl:with-param name="text" select="$code-clean" />
+                        <xsl:with-param name="preserve-intentional" select="true()" />
                     </xsl:call-template>
-                    <xsl:text>&#xA;</xsl:text>
+                    <!-- postamble - clean up start                                               -->
                     <xsl:if test="postamble[not(@visible = 'no')]">
-                        <xsl:value-of select="substring-after(postamble,'&#xA;')" />
+                      <xsl:call-template name="trim-start-lines">
+                          <xsl:with-param name="text" select="postamble" />
+                          <xsl:with-param name="preserve-intentional" select="true()" />
+                      </xsl:call-template>
                     </xsl:if>
                 </xsl:variable>
+                <!-- now sanitize the whole blob -->
                 <xsl:call-template name="sanitize-text">
                     <xsl:with-param name="text" select="$program-text" />
                 </xsl:call-template>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -2087,28 +2087,38 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:value-of select="str:padding($program-left-margin, ' ')" />
                             </xsl:variable>
                             <xsl:variable name="program-text">
+                                <!-- each section MUST end in a newline and author might not have provided one -->
+                                <!-- so first, remove up to one newline from front/back as appropriate         -->
+                                <!-- then add newline to end                                                   -->
+                                <!-- preamble - clean up end                                                   -->
                                 <xsl:for-each select="preamble">
                                     <!-- only expect one, for-each just for binding -->
-                                    <xsl:call-template name="substring-before-last">
-                                        <xsl:with-param name="input" select="." />
-                                        <xsl:with-param name="substr" select="'&#xA;'" />
+                                    <xsl:call-template name="trim-end">
+                                        <xsl:with-param name="text" select="." />
+                                        <xsl:with-param name="preserve-intentional" select="true()" />
                                     </xsl:call-template>
-                                    <xsl:text>&#xa;</xsl:text>
                                     <xsl:value-of select="$left-margin-string"/>
                                     <xsl:choose>
                                         <xsl:when test='@visible = "no"'>
-                                            <xsl:text>^^^^</xsl:text>
+                                            <xsl:text>^^^^&#xa;</xsl:text>
                                         </xsl:when>
                                         <xsl:otherwise>
-                                            <xsl:text>^^^!</xsl:text>
+                                            <xsl:text>^^^!&#xa;</xsl:text>
                                         </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:for-each>
-                                <xsl:call-template name="substring-before-last">
-                                    <xsl:with-param name="input" select="code" />
-                                    <xsl:with-param name="substr" select="'&#xA;'" />
+                                <!-- code - clean up start and end                                             -->
+                                <xsl:variable name="code-clean">
+                                  <xsl:call-template name="trim-start-lines">
+                                      <xsl:with-param name="text" select="code" />
+                                      <xsl:with-param name="preserve-intentional" select="true()" />
+                                  </xsl:call-template>
+                                </xsl:variable>
+                                <xsl:call-template name="trim-end">
+                                    <xsl:with-param name="text" select="$code-clean" />
+                                    <xsl:with-param name="preserve-intentional" select="true()" />
                                 </xsl:call-template>
-                                <xsl:text>&#xA;</xsl:text>
+                                <!-- postamble - clean up start                                               -->
                                 <xsl:for-each select="postamble">
                                     <!-- only expect one, for-each just for binding -->
                                     <xsl:value-of select="$left-margin-string"/>
@@ -2120,10 +2130,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                             <xsl:text>===!&#xa;</xsl:text>
                                         </xsl:otherwise>
                                     </xsl:choose>
-                                    <xsl:value-of select="substring-after(.,'&#xA;')" />
+                                    <xsl:call-template name="trim-start-lines">
+                                        <xsl:with-param name="text" select="." />
+                                        <xsl:with-param name="preserve-intentional" select="true()" />
+                                    </xsl:call-template>
                                 </xsl:for-each>
                             </xsl:variable>
-                            <!-- assembled code as text -->
+                            <!-- now sanitize the whole blob -->
                             <xsl:call-template name="sanitize-text">
                                 <xsl:with-param name="text" select="$program-text" />
                             </xsl:call-template>

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -41,6 +41,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!--     xsl/pretext-common.xsl (2022-03-27)                               -->
 <!--     xsl/pretext/pretext-runestone-static.xsl (2022-03-28)             -->
 
+<!-- "unit" tests for these templates are (partially) implemented in       -->
+<!-- xsl/tests/pretext-text-utilities-test.xsl                             -->
+<!-- Before modifying any templates in this file, you are encouraged to    -->
+<!-- make sure there is a set of tests for the template(s) and use those   -->
+<!-- to verify changes allong with diffs of sample-book/sample-article     -->
+
 <!-- There are &LOWERCASE; and &UPPERCASE; entities  -->
 <!-- in the "file-extension" template (only?) -->
 <!DOCTYPE xsl:stylesheet [

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -410,6 +410,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
+<!-- substring from $input after first instance of $substr         -->
+<!-- if no match, returns original string                          -->
+<!-- similar to substring-after() function but preserves original  -->
+<xsl:template name="substring-after-preserve">
+    <xsl:param name="input"/>
+    <xsl:param name="substr"/>
+    <!-- Extract the string which comes after the first occurrence -->
+    <xsl:variable name="temp" select="substring-after($input,$substr)"/>
+    <xsl:choose>
+        <xsl:when test="$temp = ''">
+            <xsl:value-of select="$input"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$temp"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- If the substring is not contained, the first substring-after()   -->
 <!-- will return empty and entire template will return empty.  To     -->
 <!-- get the whole string, prepend $input with $substr prior to using -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -895,30 +895,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
-<!-- Working from end, remove whitespace back to and including last newline -->
-<xsl:template name="strip-trailing-whitespace-line">
-    <xsl:param name="text" />
-    <xsl:variable name="last-char" select="substring($text, string-length($text), 1)" />
-    <xsl:choose>
-        <!-- if empty, quit -->
-        <xsl:when test="not($last-char)" />
-        <!-- if last character is newline, return everything else -->
-        <xsl:when test="$last-char = '&#xa;'">
-            <xsl:value-of select="substring($text, 1, string-length($text)-1)" />
-        </xsl:when>
-        <!-- if last character is whitespace, drop it -->
-        <xsl:when test="contains($whitespaces, $last-char)">
-            <xsl:call-template name="strip-trailing-whitespace">
-                <xsl:with-param name="text" select="substring($text, 1, string-length($text)-1)" />
-            </xsl:call-template>
-        </xsl:when>
-        <!-- else finished stripping, output as-is -->
-        <xsl:otherwise>
-            <xsl:value-of select="$text" />
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
 <!-- spurious newlines introduce whitespace on either side -->
 <!-- we split at newlines, strip consecutive whitesapce on either side, -->
 <!-- and replace newlines by spaces (could restore a single newline) -->

--- a/xsl/tests/null.xml
+++ b/xsl/tests/null.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- intentionally empty valid XML file for use with pretext-text-utilities-text.xsl -->
+<nothing>
+</nothing>

--- a/xsl/tests/pretext-text-utilities-test.xsl
+++ b/xsl/tests/pretext-text-utilities-test.xsl
@@ -1,0 +1,223 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2022 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Standalone testbed for pretext-text-utilities templates        -->
+<!-- Invoke this stylesheet on null.xml in the same folder:         -->
+<!-- xsltproc -dd-xinclude pretext-text-utilities-test.xsl null.xml -->
+<!--          ^double dash there                                    -->
+
+<!-- There are &LOWERCASE; and &UPPERCASE; entities  -->
+<!-- in the "file-extension" template (only?) -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../entities.ent">
+    %entities;
+]>
+
+<!-- EXSL needed for token list template (only?) -->
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:pi="http://pretextbook.org/2020/pretext/internal"
+    xmlns:str="http://exslt.org/strings"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:math="http://exslt.org/math"
+    xmlns:set="http://exslt.org/sets"
+    extension-element-prefixes="pi str math"
+>
+
+<!-- Allow serialization of XML in various contexts     -->
+<!-- See the XSL file for more info about Lenz' utility -->
+<xsl:import href="../pretext-text-utilities.xsl"/>
+
+<!-- Output helper -->
+<xsl:variable name="verbose-output" select="false()"/>
+
+<xsl:template name="assert-equal">
+  <xsl:param name="expected"/>
+  <xsl:param name="actual"/>
+  <xsl:param name="test-name"/>
+  <xsl:choose>
+    <xsl:when test="$expected = $actual">
+      <xsl:if test="$verbose-output">
+        <xsl:message>Test <xsl:value-of select="$test-name"/> passed.</xsl:message>
+      </xsl:if>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:message>Test <xsl:value-of select="$test-name"/> failed: </xsl:message>
+      <xsl:message>  expected = "<xsl:value-of select="$expected"/>"  (<xsl:value-of select="exsl:object-type($expected)"/>)</xsl:message>
+      <xsl:message>  actual = "<xsl:value-of select="$actual"/>"  (<xsl:value-of select="exsl:object-type($actual)"/>)</xsl:message>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<!--========================================================================-->
+<!-- test count-pad-length-->
+<xsl:variable name="count-pad-length-0">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="count-pad-length">
+      <xsl:with-param name="text" select="'a'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="0"/>
+    <xsl:with-param name="actual" select="number($test-val)"/>
+    <xsl:with-param name="test-name" select="'count-pad-length-0'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="count-pad-length-2">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="count-pad-length">
+      <xsl:with-param name="text" select="'  a'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="2"/>
+    <xsl:with-param name="actual" select="number($test-val)"/>
+    <xsl:with-param name="test-name" select="'count-pad-length-2'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="count-pad-length-2-empty">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="count-pad-length">
+      <xsl:with-param name="text" select="'  '"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="2"/>
+    <xsl:with-param name="actual" select="number($test-val)"/>
+    <xsl:with-param name="test-name" select="'count-pad-length-2'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<!--========================================================================-->
+<!-- test substring-after-last-->
+<xsl:variable name="substring-after-last-b1">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-last">
+      <xsl:with-param name="input" select="'aabcc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'cc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-last-b1'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-after-last-b2">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-last">
+      <xsl:with-param name="input" select="'aabccbcc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'cc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-last-b2'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-after-last-missing">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-last">
+      <xsl:with-param name="input" select="'aacc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="''"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-last-missing'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-after-last-leading">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-last">
+      <xsl:with-param name="input" select="'baacc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'aacc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-last-leading'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+
+<!--========================================================================-->
+<!-- test substring-before-last-->
+<xsl:variable name="substring-before-last-b1">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-before-last">
+      <xsl:with-param name="input" select="'aabcc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'aa'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-before-last-b1'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-before-last-b2">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-before-last">
+      <xsl:with-param name="input" select="'aabccbcc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'aabcc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-before-last-b2'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-before-last-missing">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-before-last">
+      <xsl:with-param name="input" select="'aacc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="''"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-before-last-missing'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+
+<!--========================================================================-->
+
+<!-- "main" -->
+<xsl:template match="/">
+  <xsl:message>Tests complete!</xsl:message>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/tests/pretext-text-utilities-test.xsl
+++ b/xsl/tests/pretext-text-utilities-test.xsl
@@ -212,6 +212,51 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:call-template>
 </xsl:variable>
 
+<!--========================================================================-->
+<!-- test substring-after-preserve-->
+<xsl:variable name="substring-after-preserve-b1">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-preserve">
+      <xsl:with-param name="input" select="'aabcc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'cc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-preserve-b1'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-after-preserve-miss">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-preserve">
+      <xsl:with-param name="input" select="'aacc'"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'aacc'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-preserve-miss'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="substring-after-preserve-empty">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="substring-after-preserve">
+      <xsl:with-param name="input" select="''"/>
+      <xsl:with-param name="substr" select="'b'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="''"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'substring-after-preserve-empty'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+
 
 <!--========================================================================-->
 


### PR DESCRIPTION
The HTML static and dynamic (activecode vs now) handle authored whitespace slightly differently and eat whitespace in some places it might be desirable to add it. This fixes overzealous whitespace pruning and normalizes the behavior between the two outputs.

Clean diffs on SB. None of the issues existed in it or are not apparent in diffs (different handling between static and activecode programs).

Notes:
TESTING ONLY commit illustrates problem using hello-world. Assuming you will drop that commit after using it for before/after. I could move some/all of those into a random place in SA if you want.

2nd commit has the string-utils testbed I mused about before and some tests for existing (but not all) utils.

3rd commit adds a `substring-after-preserve` util and tests for it.

4th is the actual fix for authored whitespace in programs

5th drops an unused string util. It does the same job as `trim-end` with `$preserve-intentional = true()`
