### PR TITLE
CSS: don't apply extra styling to activated webwork exercises

### DIFF
--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -146,7 +146,9 @@ $chunk-heading-font-size: 1.125em !default;
 }
 
 
-.exercise-like:not(.project-like .exercise-like, .exercise-like .exercise-like, .exercises .exercise-like, .reading-questions .exercise-like, .task, .worksheet .exercise-like) {
+// Inline exercises get C-box styling.  But we don't want this on any other exercise-like
+// Last one captures exercise-like in activated webwork.
+.exercise-like:not(.project-like .exercise-like, .exercise-like .exercise-like, .exercises .exercise-like, .reading-questions .exercise-like, .task, .worksheet .exercise-like, .problem-content .exercise-like) {
   @include C-box-mixin.box(
     $border-color: var(--exercise-like-border-color),
     $heading-background: var(--exercise-like-border-color)


### PR DESCRIPTION
The upgrade to the 2.20 webwork server means the structure of an activated webwork problem includes classes `exercise exercise-like`.  In the `denver` theme, these are selected to display the "C-box" styling for inline exercises.  This was bleeding through to this case, so I added another parent to the "don't apply this to that" list.

If this can get merged before the next release, I'd appreciate it.