### PR TITLE
Local pg files

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -535,7 +535,7 @@
 
         <p>
             It is possible to include <webwork/>/PG problems in your source. These can either be
-            authored using <pretext/> or referenced from a host
+            included from local PG files, authored using <pretext/>, or referenced from a host
             <webwork/> course. A static version of the exercise will be rendered in your static
             output formats such as <latex/>/PDF. A <q>live</q> version will be rendered in HTML
             output. If the HTML is hosted on a Runestone server, the student's progress completing

--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -87,6 +87,13 @@
         <c>templates/local/</c> folder and use it with:
         <cd>&lt;webwork source="local/my_problem.pg"/></cd>
       </p>
+      <p>
+        Alternatively, if you have a problem's PG file locally in your project's external folder,
+        for example in <c>external/pg/my_problem.pg</c>, you can use it with:
+        <cd>&lt;webwork local="pg/my_problem.pg"/></cd>
+        If the PG file relies on image files, data files, similar asset files, or nonstandard PG
+        macro files, this avenue is not likely to work as of the time of writing.
+      </p>
       <warning>
         <title>Not Every PG Problem is Compatible with <pretext/></title>
         <p>
@@ -493,12 +500,5 @@
         </p>
       </subsubsection>
     </subsection>
-
-    <subsection>
-      <title>Using a Local PG Problem File</title>
-      <p>Planned.</p>
-    </subsection>
-
   </section>
-
 </chapter>

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -189,7 +189,7 @@
       <webwork/> needs to be 2.16 or later for use with <pretext/>.
     </p>
     <p>
-      The only thing you need to do at the serverlevel is set the web server to use certain headers
+      The only thing you need to do at the server level is set the web server to use certain headers
       on content that is fetched. These headers tell a web browser that you are authorizing it to
       display content from this web server as embedded content inside pages from another web server
       (in particular, where you are hosting you <pretext/> book).
@@ -295,7 +295,7 @@
       <q>Allowed to view course home page</q> which should also be set to <c>login_proctor</c>.
     </p>
     <p>
-      In the Accounts Manager(Classlist Editor in older versions of <webwork/>), add a user named
+      In the Accounts Manager (Classlist Editor in older versions of <webwork/>), add a user named
       <c>anonymous</c> (again, you could use some other name), and set that user's permission level
       to <c>login_proctor</c>, the permission level one higher than <c>student</c>. Set that user's
       password to <c>anonymous</c> (again, you could use some other password). Note that because
@@ -535,7 +535,8 @@
         that you wrote, set defintion files corresponding to the sections (or other chunks) of your
         project, and header files for those sets. All of this was placed into your project's
         <c>generated/webwork/pg</c> folder when you executed <c>pretext -c webwork</c>, so you could
-        find it there and package it all up to send to your <webwork/> server.      </p>
+        find it there and package it all up to send to your <webwork/> server.
+      </p>
       <p>
         Alternativley, you may run the following:
       </p>

--- a/examples/webwork/minimal/external/pg/newProblem.pg
+++ b/examples/webwork/minimal/external/pg/newProblem.pg
@@ -1,0 +1,39 @@
+## DESCRIPTION
+## Give a value for pi
+## ENDDESCRIPTION
+
+## KEYWORDS('template', 'pi')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('')
+## Author('')
+## Institution('')
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",    # Standard macros for PG language
+    "PGML.pl",          # PGML markup and Math Objects
+    "PGcourse.pl",      # Customization file for the course
+);
+
+# Uncomment the following if you don't want to show which
+# answers are correct and which are incorrect
+#$showPartialCorrectAnswers = 0;
+
+$pi = Real("pi");
+
+BEGIN_PGML
+Enter a value for [`\pi`].
+
+[_]{$pi}{5}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+You could type [|pi|]* or [|3.14|]*, or [|22/7|]*,
+among other options.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -71,6 +71,11 @@
       <exercise>
         <webwork source="Library/PCC/BasicAlgebra/Geometry/CylinderVolume10.pg"/>
       </exercise>
+      <!-- An exercise with source from a local "external" asset file -->
+      <!-- The path is relative to the external assets folder         -->
+      <exercise>
+        <webwork local="pg/newProblem.pg"/>
+      </exercise>
     </section>
   </article>
 </pretext>

--- a/examples/webwork/minimal/publication.xml
+++ b/examples/webwork/minimal/publication.xml
@@ -33,9 +33,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <webwork
         server="https://webwork-ptx.aimath.org"
         course="anonymous"
-        coursepassword="anonymous"
         user="anonymous"
-        userpassword="anonymous"
+        password="anonymous"
         task-reveal="preceding-correct"
         static-processing="webwork2"
         />

--- a/examples/webwork/sample-chapter/external/pg/local_demo.pg
+++ b/examples/webwork/sample-chapter/external/pg/local_demo.pg
@@ -1,0 +1,21 @@
+# A local PG file
+
+DOCUMENT();
+loadMacros(qw(PGstandard.pl PGML.pl AnswerFormatHelp.pl PGcourse.pl));
+
+Context('Numeric');
+$a = Compute(random(1, 9, 1));
+$b = Compute(random(1, 9, 1));
+$c = $a + $b;
+
+BEGIN_PGML
+Compute the sum of [`[$a]`] and [`[$b]\text{:}`]
+
+[`[$a] + [$b] =`] [_]{$c}{5}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`[$a] + [$b] = [$c]\text{.}`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -307,6 +307,17 @@
                     </conclusion>
                 </exercise>
 
+                <exercise label="local-pg-file">
+                    <title>Local PG File</title>
+                    <introduction>
+                        <p>
+                            This problem uses a local <c>.pg</c> file instead of authored <pretext/>
+                            source.
+                        </p>
+                    </introduction>
+                    <webwork local="pg/local_demo.pg"/>
+                </exercise>
+
                 <project label="copy-webwork-add-numbers">
                     <title>Inside a <tag>project</tag></title>
                     <introduction>

--- a/js/pretext-webwork/2.19/pretext-webwork.js
+++ b/js/pretext-webwork/2.19/pretext-webwork.js
@@ -90,11 +90,19 @@ async function handleWW(ww_id, action) {
             const rawProblemSource = await fetch('generated/webwork/pg/' + ww_problemSource).then((r) => r.text());
             formData.set("rawProblemSource", rawProblemSource);
         }
+        else if (ww_origin == 'external') {
+            const rawProblemSource = await fetch(ww_sourceFilePath).then((r) => r.text());
+            formData.set("rawProblemSource", rawProblemSource);
+        }
         else if (ww_origin == 'webwork2') formData.set("sourceFilePath", ww_sourceFilePath);
     } else {
         formData.set("problemSeed", ww_container.dataset.current_seed);
         if (ww_origin == 'generated') {
             const rawProblemSource = await fetch('generated/webwork/pg/' + ww_problemSource).then((r) => r.text());
+            formData.set("rawProblemSource", rawProblemSource);
+        }
+        else if (ww_origin == 'external') {
+            const rawProblemSource = await fetch(ww_sourceFilePath).then((r) => r.text());
             formData.set("rawProblemSource", rawProblemSource);
         }
         else if (ww_origin == 'webwork2') formData.set("sourceFilePath", ww_sourceFilePath);

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -326,7 +326,7 @@ def get_cli_arguments():
         ("latex-image", "LaTeX pictures (method: [xelatex], pdflatex)"),
         (
             "webwork",
-            "WeBWorK problems in authored, PG, url, and static representations",
+            "WeBWorK problems in PG files and various representations",
         ),
         ("references", "References and citations via Citation Stylesheet Language"),
         ("pg-macros", "Server-side macros for WeBWorK problem generation"),

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -43,8 +43,10 @@
 <!-- The top of the ephemeral XML tree has some global attributes.         -->
 
 <!-- Then for each exercise, we record:                                    -->
-<!-- 1.  origin: there are two possible values                             -->
+<!-- 1.  origin: there are three possible values                           -->
 <!--        "generated" (it was authored in PTX)                           -->
+<!--        "external" (it is a local .pg file within the external folder  -->
+<!--            indicated by @local on the webwork element)                -->
 <!--        "webwork2" (it is a pg file accessible from a webwork2 host    -->
 <!--            course's templates folder indicated by @source on the      -->
 <!--            webwork element)                                           -->
@@ -52,6 +54,7 @@
 <!-- 2.  a seed for randomization                                          -->
 <!-- 3.  path: a file path to a .pg version of the problem                 -->
 <!--         path-defined-by-document-structure                            -->
+<!--         path-defined-by-@local                                        -->
 <!--         path-defined-by-@source                                       -->
 <!-- 4.  pghuman: human readable PG (for generated exercises only)         -->
 <!-- 5.  PG that is somewhat minimized (and less human-readable)           -->
@@ -172,7 +175,7 @@
     </ww-extraction>
 </xsl:template>
 
-<xsl:template match="webwork[@source|statement|task]" mode="extraction">
+<xsl:template match="webwork[@source|@local|statement|task]" mode="extraction">
     <xsl:variable name="problem">
         <xsl:value-of select="@ww-id"/>
     </xsl:variable>
@@ -180,11 +183,14 @@
         <xsl:attribute name="id">
             <xsl:value-of select="$problem" />
         </xsl:attribute>
-        <!-- 1. a generated|webwork2 flag                                          -->
+        <!-- 1. a generated|external|webwork2 flag                                 -->
         <xsl:attribute name="origin">
             <xsl:choose>
                 <xsl:when test="statement|task">
                     <xsl:text>generated</xsl:text>
+                </xsl:when>
+                <xsl:when test="@local">
+                    <xsl:text>external</xsl:text>
                 </xsl:when>
                 <xsl:when test="@source">
                     <xsl:text>webwork2</xsl:text>
@@ -228,10 +234,13 @@
 </xsl:template>
 
 <!-- Append a filename to the directory path              -->
-<xsl:template match="webwork[@source|statement|task]" mode="filename">
+<xsl:template match="webwork[@source|@local|statement|task]" mode="filename">
     <xsl:choose>
         <xsl:when test="@source">
             <xsl:value-of select="@source"/>
+        </xsl:when>
+        <xsl:when test="@local">
+            <xsl:value-of select="@local"/>
         </xsl:when>
         <xsl:when test="statement|task">
             <xsl:apply-templates select="." mode="directory-path" />

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -864,7 +864,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- element ("pi:") for later consumption.  Review the destination for     -->
 <!-- similar notes about possible changes.                                  -->
 
-<xsl:template match="webwork[* or @copy or @source]" mode="webwork">
+<xsl:template match="webwork[* or @copy or @source or @local]" mode="webwork">
     <!-- Every "webwork" that is a problem (not a generator) gets a   -->
     <!-- lifetime identification in both passes through the source.   -->
     <!-- The first migrates through the "extract-pg.xsl" template,    -->
@@ -963,6 +963,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </xsl:when>
                     <xsl:when test="$target/self::webwork[@source]">
                         <xsl:text>the @copy attribute points a "webwork" with a @source attribute.  (Replace the @copy by the @source?)</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$target/self::webwork[@local]">
+                        <xsl:text>the @copy attribute points a "webwork" with a @local attribute.  (Replace the @copy by the @local?)</xsl:text>
                     </xsl:when>
                     <xsl:when test="$target/self::webwork[@copy]">
                         <xsl:text>the @copy attribute points to "webwork" with a @copy attribute. Sorry, we are not that sophisticated.</xsl:text>


### PR DESCRIPTION
This lets you have local PG files (somewhere within your "external" directory tree). This is the next "big" WeBWorK feature from the Tacoma work. 

Additionally (meaning beyond the Tacoma work) I now have this feature working for versions of WeBWorK prior to 2.19. So this doesn't need to wait until the various WW servers are upgraded. If you test this as-is (for both the minimal and sample chapter examples), it will use the AIM server, currently at 2.17. Then if you'd like to test on a 2.19 server, switch the publisher file (for either of the two examples) to use "pretext-dev.aimath,org".

While doing this work I came across two minor things that should have been cleaner in other relatively recent PRs. They are tacked on to separate commits here. If a separate PR is best, no problem. My testing had these in place before I realized they should be separated, so including them for now.