### PR TITLE
Bare pg

### DIFF
--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -534,14 +534,14 @@
         <idx><h><webwork/></h><h><webwork/> exercise</h></idx>
 
         <p>
-            It is possible to include <webwork/>/PG problems in your source. These can either be
-            authored using <pretext/> or referenced from a host
-            <webwork/> course. A static version of the exercise will be rendered in your static
-            output formats such as <latex/>/PDF. A <q>live</q> version will be rendered in HTML
-            output. If the HTML is hosted on a Runestone server, the student's progress completing
-            the live exercises can be tracked. You can also extract the problems into a single
-            archive suitable for uploading into a <webwork/> course. This is a big topic, so see the
-            dedicated <xref ref="webwork-author"/> for details.
+            It is possible to include <webwork/>/PG problems in your source. These can be authored
+            using <pretext/>, included from local PG files, or referenced from a host <webwork/>
+            course. A static version of the exercise will be rendered in your static output formats
+            such as <latex/>/PDF. A <q>live</q> version will be rendered in HTML output. If the HTML
+            is hosted on a Runestone server, the student's progress completing the live exercises
+            can be tracked. You can also extract the problems into a single archive suitable for
+            uploading into a <webwork/> course. This is a big topic, so see the dedicated
+            <xref ref="webwork-author"/> for details.
         </p>
     </section>
 

--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -74,18 +74,12 @@
     </introduction>
 
     <subsection>
-      <title>Using an Existing <webwork/> Problem</title>
+      <title>Using an OPL <webwork/> Problem</title>
       <p>
-        If a problem already exists and is accessible from the hosting course's <c>templates/</c>
-        folder, then you can try to simply include it with a <attr>source</attr> attribute. For
-        example if it is a problem in the Open Problem Library (OPL), then relative to the
-        <c>templates/</c> folder, its path is <c>Library/.../foo.pg</c> and you may use:
+        If a problem comes from the <webwork/> Open Problem Library and is accessible from the host
+        course in the usual way using a <c>Library/...</c> path, then you can include it with a
+        <attr>source</attr> attribute. For example:
         <cd>&lt;webwork source="Library/.../foo.pg"/></cd>
-      </p>
-      <p>
-        Or if you have a problem's PG file, you can upload it into the hosting course's
-        <c>templates/local/</c> folder and use it with:
-        <cd>&lt;webwork source="local/my_problem.pg"/></cd>
       </p>
       <warning>
         <title>Not Every PG Problem is Compatible with <pretext/></title>
@@ -124,6 +118,45 @@
           GitHub, so it is more expedient to use the first option.
         </p>
       </warning>
+    </subsection>
+
+    <subsection>
+      <title>Local PG Source</title>
+      <p>
+        You can include PG source for a problem directly, as text content for the
+        <tag>webwork</tag> element. For example:
+        <pre>
+    &lt;exercise>
+        &lt;webwork>DOCUMENT();
+
+loadMacros(qw(PGstandard.pl PGML.pl PGcourse.pl));
+$pi = Real("pi");
+
+BEGIN_PGML
+Enter a value for [`\pi`].
+
+[_]{$pi}{5}
+END_PGML
+
+ENDDOCUMENT();
+&lt;/webwork>
+    &lt;/exercise>
+        </pre>
+        Note the attention paid here to whitespace. Any indentation or newline whitespace within
+        the <tag>webwork</tag> will be kept in the PG file that results from this method. Such
+        whitespace may affect the functionality of the problem.
+      </p>
+      <p>
+        If you have a problem as a PG file, you can place it in your project's folder tree and use
+        <tag>xi:include</tag> to insert the PG code as text into the <tag>webwork</tag> element:
+        <cd>&lt;webwork>&lt;xi:include parse="text" href="pg/my_problem.pg"/>&lt;/webwork></cd>
+        Two things to note. The file where you use <tag>xi:include</tag> has a root element, and
+        that root element needs to declare the <c>xi</c> namespace. So you need to have an attribute
+        <c>xmlns:xi="http://www.w3.org/2001/XInclude"</c> on that root element. Second, the
+        <attr>href</attr> specifying the path to the PG file needs to be relative to the file you
+        are working in. In the example, there is a folder named <c>pg</c> adjacent to the file we
+        are working in, and the PG file is within that folder.
+      </p>
     </subsection>
 
     <subsection>
@@ -493,12 +526,5 @@
         </p>
       </subsubsection>
     </subsection>
-
-    <subsection>
-      <title>Using a Local PG Problem File</title>
-      <p>Planned.</p>
-    </subsection>
-
   </section>
-
 </chapter>

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -23,7 +23,7 @@
 
 <!-- This is a skeleton file to hold WeBWorK problems authored in PreTeXt. -->
 
-<pretext>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude">
   <article xml:id="webwork-mini">
     <title><webwork /> Minimal Example</title>
     <frontmatter>
@@ -70,6 +70,11 @@
       <!-- The path is relative to the host course's templates folder -->
       <exercise>
         <webwork source="Library/PCC/BasicAlgebra/Geometry/CylinderVolume10.pg"/>
+      </exercise>
+      <!-- An exercise with source from a pg file. This is the default new problem file template -->
+      <!-- from a webwork2 server. The path is relative to this current file we are in.          -->
+      <exercise>
+        <webwork><xi:include parse="text" href="pg/newProblem.pg"/></webwork>
       </exercise>
     </section>
   </article>

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -20,7 +20,7 @@
 <!-- along with PreTeXt. If not, see <http://www.gnu.org/licenses/>.       -->
 <!-- ********************************************************************* -->
 
-<pretext>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
     <!-- Other languages can be used to internationalize parts of a document -->
     <!-- <pretext xml:lang="pt-BR"> -->
 
@@ -305,6 +305,54 @@
                     <conclusion>
                         <p>For more about problems that do not require any randomization, see the <url href="https://pretextbook.org/documentation.html">PTX Author Guide</url>.</p>
                     </conclusion>
+                </exercise>
+
+                <exercise label="local-pg">
+                    <title>Local PG</title>
+                    <introduction>
+                        <p>
+                            The complete text of a <c>.pg</c> file can be used as the content of a
+                            <tag>webwork</tag>. Attention should be given to newlines and white
+                            space within the <tag>webwork</tag>, as they will be included in the PG
+                            problem that is rendered.
+                        </p>
+                    </introduction>
+                    <webwork><![CDATA[DOCUMENT();
+
+loadMacros(
+  "PGstandard.pl",
+  "PGML.pl",
+  "AnswerFormatHelp.pl",
+  "PGcourse.pl",
+);
+COMMENT('Add two positive single-digit integers.');
+
+Context('Numeric');
+$a = random(1, 9, 1);
+$b = random(1, 9, 1);
+$c = Compute($a + $b);
+
+BEGIN_PGML
+Compute the sum of [`[$a]`] and [`[$b]\text{:}`]
+
+[`[$a] + [$b] =`] [_]{$c}{5} [@AnswerFormatHelp('numbers')@]*
+
+END_PGML
+
+ENDDOCUMENT();
+]]></webwork>
+                </exercise>
+
+                <exercise label="local-pg-file">
+                    <title>Local PG File</title>
+                    <introduction>
+                        <p>
+                            It is convenient to get the text of a <c>.pg</c> file using
+                            <c>xi:include</c>. This may help with file management and management of
+                            to not have to manage whitespace.
+                        </p>
+                    </introduction>
+                    <webwork><xi:include parse="text" href="pg/Adding_SingleDigit_Integers.pg"/></webwork>
                 </exercise>
 
                 <project label="copy-webwork-add-numbers">

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2666,19 +2666,22 @@
                 }
             WebWorkAuthored =
                 element webwork {
-                    UniqueID?,
-                    LabelID?,
-                    Component?,
-                    attribute seed {xsd:integer}?,
-                    attribute copy {text}?,
-                    WWDescription?,
-                    WWMacros?,
-                    element pg-code {text}?,
                     (
-                        (StatementExerciseWW, HintWW?, SolutionWW?)
-                    |
-                        (IntroductionText?, TaskWW+, ConclusionText?)
-                    )
+                        UniqueID?,
+                        LabelID?,
+                        Component?,
+                        attribute seed {xsd:integer}?,
+                        attribute copy {text}?,
+                        WWDescription?,
+                        WWMacros?,
+                        element pg-code {text}?,
+                        (
+                            (StatementExerciseWW, HintWW?, SolutionWW?)
+                        |
+                            (IntroductionText?, TaskWW+, ConclusionText?)
+                        )
+                    ) |
+                    text
                 }
             BlockStatementWW =
                         Paragraph |

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -864,7 +864,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- element ("pi:") for later consumption.  Review the destination for     -->
 <!-- similar notes about possible changes.                                  -->
 
-<xsl:template match="webwork[* or @copy or @source]" mode="webwork">
+<xsl:template match="webwork[* or @copy or @source or text()]" mode="webwork">
     <!-- Every "webwork" that is a problem (not a generator) gets a   -->
     <!-- lifetime identification in both passes through the source.   -->
     <!-- The first migrates through the "extract-pg.xsl" template,    -->


### PR DESCRIPTION
This is a replacement for #2620 and #1696 to let the full text/code of a PG problem be used directly in a `webwork` element.

- First commit has documentation and the necessary changes to xslt and schema.
- Second commit adds one example each to the webwork minimal example and the sample chapter. This is a fundamental thing that I felt should also be in the minimal example.