### PR TITLE
WeBWorK sample chapter: make PROJECT-LIKE examples not be copies

### DIFF
--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -353,7 +353,29 @@ ENDDOCUMENT();
                             <tag>conclusion</tag>.
                         </p>
                     </introduction>
-                    <webwork copy="webwork-add-numbers" seed="511"/>
+                    <webwork seed="511">
+                        <description>
+                            Add two positive single-digit integers.
+                        </description>
+                        <pg-code>
+                            $a = random(1, 9, 1);
+                            $b = random(1, 9, 1);
+                            $c = Compute($a + $b);
+                        </pg-code>
+                        <statement>
+                            <p>
+                                Compute the sum of <m><var name="$a" /></m> and
+                                <m><var name="$b" /></m>:
+                            </p>
+                            <p>
+                                <m><var name="$a" /> + <var name="$b" /> =</m>
+                                <var name="$c" width="5" category="integer" />
+                            </p>
+                        </statement>
+                        <solution>
+                            <p><m><var name="$a" /> + <var name="$b" /> = <var name="$c" /></m>.</p>
+                        </solution>
+                    </webwork>
                 </project>
 
                 <exploration label="copy-webwork-add-numbers-exploration">
@@ -364,9 +386,30 @@ ENDDOCUMENT();
                             Here, we use an <tag>exploration</tag>.
                         </p>
                     </introduction>
-                    <webwork copy="webwork-add-numbers" seed="512"/>
+                    <webwork seed="512">
+                        <description>
+                            Add two positive single-digit integers.
+                        </description>
+                        <pg-code>
+                            $a = random(1, 9, 1);
+                            $b = random(1, 9, 1);
+                            $c = Compute($a + $b);
+                        </pg-code>
+                        <statement>
+                            <p>
+                                Compute the sum of <m><var name="$a" /></m> and
+                                <m><var name="$b" /></m>:
+                            </p>
+                            <p>
+                                <m><var name="$a" /> + <var name="$b" /> =</m>
+                                <var name="$c" width="5" category="integer" />
+                            </p>
+                        </statement>
+                        <solution>
+                            <p><m><var name="$a" /> + <var name="$b" /> = <var name="$c" /></m>.</p>
+                        </solution>
+                    </webwork>
                 </exploration>
-
             </section>
 
             <section xml:id="section-the-quadratic-formula">


### PR DESCRIPTION
This changes the two PROJECT-LIKE examples in the sample chapter to not use `@copy`. The changes you will see are that things that should point to the PG file for these will now point to files `Project-1_1_1-Inside_a_project.pg` and `Exploration-1_1_2-Inside_an_exploration.pg` where they previously pointed to the first exercise's file `1_1_1-Adding_SingleDigit_Integers.pg`.

However this PR alone will not actually make the files  files `Project-1_1_1-Inside_a_project.pg` and `Exploration-1_1_2-Inside_an_exploration.pg`. That is the issue which #2658 addresses.