### PR TITLE
HTML: add permalink to chapter heading on summary pages

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -542,6 +542,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </ul>
                 </nav>
                 <xsl:apply-templates select="conclusion|outcomes"/>
+                <!-- Insert permalink -->
+                <xsl:apply-templates select="." mode="permalink"/>
             </section>
         </xsl:with-param>
     </xsl:apply-templates>


### PR DESCRIPTION
As reported https://groups.google.com/g/pretext-dev/c/mrYUFu9X3u8, the summary pages were not getting the new permalinks (simply an oversight).