### PR TITLE
Css fixes for colorado themes

### DIFF
--- a/css/colors/_palette-dark.scss
+++ b/css/colors/_palette-dark.scss
@@ -91,7 +91,7 @@ $colors: map.merge(
   // Buttons & Widgets
   "button-background": var(--background-color-gray-15),
   "button-border-color": var(--background-color-white-25),
-  "button-hover-background": var(--primary-color),
+  "button-hover-background": var(--primary-color-black-50),
   "button-text-color": var(--body-text-color),
   "code-inline": var(--background-color-gray-20),
   )

--- a/css/targets/html/boulder/_customization.scss
+++ b/css/targets/html/boulder/_customization.scss
@@ -11,14 +11,6 @@
     display: none;
 }
 
-.ptx-navbar {
-    border-top: none;
-}
-
-.ptx-page {
-    margin-top: 36px;
-    margin-bottom: 36px;
-}
 
 .button.disabled {
     display: none;

--- a/css/targets/html/boulder/theme-boulder.scss
+++ b/css/targets/html/boulder/theme-boulder.scss
@@ -13,11 +13,19 @@ $background-color-dark: hsl(270, 5%, 5%) !default;
 
 @use "sass:map";
 
-// Imports in this file can be either relative to this file or 
-// relative to css/ directory
+
+// set some default sizing variables - this will also set up
+// defaults for expandable mixin
+@use '../salem/sizing-globals' with (
+  $content-width: 600px,
+  $content-side-padding: 20px
+);
+
 // Basic components: 
-//@use 'components/pretext';// with ($inline-section-headings: false);
 @use 'components/pretext'; 
+
+@use '../salem/other-widen';
+
 @use '../denver/parts-paper';
 //@use 'shell';
 @use 'customization';

--- a/css/targets/html/boulder/theme-boulder.scss
+++ b/css/targets/html/boulder/theme-boulder.scss
@@ -8,8 +8,8 @@
 // different definitions for these variables to this file before the theme
 // is compiled.
 $primary-color: hsl(270, 40%, 15%) !default;
-$primary-color-dark: hsl(270, 40%, 70%) !default;
-$background-color-dark: hsl(270, 5%, 5%) !default;
+$primary-color-dark: hsl(270, 50%, 50%) !default;
+$background-color-dark: hsl(270, 10%, 5%) !default;
 
 @use "sass:map";
 

--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -80,11 +80,10 @@ $chunk-heading-font-size: 1.125em !default;
   padding-right: 1em;
 
   &::after {
-    content: "QED";
-    font-size: smaller;
-    font-style: oblique;
-    font-variant: small-caps;
-    float: right;
+    content: "\220E";
+    position: absolute;
+    right: 0;
+    bottom: 1.5em;
   }
 
   .heading {

--- a/css/targets/html/denver/_customizations.scss
+++ b/css/targets/html/denver/_customizations.scss
@@ -8,6 +8,27 @@ $text-color: white !default;
     content: " ";
 }
 
+
+//Give navbar a gradient background
+.ptx-navbar {
+    background: linear-gradient(to bottom, var(--banner-background), var(--navbar-background));
+
+    .button {
+        background: linear-gradient(to bottom, var(--banner-background), var(--navbar-background));
+
+        // Turn off background-image (linear gradient) on hover so it behaves like a solid color button
+        &:hover:not(.disabled) {
+            background-image: none;
+        }
+
+        &.open {
+            background-image: none;
+        }
+
+    }
+}
+
+
 // Apply blocks of colors to headings when not in dark mode
 //:root {
 //  &:not(.dark-mode) {

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -80,6 +80,14 @@ $page-width: $sidebar-total-width + $main-width + $main-right-margin;
   // The color of the shadow is mostly gray, but with a slight tint of the primary color
   box-shadow: 5px 10px 40px -10px var(--primary-color-gray-80);
 }
+@media (prefers-color-scheme: dark) {
+  .ptx-main {
+    // Dark mode shadow is just black
+    box-shadow: 5px 10px 40px -10px black;
+  }
+}
+
+
 
 // visually shift the sidebar off the page
 .ptx-sidebar {
@@ -87,16 +95,19 @@ $page-width: $sidebar-total-width + $main-width + $main-right-margin;
   margin-right: $sidebar-right-margin;
 }
 
-// move contents button out of navbar-contents and align with sidebar
-.ptx-navbar .toc-toggle {
-  transform: translateX(-$sidebar-total-width);
-  position: absolute;
-  left: 0;
-  justify-content: left;
+.ptx-navbar {
+  border: none;
+
+  // move contents button out of navbar-contents and align with sidebar
+  .toc-toggle {
+    transform: translateX(-$sidebar-total-width);
+    position: absolute;
+    left: 0;
+    justify-content: left;
+  }
 }
 
 .ptx-toc {
-  padding-top: 36px;
   border: none;
   position: sticky;
   top: $nav-height;
@@ -108,6 +119,10 @@ $page-width: $sidebar-total-width + $main-width + $main-right-margin;
   padding-left: 8px;
 }
 
+.ptx-page {
+    margin-top: 36px;
+    margin-bottom: 36px;
+}
 
 // Sidebar hits the left side of page - need to lock it in place
 $sidebar-lock-breakpoint: $main-width + 2 * $sidebar-total-width;
@@ -161,6 +176,19 @@ $page-border-breakpoint: $main-width + $sidebar-width + 2 * $sidebar-right-margi
     transform: translateX(-$sidebar-width);
     justify-content: center;
   }
+
+  // Reset margins for page now that we don't show box-shadow
+  .ptx-page {
+    margin-top: unset;
+    margin-bottom: unset;
+  }
+
+  // And lower TOC accordingly
+  .ptx-toc {
+    padding-top: 36px;
+
+  }
+
 }
 
 

--- a/css/targets/html/denver/theme-denver.scss
+++ b/css/targets/html/denver/theme-denver.scss
@@ -12,8 +12,8 @@ $color-main: null !default;
 $color-do: null !default;
 $color-fact: null !default;
 $color-meta: null !default;
-$primary-color-dark: #9db9d3 !default;
-$background-color-dark: #23241f !default;
+$primary-color-dark: hsl(210, 50%, 50%) !default;
+$background-color-dark: hsl(210, 10%, 10%) !default;
 
 @use "sass:map";
 @use 'sass:color';

--- a/css/targets/html/greeley/_chunks-greeley.scss
+++ b/css/targets/html/greeley/_chunks-greeley.scss
@@ -52,9 +52,13 @@ $border-radius: 8px !default;
 
 .proof {
   padding-bottom: 1.5em;
+  padding-left: 1em;
+  padding-right: 1em;
   &::after {
     content: "□";
-    float: right;
+    position: absolute;
+    right: 0;
+    bottom: 1.5em;
   }
 
   .heading {

--- a/css/targets/html/greeley/theme-greeley.scss
+++ b/css/targets/html/greeley/theme-greeley.scss
@@ -7,10 +7,10 @@
 // different definitions for these variables to this file before the theme
 // is compiled.
 $palette: 'grays' !default;
-$primary-color: null !default;
+$primary-color: hsl(214, 59%, 40%) !default;
 $secondary-color: null !default;
-$primary-color-dark: #829ab1 !default;
-$background-color-dark: #23241f !default;
+$primary-color-dark: hsl(214, 50%, 50%) !default;
+$background-color-dark: hsl(214, 20%, 10%) !default;
 
 @use "sass:map";
 

--- a/css/targets/html/greeley/theme-greeley.scss
+++ b/css/targets/html/greeley/theme-greeley.scss
@@ -17,8 +17,18 @@ $background-color-dark: #23241f !default;
 // Imports in this file can be either relative to this file or 
 // relative to css/ directory
 // Basic components: 
-//@use 'components/pretext';// with ($inline-section-headings: false);
-@use 'components/pretext'; 
+
+// set some default sizing variables - this will also set up
+// defaults for expandable mixin
+@use '../salem/sizing-globals' with (
+  $content-width: 600px,
+  $content-side-padding: 20px
+);
+
+@use 'components/pretext';
+
+@use '../salem/other-widen';
+
 @use '../denver/parts-paper';
 //@use 'shell';
 @use 'customization';


### PR DESCRIPTION
This fixes the tombstone placement for ends of proofs in theme-denver and theme-greeley, fixes an issue with wide elements not being placed correctly in theme-greeley and theme-boulder, and tweaks the navbar and page shadow to give a cleaner look.

Will need a follow-on theme generation commit.