### PR TITLE
CSS: reset font size/color in footnotes

### DIFF
--- a/css/components/elements/_footnotes.scss
+++ b/css/components/elements/_footnotes.scss
@@ -41,6 +41,9 @@ $border-radius: 0px !default;
   width: fit-content;
   max-width: calc(100% - 60px);
   border: 2px solid var(--knowl-border-color);
-  // position: absolute;
-  // z-index: 10;
+  //reset color/weight/size in case used in block that changed them
+  // e.g. theorem title in denver
+  color: var(--body-text-color);
+  font-weight: normal;
+  font-size: var(1rem);
 }


### PR DESCRIPTION
Fix for issue identified by @davidaustinm on `-dev`:
https://groups.google.com/d/msgid/pretext-dev/CANXmVMD4xn5yyJpu--xoZNKdrPxeCbWpjs6ouYRsA1YUEUcSQA%40mail.gmail.com?utm_medium=email&utm_source=footer