### PR TITLE
Guide: update documentation of WeBWorK publisher variables

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -972,11 +972,12 @@
             <p>
                 <webwork/> exercises in a <pretext/> project can be processed in two ways: using a
                 local copy of <c>pg</c>, or using a <c>webwork2</c> server. The variables here
-                control which method is used where, and how it is used. These are discussed again
-                in <xref ref="webwork-representations"/>.
+                control which method is used where, and how it is used. These are also discussed in
+                <xref ref="webwork-publisher"/>.
             </p>
             <p>
-                See <xref ref="online-webwork-dynamism"/> for publisher file attributes that control <webwork/>'s dynamic behavior in HTML.
+                See <xref ref="online-webwork-dynamism"/> for publisher file attributes that control
+                <webwork/>'s dynamic behavior in HTML.
             </p>
         </introduction>
 
@@ -989,8 +990,8 @@
                 can have value <c>webwork2</c> (the default) or <c>local</c>. When <webwork/>
                 exercises are processed to make static <pretext/> representations, this is the
                 method that will be used. Either communicating with a <c>webwork2</c> server or a
-                local copy of <c>pg</c>. The fastest processing happens if you use <c>local</c>.
-                See <xref ref="webwork-local-pg-static-processing"/>.
+                local copy of <c>pg</c>. The fastest processing happens if you use <c>local</c>. See
+                <xref ref="webwork-local-pg-static-processing"/>.
             </p>
         </subsection>
 
@@ -1001,7 +1002,8 @@
                     <cline>/publication/webwork/@pg-location</cline>
                 </cd>
                 gives the absolute file path to a local copy of the <c>pg</c> repository, for when
-                static processing is local. The default value is <c>/opt/webwork/pg</c>.
+                static processing is local. The default value is <c>/opt/webwork/pg</c>. See
+                <xref ref="webwork-local-pg-static-processing"/>.
             </p>
         </subsection>
 
@@ -1012,8 +1014,9 @@
                 <cd>
                     <cline>/publication/webwork/@server</cline>
                 </cd>
-                should include the protocol (e.g.<nbsp/><c>http</c> or <c>https</c>) and not include a trailing slash.
-                The server should be version 2.16 or later.
+                should include the protocol (e.g.<nbsp/><c>http</c> or <c>https</c>) and not include
+                a trailing slash. The server should be version 2.16 or later. See
+                <xref ref="webwork-representations"/>.
             </p>
         </subsection>
 
@@ -1024,16 +1027,19 @@
                 <cd>
                     <cline>/publication/webwork/@course</cline>
                 </cd>
+                See <xref ref="webwork-representations"/>.
             </p>
         </subsection>
 
         <subsection xml:id="publication-file-webwork-user">
             <title>User</title>
             <p>
-                The username that signs in to the host course to process exercises is in the attribute
+                The username that signs in to the host course to process exercises is in the
+                attribute
                 <cd>
                     <cline>/publication/webwork/@user</cline>
                 </cd>
+                See <xref ref="webwork-representations"/>.
             </p>
         </subsection>
 
@@ -1044,6 +1050,7 @@
                 <cd>
                     <cline>/publication/webwork/@password</cline>
                 </cd>
+                See <xref ref="webwork-representations"/>.
             </p>
         </subsection>
 
@@ -1054,13 +1061,17 @@
                 <cd>
                     <cline>/publication/webwork/@task-reveal</cline>
                 </cd>
-                attribute is used to control how tasks in a multi-task exercise are made available to the reader.
-                This applies to live interactive renderings of the exercises, either in HTML, in <webwork/>,
-                or otherwise. Possible values are:
+                attribute is used to control how tasks in a multi-task exercise are made available
+                to the reader. This applies to live interactive renderings of the exercises, either
+                in HTML, in <webwork/>, or otherwise. Possible values are:
                 <ul>
-                    <li><c>preceding-correct</c> (all preceding tasks must be correctly answered before the next is available)</li>
+                    <li>
+                        <c>preceding-correct</c> (all preceding tasks must be correctly answered
+                        before the next is available)
+                    </li>
                     <li><c>all</c> (all tasks are available)</li>
                 </ul>
+                See <xref ref="webwork-html-output"/>.
             </p>
         </subsection>
     </section>

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -87,7 +87,7 @@
       available from Linux package distributions, and the details differ from one flavor of Linux to
       the next. Alternatively there is a utility called <c>cpanm</c> (cpanminus) that is supposed
       to let you manage perl module installation across Linux flavors. One important difference is
-      that <c>cpanm</c> only mangages perl modules. And sometimes a perl module is actually an
+      that <c>cpanm</c> only manages perl modules. And sometimes a perl module is actually an
       interface between perl and some other system utility. <c>cpanm</c> will not actually install
       that system utility that it depends on and will just quit. Whereas Linux package distributions
       will have a more sophisticated dependency understanding, and try to install non-perl tools
@@ -136,7 +136,7 @@
       (<c>brew install cpanminus</c>, requiring you first install
       <url href="https://brew.sh/" visual="https://brew.sh/">Homebrew</url>). Or you could install
       <c>cpanm</c> directly following
-      <url href="https://metacpan.org/pod/App::cpanminus" visual="metacpan.org/pod/App::cpanminus">these instruction</url>.
+      <url href="https://metacpan.org/pod/App::cpanminus" visual="metacpan.org/pod/App::cpanminus">these instructions</url>.
     </p>
     <p>
       Once you have <c>cpanm</c>, you can opt to install the above modules one at a time, or all at
@@ -156,12 +156,13 @@
     </p>
     <p>
       Now in a publisher file, you can set the <tag>webwork</tag> element to have
-      <attr>static-processing</attr> with value <c>local</c>. If you put the <c>pg</c> repository
+      <attr>static-processing</attr> with value <c>local</c> (see
+      <xref ref="publication-file-webwork-static-processing"/>). If you put the <c>pg</c> repository
       in the default location, this is all you need to do. Otherwise, you also need to add the
-      attribute <attr>pg-location</attr> with the absolute path, for example <c>/opt/webwork/pg</c>.
-      And when you process <webwork/> exercises for static representations (following
-      <xref ref="webwork-representations"/>) your local copy of PG will be used instead of some
-      remote server.
+      attribute <attr>pg-location</attr> with the absolute path, for example <c>/opt/webwork/pg</c>
+      (see <xref ref="publication-file-webwork-pg-location"/>). And when you process <webwork/>
+      exercises for static representations (following <xref ref="webwork-representations"/>) your
+      local copy of PG will be used instead of some remote server.
     </p>
     <p>
       Note that you will still need a network connection for problems in your HTML output to render
@@ -384,13 +385,18 @@
         <c>-c webwork</c> means you are processing the <webwork/> components.
       </p>
       <p>
-        <c>-p</c> specifies the publication file, as described in <xref ref="publication-file-reference"/>.
-        In the publication file, the element <tag>webwork</tag> may have attributes <attr>server</attr>,
-        <attr>course</attr>, <attr>user</attr>, and <attr>password</attr>.
-        If absent, these default to <c>https://webwork-ptx.aimath.org</c>, <c>anonymous</c>, <c>anonymous</c>,
-        <c>anonymous</c>, and <c>anonymous</c> respectively. If you specify a server, you must correctly
-        specify the protocol (<c>http</c> versus <c>https</c>). And it must be version 2.16 or later.
-        Do not include a trailing slash.
+        <c>-p</c> specifies the publication file (see <xref ref="publication-file-reference"/>).
+        In the publication file, the element <tag>webwork</tag> may have attributes:
+        <ul>
+          <li><attr>server</attr> (<xref ref="publication-file-webwork-server"/>)</li>
+          <li><attr>course</attr> (<xref ref="publication-file-webwork-course"/>)</li>
+          <li><attr>user</attr> (<xref ref="publication-file-webwork-user"/>)</li>
+          <li><attr>password</attr> (<xref ref="publication-file-webwork-password"/>)</li>
+        </ul>
+        If absent, these default to <c>https://webwork-ptx.aimath.org</c>, <c>anonymous</c>,
+        <c>anonymous</c>, <c>anonymous</c>, and <c>anonymous</c> respectively. If you specify a
+        server, you must correctly specify the protocol (<c>http</c> versus <c>https</c>). And it
+        must be version 2.16 or later. Do not include a trailing slash.
       </p>
     </subsection>
 


### PR DESCRIPTION
I believe this addresses things mentioned in #2595.

I slipped in a few typo corrections.

Some of the diff is just reformatting lines to 100 characters or less, which I would like to continue doing whenever I edit documentation or examples now, if that is acceptable.