### PR TITLE
XSL: fix bug preventing workspace in HTML when LaTeX pubvar set to no

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6534,10 +6534,10 @@ Book (with parts), "section" at level 3
 <xsl:template match="&PROJECT-LIKE;|exercise|task" mode="sanitize-workspace">
     <!-- bail out quickly and empty if not on a worksheet    -->
     <!-- bail out if at a "task" that is not a terminal task -->
-    <!-- bail out if publisher file says to not format worksheets        -->
+    <!-- we assume LaTeX will only request this template if the publisher file allows it. -->
     <!-- NB: a blank workspace is used as a signal in "divisionexercise" -->
     <!--     in LaTeX conversion, via parameter #3 of the  environment   -->
-    <xsl:if test="ancestor::worksheet and not(child::task) and ($latex-worksheet-formatted = 'yes')">
+    <xsl:if test="ancestor::worksheet and not(child::task)">
         <!-- First element with @workspace, confined to the worksheet  -->
         <!-- Could be empty node-set, which will be empty string later -->
         <xsl:variable name="workspaced" select="ancestor-or-self::*[@workspace and ancestor::worksheet][1]"/>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -2634,6 +2634,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
+<!-- When workspace is requested, we call the modal "sanitize-workspace" which in -->
+<!-- pretext-common returns an empty string if the requested workspace is not in  -->
+<!-- an appropriate division.  But we automatically want the empty string if the  -->
+<!-- publisher variable latex-worksheet-formatted is not set to "yes", so here we -->
+<!-- only apply the template in pretext-common if the variable is set to "yes".   -->
+<!-- NB: it is important to do this here and not in the pretext-common -->
+<!-- template since that is also used for HTML                         -->
+<xsl:template match="*" mode="sanitize-workspace">
+    <xsl:if test="$b-latex-worksheet-formatted">
+        <xsl:apply-imports />
+    </xsl:if>
+</xsl:template>
 
 
 <!--##################################-->


### PR DESCRIPTION
The `sanitize-workspace` modal template lives in `pretext-common.xsl` as was using the value of the publisher variable `latex-worksheet-formatted` in deciding whether to allow workspace on an item (if the value was "no" then no workspace should appear in LaTeX).  This was bleeding through to HTML though, which also uses the template.

To fix, I removed the test on that publisher variable in `-common` and add a copy of the template in `-latex-common`.  The new template checks if the publisher wants latex worksheets formatted, and if so, applies the imported version of the template (otherwise it does nothing, which is the desired behavior).

This might cause a merge conflict with #2641, which I can resolve when appropriate.