### PR TITLE
HTML: prevent user settings from enabling darkmode when theme disables

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13617,6 +13617,11 @@ TODO:
             </xsl:choose>
         </xsl:attribute>
     </xsl:if>
+    <xsl:if test="not($b-theme-has-darkmode = 'true')">
+        <xsl:attribute name="data-darkmode">
+            <xsl:text>disabled</xsl:text>
+        </xsl:attribute>
+    </xsl:if>
 </xsl:template>
 
 <!-- Treated as characters, these could show up often, -->


### PR DESCRIPTION
Fix for issue described here:
https://groups.google.com/d/msgid/pretext-support/4646670A-E3BF-4620-BB74-291ADE43847D%40rellek.net?utm_medium=email&utm_source=footer