### PR TITLE
CSS: Better printing of code and figures/tables/exercises

### DIFF
--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -23,7 +23,7 @@
     margin: 0;
   }
 
-  .ptx-sagecell {
+  .ptx-sagecell, .tabular, .table-like, .figure-like, .exercise-like {
     break-inside: avoid;
   }
 


### PR DESCRIPTION
As requested in #2582, inline code will now appear without a background or border (just monospace font) when printing from HTML.  Also added some rules to avoid page-breaking inside a table and figure and exercise (mostly to avoid separating the title/caption from the rest of the content). 