### PR TITLE
WeBWorK: clean up some warnings from samples

### DIFF
--- a/examples/webwork/minimal/publication.xml
+++ b/examples/webwork/minimal/publication.xml
@@ -33,9 +33,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <webwork
         server="https://webwork-ptx.aimath.org"
         course="anonymous"
-        coursepassword="anonymous"
         user="anonymous"
-        userpassword="anonymous"
+        password="anonymous"
         task-reveal="preceding-correct"
         static-processing="webwork2"
         />

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -55,18 +55,6 @@
         if the initialism is changed.
         -->
         <initialism>WWSC</initialism>
-        <!--
-        With a <feedback> element, in the HTML version, you get a button
-        for reporting typos and errors.  You might link to a Google Docs
-        spreadsheet or something similar.  Default is to get a button
-        labeled "Feedback", which will be localized to your target language.
-        You can override this with some text of your choosing, but then you
-        lose the localization feature.
-        -->
-        <feedback>
-            <url>not-implemented.html</url>
-            <!-- <text>My Button Text</text>  -->
-        </feedback>
 
         <latex-image-preamble>
             \usepackage{pgfplots}


### PR DESCRIPTION
The things being changed here cause PTX warnings at run time for the HTML build. I wanted to remove these so the warnings won't distract me anymore.