### PR TITLE
CSS: always center image-archive links

### DIFF
--- a/css/components/elements/_media.scss
+++ b/css/components/elements/_media.scss
@@ -39,6 +39,9 @@ img.contained {
 .image-archive {
   margin: 0.75em auto 0;
   font-family: var(--font-monospace);
+  justify-content: center;
+  display: flex;
+  gap: 0.5em;
 }
 
 // TODO - refactor mag_popup JS and CSS


### PR DESCRIPTION
The only place these really show up in examples is in SA SBSs. There they have always been centered because of the old sbspanel code. New sbs css does not cause that centering.

I think we do want that centering, and it should be applied universally, not just in sbs.