### PR TITLE
Common: fix backmatter reading solution selection

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6852,7 +6852,7 @@ Book (with parts), "section" at level 3
             <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
             <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
             <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-            <xsl:with-param name="b-reading-solution"     select="$b-worksheet-solution" />
+            <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
             <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
             <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
             <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
@@ -6882,7 +6882,7 @@ Book (with parts), "section" at level 3
             <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
             <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
             <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-            <xsl:with-param name="b-reading-solution"     select="$b-worksheet-solution" />
+            <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
             <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
             <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
             <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
@@ -7077,7 +7077,7 @@ Book (with parts), "section" at level 3
         <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
         <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
         <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-        <xsl:with-param name="b-reading-solution"     select="$b-worksheet-solution" />
+        <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
         <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
         <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
         <xsl:with-param name="b-project-hint"         select="$b-project-hint" />


### PR DESCRIPTION
While preparing a PR to cosmetically clean up the worksheet|handout comments, I ran into what appears to be a copy/paste error for the solutions-generator.  Only noticed it since I was searching "worksheet" and it looked out of place.