### PR TITLE
GeoGebra: Fix JS variables to have valid characters

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10123,23 +10123,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <!-- We need a Javascript identifier to name the applet -->
+    <!-- Other variables will use this as the root -->
     <xsl:variable name="applet-name">
-        <xsl:apply-templates select="." mode="visible-id-no-dash" />
+        <xsl:text>ggb_</xsl:text>
+        <xsl:apply-templates select="." mode="visible-id-no-dash" />    
     </xsl:variable>
     <!-- And a Javascript identifier for the parameters -->
     <xsl:variable name="applet-parameters">
-        <xsl:apply-templates select="." mode="visible-id-no-dash" />
+        <xsl:value-of select="$applet-name"/>
         <xsl:text>_params</xsl:text>
     </xsl:variable>
     <!-- And a Javascript identifier for the onload function -->
     <xsl:variable name="applet-onload">
-        <xsl:apply-templates select="." mode="visible-id-no-dash" />
+        <xsl:value-of select="$applet-name"/>
         <xsl:text>_onload</xsl:text>
     </xsl:variable>
     <!-- And a Javascript identifier for the onload function argument -->
     <!-- not strictly necessary, but clarifies HTML                   -->
     <xsl:variable name="applet-onload-argument">
-        <xsl:apply-templates select="." mode="visible-id-no-dash" />
+        <xsl:value-of select="$applet-name"/>
         <xsl:text>_applet</xsl:text>
     </xsl:variable>
     <!-- And an HTML unique identifier -->


### PR DESCRIPTION
GeoGebra template for loading content requires forming several variables that contain key information about how to load the applet that runs GGB content. Issue #2579 showed that if a user chose an id for a figure that started with a number, that created an error.

This prepends the string 'ggb_' before the id to avoid this issue.

Are there any characters that could be in `visible-id-no-dash` other than A-Z, a-z, 0-9 and _ to worry about? If so, we'll need to add an additional filter layer.