### PR TITLE
CSS: long code-inline blocks scroll if they overflow container

### DIFF
--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -25,6 +25,10 @@
   border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
   padding: 0.0625em 0.125em;
   border-radius: 0.2em;
+  display: inline-block;
+  overflow-x: auto;
+  max-width: 100%;
+  vertical-align: middle;
 }
 
 


### PR DESCRIPTION
.code-inline that are too wide scroll instead of overflowing and possibly causing page to scroll.

This does not try to make anything wider, but is compatible with the `expandable` mixin. If that is applied to code-inline you get a wider div that scrolls when it runs out of space

See: sample-article/out/section-pre-formatted.html#section-pre-formatted-10 for good sample.