### PR TITLE
HTML: add toggle to highlight workspace in a worksheet print preview

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -179,58 +179,11 @@ section.worksheet > .heading + .para {
   }
 }
 
-
-// Note: leaving the following rules in place in anticipation of implementing a
-// workspace preview feature in the future.
- .onepage .workspace.preview {
-  border: 1px dashed grey;
-  background: rgb(240, 255, 255);
-/*  Sally suggests light and dark blue
-  background: linear-gradient(
-      #eef 0px, #eef 200px,
-      #eef 200px, #99f 205px,
-      #99f 205px, #99f 100%)
-*/
-}
-.onepage .workspace.squashed.preview {
-  border: 2px dotted grey;
-  background: #ffe;
+form.papersize-select {
+  padding-bottom: 8px;
 }
 
-.onepage .workspace.squashed.tight.preview {
-  border: 15px solid;
-  border-image: repeating-linear-gradient(
-    -35deg,
-    #f33,
-    #f33 10px,
-    #000 10px,
-    #000 20px
-  ) 20;
-/*
-  background: linear-gradient(
-      #ff0 0%, #ff0 8%,
-      #000 8%, #000 9%,
-      #ff6 9%, #ff6 17%,
-      #555 17%, #555 19%,
-      #ff8 19%, #ff8 26%,
-      #777 26%, #777 29%,
-      #ffa 29%, #ffa 37%,
-      #aaa 37%, #aaa 41%,
-      #ffd 41%, #ffd 48%,
-      #ccc 48%, #ccc 52%,
-      #ffd 52%, #ffd 59%,
-      #aaa 59%, #aaa 63%,
-      #ffa 63%, #ffa 71%,
-      #777 71%, #777 74%,
-      #ff8 74%, #ff8 81%,
-      #555 81%, #555 83%,
-      #ff6 83%, #ff6 91%,
-      #000 91%, #000 92%,
-      #ff0 92%, #ff0 100%
-      );
-*/
-  background: yellow;
-}
+
 
 
 // Screen specific styles (mostly for showing the border around a worksheet with it's "margins" and for the print controls)
@@ -255,6 +208,36 @@ section.worksheet > .heading + .para {
   // Set space between pages
   .onepage + .onepage {
     margin-top: 2.5em;
+  }
+
+
+  .workspace-container {
+    display: flex;
+    overflow: visible;
+  }
+
+  .workspace {
+    width: 100%;
+  }
+
+  .highlight-workspace .onepage .workspace {
+    border: 1px dashed grey;
+    background: hsl(224, 100%, 95%);
+  }
+
+  // Normally, the .workspace.original is hidden in the print preview, but if the highlight-workspace checkbox is checked, it will be shown.
+  .onepage .original-workspace {
+    display: none;
+  }
+
+  .highlight-workspace .onepage .original-workspace {
+    display:block;
+    width: 10px;
+    background: hsl(152, 29%, 65%);
+  }
+
+  .highlight-workspace .onepage .warning {
+    background: hsl(36, 65%, 67%);
   }
 
   .print-button {

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -271,6 +271,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -295,6 +295,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -274,6 +274,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -269,6 +269,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Reset</localization>
     <localization string-id='array'>pole</localization>
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <localization string-id='print'>Tisk</localization>
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Zavřít</localization>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -276,6 +276,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -324,9 +324,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='array'>array</localization>
     <!-- "paper size" toggle title                                -->
     <localization string-id="papersize">Paper size</localization>
+    <!-- "highlight workspace" toggle title                         -->
+    <localization string-id="highlight-workspace">Highlight workspace</localization>
     <!-- Print page button text                                   -->
     <localization string-id='print'>Print</localization>
-    <!-- Print preview tooltip text                               -->
+    <!-- Print preview tooltip/title text                         -->
     <localization string-id='print-preview'>Print preview</localization>
     <!-- Close something interactive                              -->
     <localization string-id='close'>Close</localization>

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -275,6 +275,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <localization string-id='papersize'>Tamaño del papel</localization>
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -281,6 +281,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -265,6 +265,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <localization string-id='print'>Imprimer</localization>
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Fermer</localization>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -267,6 +267,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Réinitialiser</localization>
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <localization string-id='print'>Imprimer</localization>
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <localization string-id='close'>Fermer</localization>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -269,6 +269,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -270,6 +270,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Azzera</localization>
     <localization string-id='array'>tabella</localization>
     <localization string-id='papersize'>Formato carta</localization>
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <localization string-id='print'>Stampa</localization>
     <localization string-id='print-preview'>Anteprima di stampa</localization>
     <localization string-id='close'>Chiudi</localization>

--- a/xsl/localizations/ku-CKB.xml
+++ b/xsl/localizations/ku-CKB.xml
@@ -313,6 +313,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Describe an array of fill-in-the-blanks, say for a matrix -->
     <localization string-id='array'>ڕیزکراو</localization>
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- Print page button text -->
     <localization string-id='print'>پرنت</localization>
     <!--<localization string-id='print-preview'>Print preview</localization>-->

--- a/xsl/localizations/nl-NL.xml
+++ b/xsl/localizations/nl-NL.xml
@@ -322,6 +322,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Reset an interactive to its original state               -->
     <localization string-id='reset'>Resetten</localization>
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -278,6 +278,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='reset'>Redefinir</localization>
     <localization string-id='array'>lista</localization>
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -281,6 +281,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- <localization string-id='reset'>Reset</localization> -->
     <!-- <localization string-id='array'>array</localization> -->
     <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
     <!-- <localization string-id='print'>Print</localization> -->
     <!--<localization string-id='print-preview'>Print preview</localization>-->
     <!-- <localization string-id='close'>Close</localization> -->

--- a/xsl/localizations/zh-HANS.xml
+++ b/xsl/localizations/zh-HANS.xml
@@ -311,5 +311,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='array'>数组</localization>
     <!-- Print page button text -->
     <localization string-id='print'>打印</localization>
+    <!-- <localization string-id='papersize'>Paper size</localization> -->
+    <!-- <localization string-id="highlight-workspace">Highlight workspace</localization> -->
+    <!-- <localization string-id='print-preview'>Print preview</localization> -->
     <!-- <localization string-id='close'>Close</localization> -->
 </locale>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11806,8 +11806,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="worksheet" mode="print-preview-header">
     <h2 class="print-preview">
-        <!-- TODO: add localization support-->
-        <xsl:text>Print Preview</xsl:text>
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'print-preview'"/>
+        </xsl:apply-templates>
     </h2>
 </xsl:template>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11055,7 +11055,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="print-preview-header">
                                 <xsl:apply-templates select="." mode="print-preview-header"/>
                                 <div class="print-controls">
-                                    <xsl:apply-templates select="." mode="papersize-toggle"/>
+                                    <div class="print-controls-toggles">
+                                        <xsl:apply-templates select="." mode="papersize-toggle"/>
+                                        <xsl:apply-templates select="." mode="highlight-workspace-toggle"/>
+                                    </div>
                                     <xsl:apply-templates select="." mode="print-button"/>
                                 </div>
                             </div>
@@ -11829,6 +11832,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <input type="radio" name="papersize" value="letter"/>Letter
         </label>
     </form>
+</xsl:template>
+
+<xsl:template match="*" mode="highlight-workspace-toggle"/>
+
+<xsl:template match="worksheet" mode="highlight-workspace-toggle">
+    <label for="highlight-workspace-checkbox">
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'highlight-workspace'"/>
+        </xsl:apply-templates>
+    </label>
+    <input type="checkbox" id="highlight-workspace-checkbox"/>
 </xsl:template>
 
 <!-- Primary Navigation Panels -->


### PR DESCRIPTION
If you author a worksheet, you should specify a minimum height for your workspace (right, @Alex-Jordan?).  When you view the worksheet in HTML, we make the rendered workspace fit onto pages as best we can.  Sometimes this increases or decreases workspace.  But now there will be a checkbox in the print preview that when checked will highlight the rendered workspace, together with a column in the right margin of the workspace that stretches the distance you requested.  Tool-tip alerts you to this purpose, and green/orange highlights whether the the rendered amount respects the author's wishes.  

If this looks good, then I think we should add a publisher variable that would hide this toggle (the idea being that this is really just an author-tool; instructors will likely keep it on, since it isn't too distracting, but for mature projects, it could be turned off).