### PR TITLE
CSS: remove margin from tops of poems

### DIFF
--- a/css/components/elements/_poem.scss
+++ b/css/components/elements/_poem.scss
@@ -1,7 +1,7 @@
 /* style for poems */
 .poem {
   display: table;
-  margin: 1.5em auto 0;
+  margin: 0 auto;
   width: auto;
   max-width: 90%;
 }


### PR DESCRIPTION
Remove margin from top of poem.

We generally try to apply margins based on containing element. (See _spacing.scss). Top margins for individual items end up needing to be undone too often.

This just never got cleaned up in move to that approach.