### PR TITLE
Program parts additional whitespace fixes

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10989,6 +10989,54 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </console>
             </listing>
 
+            <p>A program can also have <tag>preamble</tag> and <tag>postamble</tag>. They are tested here mostly just for their handling of leading/trailing whitespace. Note that the indentation of the start/end tags for the subelements is intentionally chaotic. There is even trailing whitespace after some of the start tags. That should not affect the indentation of the output. (However, the actual contents of the various parts of the program must all be indented to a similar degree in the source.)</p>
+
+            <program language="python" line-numbers="yes">
+                <preamble>  
+                    # meta: text in preamble with one trailing authored blank line
+                    def foo():
+                        return 42
+
+                      </preamble>
+
+                <code>
+
+                    # meta: text in code with one authored blank line before and after
+                    # meta: in the output there should be two blank lines above and three below
+                    # Your code for bar()
+
+                </code>
+                          <postamble>
+
+
+                    # meta: text in postamble with two authored blank lines preceding
+                    print(bar())</postamble>
+            </program>
+
+            <p>An interactive rendering of the same program should produce the same visible code. Both samples should end in a newline. There will be a visible difference between how this the empty line created by that newline rendered in plain HTML (the empty line is not included) and Runestone (the empty line is visible).</p>
+
+            <program language="python" line-numbers="yes" interactive="activecode">
+                <preamble>  
+                    # meta: text in preamble with one trailing authored blank line
+                    def foo():
+                        return 42
+
+                      </preamble>
+
+                <code>
+
+                    # meta: text in code with one authored blank line before and after
+                    # meta: in the output there should be two blank lines above and three below
+                    # Your code for bar()
+
+                </code>
+                          <postamble>
+
+
+                    # meta: text in postamble with two authored blank lines preceding
+                    print(bar())</postamble>
+            </program>
+
             <p>We conclude this section with a longer example of a program listing, an assembly language program from Bob Plantz, included to test a <c>listing</c> breaking across pages in PDF output.</p>
 
             <listing>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8174,6 +8174,53 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- Helper templates to ensure consistent processing of whitespace in programs. -->
+<!-- Leading lines are always cleaned up. non-authored trailing line is cleared  -->
+<xsl:template match="preamble" mode="program-part-processing">
+    <xsl:call-template name="trim-start-lines">
+        <xsl:with-param name="text">
+            <xsl:call-template name="trim-end">
+                <xsl:with-param name="text" select="." />
+                <xsl:with-param name="preserve-intentional" select="true()" />
+            </xsl:call-template>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+<!-- non-authored start/end lines are cleared                                    -->
+<xsl:template match="code" mode="program-part-processing">
+    <xsl:call-template name="trim-start-lines">
+        <xsl:with-param name="text">
+            <xsl:call-template name="trim-end">
+                <xsl:with-param name="text" select="." />
+                <xsl:with-param name="preserve-intentional" select="true()" />
+            </xsl:call-template>
+        </xsl:with-param>
+        <xsl:with-param name="preserve-intentional" select="true()" />
+    </xsl:call-template>
+</xsl:template>
+<!-- Trailing lines are always cleaned up. non-authored leading line is cleared  -->
+<xsl:template match="postamble" mode="program-part-processing">
+    <xsl:call-template name="trim-start-lines">
+        <xsl:with-param name="text">
+            <xsl:call-template name="trim-end">
+                <xsl:with-param name="text" select="." />
+            </xsl:call-template>
+        </xsl:with-param>
+        <xsl:with-param name="preserve-intentional" select="true()" />
+    </xsl:call-template>
+</xsl:template>
+<!-- Trailing lines are always cleaned up. non-authored leading line is cleared  -->
+<xsl:template match="tests" mode="program-part-processing">
+    <xsl:call-template name="trim-start-lines">
+        <xsl:with-param name="text">
+            <xsl:call-template name="trim-end">
+                <xsl:with-param name="text" select="." />
+            </xsl:call-template>
+        </xsl:with-param>
+        <xsl:with-param name="preserve-intentional" select="true()" />
+    </xsl:call-template>
+</xsl:template>
+
 <!-- This works, without keys, and could be adapted to range over actual data in text -->
 <!-- For example, this approach is used for contributors to FCLA                      -->
 <!--

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9500,33 +9500,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- build up full program text so we can apply sanitize-text to entire blob -->
                 <!-- and thus allow relative indentation for preamble/code/postamble         -->
                 <xsl:variable name="program-text">
-                    <!-- each section MUST end in a newline and author might not have provided one -->
-                    <!-- so first, remove up to one newline from front/back as appropriate         -->
-                    <!-- then add newline to end                                                   -->
-                    <!-- preamble - clean up end                                                   -->
                     <xsl:if test="preamble[not(@visible = 'no')]">
-                        <xsl:call-template name="trim-end">
-                            <xsl:with-param name="text" select="preamble" />
-                            <xsl:with-param name="preserve-intentional" select="true()" />
-                        </xsl:call-template>
+                        <xsl:apply-templates select="preamble" mode="program-part-processing"/>
                     </xsl:if>
-                    <!-- code - clean up start and end                                             -->
-                    <xsl:variable name="code-clean">
-                      <xsl:call-template name="trim-start-lines">
-                          <xsl:with-param name="text" select="code" />
-                          <xsl:with-param name="preserve-intentional" select="true()" />
-                      </xsl:call-template>
-                    </xsl:variable>
-                    <xsl:call-template name="trim-end">
-                        <xsl:with-param name="text" select="$code-clean" />
-                        <xsl:with-param name="preserve-intentional" select="true()" />
-                    </xsl:call-template>
-                    <!-- postamble - clean up start                                               -->
+                    <xsl:apply-templates select="code" mode="program-part-processing"/>
                     <xsl:if test="postamble[not(@visible = 'no')]">
-                      <xsl:call-template name="trim-start-lines">
-                          <xsl:with-param name="text" select="postamble" />
-                          <xsl:with-param name="preserve-intentional" select="true()" />
-                      </xsl:call-template>
+                        <xsl:apply-templates select="postamble" mode="program-part-processing"/>
                     </xsl:if>
                 </xsl:variable>
                 <!-- now sanitize the whole blob -->

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -2053,7 +2053,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- empty node-set.                                       -->
 <xsl:template match="program" mode="runestone-activecode">
     <xsl:param name="exercise-statement" select="/.."/>
-
     <xsl:variable name="active-language">
         <xsl:apply-templates select="." mode="active-language"/>
     </xsl:variable>
@@ -2126,42 +2125,46 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:with-param name="active-language" select="$active-language"/>
                                 <xsl:with-param name="hosting" select="$hosting"/>
                             </xsl:call-template>
-                            <!-- this is a bit awful, but we need to figure out how much margin -->
-                            <!-- to add to runestone dividers. So preassemble program for       -->
-                            <!-- computation and then discard                                   -->
+                            <!-- This is a bit awful, but we need to figure out how much margin     -->
+                            <!-- to add to runestone dividers. It must match indentation used for   -->
+                            <!-- the overall program.                                               -->
+                            <!-- To avoid as much as possible of the duplicate work, clean each     -->
+                            <!-- part and store those for reuse later.                              -->
+                            <xsl:variable name="program-preamble-trimmed">
+                                <xsl:apply-templates select="preamble" mode="program-part-processing"/>
+                            </xsl:variable>
+                            <xsl:variable name="program-code-trimmed">
+                                <xsl:apply-templates select="code" mode="program-part-processing"/>
+                            </xsl:variable>
+                            <xsl:variable name="program-postamble-trimmed">
+                                <xsl:apply-templates select="postamble" mode="program-part-processing"/>
+                            </xsl:variable>
+                            <!-- Now temporarily assemble to count left margin spaces                -->
                             <xsl:variable name="program-left-margin">
-                                <xsl:variable name="raw-program-text">
-                                    <xsl:value-of select="preamble"/>
-                                    <xsl:value-of select="code"/>
-                                    <xsl:value-of select="postamble"/>
-                                </xsl:variable>
-                                <xsl:variable name="trimmed-program-text">
-                                    <xsl:call-template name="trim-start-lines">
-                                        <xsl:with-param name="text">
-                                            <xsl:call-template name="trim-end">
-                                                <xsl:with-param name="text" select="$raw-program-text" />
-                                            </xsl:call-template>
-                                        </xsl:with-param>
-                                    </xsl:call-template>
-                                </xsl:variable>
-                                <xsl:call-template name="left-margin">
-                                  <xsl:with-param name="text" select="$trimmed-program-text" />
+                                <xsl:call-template name="count-pad-length">
+                                    <xsl:with-param name="text">
+                                        <!-- need to clear any blank line left by empty preamble and/or -->
+                                        <!-- leading blank lines at the start of code if no preamble    -->
+                                        <xsl:call-template name="trim-start-lines">
+                                            <xsl:with-param name="text">
+                                                <xsl:value-of select="$program-preamble-trimmed"/>
+                                                <xsl:value-of select="$program-code-trimmed"/>
+                                                <xsl:value-of select="$program-postamble-trimmed"/>
+                                            </xsl:with-param>
+                                        </xsl:call-template>
+                                    </xsl:with-param>
                                 </xsl:call-template>
                             </xsl:variable>
+                            <!-- Build actual string we will prepend to magic dividers -->
                             <xsl:variable name="left-margin-string">
                                 <xsl:value-of select="str:padding($program-left-margin, ' ')" />
                             </xsl:variable>
+                            <!-- Now we are ready to build the real program text.                       -->
+                            <!-- For historical reasons, this does not include potential <tests> child. -->
                             <xsl:variable name="program-text">
-                                <!-- each section MUST end in a newline and author might not have provided one -->
-                                <!-- so first, remove up to one newline from front/back as appropriate         -->
-                                <!-- then add newline to end                                                   -->
-                                <!-- preamble - clean up end                                                   -->
                                 <xsl:for-each select="preamble">
                                     <!-- only expect one, for-each just for binding -->
-                                    <xsl:call-template name="trim-end">
-                                        <xsl:with-param name="text" select="." />
-                                        <xsl:with-param name="preserve-intentional" select="true()" />
-                                    </xsl:call-template>
+                                    <xsl:value-of select="$program-preamble-trimmed"/>
                                     <xsl:value-of select="$left-margin-string"/>
                                     <xsl:choose>
                                         <xsl:when test='@visible = "no"'>
@@ -2173,17 +2176,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <!-- code - clean up start and end                                             -->
-                                <xsl:variable name="code-clean">
-                                  <xsl:call-template name="trim-start-lines">
-                                      <xsl:with-param name="text" select="code" />
-                                      <xsl:with-param name="preserve-intentional" select="true()" />
-                                  </xsl:call-template>
-                                </xsl:variable>
-                                <xsl:call-template name="trim-end">
-                                    <xsl:with-param name="text" select="$code-clean" />
-                                    <xsl:with-param name="preserve-intentional" select="true()" />
-                                </xsl:call-template>
-                                <!-- postamble - clean up start                                               -->
+                                <xsl:value-of select="$program-code-trimmed"/>
+                                <!-- postamble - clean up start                                                -->
                                 <xsl:for-each select="postamble">
                                     <!-- only expect one, for-each just for binding -->
                                     <xsl:value-of select="$left-margin-string"/>
@@ -2195,10 +2189,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                             <xsl:text>===!&#xa;</xsl:text>
                                         </xsl:otherwise>
                                     </xsl:choose>
-                                    <xsl:call-template name="trim-start-lines">
-                                        <xsl:with-param name="text" select="." />
-                                        <xsl:with-param name="preserve-intentional" select="true()" />
-                                    </xsl:call-template>
+                                    <xsl:value-of select="$program-postamble-trimmed"/>
                                 </xsl:for-each>
                             </xsl:variable>
                             <!-- now sanitize the whole blob -->
@@ -2241,7 +2232,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                             </xsl:if>
                                         </xsl:otherwise>
                                     </xsl:choose>
-                                    <!-- historical behavior is to use sanitized version -->
                                     <xsl:value-of select="$tests-content"/>
                                 </xsl:if>
                                 <xsl:if test="tests/iotest">


### PR DESCRIPTION
Adds the sample of program parts whitespace handling requested here:
https://github.com/PreTeXtBook/pretext/pull/2548

As part of constructing that sample, I made the tag indentation intentionally awful. Which broke the indentation of the constructed code in the Runestone version that includes the "magic string" block separators.

So this also fixes that issue. There are three places that were all doing the same string manipulation to the various program sub-elements, so this moves that work into some new templates to simplify/unify that work.

First two commits should produce clean diffs with both SA and SB.

Sample article new example will look fine when applied after those two. If rotated to the front, it should produce incorrectly formatted RS code because the "magic strings" indentation was thrown off by the ugly tag whitespace.
<img width="749" height="468" alt="image" src="https://github.com/user-attachments/assets/bf76cac4-34aa-4cfb-8342-44821148c31e" />
