### PR TITLE
HTML: aligned figcaptions in sidebysides

### DIFF
--- a/css/components/chunks/_sidebyside.scss
+++ b/css/components/chunks/_sidebyside.scss
@@ -4,50 +4,96 @@
     margin-top: 1.5em;
 }
 
-.sidebyside {
 
-  .sbsrow {
-    display: flex;
-    justify-content: space-between;
+// sidebysides get laid out into a grid with two rows. "Plain panels" without
+// a caption are in the first row. Panels with things like tables/figures with
+// captions we want to align are decomposed across two rows.
+// If there is no content (no captions) in a second row, it will collapse.
+
+// 1| plain panel | figure-like/table-like
+// 2|             | figcaption
+.sbsrow {
+  display: grid;
+  grid-template-rows: auto auto;
+}
+
+.sbspanel {
+  // most sbspanels are in the first row
+  grid-row: 1; 
+
+  // tables and their captions get centered when in panels
+  & > .table > figcaption {
+    text-align: center;
   }
+  .tabular {
+    overflow-x: auto;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
 
-  /* containers of desired width for actual content */
-  .sbspanel {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
 
-    // &.top is default
+// panel content alignment options
+.sbspanel--top {
+  align-self: start;
+}
 
-    &.middle {
-      justify-content: center;
-      /* should that be space-between? */
-    }
-  
-    &.bottom {
-      justify-content: flex-end;
-    }
+.sbspanel--middle {
+  align-self: center;
+}
 
-    /* fixed-width items are centered horizontally in their panel */
-    &.fixed-width {
-      align-items: center;
-    }
+.sbspanel--bottom {
+  align-self: end;
+}
 
-    // no top-margin for first items inside the panel
-    & > *:first-child {
-      margin-top: 0;
-    }
 
-    table {
-      /* see Sec 23.12 of sample article */
-      overflow-x: auto;
-      margin-left: auto;
-      margin-right: auto;
-    }
+// sbspanels with figures or tables get decomposed into two rows
+// both the panel and the figure-like/table-like element should
+// be ignored by the grid layout so we can place the items inside
+// the *-like into the grid
+.sbspanel:has(.figure-like, .table-like),
+.sbspanel > :is(.figure-like, .table-like) {
+  display: contents;
+}
 
-    // make sure programs don't break containment while in sbs
-    .program {
-      max-width: 100%;
-    }
+
+// first child of decomposed *-like goes to the first row
+.sbspanel > :is(.figure-like, .table-like) > *:first-child {
+  grid-row: 1;
+  align-items: start;
+  align-self: start;
+}
+
+// and gets alignment info
+.sbspanel--top > :is(.figure-like, .table-like) > *:first-child {
+  align-items: start;
+  align-self: start;
+}
+
+.sbspanel--middle > :is(.figure-like, .table-like) > *:first-child {
+  align-items: center;
+  align-self: center;
+}
+
+.sbspanel--bottom > :is(.figure-like, .table-like) > *:first-child {
+  align-items: end;
+  align-self: end;
+}
+
+
+// second child of decomposed *-like goes to the second row
+.sbspanel > :is(.figure-like, .table-like) > *:nth-child(2) {
+  margin-top: 0.5em;
+  grid-row: 2;
+  width: 100%;
+}
+
+
+// make sure content for a panel stays in the correct column
+// otherwise captions may shift left into columns that do not have
+// second row content
+@for $col from 2 through 10 {
+  .sbspanel:nth-of-type(#{$col}) * {
+    grid-column: #{$col};
   }
 }

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6619,13 +6619,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:choose>
         </xsl:attribute>
         <xsl:attribute name="style">
-            <xsl:text>width:</xsl:text>
-            <xsl:call-template name="relative-width">
-                <xsl:with-param name="width" select="$width" />
-                <xsl:with-param name="left-margin"  select="$left-margin" />
-                <xsl:with-param name="right-margin" select="$right-margin" />
-            </xsl:call-template>
-            <xsl:text>;</xsl:text>
             <xsl:if test="$sbsdebug">
                 <xsl:text>box-sizing: border-box;</xsl:text>
                 <xsl:text>-moz-box-sizing: border-box;</xsl:text>
@@ -6652,6 +6645,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
     <xsl:variable name="left-margin"  select="$layout/left-margin" />
     <xsl:variable name="right-margin" select="$layout/right-margin" />
+
+    <xsl:variable name="column-widths">
+        <xsl:for-each select="$layout/width">
+            <xsl:call-template name="relative-width">
+                <xsl:with-param name="width" select="." />
+                <xsl:with-param name="left-margin"  select="$left-margin" />
+                <xsl:with-param name="right-margin" select="$right-margin" />
+            </xsl:call-template>
+            <xsl:if test="position() != last()">
+                <xsl:text> </xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:variable>
 
     <!-- A "sidebyside" div, to contain headers, -->
     <!-- panels, captions rows as "sbsrow" divs  -->
@@ -6680,6 +6686,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>;</xsl:text>
                 <xsl:text>margin-right:</xsl:text>
                 <xsl:value-of select="$right-margin" />
+                <xsl:text>;</xsl:text>
+                <xsl:text>grid-template-columns:</xsl:text>
+                <xsl:value-of select="$column-widths" />
+                <xsl:text>;</xsl:text>
+                <xsl:text>column-gap:</xsl:text>
+                <xsl:value-of select="$layout/space-width" />
                 <xsl:text>;</xsl:text>
                 <xsl:if test="$sbsdebug">
                     <xsl:text>box-sizing: border-box;</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6608,13 +6608,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- the CSS class equals the source attribute, but that may change -->
             <xsl:choose>
                 <xsl:when test="$valign = 'top'">
-                    <xsl:text> top</xsl:text>
+                    <xsl:text> sbspanel--top top</xsl:text>
                 </xsl:when>
                 <xsl:when test="$valign = 'middle'">
-                    <xsl:text> middle</xsl:text>
+                    <xsl:text> sbspanel--middle middle</xsl:text>
                 </xsl:when>
                 <xsl:when test="$valign = 'bottom'">
-                    <xsl:text> bottom</xsl:text>
+                    <xsl:text> sbspanel--bottom bottom</xsl:text>
                 </xsl:when>
             </xsl:choose>
         </xsl:attribute>


### PR DESCRIPTION
This did take a little HTML changing... the inline style tags that are generated based on authored widths now need to be applied as `grid-template-columns` on the sbsrow, instead of individually on panels.

Note that the HTML changes will cause sidebysides in legacy themes to look janky. So this is a breaking change for them. We could do a legacy theme detection to decide which version of HTML to emit, but I don't think we want to fill the codebase with lots of those switches. 

Legacy themes are already "decaying" (the copy to clipboard icon is a good example), this will just be another (albeit more central) thing in the list of items that don't quite work right if you try to build new HTML and use a legacy theme.