### PR TITLE
Disable code-copy on derived HTML

### DIFF
--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -186,6 +186,9 @@
 
 <xsl:variable name="b-endnotes-have-math" select="$endnotes-have-math = 'true'"/>
 
+<!-- Disable clipboardable -->
+<xsl:variable name="b-add-clipboardable" select="false()"/>
+
 <!-- ############## -->
 <!-- Entry Template -->
 <!-- ############## -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -208,6 +208,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.presentation" select="'no'" />
 <xsl:variable name="b-html-presentation" select="$html.presentation = 'yes'" />
 
+<!-- "clipboardable" adds a clickable copy button to code chunks -->
+<!-- We disable this on derived HTML (epub etc) -->
+<xsl:variable name="b-add-clipboardable" select="true()"/>
+
 <!-- ############### -->
 <!-- Source Analysis -->
 <!-- ############### -->
@@ -8741,7 +8745,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original" select="true()" />
     <xsl:element name="pre">
         <xsl:attribute name="class">
-            <xsl:text>code-display tex2jax_ignore clipboardable</xsl:text>
+            <xsl:text>code-display tex2jax_ignore</xsl:text>
+            <xsl:if test="$b-add-clipboardable">
+                <xsl:text> clipboardable</xsl:text>
+            </xsl:if>
         </xsl:attribute>
         <xsl:choose>
             <xsl:when test="not(@showspaces) or (@showspaces = 'none')">
@@ -8759,7 +8766,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original" select="true()" />
     <xsl:element name="pre">
         <xsl:attribute name="class">
-            <xsl:text>code-display tex2jax_ignore clipboardable</xsl:text>
+            <xsl:text>code-display tex2jax_ignore</xsl:text>
+            <xsl:if test="$b-add-clipboardable">
+                <xsl:text> clipboardable</xsl:text>
+            </xsl:if>
         </xsl:attribute>
         <xsl:apply-templates select="cline" />
     </xsl:element>
@@ -9441,7 +9451,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <pre>
             <!-- always identify as coming from "program" -->
             <xsl:attribute name="class">
-                <xsl:text>program clipboardable</xsl:text>
+                <xsl:text>program</xsl:text>
+                <xsl:if test="$b-add-clipboardable">
+                    <xsl:text> clipboardable</xsl:text>
+                </xsl:if>
                 <!-- conditionally request line numbers -->
                 <xsl:if test="@line-numbers = 'yes'">
                     <xsl:text> line-numbers</xsl:text>
@@ -9536,7 +9549,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- An interactive command-line session with a prompt, input and output -->
 <xsl:template match="console" mode="code-inclusion">
     <!-- ignore prompt, and pick it up in trailing input -->
-    <pre class="console clipboardable">
+    <pre>
+        <xsl:attribute name="class">
+            <xsl:text>console</xsl:text>
+            <xsl:if test="$b-add-clipboardable">
+                <xsl:text> clipboardable</xsl:text>
+            </xsl:if>
+        </xsl:attribute>
         <xsl:apply-templates select="input|output"/>
     </pre>
 </xsl:template>

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -56,6 +56,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:param name="jupyter.kernel" select="''" />
 
+<!-- Disable clipboardable -->
+<xsl:variable name="b-add-clipboardable" select="false()"/>
+
 <!-- ############## -->
 <!-- Entry Template -->
 <!-- ############## -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -44,6 +44,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- entry template                               -->
 <xsl:import href="pretext-html.xsl" />
 
+<!-- Disable clipboardable -->
+<xsl:variable name="b-add-clipboardable" select="false()"/>
+
 <!-- HTML5 format -->
 <xsl:output method="html" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat"/>
 


### PR DESCRIPTION
This picks up the questions raised at #2535 I'll try to drop in tomorrow to discuss any issues

- Uses a variable to disable adding the clipboardable class name in derived HTML documents  (epub, revealjs, jupyter)
- Another question was regarding the print-worksheet stylesheet receiving the `.clipboardable` styles from `_codelike.scss`. I think that is not an issue in practice, as the key affected element of `.code-copy` is disabled in print media, but if @oscarlevin has some concerns we can figure out how to disable it.
- Another question was about applying this to the `pre` element. I'm not sure that's a good idea in general, I believe the `pre` element is used on some cases like sage-cells, or activecode, where we would not want this to apply, or at least I am not sure how to apply it given the overwrites happening. Is there some part that generates the "pre elements not affected by other things"? Maybe that's a place to add it?

Question: Would it be better if the variable started out as false, then overwritten as true in the file that produces the html output? Would that be `pretext-basic-html`?