### PR TITLE
CSS: workaround for Firefox bug not respecting variable margins in @page

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -299,6 +299,8 @@ section.worksheet > .heading + .para {
   }
 
   @page {
-    margin: var(--ws-top-margin) var(--ws-right-margin) var(--ws-bottom-margin) var(--ws-left-margin);
+    // Note: when we allow custom margins, the javascript will need to change these defaults.
+    // Default margins appear to be necessary for Firefox and Safari (Chrome already works with the variable values).
+    margin: var(--ws-top-margin, 40px) var(--ws-right-margin, 55px) var(--ws-bottom-margin, 45px) var(--ws-left-margin, 45px);
   }
 }


### PR DESCRIPTION
Not sure if this is enough of a bug to warrant your immediate attention, although this should be a quick one.  

The issue with Firefox not respecting the margins when printing worksheets seems to be a bug with Firefox (although it is also present in Safari I think).  While you can absolutely set margins for printing in the `@page` rule, these browsers to not evaluate the CSS variables.  This adds default fallbacks, which do get recognized correctly.  

For now, this is an easy fix.  When custom margins get implemented, we will need to be careful and override this rule.