### PR TITLE
Footnotes for URLs

### DIFF
--- a/css/components/elements/_footnotes.scss
+++ b/css/components/elements/_footnotes.scss
@@ -5,6 +5,10 @@ $border-radius: 0px !default;
   position: relative;
 }
 
+.ptx-footnote.url-fn {
+  display: none;
+}
+
 .ptx-footnote[open] {
   display: contents;
 }

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1188,7 +1188,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- NB: interior of "website" is a "url" in author's -->
         <!-- source, but the pre-processor adds a footnote    -->
         <!-- Only one presumed, and thus enforced here        -->
-         <!-- Kill this? -->
         <xsl:apply-templates select="url[1]|fn[1]" />
     </div>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1188,6 +1188,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- NB: interior of "website" is a "url" in author's -->
         <!-- source, but the pre-processor adds a footnote    -->
         <!-- Only one presumed, and thus enforced here        -->
+         <!-- Kill this? -->
         <xsl:apply-templates select="url[1]|fn[1]" />
     </div>
 </xsl:template>
@@ -2594,6 +2595,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- be rendered, but perhaps not well. Caveat emptor.                    -->
 <xsl:template match="fn">
     <details class="ptx-footnote" aria-live="polite">
+        <!-- If the fn is for holding the content of a URL, then we add an additional class for the CSS to find -->
+        <xsl:if test="@pi:url">
+            <xsl:attribute name="class">
+                <xsl:text>ptx-footnote url-fn</xsl:text>
+            </xsl:attribute>
+        </xsl:if>
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <!-- A superscript number, as the clickable content -->
         <summary class="ptx-footnote__number">


### PR DESCRIPTION
There is no good reason to include the footnote containing the URL for a link in HTML (like there is for print where the link might be text and not itself a URL).  This adds a class to such footnote elements and sets the CSS to not display them by default (a style author could override this).

Note that this does not interrupt numbering which is good, since numbers will still match other output formats.