### PR TITLE
Catch and fail on missing xi namespace prefix errors

### DIFF
--- a/examples/hello-world/article.xml
+++ b/examples/hello-world/article.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<article xml:id="hello-world">
+    <p>Hello, World!</p>
+    
+    <!-- <p> -->
+
+    <xi:include parse="text" href="para.xml"/>
+</article>

--- a/examples/hello-world/hello-world.xml
+++ b/examples/hello-world/hello-world.xml
@@ -37,8 +37,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                                                                    -->
 <!-- 6.  Experiment with other available conversions                                    -->
 
-<pretext>
-    <article xml:id="hello-world">
-       <p>Hello, World!</p>
-    </article>
+<pretext  xmlns:xi="http://www.w3.org/2001/XInclude" >
+    <xi:include href="article.xml"/>
 </pretext>

--- a/examples/hello-world/para.xml
+++ b/examples/hello-world/para.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<p>Hello</p>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4590,7 +4590,14 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
     huge_parser = ET.XMLParser(huge_tree=True)
     src_tree = ET.parse(xml, parser=huge_parser)
     try:
-        src_tree.xinclude()
+        # Build custom includer so we can check error log
+        # undefined namespace prefixes (e.g. xi:) go in error log of XInclude object
+        # but do not cause it to fail/throw
+        includer = ET.XInclude()
+        includer(src_tree.getroot())
+        if includer.error_log:
+            # intentionally trigger exception handler for its better message
+            raise ET.XIncludeError("unused")
     except ET.XIncludeError as e:
         # xinclude() does not show what file a parsing error occured in
         # So if there was an error, build a custom loader and redo with ElementInclude


### PR DESCRIPTION
This is a fun one...

Motivated by the Doenet inclusion error reported by Jen on `-support`.

libxml treats a missing namespace prefix as a logged but not fatal error. Try xsltproc to apply `pretext-html.xsl` to the modified `hello-world.xml` file. It outputs an error message but completes.

This behavior also appears true of the libxml used by `lxml`. When we do `src_tree.include()`, it does not throw an exception if there is a missing `xmlns:xi="http://www.w3.org/2001/XInclude"`

* Use just the first commit with changed hello world. Try running old pretext on it. Should complete happily. 
* Now uncomment line 7 of `article.xml`, which has an unrelated parse error.
* Rerun pretext. It should fail and report `Namespace prefix xi on include`. The error is triggering the fallback processing using the custom loader. It notices and reports the issue.

Now apply the second commit.
It creates an `etree.XInclude` object and uses that to do the inclusion processing. That lets us check the error log for any issues that were considered non-fatal and turn them into fatal ones.


Currently anything in the error log is treated as fatal, and not just missing xi prefix. We could do some parsing to narrow that down. But running on a few large books I don't run into any other issues. I feel like we are better off with the current aggressive failing. If we ever encounter a false positive we can exclude that.