### PR TITLE
Fix bug: ensure runestone profile menu opens above navbar in mobile view

### DIFF
--- a/css/components/helpers/_buttons-default.scss
+++ b/css/components/helpers/_buttons-default.scss
@@ -53,7 +53,7 @@ $border-radius: 0 !default;
   position: relative;
 
   .dropdown-content {
-    display: hidden;
+    display: none;
     position: absolute;
     background-color: var(--dropdown-background);
     min-width: 160px;

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -114,11 +114,12 @@ $center-content: true !default;
     min-width: 70px;
   }
 
-  .runestone-profile {
-    @include buttons.ptx-dropdown-button;
-  }
 }
 
+// Button in the navbar, but needs to be less specific so not nested in previous
+.runestone-profile {
+  @include buttons.ptx-dropdown-button;
+}
 
 @if $max-width > 0 {
   @media screen and (min-width: $max-width) {


### PR DESCRIPTION
@DavidCooperWCU noticed a bug with the CSS for the Runestone Profile (person) menu; it was opening downward in mobile view, which since the button was already at the bottom of the page was not particularly helpful.

We already have a selector for this case, but because the original selector is being included inside `.runestone-profile`, it's specificity was too low to override properly.  "Fixed" by adding `!important`, which I know isn't ideal, but seemed reasonable in this case.

Also fixed an invalid display property for the original selector.

@ascholer?