### PR TITLE
HTML: only link ol-marker.css when it exists

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -252,6 +252,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="$document-root//ol[@marker and count(. | key('marker-key', @marker)[1]) = 1]" mode="ol-markers"/>
     </ol-markers>
 </xsl:variable>
+<xsl:variable name="b-needs-custom-marker-css" select="boolean($document-root//ol[@marker])"/>
 
 
 <!-- ######## -->
@@ -5776,11 +5777,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- CSS file for custom ol markers -->
 <xsl:template name="ol-marker-styles">
     <xsl:variable name="ol-marker-nodes" select="exsl:node-set($ol-markers)" />
-    <xsl:if test="$ol-marker-nodes//ol-marker">
-        <exsl:document href="ol-markers.css" method="text">
-            <xsl:apply-templates select="$ol-marker-nodes//ol-marker" mode="ol-marker-style" />
-        </exsl:document>
-    </xsl:if>
+    <exsl:document href="ol-markers.css" method="text">
+        <xsl:apply-templates select="$ol-marker-nodes//ol-marker" mode="ol-marker-style" />
+    </exsl:document>
 </xsl:template>
 
 <!-- We let CSS react to narrow titles for dl -->
@@ -13525,7 +13524,9 @@ TODO:
 <!-- CSS header -->
 <xsl:template name="css-common">
     <!-- Temporary until css handling overhaul by ascholer complete -->
-    <link href="{$html.css.dir}/ol-markers.css" rel="stylesheet" type="text/css"/>
+    <xsl:if test="$b-needs-custom-marker-css">
+        <link href="{$html.css.dir}/ol-markers.css" rel="stylesheet" type="text/css"/>
+    </xsl:if>
     <!-- If extra CSS is specified, then unpack multiple CSS files -->
     <xsl:if test="not($html.css.extra = '')">
         <xsl:variable name="csses" select="str:tokenize($html.css.extra, ', ')"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -252,7 +252,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="$document-root//ol[@marker and count(. | key('marker-key', @marker)[1]) = 1]" mode="ol-markers"/>
     </ol-markers>
 </xsl:variable>
-<xsl:variable name="b-needs-custom-marker-css" select="boolean($document-root//ol[@marker])"/>
+<xsl:variable name="b-needs-custom-marker-css" select="boolean(exsl:node-set($ol-markers)/ol-markers/ol-marker)"/>
 
 
 <!-- ######## -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5740,13 +5740,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:for-each >
 </xsl:template>
 
-<xsl:template match="ol" mode="ol-marker-class">
-    <xsl:if test="@format-code = 'a' and @ordered-list-level = '1'">
-        <xsl:text>lower-alpha-level-1</xsl:text>
-    </xsl:if>
+<xsl:template match="ol[not(@marker) and @format-code = 'a' and @ordered-list-level = '1']" mode="ol-marker-class">
+    <xsl:text>lower-alpha-level-1</xsl:text>
 </xsl:template>
 
-<xsl:template match="ul" mode="ol-marker-class"/>
+<xsl:template match="ol|ul" mode="ol-marker-class"/>
 
 <xsl:template match="ol[@marker]" mode="ol-markers">
     <xsl:element name="ol-marker">


### PR DESCRIPTION
See title. Avoids 404 in case project does not contain any `ol|ul` with `@marker`.

Also snuck in a little simplification that was discussed in the comments of #2402 (separate commit).