### PR TITLE
Add CSS styling for .booktitle.

### DIFF
--- a/css/components/elements/_misc-content.scss
+++ b/css/components/elements/_misc-content.scss
@@ -151,7 +151,9 @@ article.theorem-like .emphasis {
   overflow-x: auto;
 }
 
-
+.booktitle {
+    font-style: oblique;
+}
 
 /* Adapted from William Hammond (attributed to David Carlisle) */
 /* "mathjax-users" Google Group, 2015-12-27 */


### PR DESCRIPTION
I noticed that the modern, component-based CSS styles didn't have any styling for .booktitle. Added one copied from `legacy/pretext_add_on.css`. (I think I added it the right place so it will apply to all the themes?)