### PR TITLE
WeBWorK: better handling of LaTeX macros in interactive exercises

### DIFF
--- a/js/pretext-webwork/2.16/pretext-webwork.js
+++ b/js/pretext-webwork/2.16/pretext-webwork.js
@@ -476,7 +476,11 @@ function handleWW(ww_id, action) {
                  max-width:100%;
             }
             </style>` +
-            '</head><body><main class="pretext-content">' + form.outerHTML + '</main></body>' +
+            '</head><body>' +
+            '<div id="latex-macros" class="hidden-content process-math" style="display:none"><span class="process-math">\\(' +
+            document.getElementById('latex-macros-text').textContent +
+            '\\)</span></div>' +
+            '<main class="pretext-content">' + form.outerHTML + '</main></body>' +
             '</html>';
 
         let iframe;

--- a/js/pretext-webwork/2.17/pretext-webwork.js
+++ b/js/pretext-webwork/2.17/pretext-webwork.js
@@ -744,7 +744,11 @@ function handleWW(ww_id, action) {
 				background-repeat: no-repeat;
 			}
 			</style>` +
-			'</head><body><main class="pretext-content">' + form.outerHTML + '</main></body>' +
+			'</head><body>' +
+			'<div id="latex-macros" class="hidden-content process-math" style="display:none"><span class="process-math">\\(' +
+			document.getElementById('latex-macros-text').textContent +
+			'\\)</span></div>' +
+			'<main class="pretext-content">' + form.outerHTML + '</main></body>' +
 			'</html>';
 
 		let iframe;

--- a/js/pretext-webwork/2.18/pretext-webwork.js
+++ b/js/pretext-webwork/2.18/pretext-webwork.js
@@ -744,7 +744,11 @@ function handleWW(ww_id, action) {
 				background-repeat: no-repeat;
 			}
 			</style>` +
-			'</head><body><main class="pretext-content">' + form.outerHTML + '</main></body>' +
+			'</head><body>' +
+			'<div id="latex-macros" class="hidden-content process-math" style="display:none"><span class="process-math">\\(' +
+			document.getElementById('latex-macros-text').textContent +
+			'\\)</span></div>' +
+			'<main class="pretext-content">' + form.outerHTML + '</main></body>' +
 			'</html>';
 
 		let iframe;

--- a/js/pretext-webwork/2.19/pretext-webwork.js
+++ b/js/pretext-webwork/2.19/pretext-webwork.js
@@ -415,6 +415,9 @@ async function handleWW(ww_id, action) {
                 .quill-toolbar { scrollbar-width: thin; overflow-x: hidden; }
             </style>` +
             '</head><body>' +
+            '<div id="latex-macros" class="hidden-content process-math" style="display:none"><span class="process-math">\\(' +
+            document.getElementById('latex-macros-text').textContent +
+            '\\)</span></div>' +
             '<main class="pretext-content problem-content" data-iframe-height="1">' + form.outerHTML + '</main></body>' +
             '</html>';
 

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -760,35 +760,6 @@
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:call-template>
     <xsl:text>TEXT(beginproblem());&#xa;</xsl:text>
-    <xsl:if test="not($b-human-readable)">
-        <!-- see select-latex-macros template -->
-        <xsl:variable name="macros">
-            <xsl:call-template name="select-latex-macros"/>
-        </xsl:variable>
-        <xsl:if test="$macros != ''">
-            <xsl:variable name="wrapped-macros">
-                <xsl:text>&lt;div style="display:none;">\(</xsl:text>
-                <xsl:value-of select="$macros" />
-                <xsl:text>\)&lt;/div></xsl:text>
-            </xsl:variable>
-            <xsl:variable name="delimiter">
-                <xsl:call-template name="find-unused-character">
-                    <xsl:with-param name="string" select="$wrapped-macros"/>
-                    <!-- https://stackoverflow.com/questions/43617820/what-are-the-legal-delimiters-for-perl-5s-pick-your-own-quotes-operators    -->
-                    <!-- NB: don't use (), <>, [], {}, because as perl delimiters, closer must be the right version; too complicated to check for -->
-                    <xsl:with-param name="charset" select="concat($apos,'|/?.,+-_~`!@$%^&amp;*')"/>
-                </xsl:call-template>
-            </xsl:variable>
-            <xsl:text>TEXT(MODES(PTX=&gt;'',HTML=&gt;</xsl:text>
-            <xsl:if test="$delimiter != $apos">
-                <xsl:text>q</xsl:text>
-            </xsl:if>
-            <xsl:value-of select="$delimiter"/>
-            <xsl:value-of select="$wrapped-macros"/>
-            <xsl:value-of select="$delimiter"/>
-            <xsl:text>));&#xa;</xsl:text>
-        </xsl:if>
-    </xsl:if>
     <xsl:if test="$b-human-readable">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
@@ -1668,40 +1639,6 @@
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- Inside math we need to print definitions for PTX author-defined      -->
-<!-- LaTeX macros to support WeBWorK's images display mode.               -->
-
-<!-- TODO: This named template examines the current context (see '.' in   -->
-<!-- contains() below), so should be a match template. But its recursive  -->
-<!-- implementation makes it a named template for now.                    -->
-<xsl:template name="select-latex-macros">
-    <xsl:param name="macros" select="$latex-macros" />
-    <xsl:variable name="trimmed-start">
-        <xsl:if test="contains($macros, '\newcommand{')">
-            <xsl:value-of select="substring-after($macros, '\newcommand{')"/>
-        </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="macro-name">
-        <xsl:if test="contains($trimmed-start, '}')">
-            <xsl:value-of select="substring-before($trimmed-start, '}')"/>
-        </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="macro-command">
-        <xsl:value-of select="substring-before($macros, '&#xa;')"/>
-    </xsl:variable>
-    <xsl:variable name="next-lines">
-        <xsl:value-of select="substring-after($macros, '&#xa;')"/>
-    </xsl:variable>
-    <xsl:if test="contains(., $macro-name)">
-        <xsl:value-of select="normalize-space($macro-command)"/>
-    </xsl:if>
-    <xsl:if test="not($next-lines = '')">
-        <xsl:call-template name="select-latex-macros">
-            <xsl:with-param name="macros" select="$next-lines"/>
-        </xsl:call-template>
-    </xsl:if>
-</xsl:template>
-
 <!-- ##################################################################### -->
 <!-- ##################################################################### -->
 <!-- Above: templates for elements that only ever apply within a webwork   -->
@@ -1800,9 +1737,6 @@
 <xsl:template match="m">
     <xsl:param name="b-human-readable" />
     <xsl:text>[`</xsl:text>
-    <xsl:if test="$b-human-readable">
-        <xsl:call-template name="select-latex-macros"/>
-    </xsl:if>
     <xsl:apply-templates select="text()|var" />
     <!-- look ahead to absorb immediate clause-ending punctuation -->
     <xsl:apply-templates select="." mode="get-clause-punctuation" />
@@ -1817,9 +1751,6 @@
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:text>[```</xsl:text>
-    <xsl:if test="$b-human-readable">
-        <xsl:call-template name="select-latex-macros"/>
-    </xsl:if>
     <xsl:apply-templates select="text()|var" />
     <!-- look ahead to absorb immediate clause-ending punctuation -->
     <xsl:apply-templates select="." mode="get-clause-punctuation" />
@@ -1902,9 +1833,6 @@
         <xsl:call-template name="potential-list-indent" />
     </xsl:if>
     <xsl:text>[```</xsl:text>
-    <xsl:if test="$b-human-readable">
-        <xsl:call-template name="select-latex-macros"/>
-    </xsl:if>
     <xsl:value-of select="$content" />
     <xsl:if test="ancestor::ul|ancestor::ol">
         <xsl:call-template name="potential-list-indent" />

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13691,17 +13691,23 @@ TODO:
 <!-- sneaking in packages, which load first, in       -->
 <!-- case authors want to build on these macros       -->
 <xsl:template name="latex-macros">
+    <xsl:variable name="packages-and-macros">
+        <xsl:value-of select="$latex-packages-mathjax"/>
+        <xsl:value-of select="$latex-macros"/>
+        <xsl:call-template name="fillin-math"/>
+        <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
+        <xsl:if test="$b-has-sfrac">
+            <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
+        </xsl:if>
+    </xsl:variable>
     <div id="latex-macros" class="hidden-content process-math" style="display:none">
+        <xsl:if test="$b-has-webwork-reps">
+            <p id="latex-macros-text">
+                <xsl:value-of select="$packages-and-macros"/>
+            </p>
+        </xsl:if>
         <xsl:call-template name="inline-math-wrapper">
-            <xsl:with-param name="math">
-                <xsl:value-of select="$latex-packages-mathjax"/>
-                <xsl:value-of select="$latex-macros"/>
-                <xsl:call-template name="fillin-math"/>
-                <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
-                <xsl:if test="$b-has-sfrac">
-                    <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
-                </xsl:if>
-            </xsl:with-param>
+            <xsl:with-param name="math" select="$packages-and-macros"/>
         </xsl:call-template>
     </div>
 </xsl:template>


### PR DESCRIPTION
Before this commit, when a WW exercise uses a custom LaTeX macro, and when that exercise is going to be rendered live, we open each chunk of math with whatever custom LaTeX definitions are needed for that chunk of math. This is pretty inefficient, since you might be redefining macros over and over again in the same exercise. Also it clutters up the MathJax tool that gives a user the tex code that was used to generate that chunk of math.

This changes all that. The PG being used for rendering the live version of the exercise now has no latex macro definitions at all. Instead, all of the project's custom LaTeX macros are loaded into MathJax once at the start of the problem (which, I should remind everyone, is within an iframe and not subject to the MathJax happenings in the ambient page.)

To accomplish that, the LaTeX macros text is kept in a visually hidden place in the ambient page, so that javascript can grab it and insert it at the start of the problem. This needs to be a separate instance of writing the LaTeX macros into the ambient page from what is already there. Because what is already there gets ingestedby MathJax, and becomes something completely different in the DOM to how it was born.

I can't think of an alternate way to reach the objective, except maybe to put the latex macros into a data attribute instead of into an element. I'll make that change if it seems better.

Either way, the second copy of the latex macros text will only show up in the HTML if the project is using WeBWorK. So no unnecessary clutter for other projects.