### PR TITLE
LaTeX: Use mermaid@label for extraction filename

### DIFF
--- a/xsl/extract-mermaid.xsl
+++ b/xsl/extract-mermaid.xsl
@@ -45,14 +45,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:variable name="mermaid-extracting"><xsl:value-of select="true()"/></xsl:variable>
 
-<xsl:template match="image[mermaid]" mode="extraction">
+<xsl:template match="image/mermaid" mode="extraction">
     <xsl:variable name="filebase">
-        <xsl:apply-templates select="." mode="assembly-id"/>
+        <xsl:apply-templates select="@label"/>
     </xsl:variable>
 
     <exsl:document href="{$filebase}.mmd" method="text">
         <xsl:call-template name="sanitize-text">
-            <xsl:with-param name="text" select="./mermaid" />
+            <xsl:with-param name="text" select="." />
         </xsl:call-template>
     </exsl:document>
 </xsl:template>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2848,7 +2848,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <image>
                         <xsl:attribute name="pi:generated">
                             <xsl:text>mermaid/</xsl:text>
-                            <xsl:apply-templates select="." mode="assembly-id"/>
+                            <xsl:apply-templates select="mermaid/@label"/>
                             <xsl:choose>
                                 <!-- latex-print will be B&W target -->
                                 <xsl:when test="$b-latex-print">


### PR DESCRIPTION
Fix for issue noted here:
https://github.com/PreTeXtBook/pretext/pull/2555
Bases Mermaid filename on label applied to `<mermaid>` element itself.

This makes mermaid extraction work with what is in that PR, but it would break existing instances. I don't see any deprecation warning or repair for the change. It feels like one both of those should be put in place before this gets merged. I'm on the road starting tomorrow. Some access to code, but limited time.