### PR TITLE
WeBWorK: restore PROJECT-LIKE processing

### DIFF
--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -78,7 +78,7 @@
 <!-- Then chunk the document to write reasonable problem definition files     -->
 <xsl:template match="/">
     <xsl:apply-templates select="$original" mode="generic-warnings"/>
-    <xsl:apply-templates select="$document-root//exercise/webwork[statement|task|text()]" mode="write-file"/>
+    <xsl:apply-templates select="$document-root//webwork[statement|task|text()]" mode="write-file"/>
     <xsl:apply-templates select="$document-root" mode="chunking"/>
 </xsl:template>
 


### PR DESCRIPTION
This restores an edit that was part of #2648 but somewhere got reverted when fixing a merge conflict.  This should now correctly create the `.pg` files for source-authored webwork problems inside project-like.