### PR TITLE
WeBWorK: don't call pg_macros needlessly

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1292,7 +1292,7 @@ def webwork_to_xml(
         os.mkdir(ww_macros_dir)
 
     # construct the generated pg files, etc, which may need to be read later for rendering problems
-    webwork_sets(xml_source, pub_file, stringparams, ww_pg_dir, False)
+    webwork_sets(xml_source, pub_file, stringparams, ww_pg_dir, False, False)
     pg_macros(xml_source, pub_file, stringparams, ww_macros_dir)
 
     if ww_xml.find("server-params-pub").find("ww-domain") is not None:
@@ -2054,7 +2054,7 @@ def webwork_to_xml(
 ################################
 
 
-def webwork_sets(xml_source, pub_file, stringparams, dest_dir, tgz):
+def webwork_sets(xml_source, pub_file, stringparams, dest_dir, tgz, need_macros):
 
     # to ensure provided stringparams aren't mutated unintentionally
     stringparams = stringparams.copy()
@@ -2071,7 +2071,8 @@ def webwork_sets(xml_source, pub_file, stringparams, dest_dir, tgz):
     folder = os.path.join(tmp_dir, folder_name)
     macros_folder = os.path.join(folder, 'macros')
     os.mkdir(macros_folder)
-    pg_macros(xml_source, pub_file, stringparams, macros_folder)
+    if need_macros:
+        pg_macros(xml_source, pub_file, stringparams, macros_folder)
     if tgz:
         archive_file = os.path.join(tmp_dir, folder_name + ".tgz")
         targz(archive_file, folder)

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -844,7 +844,7 @@ def main():
         elif args.format == "assembly-version":
             ptx.assembly(xml_source, publication_file, stringparams, out_file, dest_dir, "version" )
         elif args.format == "webwork-sets":
-            ptx.webwork_sets(xml_source, publication_file, stringparams, dest_dir, args.tgz)
+            ptx.webwork_sets(xml_source, publication_file, stringparams, dest_dir, args.tgz, True)
         # 2020-05-19 MathBookXMLtoSWS class removed
         elif args.format == "sagenb":
             raise NotImplementedError(


### PR DESCRIPTION
Without this change, when `webwork_to_xml` is called, both `webwork_sets` and `pg_macros` are called. But `webwork_sets` also calls `pg_macros`. So there's a redundancy here, and it's wasteful that `pg_macros` is called twice.

At first glance, we would just remove the `pg_macros` call from `webwork_to_xml`. But when `webwork_to_xml` calls `pg_macros`, it requires the macros file to be built in a certain predictable place.  And when `pg_macros` is called directly by a user, it needs to place the macros file in the "destination directory", which is a different place.

So the changes here are meant to get around this puzzle. `webwork_to_xml` will still call `pg_macros` and tell it where to build the macros folder. But when `webwork_to_xml` calls `webwork_sets`, it now uses a new argument telling `webwork_sets` to skip the `pg_macros` call. We get rid of a redundant call of `pg_macros` without changing the behavior of a user calling `pg_macros` directly.