### PR TITLE
CSS: improve printing from html; unified across themes

### DIFF
--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -15,10 +15,23 @@
     display:none;
   }
 
-  .pretext .ptx-main .ptx-content {
-    margin-left: auto;
-    margin-right: auto;
-    border:none;
+  .ptx-page, .ptx-main, .ptx-main .ptx-content {
+    all: unset !important;
+    width: 100%;
+    border: none;
     padding: 0;
+    margin: 0;
+  }
+
+  .ptx-sagecell {
+    break-inside: avoid;
+  }
+
+  .heading {
+    break-after: avoid;
+  }
+
+  @page {
+    margin: 0.75in 0.75in 0.75in 0.75in;
   }
 }


### PR DESCRIPTION
Largely because the Colorado-based themes do different things from the other themes with page margins, if a user tried to print from html (in general, not a worksheet), these were getting really extreme margins.  This PR fixes that, and improves printing for all themes by using the `@page` selector to set 0.75 inch margins around each page.  Page breaks right after headings are avoided, as are page breaks inside sage cells.

Tested on all themes. 