### PR TITLE
WeBWorK: process PROJECT-LIKE correctly

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -343,17 +343,31 @@ ENDDOCUMENT();
                     <webwork><xi:include parse="text" href="pg/Adding_SingleDigit_Integers.pg"/></webwork>
                 </exercise>
 
-                <project label="copy-webwork-add-numbers">
-                    <title>Inside a <tag>project</tag></title>
-                    <introduction>
-                        <p>
-                            If you like, you can have a <webwork/> inside a PROJECT-LIKE block.
-                            Just like with an <tag>exercise</tag>, it can be preceded with an optional <tag>introduction</tag>
-                            and followed by an optional <tag>conclusion</tag>.
-                        </p>
-                    </introduction>
-                    <webwork copy="webwork-add-numbers" seed="511"/>
-                </project>
+                <subsection>
+                    <project label="copy-webwork-add-numbers">
+                        <title>Inside a <tag>project</tag></title>
+                        <introduction>
+                            <p>
+                                If you like, you can have a <webwork/> inside a <tag>project</tag>.
+                                Just like with an <tag>exercise</tag>, it can be preceded with an
+                                optional <tag>introduction</tag> and followed by an optional
+                                <tag>conclusion</tag>.
+                            </p>
+                        </introduction>
+                        <webwork copy="webwork-add-numbers" seed="511"/>
+                    </project>
+
+                    <exploration label="copy-webwork-add-numbers-exploration">
+                        <title>Inside an <tag>exploration</tag></title>
+                        <introduction>
+                            <p>
+                                There are other <q>project-like</q> tags besides <tag>project</tag>.
+                                Here, we use an <tag>exploration</tag>.
+                            </p>
+                        </introduction>
+                        <webwork copy="webwork-add-numbers" seed="512"/>
+                    </exploration>
+                </subsection>
 
             </section>
 

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -245,10 +245,11 @@
         </xsl:when>
         <xsl:when test="statement|task|text()">
             <xsl:apply-templates select="." mode="directory-path" />
-            <xsl:if test="parent::project">
-                <xsl:text>Project-</xsl:text>
+            <xsl:if test="parent::*[&PROJECT-FILTER;]">
+                <xsl:apply-templates select="parent::*" mode="type-name"/>
+                <xsl:text>-</xsl:text>
             </xsl:if>
-            <xsl:apply-templates select="parent::exercise" mode="numbered-title-filesafe" />
+            <xsl:apply-templates select="parent::*" mode="numbered-title-filesafe" />
             <xsl:text>.pg</xsl:text>
         </xsl:when>
     </xsl:choose>
@@ -750,10 +751,12 @@
     <xsl:text>## Section1(not reported</xsl:text>
         <!-- <xsl:apply-templates select="ancestor::exercise" mode="structure-number" /> -->
     <xsl:text>)&#xa;</xsl:text>
-    <!-- WW problem is always enclosed directly by an PTX exercise -->
-    <xsl:text>## Problem1(</xsl:text>
-        <xsl:apply-templates select="parent::exercise" mode="number" />
-    <xsl:text>)&#xa;</xsl:text>
+    <!-- WW problem is always enclosed directly by a PTX exercise or PROJECT-LIKE -->
+    <xsl:if test="parent::exercise">
+        <xsl:text>## Problem1(</xsl:text>
+            <xsl:apply-templates select="parent::exercise" mode="number" />
+        <xsl:text>)&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>## Author(</xsl:text>
     <xsl:text>)&#xa;</xsl:text>
     <xsl:text>## Institution(</xsl:text>

--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -78,7 +78,7 @@
 <!-- Then chunk the document to write reasonable problem definition files     -->
 <xsl:template match="/">
     <xsl:apply-templates select="$original" mode="generic-warnings"/>
-    <xsl:apply-templates select="$document-root//exercise/webwork[statement|task]" mode="write-file"/>
+    <xsl:apply-templates select="$document-root//webwork[statement|task]" mode="write-file"/>
     <xsl:apply-templates select="$document-root" mode="chunking"/>
 </xsl:template>
 
@@ -127,8 +127,9 @@
 <!-- Append a filename to the directory path              -->
 <xsl:template match="webwork[statement|task]" mode="relative-filename">
     <xsl:apply-templates select="." mode="directory-path" />
-    <xsl:if test="parent::project">
-        <xsl:text>Project-</xsl:text>
+    <xsl:if test="parent::*[&PROJECT-FILTER;]">
+        <xsl:apply-templates select="parent::*" mode="type-name"/>
+        <xsl:text>-</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="parent::*" mode="numbered-title-filesafe" />
     <xsl:text>.pg</xsl:text>


### PR DESCRIPTION
Note: This will have a small clash with #2646. Not sure which to process first, as I think the Active Calculus project is interested in both so that their WW server can transition to webwork.runestone.academy.

Up until this PR, `webwork` within a PROJECT-LIKE did not work out well in many scenarios unless the PROJECT-LIKE was specifically a `project`. Also the word "Project" was used in a hard coded way, rather than allow for localization or a custom name.
