### PR TITLE
HTML: fix detection of theme options in publication file

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2387,9 +2387,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Must be an option in the theme or a custom theme -->
         <xsl:when test="$html-theme/option[@name = $optname] or $html-theme[@name = 'custom']">
             <xsl:choose>
-                <xsl:when test="$publication/html/css/options/@*[name() = $optname]">
+                <xsl:when test="$publication/html/css/@*[name() = $optname]">
                     <!-- Exists in pub file, use that -->
-                    <xsl:value-of select="$publication/html/css/options/@*[name() = $optname]"/>
+                    <xsl:value-of select="$publication/html/css/@*[name() = $optname]"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <!-- Use default from theme def -->


### PR DESCRIPTION
Addresses https://github.com/PreTeXtBook/pretext/issues/2570

The location of options on a theme in the CSS changed from attributes on sub-element to attributes on `html/css/`. That change did not get reflected to the code that looks up options like `@provide-dark-mode`. This fixes that.