### PR TITLE
HTML: override pubfile specified legacy css themes

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2329,26 +2329,39 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!--                              -->
 
 <xsl:variable name="html-theme-name">
+    <xsl:variable name="warning-message">PTX:WARNING: The "FROMSTYLE" style requested in publication/html/css is deprecated. Your book will be built with theme="TOSTYLE". See the "Styling" section in Ch 29 of the Guide for other options.</xsl:variable>
     <xsl:choose>
         <xsl:when test="$publication/html/css/@theme">
             <xsl:value-of select="$publication/html/css/@theme"/>
         </xsl:when>
         <xsl:otherwise>
-            <!-- legacy style detection -->
+            <!-- legacy style detection and overriding -->
             <xsl:choose>
                 <!-- crc and min are best detected via @shell -->
                 <xsl:when test="contains($publication/html/css/@shell, 'crc')">
-                    <xsl:text>crc-legacy</xsl:text>
+                    <xsl:message><xsl:value-of select="str:replace(str:replace($warning-message, 'FROMSTYLE', 'crc'), 'TOSTYLE', 'denver')"/></xsl:message>
+                    <xsl:text>denver</xsl:text>
                 </xsl:when>
                 <xsl:when test="contains($publication/html/css/@shell, 'min')">
-                    <xsl:text>min-legacy</xsl:text>
+                    <xsl:message><xsl:value-of select="str:replace(str:replace($warning-message, 'FROMSTYLE', 'min'), 'TOSTYLE', 'tacoma')"/></xsl:message>
+                    <xsl:text>tacoma</xsl:text>
                 </xsl:when>
                 <!-- others by @style                         -->
-                <xsl:when test="$publication/html/css/@style">
-                    <xsl:value-of select="$publication/html/css/@style"/>
-                    <xsl:text>-legacy</xsl:text>
+                <xsl:when test="contains($publication/html/css/@style, 'wide')">
+                    <xsl:message><xsl:value-of select="str:replace(str:replace($warning-message, 'FROMSTYLE', 'wide'), 'TOSTYLE', 'salem')"/></xsl:message>
+                    <xsl:text>salem</xsl:text>
                 </xsl:when>
-                <xsl:otherwise><xsl:text>default-modern</xsl:text></xsl:otherwise>
+                <xsl:when test="contains($publication/html/css/@style, 'oscarlevin')">
+                    <xsl:message><xsl:value-of select="str:replace(str:replace($warning-message, 'FROMSTYLE', 'oscarlevin'), 'TOSTYLE', 'denver')"/></xsl:message>
+                    <xsl:text>denver</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:variable name="legacy-style">
+                    <xsl:value-of select="$publication/html/css/@style"/>
+                  </xsl:variable>
+                  <xsl:message><xsl:value-of select="str:replace(str:replace($warning-message, 'FROMSTYLE', $legacy-style), 'TOSTYLE', 'default-modern')"/></xsl:message>
+                  <xsl:text>default-modern</xsl:text>
+                </xsl:otherwise>
             </xsl:choose>
         </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
Substitutes out any specified legacy CSS theme with closest modern one. Emits warning that change is being made.

This code runs in the `html-theme-name` variable setting where the selection logic already is. There still is a "standard" deprecation message that comes from the pubfile variable itself. 

I don't think two messages hurt... Eventually the whole "legacy" selection block in `html-theme-name` maybe goes away and any unrecognized theme including legacy ones becomes `default-modern`. At that point we just leave the standard pubfile deprecation message. 

I think this code is just for the interim period where the deprecation is going from voluntary compliance to enforced compliance.

Needs release coordination with @oscarlevin to make freeze point clear for anyone who needs a legacy style for longer. And possibly an announcement at that point.