### PR TITLE
FITB: fix host-platform for extracting dynamic substitutions 

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1099,6 +1099,8 @@ def dynamic_substitutions(xml_source, pub_file, stringparams, xmlid_root, dest_d
         stringparams["publisher"] = pub_file
     if xmlid_root:
         stringparams["subtree"] = xmlid_root
+    # Always act as though web is the target
+    stringparams["host-platform"] = "web"
 
     tmp_dir = get_temporary_directory()
 


### PR DESCRIPTION
When trying to build a complete target (e.g. sample-book) for runestone, the CLI calls the extract dynamic substitutions routine with the target platform as runestone. However, the stand-alone pages that are produced for extraction are actually being hosted locally and so need to use host-platform as `web`.

Modified `pretext.py` to override the stringparam for host-platform for this call.