### PR TITLE
Auto close TOC when navigating back with back button.

### DIFF
--- a/js/pretext.js
+++ b/js/pretext.js
@@ -108,6 +108,13 @@ window.addEventListener("DOMContentLoaded",function(event) {
                 toggletoc();
             }
         });
+
+        window.addEventListener('pageshow', (e) => {
+            if (e.persisted) {
+                sidebar.classList.remove('visible');
+                sidebar.classList.add('hidden');
+            }
+        });
     }
 });
 


### PR DESCRIPTION
I noticed one more subtlety with the auto-closing TOC: if you open the TOC and then click a link that navigates to a different page and then hit the back button the TOC is still open when you come back. Which seems wrong to me since it should go away once you make a selection. This PR fixes that.