### PR TITLE
Add `handout` division with expanded workspace options

### DIFF
--- a/css/targets/print-worksheet/_chunks-worksheet.scss
+++ b/css/targets/print-worksheet/_chunks-worksheet.scss
@@ -23,7 +23,8 @@ $border-radius: 8px !default;
 .project-like,
 .remark-like,
 .openproblem-like,
-.computation-like {
+.computation-like,
+.assemblage-like {
   > .heading {
     display: block;
     font-size: 1.1em;

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -77,7 +77,7 @@
 
 
 // Set font appropriate for printing
-section.worksheet {
+section.worksheet, section.handout {
   font-size: 11pt;
   font-family: var(--font-print);
 }
@@ -103,7 +103,7 @@ summary {
   display: inline;
 }
 
-details > div.knowl__content {
+.knowl__content {
   display: inline;
   margin: unset;
   border: none;
@@ -113,6 +113,11 @@ details > div.knowl__content {
 
 .knowl__link {
   all: unset
+}
+
+.code-inline {
+  border: unset;
+  background: unset;
 }
 
 .onepage article {
@@ -139,12 +144,12 @@ details > div.knowl__content {
   margin-left: 0;
 }
 
-section.worksheet > .heading {
+section.worksheet > .heading, section.handout > .heading {
   display: inline;
   font-size: 1.1em;
 }
 
-section.worksheet > .heading + .para {
+section.worksheet > .heading + .para, section.handout > .heading + .para {
   display: inline;
 }
 
@@ -174,7 +179,7 @@ form.papersize-select {
     margin: 50px auto;
   }
 
-  .worksheet {
+  .worksheet, .handout {
     max-width: var(--ws-width);
     margin: 0 auto;
   }
@@ -254,7 +259,7 @@ form.papersize-select {
     display: none;
   }
 
-  section.worksheet {
+  section.worksheet, section.handout {
     border: none;
     width: 100%;
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -926,7 +926,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <case direction="cycle">
                         <p>Does the first statement imply the second?</p>
                         </case>
-                        
+
                     <case direction="cycle">
                         <title>The <q>middle</q> case</title>
                         <p>Does the second statement imply the third?</p>
@@ -15640,6 +15640,181 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </exercisegroup>
             </worksheet>
        </section>
+
+        <section xml:id="handouts" label="section-handouts">
+            <title>Handouts</title>
+
+            <introduction>
+                <title>About Handouts</title>
+                <p>
+                    Like worksheets, a <term>handout</term> is a division that is inteded to be printed for use in a classroom.
+                    In HTML output, you get the same print preview and page layout as you do with worksheets; in PDF, these will start on a new page with possibly different margins than the rest of the document.
+                </p>
+
+                <p>
+                    Unlike worksheets, handouts do not have a special class of exercises or activities (exercises in a handout are treated like an <em>inline</em> exercise).
+                    The other main distinction is that a handout lets workspace be specified on pretty much any block or paragraph element, not just exercises, tasks, and project-like elements.  This allows them to be used in the creation of guided notes containing some premade content with lots of space for students to fill in details during class.
+                </p>
+            </introduction>
+
+            <handout xml:id="handout-derivative-rules" label="handout-derivative-rules">
+                <title>Derivative Rules</title>
+                <page>
+                <paragraphs>
+                <title>Rules for specific types of functions</title>
+                <dl>
+                    <li>
+                        <title>Constant functions</title>
+                        <p>
+                            <m>(k)' = 0</m>
+                        </p>
+                    </li>
+
+                    <li>
+                    <title>Power functions</title>
+                    <p><m>(x^{n})' = nx^{n-1}</m></p>
+                    </li>
+
+                    <li>
+                        <title>Exponential functions</title>
+                        <p>
+                            <m>(a^{x})' = \ln(a) a^{x} \text{ (for } a>0\text{)}</m>
+                        </p>
+                        <p>
+                                <m>(e^{x})' = e^{x}</m>
+                        </p>
+                    </li>
+
+                    <li>
+                        <title>Logarithmic functions</title>
+                        <p><m>(\ln(x))' = \frac{1}{x}</m></p>
+                    </li>
+
+                <li>
+                    <title>Trigonometric functions</title>
+                    <p><m>(\sin(x))' = \cos(x)</m>.</p>
+                    <p> <m>(\cos(x))' = -\sin(x)</m>.</p>
+                    <p><m>(\tan(x))' = \sec^{2}(x) = \frac{1}{\cos^{2}(x)}</m>.</p>
+                    <p><m>(\arcsin(x))' = \frac{1}{\sqrt{1-x^{2}}}</m>.</p>
+                    <p><m>(\arctan(x))' = \frac{1}{1+x^{2}}</m>.</p>
+                </li>
+                </dl>
+                </paragraphs>
+
+                <paragraphs>
+                <title>Rules for combinations of functions</title>
+                <dl>
+                    <li>
+                        <title>Constant multiples</title>
+                        <p>
+                            <m>(k\cdot f(x))' = k\cdot f'(x)</m>
+                        </p>
+                    </li>
+
+                    <li>
+                        <title>Sum and difference</title>
+                        <p>
+                            <m>(f(x) \pm g(x))' = f'(x) \pm g'(x)</m>
+                        </p>
+                    </li>
+
+                    <li>
+                        <title>Products (the product rule)</title>
+                        <p>
+                            <m>(f(x)\cdot g(x))' = f'(x)g(x) + f(x)g'(x)</m>
+                        </p>
+                    </li>
+
+                    <li>
+                        <title>Quotients (the quotient rule)</title>
+                        <p>
+                            <m>\left(\frac{f(x)}{g(x)}\right)' = \frac{f'(x)g(x) - f(x)g'(x)}{(g(x))^{2}}</m>
+                        </p>
+                    </li>
+
+                <li>
+                    <title>Compositions (the chain rule)</title>
+                    <p>
+                        <m>(f(g(x)))' = f'(g(x))\cdot g'(x)</m>
+                    </p>
+                </li>
+            </dl>
+                </paragraphs>
+            </page>
+        </handout>
+
+        <handout>
+            <title>Guided Notes: Derivatives of sums</title>
+            <page>
+                <p workspace="1in">
+                    Today we will explore how to take the derivative of the sum of two functions.  For example, if <me>f(x) = x^2 + 3x</me>, what is <m>f'(x)</m>?  What two functions is this the sum of?  What are the derivatives of each of those functions?
+                </p>
+
+                <p>
+                    To be sure of the derivative of the sum, we should use the definition of the derivative.
+                </p>
+
+                <definition workspace=".75in">
+                    <title>Definition of the Derivative</title>
+                    <statement>
+                    <p>
+                        The derivative of a function <m>f(x)</m> at any point <m>x</m> is defined as...
+                    </p>
+                    </statement>
+                </definition>
+
+                <p workspace="2in">
+                    Now let's apply this definition to the function <m>f(x) = x^2 + 3x</m>. We have:
+                </p>
+
+                <p workspace="0.25in">
+                    What should the general rule be?
+                </p>
+            </page>
+
+            <page>
+                <theorem workspace="0.5in">
+                    <statement>
+                        <p>
+                            For any two differentiable functions <m>f(x)</m> and <m>g(x)</m>, the derivative of their sum <m>h(x) = f(x) + g(x)</m> is given by:
+                        </p>
+                    </statement>
+                    <proof workspace="3in">
+                        <p>
+                            Let <m>f(x)</m> and <m>g(x)</m> be differentiable functions and let <m>h(x) = f(x) + g(x)</m>.  Then by the limit definition of the derivative,
+                        </p>
+
+                    </proof>
+
+                </theorem>
+
+                <example workspace="1in">
+                    <statement>
+                        <p>
+                            Find the derivative of <m>f(x) = x^5 + e^x</m>.
+                        </p>
+                    </statement>
+                </example>
+
+                <example workspace="1in">
+                    <statement>
+                        <p>
+                            Find the derivative of <m>f(x) = \sqrt{x} + x^3 + 7x</m>.
+                        </p>
+                    </statement>
+                </example>
+
+                <example workspace="1in">
+                    <statement>
+                        <p>
+                            Find the derivative of <m>f(x) = 5x^4</m>.
+                        </p>
+                    </statement>
+                </example>
+            </page>
+        </handout>
+        </section>
+
 
         <section xml:id="exercises-single" label="section-exercises-single">
             <title>Exercises, One Subsection</title>

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -614,7 +614,7 @@ function setInitialWorkspaceHeights() {
 
 // If a worksheet includes authored pages, we only need to put content before the first page and after the last page into the first and last pages, respectively.
 function adjustWorksheetPages() {
-    const worksheet = document.querySelector('section.worksheet');
+    const worksheet = document.querySelector('section.worksheet, section.handout');
     if (!worksheet) {
         console.warn("No worksheet found, exiting adjustWorksheetPages.");
         return;
@@ -655,7 +655,7 @@ function createWorksheetPages(margins) {
     const conservativeContentHeight = 1056 - (margins.top + margins.bottom); // in pixels
     const conservativeContentWidth = 794 - (margins.left + margins.right); // in pixels
 
-    const worksheet = document.querySelector('section.worksheet');
+    const worksheet = document.querySelector('section.worksheet, section.handout');
     if (!worksheet) {
         console.warn("No worksheet found, exiting layoutWorksheet.");
         return;
@@ -968,7 +968,7 @@ window.addEventListener("load",function(event) {
   // We condition on the existence of the papersize radio buttons, which only appear in the worksheet print preview.
   if (document.querySelector('input[name="papersize"]')) {
     // First, get the margins for pages to be passed around as needed.
-    const marginList = document.querySelector('section.worksheet').getAttribute('data-margins').split(' ');
+    const marginList = document.querySelector('section.worksheet, section.handout').getAttribute('data-margins').split(' ');
     // Convert margin values to pixels if they are not already numbers
     function toPixels(value) {
         if (typeof value === "number") return value;

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -31,18 +31,18 @@
 <!ENTITY SIMPLECHAR "concat(&DIGIT;,&ALPHABET;)">
 
 <!-- for match/select -->
-<!ENTITY STRUCTURAL "book|article|slideshow|letter|memo|frontmatter|part|chapter|appendix|index|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary|backmatter">
+<!ENTITY STRUCTURAL "book|article|slideshow|letter|memo|frontmatter|part|chapter|appendix|index|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|handout|reading-questions|solutions|references|glossary|backmatter">
 
 <!ENTITY TRADITIONAL-DIVISION "book|article|part|chapter|section|subsection|subsubsection|appendix">
 
-<!ENTITY SPECIALIZED-DIVISION "exercises|worksheet|reading-questions|references|glossary|solutions">
+<!ENTITY SPECIALIZED-DIVISION "exercises|worksheet|handout|reading-questions|references|glossary|solutions">
 
 <!-- for filtering nodes, eg *[&STRUCTURAL-FILTER;], *[not(&STRUCTURAL-FILTER;)] -->
-<!ENTITY STRUCTURAL-FILTER "self::book or self::article or self::slideshow or self::letter or self::memo or self::frontmatter or self::part or self::chapter or self::appendix or self::index or self::preface or self::acknowledgement or self::biography or self::foreword or self::dedication or self::colophon or self::section or self::subsection or self::subsubsection or self::slide or self::exercises or self::worksheet or self::reading-questions or self::solutions or self::references or self::glossary or self::backmatter">
+<!ENTITY STRUCTURAL-FILTER "self::book or self::article or self::slideshow or self::letter or self::memo or self::frontmatter or self::part or self::chapter or self::appendix or self::index or self::preface or self::acknowledgement or self::biography or self::foreword or self::dedication or self::colophon or self::section or self::subsection or self::subsubsection or self::slide or self::exercises or self::worksheet or self::handout or self::reading-questions or self::solutions or self::references or self::glossary or self::backmatter">
 
 <!ENTITY TRADITIONAL-DIVISION-FILTER "self::book or self::article or self::part or self::chapter or self::section or self::subsection or self::subsubsection or self::appendix">
 
-<!ENTITY SPECIALIZED-DIVISION-FILTER "self::exercises or self::worksheet or self::reading-questions or self::references or self::glossary or self::solutions">
+<!ENTITY SPECIALIZED-DIVISION-FILTER "self::exercises or self::worksheet or self::handout or self::reading-questions or self::references or self::glossary or self::solutions">
 
 <!-- NB: (2019-06-12)  Only the two metadata "filters" seem to          -->
 <!-- be in use, so only those are being maintained.  grep'ing on        -->
@@ -144,4 +144,4 @@
 <!-- true. We are positive, so as new locations of "exercise"          -->
 <!-- are added, then this need not change                              -->
 <!-- Typical use: self::exercise and boolean(&INLINE-EXERCISE-FILTER;) -->
-<!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::section|parent::subsection|parent::subsubsection">
+<!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::section|parent::subsection|parent::subsubsection|parent::handout">

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -86,6 +86,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Slot</localization>
     <localization string-id='exercises'>Oefeninge</localization>
     <localization string-id='worksheet'>Werkblad</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Leesvrae</localization>
     <localization string-id='solutions'>Oplossings</localization>
     <localization string-id='glossary'>Woordelys</localization>

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -89,6 +89,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='exercises'>Упражнения</localization>
 <!--
     <localization string-id='worksheet'>Worksheet</localization>
+    <localization string-id='handout'>Handout</localization>
     <localization string-id='reading-questions'>Reading Questions</localization>
 -->
     <localization string-id='solutions'>Решения</localization>

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -84,6 +84,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusió</localization>
     <localization string-id='exercises'>Exercicis</localization>
     <localization string-id='worksheet'>Full de treball</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Preguntes de comprensió lectora</localization>
     <localization string-id='solutions'>Solucions</localization>
     <localization string-id='glossary'>Glossari</localization>

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -82,6 +82,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Závěr</localization>
     <localization string-id='exercises'>Cvičení</localization>
     <localization string-id='worksheet'>Pracovní list</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Otázky ze čtení</localization>
     <localization string-id='solutions'>Řešení</localization>
     <localization string-id='glossary'>Vysvětlivky</localization>

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -86,6 +86,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Schluss</localization>
     <localization string-id='exercises'>Übungen</localization>
     <localization string-id='worksheet'>Arbeitsblatt</localization>
+    <!-- <localization string-id='handout'>Handout</localization>-->
     <localization string-id='reading-questions'>Lesefragen</localization>
     <localization string-id='solutions'>Lösungen</localization>
     <!-- Wörterverzeichnis scheint viel weniger benutzt zu sein, s. Google ngram -->

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -94,6 +94,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusion</localization>
     <localization string-id='exercises'>Exercises</localization>
     <localization string-id='worksheet'>Worksheet</localization>
+    <localization string-id='handout'>Handout</localization>
     <localization string-id='reading-questions'>Reading Questions</localization>
     <localization string-id='solutions'>Solutions</localization>
     <localization string-id='glossary'>Glossary</localization>

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -85,6 +85,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusión</localization>
     <localization string-id='exercises'>Ejercicios</localization>
     <localization string-id='worksheet'>Hoja de trabajo</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Preguntas de comprensión</localization>
     <localization string-id='solutions'>Soluciones</localization>
     <localization string-id='glossary'>Glosario</localization>

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -80,6 +80,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Päätäntä</localization>
     <localization string-id='exercises'>Harjoitustehtävät</localization>
     <localization string-id='worksheet'>Tehtävämoniste</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Luetun ymmärtäminen</localization>
     <localization string-id='solutions'>Ratkaisut</localization>
     <localization string-id='glossary'>Sanasto</localization>

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -83,6 +83,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusion</localization>
     <localization string-id='exercises'>Exercices</localization>
     <localization string-id='worksheet'>Feuille d'activités</localization> <!-- Harmonisation avec worksheetexercise -->
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Questions de compréhension de la lecture</localization> <!-- Peut-être un peu long /might be a bit too long -->
     <localization string-id='solutions'>Solutions</localization>
     <localization string-id='glossary'>Glossaire</localization>

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -85,6 +85,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusion</localization>
     <localization string-id='exercises'>Exercices</localization>
     <localization string-id='worksheet'>Feuille d'activités</localization> <!-- À défaut d'un meilleur terme -->
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Questions de compréhension de la lecture</localization> <!-- Peut-être un peu long /might be a bit too long -->
     <localization string-id='solutions'>Solutions</localization>
     <localization string-id='glossary'>Glossaire</localization>

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -85,6 +85,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Következtetés</localization>
     <localization string-id='exercises'>Feladatok</localization>
     <!-- <localization string-id='worksheet'>Worksheet</localization> -->
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <!-- <localization string-id='reading-questions'>Reading Questions</localization> -->
     <!-- <localization string-id='solutions'>Solutions</localization> -->
     <!-- <localization string-id='glossary'>Glossary</localization> -->

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -86,6 +86,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusione</localization>
     <localization string-id='exercises'>Esercizi</localization>
     <localization string-id='worksheet'>Scheda didattica</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Domande di comprensione del testo</localization>
     <localization string-id='solutions'>Soluzioni</localization>
     <localization string-id='glossary'>Glossario</localization>

--- a/xsl/localizations/ku-CKB.xml
+++ b/xsl/localizations/ku-CKB.xml
@@ -90,6 +90,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>دەرئەنجام</localization>
     <localization string-id='exercises'>مەشق</localization>
     <localization string-id='worksheet'>پەڕەیکار</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>پرسیاری خوێندنەوە</localization>
     <localization string-id='solutions'>شیکار</localization>
     <localization string-id='glossary'>فەرهەنگۆک</localization>

--- a/xsl/localizations/nl-NL.xml
+++ b/xsl/localizations/nl-NL.xml
@@ -92,6 +92,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Slot</localization>
     <localization string-id='exercises'>Oefeningen</localization>
     <localization string-id='worksheet'>Werkblad</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <!-- <localization string-id='reading-questions'>Reading Questions</localization> -->
     <localization string-id='solutions'>Oplossingen</localization>
     <localization string-id='glossary'>Begrippenlijst</localization>

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -89,6 +89,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='exercises'>Exercícios</localization>
     <!-- Translation needed for Brazilian Portugese -->
     <localization string-id='worksheet'>Lista de Exercícios</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>Exercícios de Interpretação</localization>
     <localization string-id='solutions'>Soluções</localization>
     <localization string-id='glossary'>Glossário</localization>

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -86,6 +86,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>Conclusão</localization>
     <localization string-id='exercises'>Exercícios</localization>
     <!-- <localization string-id='worksheet'>Worksheet</localization> -->
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <!-- <localization string-id='reading-questions'>Reading Questions</localization> -->
     <!-- <localization string-id='solutions'>Solutions</localization> -->
     <!-- <localization string-id='glossary'>Glossary</localization> -->

--- a/xsl/localizations/zh-HANS.xml
+++ b/xsl/localizations/zh-HANS.xml
@@ -94,6 +94,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <localization string-id='conclusion'>结论</localization>
     <localization string-id='exercises'>练习</localization>
     <localization string-id='worksheet'>工作单</localization>
+    <!-- <localization string-id='handout'>Handout</localization> -->
     <localization string-id='reading-questions'>问题</localization>
     <localization string-id='solutions'>解答</localization>
     <localization string-id='glossary'>术语</localization>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1994,7 +1994,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The @struct attribute is the structure number of the *parent*          -->
 <!-- (container), which seems odd here, but fits the general scheme better. -->
 <!-- The @level attribute is helpful, and trvislly to compute here.         -->
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet" mode="augment">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout" mode="augment">
     <xsl:param name="parent-struct"/>
     <xsl:param name="level"/>
     <xsl:param name="ordered-list-level" />
@@ -2026,7 +2026,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="next-level" select="$level + 1"/>
     <xsl:variable name="next-ordered-list-level">
         <xsl:choose>
-            <xsl:when test="self::exercises or self::worksheet or self::reading-questions or self::references">
+            <xsl:when test="self::exercises or self::worksheet or self::handout or self::reading-questions or self::references">
                 <xsl:number value="1" />
             </xsl:when>
             <xsl:otherwise>

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -141,6 +141,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
       $document-root//subsubsection
     | $document-root//subsection/exercises
     | $document-root//subsection/worksheet
+    | $document-root//subsection/handout
     | $document-root//subsection/reading-questions
     | $document-root//subsection/solutions
     | $document-root//subsection/references
@@ -149,6 +150,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-has-level-five" select="boolean(
       $document-root//subsubsection/exercises
     | $document-root//subsubsection/worksheet
+    | $document-root//subsubsection/handout
     | $document-root//subsubsection/reading-questions
     | $document-root//subsubsection/solutions
     | $document-root//subsubsection/references
@@ -344,7 +346,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- 5 (specialized)                     cell-7                      cell-7 -->
 
 <!-- Divisions apparent in a rendered BRF. -->
-<xsl:template match="chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary">
+<xsl:template match="chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|handout|reading-questions|solutions|references|glossary">
 
     <!-- Determine: newpage, centered, cell5, cell7 -->
     <xsl:variable name="heading-style">
@@ -484,7 +486,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- True divisions, +1 from parent -->
-<xsl:template match="part|chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary" mode="braille-level">
+<xsl:template match="part|chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|handout|reading-questions|solutions|references|glossary" mode="braille-level">
     <xsl:variable name="parent-level">
         <xsl:apply-templates select="parent::*" mode="braille-level"/>
     </xsl:variable>
@@ -496,7 +498,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Specialized divisions can appear at many levels, but will -->
 <!-- be formatted according to their level in the hierarchy.   -->
 <!-- See table above for explanation of choices here.          -->
-<xsl:template match="chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary" mode="heading-style">
+<xsl:template match="chapter|appendix|index[index-list]|index-part|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|handout|reading-questions|solutions|references|glossary" mode="heading-style">
     <xsl:variable name="braille-level">
         <xsl:apply-templates select="." mode="braille-level"/>
     </xsl:variable>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -525,7 +525,7 @@ Book (with parts), "section" at level 3
 <!-- application we compute the "old" level to test for consistency.         -->
 
 <!-- ####################################################################### -->
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet" mode="new-level">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout" mode="new-level">
     <xsl:variable name="old-level">
         <xsl:apply-templates select="." mode="level"/>
     </xsl:variable>
@@ -575,7 +575,7 @@ Book (with parts), "section" at level 3
 <!-- chapters of books, sections of articles, or in the case of         -->
 <!-- solutions or references, children of an appendix.                  -->
 
-<xsl:template match="colophon|biography|dedication|acknowledgement|preface|chapter|section|subsection|subsubsection|slide|appendix|index|colophon|exercises|reading-questions|references|solutions|glossary|worksheet" mode="level">
+<xsl:template match="colophon|biography|dedication|acknowledgement|preface|chapter|section|subsection|subsubsection|slide|appendix|index|colophon|exercises|reading-questions|references|solutions|glossary|worksheet|handout" mode="level">
     <xsl:variable name="level-above">
         <xsl:apply-templates select="parent::*" mode="level"/>
     </xsl:variable>
@@ -2180,7 +2180,7 @@ Book (with parts), "section" at level 3
         <!-- there could be metadata, "introduction", etc.)  We know there are no  -->
         <!-- traditional divisions as subdiivisions at this point.  So we test for -->
         <!-- at least one worksheet and no other specialized divisions.            -->
-        <xsl:when test="worksheet and not(exercises|references|glossary|reading-questions|solutions)">
+        <xsl:when test="(worksheet or handout) and not(exercises|references|glossary|reading-questions|solutions)">
             <xsl:value-of select="false()" />
         </xsl:when>
         <xsl:otherwise>
@@ -2217,7 +2217,7 @@ Book (with parts), "section" at level 3
 <xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
     <xsl:variable name="has-traditional" select="boolean(&TRADITIONAL-DIVISION;)"/>
     <xsl:variable name="all-children" select="*"/>
-    <xsl:variable name="all-worksheet" select="title|shorttitle|plaintitle|idx|introduction|worksheet|conclusion"/>
+    <xsl:variable name="all-worksheet" select="title|shorttitle|plaintitle|idx|introduction|worksheet|handout|conclusion"/>
     <xsl:variable name="only-worksheets" select="count($all-children) = count($all-worksheet)"/>
 
     <xsl:value-of select="$has-traditional or $only-worksheets"/>
@@ -2232,7 +2232,7 @@ Book (with parts), "section" at level 3
 <!-- they do not even have a number (singleton "references" as    -->
 <!-- child of "backmatter").  This template returns "true" if a   -->
 <!-- specialized division "owns" its "own" number.                -->
-<xsl:template match="exercises|worksheet|references|glossary|reading-questions|solutions" mode="is-specialized-own-number">
+<xsl:template match="exercises|worksheet|handout|references|glossary|reading-questions|solutions" mode="is-specialized-own-number">
     <xsl:choose>
         <!-- *Some* specialized divisions can appear as a child of the    -->
         <!-- "backmatter" too.  But only those below.  The rest are       -->
@@ -2584,7 +2584,7 @@ Book (with parts), "section" at level 3
 <!-- Some items have default titles that make sense         -->
 <!-- Typically these are one-off subdivisions (eg preface), -->
 <!-- or repeated generic divisions (eg exercises)           -->
-<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|abstract|references|glossary|exercises|worksheet|reading-questions|exercisegroup|solutions|backmatter|index|case|interactive/instructions|keywords" mode="has-default-title">
+<xsl:template match="frontmatter|colophon|preface|foreword|acknowledgement|dedication|biography|abstract|references|glossary|exercises|worksheet|handout|reading-questions|exercisegroup|solutions|backmatter|index|case|interactive/instructions|keywords" mode="has-default-title">
     <xsl:text>true</xsl:text>
 </xsl:template>
 <xsl:template match="*" mode="has-default-title">
@@ -2875,7 +2875,7 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Introductions and Conclusions -->
-<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|reading-questions/introduction|glossary/introduction|references/introduction|article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|reading-questions/conclusion|glossary/conclusion|references/conclusion" mode="title-wants-punctuation">
+<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction|glossary/introduction|references/introduction|article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion|glossary/conclusion|references/conclusion" mode="title-wants-punctuation">
     <xsl:value-of select="true()"/>
 </xsl:template>
 <xsl:template match="*" mode="title-wants-punctuation">
@@ -3800,7 +3800,7 @@ Book (with parts), "section" at level 3
 </xsl:template>
 
 <!-- Serial Numbers: Specialized Divisions -->
-<xsl:template match="exercises|solutions|worksheet|reading-questions|references|glossary" mode="serial-number">
+<xsl:template match="exercises|solutions|worksheet|handout|reading-questions|references|glossary" mode="serial-number">
     <xsl:variable name="is-numbered">
         <xsl:apply-templates select="." mode="is-specialized-own-number"/>
     </xsl:variable>
@@ -3850,9 +3850,9 @@ Book (with parts), "section" at level 3
     <!-- determine if the object being numbered is inside  -->
     <!-- a decorative "exercises" or "worksheet" -->
     <xsl:variable name="inside-decorative">
-        <xsl:if test="ancestor::*[self::exercises or self::reading-questions or self::worksheet]">
+        <xsl:if test="ancestor::*[self::exercises or self::reading-questions or self::worksheet or self::handout]">
             <xsl:variable name="is-numbered">
-                <xsl:apply-templates select="ancestor::*[self::exercises or self::worksheet or self::reading-questions]" mode="is-specialized-own-number"/>
+                <xsl:apply-templates select="ancestor::*[self::exercises or self::worksheet or self::handout or self::reading-questions]" mode="is-specialized-own-number"/>
             </xsl:variable>
             <xsl:if test="not($is-numbered ='true')">
                 <xsl:text>true</xsl:text>
@@ -4007,13 +4007,13 @@ Book (with parts), "section" at level 3
             <xsl:number from="chapter|book/backmatter/appendix" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout|chapter/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet|section/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout|section/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout|subsection/reading-questions" level="any" count="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;" />
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>PTX:ERROR: Subtree level for atomic block number computation is out-of-bounds (<xsl:value-of select="$subtree-level" />)</xsl:message>
@@ -4048,13 +4048,13 @@ Book (with parts), "section" at level 3
             <xsl:number from="chapter|book/backmatter/appendix" level="any" count="&PROJECT-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/reading-questions" level="any" count="&PROJECT-LIKE;" />
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout|chapter/reading-questions" level="any" count="&PROJECT-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet|section/reading-questions" level="any" count="&PROJECT-LIKE;" />
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout|section/reading-questions" level="any" count="&PROJECT-LIKE;" />
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/reading-questions" level="any" count="&PROJECT-LIKE;" />
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout|subsection/reading-questions" level="any" count="&PROJECT-LIKE;" />
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>PTX:ERROR: Subtree level for project number computation is out-of-bounds (<xsl:value-of select="$subtree-level" />)</xsl:message>
@@ -4106,21 +4106,21 @@ Book (with parts), "section" at level 3
                 list[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/reading-questions" level="any"
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout|chapter/reading-questions" level="any"
                 count="figure[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 table[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 listing[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 list[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet|section/reading-questions" level="any"
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout|section/reading-questions" level="any"
                 count="figure[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 table[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 listing[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 list[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/reading-questions" level="any"
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout|subsection/reading-questions" level="any"
                 count="figure[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 table[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
                 listing[not(parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)]|
@@ -4162,15 +4162,15 @@ Book (with parts), "section" at level 3
                 count="exercise[boolean(&INLINE-EXERCISE-FILTER;)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet" level="any"
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout" level="any"
                 count="exercise[boolean(&INLINE-EXERCISE-FILTER;)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet" level="any"
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout" level="any"
                 count="exercise[boolean(&INLINE-EXERCISE-FILTER;)]" />
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet" level="any"
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout" level="any"
                 count="exercise[boolean(&INLINE-EXERCISE-FILTER;)]" />
         </xsl:when>
         <xsl:otherwise>
@@ -4207,13 +4207,13 @@ Book (with parts), "section" at level 3
             <xsl:number from="chapter|book/backmatter/appendix" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout|chapter/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet|section/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout|section/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout|subsection/reading-questions" level="any" count="men|md/mrow[@number = 'yes']|mdn/mrow[not(@number = 'no' or @tag)]"/>
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>PTX:ERROR: Subtree level for equation number computation is out-of-bounds (<xsl:value-of select="$subtree-level" />)</xsl:message>
@@ -4317,13 +4317,13 @@ Book (with parts), "section" at level 3
             <xsl:number from="chapter|book/backmatter/appendix" level="any" count="fn" />
         </xsl:when>
         <xsl:when test="$subtree-level=2">
-            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/reading-questions" level="any" count="fn" />
+            <xsl:number from="section|article/backmatter/appendix|chapter/exercises|chapter/worksheet|chapter/handout|chapter/reading-questions" level="any" count="fn" />
         </xsl:when>
         <xsl:when test="$subtree-level=3">
-            <xsl:number from="subsection|section/exercises|section/worksheet|section/reading-questions" level="any" count="fn" />
+            <xsl:number from="subsection|section/exercises|section/worksheet|section/handout|section/reading-questions" level="any" count="fn" />
         </xsl:when>
         <xsl:when test="$subtree-level=4">
-            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/reading-questions" level="any" count="fn" />
+            <xsl:number from="subsubsection|subsection/exercises|subsection/worksheet|subsection/handout|subsection/reading-questions" level="any" count="fn" />
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>PTX:ERROR: Subtree level for footnote number computation is out-of-bounds (<xsl:value-of select="$subtree-level" />)</xsl:message>
@@ -4570,14 +4570,14 @@ Book (with parts), "section" at level 3
 <!-- level when passed recursively.                            -->
 
 <xsl:template match="*" mode="multi-number">
-    <xsl:param name="nodes" select="ancestor::*[self::part or self::chapter or self::appendix or self::section or self::subsection or self::subsubsection or self::exercises or self::reading-questions or self::solutions or self::references or self::glossary or self::worksheet or self::backmatter[$b-has-parts]]"/>
+    <xsl:param name="nodes" select="ancestor::*[self::part or self::chapter or self::appendix or self::section or self::subsection or self::subsubsection or self::exercises or self::reading-questions or self::solutions or self::references or self::glossary or self::worksheet or self::handout or self::backmatter[$b-has-parts]]"/>
     <xsl:param name="levels" />
     <xsl:param name="pad" />
 
     <!-- Test if last node is unnumbered specialized division -->
     <!-- we do not want to duplicate the serial number, which is from the containing division -->
     <xsl:variable name="decorative-division">
-        <xsl:if test="$nodes[last()][self::exercises or self::worksheet or self::reading-questions]">
+        <xsl:if test="$nodes[last()][self::exercises or self::worksheet or self::handout or self::reading-questions]">
             <xsl:variable name="is-numbered">
                 <xsl:apply-templates select="$nodes[last()]" mode="is-specialized-own-number"/>
             </xsl:variable>
@@ -4673,7 +4673,7 @@ Book (with parts), "section" at level 3
 <!-- the serial-numer and the structure-number, so that other -->
 <!-- devices (like local numbers) will behave correctly.      -->
 <!-- Serial numbers are computed elsewhere, but in tandem.    -->
-<xsl:template match="exercises|solutions[not(parent::backmatter)]|worksheet|reading-questions|references[not(parent::backmatter)]|glossary[not(parent::backmatter)]" mode="structure-number">
+<xsl:template match="exercises|solutions[not(parent::backmatter)]|worksheet|handout|reading-questions|references[not(parent::backmatter)]|glossary[not(parent::backmatter)]" mode="structure-number">
     <xsl:variable name="is-numbered">
         <xsl:apply-templates select="." mode="is-specialized-own-number"/>
     </xsl:variable>
@@ -6092,7 +6092,7 @@ Book (with parts), "section" at level 3
         <!-- Since exercises divisions and references are top-level -->
         <!-- ordered lists, when these are the only interesting     -->
         <!-- ancestor, we add one to the level and return           -->
-        <xsl:when test="(ancestor::exercises or ancestor::worksheet or ancestor::reading-questions or ancestor::references) and not(ancestor::ol)">
+        <xsl:when test="(ancestor::exercises or ancestor::worksheet or ancestor::handout or ancestor::reading-questions or ancestor::references) and not(ancestor::ol)">
             <xsl:value-of select="$level + 1" />
         </xsl:when>
         <xsl:when test="ancestor::ol">
@@ -6108,7 +6108,7 @@ Book (with parts), "section" at level 3
 
 <!-- Exercises and References are        -->
 <!-- specialized top-level ordered lists -->
-<xsl:template match="exercises|worksheet|reading-questions|references" mode="ordered-list-level">
+<xsl:template match="exercises|worksheet|handout|reading-questions|references" mode="ordered-list-level">
     <xsl:value-of select="0" />
 </xsl:template>
 
@@ -6538,7 +6538,8 @@ Book (with parts), "section" at level 3
     <!-- the publisher file allows it.                       -->
     <!-- NB: a blank workspace is used as a signal in "divisionexercise" -->
     <!--     in LaTeX conversion, via parameter #3 of the  environment   -->
-    <xsl:if test="ancestor::worksheet and not(child::task)">
+
+    <xsl:if test="(ancestor::worksheet or ancestor::handout) and not(child::task)">
         <!-- First element with @workspace, confined to the worksheet  -->
         <!-- Could be empty node-set, which will be empty string later -->
         <xsl:variable name="raw-workspace">
@@ -7111,7 +7112,7 @@ Book (with parts), "section" at level 3
 <!-- Worksheet Margins -->
 <!-- ################# -->
 
-<xsl:template match="worksheet" mode="worksheet-margin">
+<xsl:template match="worksheet|handout" mode="worksheet-margin">
     <xsl:param name="author-side"/>
     <xsl:param name="publisher-side"/>
     <xsl:choose>
@@ -11052,10 +11053,10 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
             <xsl:text>Your &lt;book&gt; does not have any chapters.  Maybe you forgot the '--xinclude' switch on your 'xsltproc' command line?</xsl:text>
         </xsl:message>
     </xsl:if>
-    <xsl:if test="article and not(article/p) and not(article/section) and not(article/worksheet)">
+    <xsl:if test="article and not(article/p) and not(article/section) and not(article/worksheet) and not(article/handout)">
         <xsl:message>
             <xsl:text>PTX:WARNING:    </xsl:text>
-            <xsl:text>Your &lt;article&gt; does not have any sections or worksheets, nor any top-level paragraphs.  Maybe you forgot the '--xinclude' switch on your 'xsltproc' command line?</xsl:text>
+            <xsl:text>Your &lt;article&gt; does not have any sections, worksheets, or handouts, nor any top-level paragraphs.  Maybe you forgot the '--xinclude' switch on your 'xsltproc' command line?</xsl:text>
         </xsl:message>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -596,7 +596,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- For a "worksheet" (only), we do it again, to generate -->
     <!-- a standalone printable and editable version.          -->
     <!-- NB we don't produce these for portable html.          -->
-    <xsl:if test="self::worksheet and not($b-portable-html)">
+    <xsl:if test="(self::worksheet or self::handout) and not($b-portable-html)">
         <xsl:apply-templates select="." mode="standalone-worksheet">
             <xsl:with-param name="heading-level" select="$heading-level"/>
         </xsl:apply-templates>
@@ -785,7 +785,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Worksheets generate one additional version     -->
 <!-- designed for printing, on Letter or A4 paper.  -->
-<xsl:template match="worksheet" mode="standalone-worksheet">
+<xsl:template match="worksheet|handout" mode="standalone-worksheet">
     <xsl:param name="heading-level"/>
 
     <xsl:variable name="base-filename">
@@ -910,7 +910,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- *display* a number at birth is therefore more complicated    -->
 <!-- than *having* a number or not.                               -->
 <!-- NB: We sneak in links for standalone versions of worksheets. -->
-<xsl:template match="exercises|solutions|glossary|references|worksheet|reading-questions" mode="heading-content">
+<xsl:template match="exercises|solutions|glossary|references|worksheet|handout|reading-questions" mode="heading-content">
     <span class="type">
         <xsl:apply-templates select="." mode="type-name"/>
     </span>
@@ -933,7 +933,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- $paper is LOWER CASE "a4" and "letter"                         -->
     <!-- NB until worksheet printing can be done without extra files,   -->
     <!-- we omit this for portable html.                                -->
-    <xsl:if test="self::worksheet and not($b-portable-html)">
+    <xsl:if test="(self::worksheet or self::handout) and not($b-portable-html)">
         <xsl:apply-templates select="." mode="standalone-worksheet-links"/>
     </xsl:if>
 </xsl:template>
@@ -945,7 +945,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- worksheet instead of linking to separate file.                 -->
 <!-- We isolate link creation, so we can kill it simply in          -->
 <!-- derivative  conversions                                        -->
-<xsl:template match="worksheet" mode="standalone-worksheet-links">
+<xsl:template match="worksheet|handout" mode="standalone-worksheet-links">
     <xsl:variable name="filename">
         <xsl:apply-templates select="." mode="standalone-worksheet-filename"/>
     </xsl:variable>
@@ -11828,7 +11828,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="print-button"/>
 
-<xsl:template match="worksheet" mode="print-button">
+<xsl:template match="worksheet|handout" mode="print-button">
     <xsl:variable name="print-text">
         <xsl:apply-templates select="." mode="type-name">
             <xsl:with-param name="string-id" select="'print'"/>
@@ -11846,7 +11846,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="print-preview-header"/>
 
-<xsl:template match="worksheet" mode="print-preview-header">
+<xsl:template match="worksheet|handout" mode="print-preview-header">
     <h2 class="print-preview">
         <xsl:apply-templates select="." mode="type-name">
             <xsl:with-param name="string-id" select="'print-preview'"/>
@@ -11856,7 +11856,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="papersize-toggle"/>
 
-<xsl:template match="worksheet" mode="papersize-toggle">
+<xsl:template match="worksheet|handout" mode="papersize-toggle">
     <xsl:variable name="papersize">
         <xsl:apply-templates select="." mode="type-name">
             <xsl:with-param name="string-id" select="'papersize'"/>
@@ -11875,7 +11875,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="highlight-workspace-toggle"/>
 
-<xsl:template match="worksheet" mode="highlight-workspace-toggle">
+<xsl:template match="worksheet|handout" mode="highlight-workspace-toggle">
     <label for="highlight-workspace-checkbox">
         <xsl:apply-templates select="." mode="type-name">
             <xsl:with-param name="string-id" select="'highlight-workspace'"/>
@@ -12094,11 +12094,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- NB no "book", "article" -->
-<xsl:template match="frontmatter|abstract|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|backmatter|appendix|index|backmatter/colophon" mode="toc-item">
+<xsl:template match="frontmatter|abstract|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout|backmatter|appendix|index|backmatter/colophon" mode="toc-item">
     <li>
         <xsl:apply-templates select="." mode="toc-item-properties"/>
         <!-- Recurse into children divisions (if any)-->
-        <xsl:variable name="child-list" select="frontmatter|abstract|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|backmatter|appendix|index|backmatter/colophon"/>
+        <xsl:variable name="child-list" select="frontmatter|abstract|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout|backmatter|appendix|index|backmatter/colophon"/>
         <xsl:if test="$child-list">
             <ul>
                 <!-- copy id of this ui for use in customization pass, will remove there -->
@@ -12318,7 +12318,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Every item that could be a TOC entry, mined from the schema. -->
-<xsl:template match="frontmatter|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|backmatter|appendix|index|backmatter/colophon" mode="toc-item-list">
+<xsl:template match="frontmatter|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout|backmatter|appendix|index|backmatter/colophon" mode="toc-item-list">
     <division>
         <xsl:apply-templates select="." mode="doc-manifest-division-attributes"/>
         <!-- Recurse into children divisions (if any)                 -->
@@ -13887,7 +13887,7 @@ TODO:
 <!-- We put page-margins-attributes only on worksheet sections -->
 <xsl:template match="*" mode="page-margins-attribute"/>
 
-<xsl:template match="worksheet" mode="page-margins-attribute">
+<xsl:template match="worksheet|handout" mode="page-margins-attribute">
     <xsl:attribute name="data-margins">
         <!-- A space-separated list for top, right, bottom, and left margins -->
         <xsl:apply-templates select="." mode="worksheet-margin">
@@ -13916,7 +13916,7 @@ TODO:
 <!-- into an HTML section.onepage.  Note that an "introduction" and    -->
 <!-- "objectives" can precede the first "page" as HTML output, and the -->
 <!-- final "page" may be followed by a "conclusion" and "outcomes"     -->
-<xsl:template match="worksheet/page">
+<xsl:template match="worksheet/page|handout/page">
     <section class="onepage">
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="*"/>
@@ -13925,7 +13925,7 @@ TODO:
 
 <!-- A template ensures standalone page creation, -->
 <!-- and links to same, are consistent            -->
-<xsl:template match="worksheet" mode="standalone-worksheet-filename">
+<xsl:template match="worksheet|handout" mode="standalone-worksheet-filename">
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>-printable</xsl:text>
     <xsl:text>.html</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -4380,30 +4380,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="b-has-answer"  select="$b-has-answer"/>
                 <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
             </xsl:apply-templates>
-            <!-- optionally, an indication of workspace -->
-            <!-- for a print version of a worksheet     -->
-            <xsl:choose>
-                <xsl:when test="self::static">
-                    <xsl:apply-templates select="ancestor::exercise" mode="worksheet-workspace"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:apply-templates select="." mode="worksheet-workspace"/>
-                </xsl:otherwise>
-            </xsl:choose>
         </xsl:when>
         <!-- TODO: contained "if" should just be a new "when"? (look around for similar)" -->
         <xsl:otherwise>
             <!-- no explicit "statement", so all content is the statement -->
             <!-- the "dry-run" templates should prevent an empty shell  -->
-            <xsl:if test="$b-has-statement" select="*">
+            <xsl:if test="$b-has-statement">
                 <xsl:apply-templates select="*">
                     <xsl:with-param name="b-original" select="$b-original" />
                     <xsl:with-param name="block-type" select="$block-type"/>
                 </xsl:apply-templates>
                 <!-- no separator, since no trailing components -->
-                <!-- optionally, an indication of workspace     -->
-                <!-- for a print version of a worksheet         -->
-                <xsl:apply-templates select="." mode="worksheet-workspace"/>
             </xsl:if>
         </xsl:otherwise>
     </xsl:choose>
@@ -4474,7 +4461,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- prints invisible.  No @workspace attribute, nothing is added.     -->
 <!-- We rely on a template in -common to error-check the value of      -->
 <!-- the attribute.                                                    -->
-<xsl:template match="*" mode="worksheet-workspace">
+<xsl:template match="*" mode="workspace">
     <xsl:variable name="vertical-space">
         <xsl:apply-templates select="." mode="sanitize-workspace"/>
     </xsl:variable>
@@ -5030,6 +5017,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="b-original" select="$b-original" />
             <xsl:with-param name="block-type" select="$block-type" />
         </xsl:apply-templates>
+        <!-- Apply workspace div (but not in project, exercises or tasks, -->
+        <!-- since they get them applied in their exercise-content        -->
+        <!-- template). Unless the element is in a worksheet or handout,  -->
+        <!-- this div will be killed by the sanatize-workspace template.  -->
+        <!--<xsl:if test="not(&PROJECT-FILTER; or self::exercise or self::task)">-->
+            <xsl:apply-templates select="." mode="workspace"/>
+        <!--</xsl:if>-->
         <!-- Insert a permalink as the last child of the block, but only   -->
         <!-- if not FIGURE-LIKE (these get their permalink on the caption) -->
         <xsl:if test="not(&FIGURE-FILTER;)">
@@ -5104,6 +5098,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates>
             <xsl:with-param name="b-original" select="$b-original" />
         </xsl:apply-templates>
+        <!-- Insert workspace (will only apply to p inside worksheet/handout -->
+        <xsl:apply-templates select="." mode="workspace"/>
         <!-- Insert permalink -->
         <xsl:apply-templates select="." mode="permalink"/>
     </div>
@@ -5197,6 +5193,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:for-each>
         <!-- INDENT ABOVE ON A WHITESPACE COMMIT -->
+    <!-- Insert workspace (will only apply to p inside worksheet/handout) -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <!-- Insert permalink -->
     <xsl:apply-templates select="." mode="permalink"/>
     </div>
@@ -5300,6 +5298,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
                     </xsl:otherwise>
                 </xsl:choose>
+                <!-- Insert workspace (will only apply if in worksheet/handout) -->
+                <xsl:apply-templates select="." mode="workspace"/>
                 <!-- Insert permalink -->
                 <xsl:apply-templates select="." mode="permalink"/>
             </xsl:element>
@@ -5337,6 +5337,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates>
                     <xsl:with-param name="b-original" select="$b-original" />
                 </xsl:apply-templates>
+                <!-- Insert workspace -->
+                <xsl:apply-templates select="." mode="workspace"/>
             </xsl:element>
         </xsl:otherwise>
     </xsl:choose>

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -85,6 +85,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:call-template>
 </xsl:template>
 
+<xsl:template match="handout">
+    <xsl:call-template name="banner-warning">
+        <xsl:with-param name="warning">Handouts are not yet supported in latex-classic conversions.  No content of such a division will be included in your output, and xref's to such divisions will be broken.</xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
 <!-- Defaults that can be overriden by style files -->
 <xsl:variable name="documentclass" select="'article'"/>
 <xsl:variable name="bibliographystyle" select="'amsplain'"/>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -2633,6 +2633,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}&#xa;</xsl:text>
 </xsl:template>
 
+<!-- Vertical workspace for worksheets and handouts -->
+<xsl:template match="*" mode="workspace">
+    <xsl:variable name="vertical-space">
+        <xsl:apply-templates select="." mode="sanitize-workspace"/>
+    </xsl:variable>
+    <xsl:if test="not($vertical-space = '')">
+        <xsl:text>\par\rule{\workspacestrutwidth}{</xsl:text>
+        <xsl:value-of select="$vertical-space"/>
+        <xsl:text>}%&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
 
 <!-- When workspace is requested, we call the modal "sanitize-workspace" which in -->
 <!-- pretext-common returns an empty string if the requested workspace is not in  -->
@@ -5786,6 +5798,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- explicitly ignore PROOF-LIKE and pickup just for theorems      -->
     <!-- Alternative: ocate first PROOF-LIKE, select only preceding:: ? -->
     <xsl:apply-templates select="*[not(&PROOF-FILTER;)]" />
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
         <xsl:value-of select="local-name(.)" />
     <xsl:text>}&#xa;</xsl:text>
@@ -5827,6 +5841,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
     <xsl:value-of select="$environment-name"/>
     <xsl:text>}&#xa;</xsl:text>
@@ -5846,6 +5862,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="type-name"/>
     <xsl:text>}&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
     <xsl:value-of select="$environment-name"/>
     <xsl:text>}&#xa;</xsl:text>
@@ -5888,6 +5906,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}</xsl:text>
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{case}&#xa;</xsl:text>
 </xsl:template>
 
@@ -6294,6 +6314,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
         <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
     </xsl:apply-templates>
+    <!-- Currently inline exercises and project-like elements -->
+    <!-- are not getting workspace above, so we add it here.  -->
+    <xsl:if test="$inline or $project">
+        <xsl:apply-templates select="." mode="workspace"/>
+    </xsl:if>
     <!-- closing % necessary, as newline between adjacent environments -->
     <!-- will cause a slight indent on trailing exercise               -->
     <xsl:text>\end{</xsl:text>
@@ -6625,14 +6650,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:apply-templates>
                 <!-- possibly add some workspace for items from a worksheet     -->
                 <!-- an empty result is a signal there is no workspace authored -->
-                <xsl:variable name="vertical-space">
-                    <xsl:apply-templates select="." mode="sanitize-workspace"/>
-                </xsl:variable>
-                <xsl:if test="not($vertical-space = '')">
-                    <xsl:text>\par\rule{\workspacestrutwidth}{</xsl:text>
-                    <xsl:value-of select="$vertical-space"/>
-                    <xsl:text>}%&#xa;</xsl:text>
-                </xsl:if>
+                <xsl:apply-templates select="." mode="workspace"/>
             </xsl:if>
         </xsl:for-each>
 
@@ -7005,6 +7023,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="*"/>
         </xsl:otherwise>
     </xsl:choose>
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
         <xsl:value-of select="local-name(.)" />
     <xsl:text>}&#xa;</xsl:text>
@@ -7050,6 +7070,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%&#xa;</xsl:text>
     <!-- Coordinate with schema, since we enforce it here -->
     <xsl:apply-templates select="p|blockquote|pre|image|video|program|console|tabular|sidebyside|sbsgroup" />
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
     <xsl:value-of select="local-name(.)" />
     <xsl:text>}&#xa;</xsl:text>
@@ -7080,6 +7102,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="introduction" />
     <xsl:apply-templates select="ol|ul|dl" />
     <xsl:apply-templates select="conclusion" />
+    <!-- Apply workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
     <xsl:text>\end{</xsl:text>
     <xsl:value-of select="local-name(.)" />
     <xsl:text>}&#xa;</xsl:text>
@@ -7207,6 +7231,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:apply-templates/>
     <xsl:text>%&#xa;</xsl:text>
+    <!-- Add workspace if appropriate -->
+    <xsl:apply-templates select="." mode="workspace"/>
 </xsl:template>
 
 <!-- For a memo, not indenting the first paragraph helps -->
@@ -7623,6 +7649,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(p)">
         <xsl:text>%&#xa;</xsl:text>
     </xsl:if>
+    <xsl:apply-templates select="." mode="workspace"/>
 </xsl:template>
 
 <!-- In an unordered list, an item cannot be a target -->
@@ -7640,6 +7667,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(p)">
         <xsl:text>%&#xa;</xsl:text>
     </xsl:if>
+    <xsl:apply-templates select="." mode="workspace"/>
 </xsl:template>
 
 <!-- Description lists always have title as additional -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1029,6 +1029,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         ($document-root//section/worksheet)[1]|
         ($document-root//subsection/worksheet)[1]|
         ($document-root//subsubsection/worksheet)[1]|
+        ($document-root//chapter/handout|$root/article/handout)[1]|
+        ($document-root//section/handout)[1]|
+        ($document-root//subsection/handout)[1]|
+        ($document-root//subsubsection/handout)[1]|
         ($document-root//chapter/reading-questions|$root/article/reading-questions)[1]|
         ($document-root//section/reading-questions)[1]|
         ($document-root//subsection/reading-questions)[1]|
@@ -2305,8 +2309,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:for-each>
     <!-- INTRODUCTION, CONCLUSION (divisional) -->
     <xsl:variable name="introduction-reps" select="
-        ($root/article/introduction|$document-root//chapter/introduction|$document-root//section/introduction|$document-root//subsection/introduction|$document-root//appendix/introduction|$document-root//exercises/introduction|$document-root//solutions/introduction|$document-root//worksheet/introduction|$document-root//reading-questions/introduction|$document-root//glossary/introduction|$document-root//references/introduction)[1]|
-        ($root/article/conclusion|$document-root//chapter/conclusion|$document-root//section/conclusion|$document-root//subsection/conclusion|$document-root//appendix/conclusion|$document-root//exercises/conclusion|$document-root//solutions/conclusion|$document-root//worksheet/conclusion|$document-root//reading-questions/conclusion|$document-root//glossary/conclusion|$document-root//references/conclusion)[1]"/>
+        ($root/article/introduction|$document-root//chapter/introduction|$document-root//section/introduction|$document-root//subsection/introduction|$document-root//appendix/introduction|$document-root//exercises/introduction|$document-root//solutions/introduction|$document-root//worksheet/introduction|$document-root//handout/introduction|$document-root//reading-questions/introduction|$document-root//glossary/introduction|$document-root//references/introduction)[1]|
+        ($root/article/conclusion|$document-root//chapter/conclusion|$document-root//section/conclusion|$document-root//subsection/conclusion|$document-root//appendix/conclusion|$document-root//exercises/conclusion|$document-root//solutions/conclusion|$document-root//worksheet/conclusion|$document-root//handout/conclusion|$document-root//handout/conclusion|$document-root//reading-questions/conclusion|$document-root//glossary/conclusion|$document-root//references/conclusion)[1]"/>
     <xsl:if test="$introduction-reps">
         <xsl:text>%%&#xa;</xsl:text>
         <xsl:text>%% xparse environments for introductions and conclusions of divisions&#xa;</xsl:text>
@@ -2686,7 +2690,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Divisions in the back matter vary between books and articles -->
 <!--     Book:    children of backmatter -> chapter               -->
 <!--     Article: children of backmatter -> section               -->
-<xsl:template match="exercises|solutions|worksheet|reading-questions|references|glossary|appendix|index" mode="division-name">
+<xsl:template match="exercises|solutions|worksheet|handout|reading-questions|references|glossary|appendix|index" mode="division-name">
     <xsl:choose>
         <xsl:when test="parent::article">
             <xsl:text>section</xsl:text>
@@ -2890,7 +2894,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Pervasive -->
 <!-- Specialized divisions                         -->
 <!-- Product of PTX name with LaTeX level/division -->
-<xsl:template match="exercises|solutions|worksheet|reading-questions|glossary|references|index" mode="division-environment-name">
+<xsl:template match="exercises|solutions|worksheet|handout|reading-questions|glossary|references|index" mode="division-environment-name">
     <xsl:value-of select="local-name(.)"/>
     <xsl:text>-</xsl:text>
     <xsl:apply-templates select="." mode="division-name"/>
@@ -2904,7 +2908,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- division should be numberless at birth.  This needs to be broken  -->
 <!-- out since when we *create* the environments in the preamble we    -->
 <!-- just make "regular" and "numberless" variants, always.            -->
-<xsl:template match="exercises|worksheet|references|glossary|reading-questions|solutions" mode="division-environment-name-suffix">
+<xsl:template match="exercises|worksheet|handout|references|glossary|reading-questions|solutions" mode="division-environment-name-suffix">
     <xsl:variable name="is-numbered">
         <xsl:apply-templates select="." mode="is-specialized-own-number"/>
     </xsl:variable>
@@ -2918,7 +2922,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- specialized divisions improperly                       -->
 <xsl:template match="*" mode="division-environment-name-suffix"/>
 
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|index|exercises|solutions|worksheet|reading-questions|glossary|references" mode="environment">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|index|exercises|solutions|worksheet|handout|reading-questions|glossary|references" mode="environment">
     <!-- for specialized divisions we always make a numbered -->
     <!-- and unnumbered version, with the latter happening   -->
     <!-- on a second trip through the template               -->
@@ -2981,7 +2985,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- close the environment definition, no finish -->
     <xsl:text>}{}%&#xa;</xsl:text>
     <!-- send specialized division back through a second time -->
-    <xsl:if test="not($second-trip) and boolean(self::exercises|self::solutions|self::worksheet|self::reading-questions|self::glossary|self::references)">
+    <xsl:if test="not($second-trip) and boolean(self::exercises|self::solutions|self::worksheet|self::handout|self::reading-questions|self::glossary|self::references)">
         <xsl:apply-templates select="." mode="environment">
             <xsl:with-param name="second-trip" select="true()"/>
         </xsl:apply-templates>
@@ -5449,7 +5453,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################ -->
 
 <!-- Divisions, "part" to "subsubsection", and specialized -->
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|worksheet|reading-questions|solutions|glossary|references">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|worksheet|handout|reading-questions|solutions|glossary|references">
     <xsl:apply-templates select="." mode="console-typeout" />
     <xsl:apply-templates select="." mode="begin-language" />
     <xsl:apply-templates select="." mode="latex-division-heading" />
@@ -5519,12 +5523,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- LaTeX chapter for a "book" and a LaTeX "section" for an "article". -->
 <!-- Specialized Divisions: we do not implement "author", "subtitle",   -->
 <!-- or "epigraph" yet.  These may be added/supported later.            -->
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|solutions|reading-questions|glossary|references|index|worksheet" mode="latex-division-heading">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|solutions|reading-questions|glossary|references|index|worksheet|handout" mode="latex-division-heading">
     <!-- NB: could be obsoleted, see single use -->
-    <xsl:variable name="b-is-specialized" select="boolean(self::exercises|self::solutions[not(parent::backmatter)]|self::reading-questions|self::glossary|self::references|self::worksheet|self::index)"/>
+    <xsl:variable name="b-is-specialized" select="boolean(self::exercises|self::solutions[not(parent::backmatter)]|self::reading-questions|self::glossary|self::references|self::worksheet|self::handout|self::index)"/>
 
     <!-- change geometry if worksheet should be formatted -->
-    <xsl:if test="self::worksheet and $b-latex-worksheet-formatted">
+    <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
         <!-- \newgeometry includes a \clearpage -->
         <xsl:apply-templates select="." mode="new-geometry"/>
     </xsl:if>
@@ -5598,7 +5602,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- the four margins, in units LaTeX understands (such as -->
 <!-- cm, in, pt).  This only produces text, so could go in -->
 <!-- -common, but is also only useful for LaTeX output.    -->
-<xsl:template match="worksheet" mode="new-geometry">
+<xsl:template match="worksheet|handout" mode="new-geometry">
     <!-- Four similar "choose" effect hierarchy/priority -->
     <!-- NB: a publisher string parameter to      -->
     <!-- *really* override (worksheet.left, etc.) -->
@@ -5627,7 +5631,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Footings are straightforward -->
-<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|solutions|reading-questions|glossary|references|index|worksheet" mode="latex-division-footing">
+<xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|solutions|reading-questions|glossary|references|index|worksheet|handout" mode="latex-division-footing">
     <!-- For references we close a list holding "biblio"    -->
     <!-- unless we already added it before the "conclusion" -->
     <xsl:if test="self::references and not(conclusion)">
@@ -5639,7 +5643,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="self::worksheet and $b-latex-worksheet-formatted">
+    <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
         <!-- \restoregeometry includes a \clearpage -->
         <xsl:text>\restoregeometry&#xa;</xsl:text>
     </xsl:if>
@@ -5651,7 +5655,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Title optional (and discouraged), in argument    -->
 <!-- typically just a few paragraphs                  -->
 <!-- NB: a glossary has a "headnote" (elsewhere) and does not have a "conclusion" -->
-<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|reading-questions/introduction|references/introduction">
+<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction|references/introduction">
     <xsl:text>\begin{introduction}</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:apply-templates select="." mode="title-full" />
@@ -5666,7 +5670,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|reading-questions/conclusion|references/conclusion">
+<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion|references/conclusion">
     <!-- We will not close the list of references when -->
     <!-- it has an "introduction".  Now is the time.   -->
     <xsl:if test="parent::references">
@@ -5696,7 +5700,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Produce a  \clearpage  indicating the end -->
 <!-- of a page, but not for the last page.     -->
 
-<xsl:template match="worksheet/page">
+<xsl:template match="worksheet/page|handout/page">
     <xsl:apply-templates select="*"/>
     <xsl:if test="following-sibling::page and $b-latex-worksheet-formatted">
         <xsl:text>\clearpage&#xa;</xsl:text>
@@ -7561,7 +7565,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
     <xsl:text>\begin{enumerate}</xsl:text>
     <!-- override LaTeX defaults as indicated -->
-    <xsl:if test="@marker or ($format-code = '0') or ancestor::exercises or ancestor::worksheet or ancestor::reading-questions or ancestor::references">
+    <xsl:if test="@marker or ($format-code = '0') or ancestor::exercises or ancestor::worksheet or ancestor::handout or ancestor::reading-questions or ancestor::references">
         <xsl:text>[label={</xsl:text>
         <xsl:apply-templates select="." mode="latex-list-label" />
         <xsl:if test="$format-code = '0'">
@@ -10573,7 +10577,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- not be numbered correctly via LaTeX's label/ref system, -->
 <!-- so we will use the hypertarget/hyperlink system         -->
 <!-- NB: template returns strings "true" or "false"          -->
-<xsl:template  match="exercises|reading-questions|glossary|references|worksheet|solutions" mode="xref-as-ref">
+<xsl:template  match="exercises|reading-questions|glossary|references|worksheet|handout|solutions" mode="xref-as-ref">
     <xsl:apply-templates select="." mode="is-specialized-own-number"/>
 </xsl:template>
 
@@ -10721,7 +10725,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This template just copies the gut of two above, perhaps -->
 <!-- there should be two utility templates that each get     -->
 <!-- called twice overall.                                   -->
-<xsl:template  match="exercises|reading-questions|glossary|references|worksheet|solutions" mode="xref-number">
+<xsl:template  match="exercises|reading-questions|glossary|references|worksheet|handout|solutions" mode="xref-number">
     <xsl:param name="xref" select="/.." />
 
     <xsl:variable name="is-numbered">

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -88,13 +88,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- we might enforce some assumptions here, and elsewhere, by only   -->
 <!-- including predecessors in the @count attribute.                  -->
 <xsl:template match="section" mode="division-serial-number">
-    <xsl:number count="section|exercises|reading-questions|solutions|references|glossary|worksheet" format="1" />
+    <xsl:number count="section|exercises|reading-questions|solutions|references|glossary|worksheet|handout" format="1" />
 </xsl:template>
 <xsl:template match="subsection" mode="division-serial-number">
-    <xsl:number count="subsection|exercises|reading-questions|solutions|references|glossary|worksheet" format="1" />
+    <xsl:number count="subsection|exercises|reading-questions|solutions|references|glossary|worksheet|handout" format="1" />
 </xsl:template>
 <xsl:template match="subsubsection" mode="division-serial-number">
-    <xsl:number count="subsubsection|exercises|reading-questions|solutions|references|glossary|worksheet" format="1" />
+    <xsl:number count="subsubsection|exercises|reading-questions|solutions|references|glossary|worksheet|handout" format="1" />
 </xsl:template>
 
 <!-- Specialized Divisions -->
@@ -110,8 +110,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- peer is listed here in the "match", but only one  -->
 <!-- type will actually be present in the structured   -->
 <!-- division.                                         -->
-<xsl:template match="exercises|reading-questions|solutions|references|glossary|worksheet" mode="division-serial-number">
-    <xsl:number count="chapter|section|subsection|subsubsection|exercises|reading-questions|solutions|references|glossary|worksheet" format="1" />
+<xsl:template match="exercises|reading-questions|solutions|references|glossary|worksheet|handout" mode="division-serial-number">
+    <xsl:number count="chapter|section|subsection|subsubsection|exercises|reading-questions|solutions|references|glossary|worksheet|handout" format="1" />
 </xsl:template>
 <!-- Following "backmatter" matches will be more specific than above -->
 <!-- A "solutions" is a specialized division, but is numbered        -->

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -571,7 +571,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Runestone "subchapter".  Runestone "timed exams" (on a per-chapter -->
 <!-- basis here), which are an "exercises" with a @time-limit, are      -->
 <!-- exceptional and have templates elsewhere.                          -->
-<xsl:template match="section|chapter/exercises[not(@time-limit)]|chapter/worksheet|chapter/reading-questions" mode="runestone-manifest">
+<xsl:template match="section|chapter/exercises[not(@time-limit)]|chapter/worksheet|chapter/handout|chapter/reading-questions" mode="runestone-manifest">
     <subchapter>
         <!-- some properties of the division -->
         <xsl:apply-templates select="." mode="runestone-division-properties"/>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -85,7 +85,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Divisions -->
 <!-- ######### -->
 
-<xsl:template match="part|chapter|section|subsection|subsubsection|exercises|reading-questions|worksheet|glossary|references|solutions">
+<xsl:template match="part|chapter|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
     <!-- empty line prior -->
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="." mode="type-name"/>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -119,7 +119,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$version-root/book/chapter/section">2</xsl:when>
         <xsl:when test="$version-root/book/chapter">1</xsl:when>
         <xsl:when test="$version-root/article/section/subsection">2</xsl:when>
-        <xsl:when test="$version-root/article/section|$version-root/article/worksheet">1</xsl:when>
+        <xsl:when test="$version-root/article/section|$version-root/article/worksheet|$version-root/article/handout">1</xsl:when>
         <xsl:when test="$version-root/article">0</xsl:when>
         <xsl:when test="$version-root/slideshow">0</xsl:when>
         <xsl:when test="$version-root/letter">0</xsl:when>


### PR DESCRIPTION
This PR implements a new division, `handout` which mimics `worksheet` in that it gets a print preview for HTML and custom margins in PDF, but does not have the special treatment of exercises that a `worksheet` does.  Since a common use case for a handout is "guided notes" in which the instructor provides printouts of the day's notes with room for students to fill in pieces that will be done in class, we expand the elements that can accept `@workspace` to include almost all blocks, `p` and `li`.  Technically, this additional workspace opportunity is available in `worksheet` as well, but we could lock that down if we wanted.

Diffs after the first 7 commits show only that two "bugs" were fixed: previously, workspace was added to the copy of elements in (backmatter) `solutions` in HTML, and project-like were not getting workspace in LaTeX.  The refactoring of workspace fixed this.

Added examples to the sample article, which revealed some bugs with the print-worksheet css, which are now also fixed.

A later PR can do some cosmetic cleanup of the code (e.g., "worksheet" is used where now "worksheet/handout" or "printable" would be more appropriate), add info to the guide, and amend the schema (although worksheet is still only in the dev schema).