### PR TITLE
HTML: add descriptions to Asymptote images

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6153,7 +6153,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <iframe src="{$html-filename}" class="asymptote">
             <xsl:if test="shortdescription">
                 <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription"/>
+                    <xsl:value-of select="shortdescription"/>
                 </xsl:attribute>
             </xsl:if>
         </iframe>


### PR DESCRIPTION
Two changes to the Asymptote template:

1. If `<shortdescription>` is present, write it to the `title` attribute of the `iframe` containing the Asymptote image
2. When `<description>` is structured by `<p>`, add the "info" button containing the long description below the Asymptote image.