### PR TITLE
CSS: fix worksheet printing bug by removing top margin on pages

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -256,27 +256,25 @@ form.papersize-select {
 
   section.worksheet {
     border: none;
-  }
-
-  .worksheet {
     width: 100%;
+
+    .onepage {
+      margin-top: 0;
+      width: 100%;
+      height: var(--ws-content-height);
+      overflow: hidden;
+      page-break-after: always;
+      page-break-inside: avoid;
+    }
+    // Never show the workspace preview in print
+    div.workspace,
+    div.workspace.squashed.tight {
+      border: none;
+      padding: 0;
+      background: none !important;
+    }
   }
 
-  .onepage {
-    width: 100%;
-    height: var(--ws-content-height);
-    overflow: hidden;
-    page-break-after: always;
-    page-break-inside: avoid;
-  }
-
-  // Never show the workspace preview in print
-  .onepage div.workspace,
-  .onepage div.workspace.squashed.tight {
-    border: none;
-    padding: 0;
-    background: none !important;
-  }
   a {
     color: black;
   }


### PR DESCRIPTION
This fixes a bug with worksheet printing from HTML that @mitchkeller identified.  Added a `margin-top: 0` to the `.onepage` rule, and nested the print rules to ensure high enough specificity to override the conflicting rules in `_spacing.scss`.