### PR TITLE
Script: add longer interactive preview timeout "method"

### DIFF
--- a/doc/guide/developer/pretext-script.xml
+++ b/doc/guide/developer/pretext-script.xml
@@ -175,8 +175,14 @@ The script should be run on the entire document, even if all the images are in o
                     <cell><c>-c doc -f pdf</c></cell>
                     <cell>[<c>xelatex</c>], <c>pdflatex</c></cell>
                 </row>
+                <row>
+                    <cell><c>-c preview</c></cell>
+                    <cell>[<c>fast</c>], <c>slow</c></cell>
+                </row>
             </tabular>
         </table>
+
+        <p>For generation of preview images for interactive elements, <c>fast</c> is the default of a 5 second timeout to allow the page to load; if the interactive element is taking longer to load, using <c>slow</c> will double the timeout.</p>
     </section>
 
     <section xml:id="pretext-output">

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -215,6 +215,23 @@ def sanitize_method(method, component, format):
         # set correctly
         else:
             return method
+    elif component == "preview":
+        # unset by command-line, use default
+        if not (method):
+            return "fast"
+        # set, but illegal
+        elif not (method in ["fast", "slow"]):
+            msg = "\n".join(
+                [
+                    'the method given for generating preview images ("{}") is not "fast" or "slow",',
+                    '             so using the default method instead ("fast")',
+                ]
+            )
+            log.warning(msg.format(method))
+            return "fast"
+        # set correctly
+        else:
+            return method
     # inappropriate attempt to use this argument
     elif method:
         msg = "".join(
@@ -707,7 +724,7 @@ def main():
         )
     elif args.component == "preview":
         ptx.preview_images(
-            xml_source, publication_file, stringparams, args.xmlid, dest_dir
+            xml_source, publication_file, stringparams, args.xmlid, dest_dir, method
         )
     elif args.component == "mom":
         ptx.mom_static_problems(


### PR DESCRIPTION
Sometimes an `interactive` needs to load external resources (such as Doenet) which takes longer than the 5 seconds we give for loading the page before taking the screenshot.  This adds an option as `-M --method` on the `preview` component, with values "fast" (default) or "slow" (10 second timeout).

The CLI will also get a flag that has the same effect.