### PR TITLE
Use the code-wrapper template to process tag/tage/attr

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10521,37 +10521,34 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 
 <!-- A tag, with angle brackets and monospace font -->
 <xsl:template match="tag">
-    <xsl:variable name="the-element">
-        <c>
+    <xsl:call-template name="code-wrapper">
+        <xsl:with-param name="content">
             <xsl:text>&lt;</xsl:text>
-            <xsl:apply-templates/>
+            <xsl:value-of select="text()" />
             <xsl:text>&gt;</xsl:text>
-        </c>
-    </xsl:variable>
-    <xsl:apply-templates select="exsl:node-set($the-element)/*" />
+        </xsl:with-param>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- An empty tag, with angle brackets and monospace font -->
 <xsl:template match="tage">
-    <xsl:variable name="the-element">
-        <c>
+    <xsl:call-template name="code-wrapper">
+        <xsl:with-param name="content">
             <xsl:text>&lt;</xsl:text>
-            <xsl:apply-templates/>
+            <xsl:value-of select="text()" />
             <xsl:text>/&gt;</xsl:text>
-        </c>
-    </xsl:variable>
-    <xsl:apply-templates select="exsl:node-set($the-element)/*" />
+        </xsl:with-param>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- An attribute, with @ and monospace font -->
 <xsl:template match="attr">
-    <xsl:variable name="the-attribute">
-        <c>
+    <xsl:call-template name="code-wrapper">
+        <xsl:with-param name="content">
             <xsl:text>@</xsl:text>
-            <xsl:apply-templates/>
-        </c>
-    </xsl:variable>
-    <xsl:apply-templates select="exsl:node-set($the-attribute)/*" />
+            <xsl:value-of select="text()" />
+        </xsl:with-param>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- ################### -->


### PR DESCRIPTION
tag/tage/attr were using a "wrap in c and reevaluate" approach that resulted in double-escaping and needless processing especially in latex. This attempts to simplify the call by simply using `value-of` on the text content of the tag rather than apply-templates, and using the code-wrapper template instead of "wrapping in c and reevaluating".