### PR TITLE
Backmatter solutions for project-like in worksheets

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -15639,9 +15639,146 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </exercise>
                 </exercisegroup>
             </worksheet>
-       </section>
+        </section>
 
-        <section xml:id="exercises-single" label="section-exercises-single">
+        <section xml:id="worksheet-solution-testing" label="section-worksheet-solutions-testing">
+            <title>Worksheet Solution Testing</title>
+            <introduction>
+                <p>
+                    Solutions to projects and worksheets can both be selected independently for the auto-generated solutions divisions.  What happens when a worksheet contains a project?  Here we explore the various combinations.
+                </p>
+            </introduction>
+
+            <subsection>
+               <title>Subsection with only exercise</title>
+               <exercise>
+                   <statement>
+                        <p>This is an exercise's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is an exercise's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the exercise's solution.</p>
+                    </solution>
+                </exercise>
+            </subsection>
+            <subsection>
+                <title>Subsection with only project</title>
+                <project>
+                    <statement>
+                        <p>This is a project's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is a project's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the project's solution.</p>
+                    </solution>
+                </project>
+            </subsection>
+            <subsection>
+                <title>Subsection with both exercise and project</title>
+                <exercise>
+                    <statement>
+                        <p>This is an exercise's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is an exercise's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the exercise's solution.</p>
+                    </solution>
+                </exercise>
+                <project>
+                    <statement>
+                        <p>This is a project's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is a project's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the project's solution.</p>
+                    </solution>
+                </project>
+            </subsection>
+            <worksheet>
+               <title>Worksheet with only exercise</title>
+               <exercise>
+                   <statement>
+                       <p>This is an exercise's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is an exercise's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the exercise's solution.</p>
+                    </solution>
+                </exercise>
+            </worksheet>
+            <worksheet>
+                <title>Worksheet with only project</title>
+                <project>
+                    <statement>
+                        <p>This is a project's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is a project's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the project's solution.</p>
+                    </solution>
+                </project>
+            </worksheet>
+            <worksheet>
+                <title>Worksheet with both exercise and project</title>
+                <exercise>
+                    <statement>
+                        <p>This is an exercise's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is an exercise's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the exercise's solution.</p>
+                    </solution>
+                </exercise>
+                <project>
+                    <statement>
+                        <p>This is a project's statement.</p>
+                    </statement>
+                    <answer>
+                        <p>This is a project's answer.</p>
+                    </answer>
+                    <solution>
+                        <p>This is the project's solution.</p>
+                    </solution>
+                </project>
+            </worksheet>
+            <solutions inline="answer">
+                <title>Inline answers only</title>
+            </solutions>
+            <solutions project="answer">
+                <title>Project answers only</title>
+            </solutions>
+            <solutions worksheet="answer">
+                <title>Worksheet answers only</title>
+            </solutions>
+            <solutions inline="answer" project="statement">
+                <title>Inline answers, project statement</title>
+            </solutions>
+            <solutions inline="answer" worksheet="statement">
+                <title>Inline answers, worksheet statement</title>
+            </solutions>
+            <solutions project="answer" worksheet="statement">
+                <title>Project answers, worksheet statement</title>
+            </solutions>
+            <solutions inline="answer" project="statement" worksheet="solution">
+                <title>Inline answers, project statement, worksheet solution</title>
+            </solutions>
+        </section>
+
+       <section xml:id="exercises-single" label="section-exercises-single">
             <title>Exercises, One Subsection</title>
 
             <p>This <tag>section</tag> of the sample article demonstrates an <q>unstructured division.</q>  There are no <tag>subsection</tag>, you are just reading the first two paragraphs, followed by some nonsense text.  Then there is a <em>single</em> <tag>exercises</tag> division.  Note that this division is not numbered (since it is unique within the <tag>section</tag>).  And a cross-reference to one of the contained <tag>exercise</tag> will be numbered as a member of the <tag>section</tag>, <xref ref="exercise-challenging-one-unstructured" text="type-global"/>.</p>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6425,6 +6425,10 @@ Book (with parts), "section" at level 3
     <xsl:param name="b-worksheet-hint" />
     <xsl:param name="b-worksheet-answer" />
     <xsl:param name="b-worksheet-solution" />
+    <xsl:param name="b-project-statement" />
+    <xsl:param name="b-project-hint" />
+    <xsl:param name="b-project-answer" />
+    <xsl:param name="b-project-solution" />
 
     <xsl:apply-templates select=".//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
@@ -6433,6 +6437,14 @@ Book (with parts), "section" at level 3
         <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer" />
         <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution" />
     </xsl:apply-templates>
+    <xsl:apply-templates select=".//activity|.//exploration|.//investigation|.//project" mode="dry-run">
+        <xsl:with-param name="admit"           select="$admit"/>
+        <xsl:with-param name="b-has-statement" select="$b-worksheet-statement or $b-project-statement" />
+        <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint or $b-project-hint" />
+        <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer or $b-project-answer" />
+        <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution or $b-project-solution" />
+    </xsl:apply-templates>
+
 </xsl:template>
 
 <xsl:template match="reading-questions" mode="dry-run">
@@ -6921,7 +6933,7 @@ Book (with parts), "section" at level 3
                 <!-- N.B.: inline exercises and PROJECT-LIKE can be   -->
                 <!-- "hidden" inside the "paragraphs" pseudo-division -->
                 <!-- Everything below is 1 deeper than the division's heading -->
-                <xsl:for-each select="exercise|subexercises|exercisegroup|&PROJECT-LIKE;|paragraphs/exercise|paragraphs/*[&PROJECT-FILTER;]|self::worksheet//exercise">
+                <xsl:for-each select="exercise|subexercises|exercisegroup|&PROJECT-LIKE;|paragraphs/*[self::exercise or &PROJECT-FILTER;]|self::worksheet//*[self::exercise or &PROJECT-FILTER;]">
                      <xsl:choose>
                         <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;)">
                             <xsl:apply-templates select="." mode="solutions">
@@ -6981,6 +6993,19 @@ Book (with parts), "section" at level 3
                                 <xsl:with-param name="b-has-answer"    select="$b-reading-answer" />
                                 <xsl:with-param name="b-has-hint"      select="$b-reading-hint" />
                                 <xsl:with-param name="b-has-solution"  select="$b-reading-solution" />
+                            </xsl:apply-templates>
+                        </xsl:when>
+                        <!-- Project-like that are inside worksheets should appear if either worksheet or project components are true -->
+                        <xsl:when test="(&PROJECT-FILTER;) and ancestor::worksheet">
+                            <xsl:apply-templates select="." mode="solutions">
+                                <xsl:with-param name="purpose" select="$purpose"/>
+                                <xsl:with-param name="admit"   select="$admit"/>
+                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
+                                <xsl:with-param name="b-has-statement" select="$b-worksheet-statement or $b-project-statement" />
+                                <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer or $b-project-answer" />
+                                <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint or $b-project-hint" />
+                                <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution or $b-project-solution" />
                             </xsl:apply-templates>
                         </xsl:when>
                         <xsl:when test="&PROJECT-FILTER;">


### PR DESCRIPTION
As [discussed on -dev](https://groups.google.com/g/pretext-dev/c/A4zqTH_hTV4), project-like would not show up in solutions divisions if the project-like was contained in a worksheet that didn't already have an exercise.  

This implements one possible solution.  Note that there are two pieces to getting material in a solutions: you must ensure that the modal `dry-run` marks the division as something that has content, and then you must put the content in there.

The present approach will include a component of a project in a worksheet for a `solutions` division that has either `@worksheet="..."` or `@project="..."`.  See the new section of the sample article for the various combinations of what can happen (in particular, what happens when different components are selected).

I did zero testing on the solutions-manuals latex build.