### PR TITLE
Handouts: clean up outdated worksheet-only variable names and comments

### DIFF
--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -3,7 +3,7 @@
 // Get rid of UI elements.
 // Leave margin fiddling for system print dialog.
 
-// Worksheet printing is handled in print-worksheet.scss
+// Worksheet and handout printing is handled in print-worksheet.scss
 
 @media print {
   .pretext .ptx-masthead,

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -612,16 +612,16 @@ function setInitialWorkspaceHeights() {
     });
 }
 
-// If a worksheet includes authored pages, we only need to put content before the first page and after the last page into the first and last pages, respectively.
-function adjustWorksheetPages() {
-    const worksheet = document.querySelector('section.worksheet, section.handout');
-    if (!worksheet) {
-        console.warn("No worksheet found, exiting adjustWorksheetPages.");
+// If a printout (worksheet or handout) includes authored pages, we only need to put content before the first page and after the last page into the first and last pages, respectively.
+function adjustPrintoutPages() {
+    const printout = document.querySelector('section.worksheet, section.handout');
+    if (!printout) {
+        console.warn("No printout found, exiting adjustPrintoutPages.");
         return;
     }
-    const pages = worksheet.querySelectorAll('.onepage');
+    const pages = printout.querySelectorAll('.onepage');
     if (pages.length === 0) {
-        console.warn("No pages found in worksheet, exiting adjustWorksheetPages.");
+        console.warn("No pages found in printout, exiting adjustPrintoutPages.");
         return;
     }
     // Find all children before the first .onepage element:
@@ -629,7 +629,7 @@ function adjustWorksheetPages() {
     const lastPage = pages[pages.length - 1];
     // Move all children before the first page into the first page
     const pageFirstChild = firstPage.firstChild;
-    let currentChild = worksheet.firstChild;
+    let currentChild = printout.firstChild;
     while (currentChild && currentChild !== firstPage) {
         const nextChild = currentChild.nextSibling; // Save the next sibling before removing
         firstPage.insertBefore(currentChild, pageFirstChild); // Move to the first page
@@ -645,8 +645,8 @@ function adjustWorksheetPages() {
     console.log("Moved all content before the first page and after the last page into the respective pages.");
 }
 
-// This is the main function we will call then a worksheet does not come from the XSL with pages already defined (for now, the XSL will keep the <page> behavior as an option).
-function createWorksheetPages(margins) {
+// This is the main function we will call then a printout does not come from the XSL with pages already defined (for now, the XSL will keep the <page> behavior as an option).
+function createPrintoutPages(margins) {
 
     // Assumptions: needs to work for both letter (8.5in x 11in) and a4 (210mm x 297mm) paper sizes.  We will work in pixels (96/in): those are 816px x 1056px and 794px x 1122.5px respectively (1 inch = 96 px, 1 cm = 37.8 px).  We assume that the printing interface of the browser will do the right thing with these.
 
@@ -655,18 +655,18 @@ function createWorksheetPages(margins) {
     const conservativeContentHeight = 1056 - (margins.top + margins.bottom); // in pixels
     const conservativeContentWidth = 794 - (margins.left + margins.right); // in pixels
 
-    const worksheet = document.querySelector('section.worksheet, section.handout');
-    if (!worksheet) {
-        console.warn("No worksheet found, exiting layoutWorksheet.");
+    const printout = document.querySelector('section.worksheet, section.handout');
+    if (!printout) {
+        console.warn("No printout found, exiting createPrintoutPages.");
         return;
     }
-    worksheet.style.width = toString(conservativeContentWidth + margins.left + margins.right) + 'px';
+    printout.style.width = toString(conservativeContentWidth + margins.left + margins.right) + 'px';
     // Set the height of each workspace based on its data-space attribute
-    setInitialWorkspaceHeights(worksheet);
+    setInitialWorkspaceHeights(printout);
 
-    // We want to consider each "block" of the worksheet.  Some of these will be direct children of the worksheet, some will be nested inside these children.  So first create a list of the elements that we consider blocks.
+    // We want to consider each "block" of the printout.  Some of these will be direct children of the printout, some will be nested inside these children.  So first create a list of the elements that we consider blocks.
     let rows = [];
-    for (const child of worksheet.children) {
+    for (const child of printout.children) {
         if (child.classList.contains('sidebyside')) {
             // sidebyside could have tasks, but we don't want to dive further into them.
             rows.push(child);
@@ -727,14 +727,14 @@ function createWorksheetPages(margins) {
             const row = blockList[j].elem;
             pageDiv.appendChild(row);
         }
-        worksheet.appendChild(pageDiv);
+        printout.appendChild(pageDiv);
     }
 
     // remove any old content that is not in a page
-    for (const child of worksheet.children) {
+    for (const child of printout.children) {
         if (!child.classList.contains('onepage')) {
             console.log("Removing old child not in a page:", child);
-            worksheet.removeChild(child);
+            printout.removeChild(child);
         }
     }
 }
@@ -963,9 +963,9 @@ function toggleWorkspaceHighlight(isChecked) {
     }
 }
 
-// Worksheet print preview and page setup
+// Printout print preview and page setup
 window.addEventListener("load",function(event) {
-  // We condition on the existence of the papersize radio buttons, which only appear in the worksheet print preview.
+  // We condition on the existence of the papersize radio buttons, which only appear in the printout print preview.
   if (document.querySelector('input[name="papersize"]')) {
     // First, get the margins for pages to be passed around as needed.
     const marginList = document.querySelector('section.worksheet, section.handout').getAttribute('data-margins').split(' ');
@@ -1065,13 +1065,13 @@ window.addEventListener("load",function(event) {
     born_hidden_knowls.forEach(function(detail) {
         detail.open = true;
     });
-    // If the worksheet has authored pages, there will be at least one .onepage element.
+    // If the printout has authored pages, there will be at least one .onepage element.
     if (document.querySelector('.onepage')) {
-        adjustWorksheetPages();
+        adjustPrintoutPages();
         /* not the right way:  need to figure out what this needs to wait for */
-        //window.setTimeout(adjustWorksheetPages, 1000);
+        //window.setTimeout(adjustPrintoutPages, 1000);
     } else {
-        createWorksheetPages(margins);
+        createPrintoutPages(margins);
     }
     // After pages are set up, we adjust the workspace heights to fit the page (based on the paper size).
     adjustWorkspaceToFitPage({paperSize: paperSize, margins: margins});

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -135,7 +135,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- We need to determine "how deep" the division hierarchy goes, so       -->
 <!-- we probe for depths of four and five.  Note how specialized           -->
 <!-- divisions result in additional depth beyond traditional divisions.    -->
-<!-- (exercises|worksheet|reading-questions|solutions|references|glossary) -->
+<!-- (exercises|worksheet|handout|reading-questions|solutions|references|glossary) -->
 
 <xsl:variable name="b-has-level-four" select="boolean(
       $document-root//subsubsection

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2176,10 +2176,11 @@ Book (with parts), "section" at level 3
         <xsl:when test="part or chapter or section or subsection or subsubsection">
             <xsl:value-of select="false()" />
         </xsl:when>
-        <!-- One exception, a division full of only "worksheet" (as a subdivision, -->
-        <!-- there could be metadata, "introduction", etc.)  We know there are no  -->
-        <!-- traditional divisions as subdiivisions at this point.  So we test for -->
-        <!-- at least one worksheet and no other specialized divisions.            -->
+        <!-- One exception, a division full of only "worksheet" or "handout"     -->
+        <!-- (as a subdivision, there could be metadata, "introduction", etc.)   -->
+        <!-- We know there are no traditional divisions as subdiivisions at this -->
+        <!-- point.  So we test for at least one worksheet or handout and no     -->
+        <!-- other specialized divisions.                                        -->
         <xsl:when test="(worksheet or handout) and not(exercises|references|glossary|reading-questions|solutions)">
             <xsl:value-of select="false()" />
         </xsl:when>
@@ -2199,8 +2200,8 @@ Book (with parts), "section" at level 3
 <!-- There are two models for most of the divisions (part -->
 <!-- through subsubsection, plus appendix).  One has      -->
 <!-- subdivisions, and possibly multiple "exercises", or  -->
-<!-- other specialized subdivisions.  (Namely             -->
-<!-- "worksheet", "exercises", "solutions", and not       -->
+<!-- other specialized subdivisions.  (Namely "worksheet",-->
+<!-- "handout", "exercises", "solutions", and not         -->
 <!-- "references", "glossary", nor "reading-questions".)  -->
 <!-- The other has no subdivisions, and then at most one  -->
 <!-- of each type of specialized subdivision, which       -->
@@ -2214,6 +2215,7 @@ Book (with parts), "section" at level 3
 <!-- An exception is a division of *only* worksheets.     -->
 <!-- Although there could be titles and the like.         -->
 <!-- So we compare all-children to  metadata + worksheet. -->
+<!-- TODO: should there be a similar exception for handouts? -->
 <xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
     <xsl:variable name="has-traditional" select="boolean(&TRADITIONAL-DIVISION;)"/>
     <xsl:variable name="all-children" select="*"/>
@@ -3866,8 +3868,8 @@ Book (with parts), "section" at level 3
     <xsl:param name="numbering-items" />
     <!-- determine enclosing level of numbered item -->
 
-    <!-- determine if the object being numbered is inside  -->
-    <!-- a decorative "exercises" or "worksheet" -->
+    <!-- determine if the object being numbered is inside    -->
+    <!-- a decorative "exercises", "worksheet", or "handout" -->
     <xsl:variable name="inside-decorative">
         <xsl:if test="ancestor::*[self::exercises or self::reading-questions or self::worksheet or self::handout]">
             <xsl:variable name="is-numbered">
@@ -6558,12 +6560,12 @@ Book (with parts), "section" at level 3
 <!-- the element from this template would be useful.                       -->
 <xsl:template match="*" mode="dry-run"/>
 
-<!-- This template is called for items in a worksheet that can have a  -->
+<!-- This template is called for items in a printout that can have a   -->
 <!-- workspace specified.  It is important that this sometimes returns -->
 <!-- an empty string, since that is a signal to not construct some     -->
 <!-- surrounding infrastructure to implement the necessary space.      -->
 <xsl:template match="*" mode="sanitize-workspace">
-    <!-- bail out quickly and empty if not on a worksheet    -->
+    <!-- bail out quickly and empty if not on a printout     -->
     <!-- bail out if at a "task" that is not a terminal task -->
     <!-- we assume LaTeX will only request this template if  -->
     <!-- the publisher file allows it.                       -->
@@ -6571,7 +6573,7 @@ Book (with parts), "section" at level 3
     <!--     in LaTeX conversion, via parameter #3 of the  environment   -->
 
     <xsl:if test="(ancestor::worksheet or ancestor::handout) and not(child::task)">
-        <!-- First element with @workspace, confined to the worksheet  -->
+        <!-- First element with @workspace, confined to the printout   -->
         <!-- Could be empty node-set, which will be empty string later -->
         <xsl:variable name="raw-workspace">
             <xsl:choose>
@@ -6623,8 +6625,6 @@ Book (with parts), "section" at level 3
 <!-- We kill the worksheet @workspace option for WW exercises until    -->
 <!-- we have a better understanding of just how this will be specified -->
 <!-- A no-op, just remove to enable, but will need testing             -->
-<!-- EXAMPLE-LIKE look like things to do, but are not, and so do       -->
-<!-- not have @workspace inside a worksheet                            -->
 <xsl:template match="webwork-reps/static|webwork-reps/static/stage|exercisegroup|&SOLUTION-LIKE;" mode="sanitize-workspace"/>
 
 
@@ -7139,11 +7139,11 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
-<!-- ################# -->
-<!-- Worksheet Margins -->
-<!-- ################# -->
+<!-- ################ -->
+<!-- Printout Margins -->
+<!-- ################ -->
 
-<xsl:template match="worksheet|handout" mode="worksheet-margin">
+<xsl:template match="worksheet|handout" mode="printout-margin">
     <xsl:param name="author-side"/>
     <xsl:param name="publisher-side"/>
     <xsl:choose>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -585,7 +585,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- worth, or just a subdivision within a page    -->
 <!-- Increment $heading-level via this template    -->
 <!-- We use a modal template, so it can be called  -->
-<!-- two more times for a worksheet to make        -->
+<!-- one more time for a printout to make          -->
 <!-- printable standalone versions.                -->
 <xsl:template match="&STRUCTURAL;">
     <xsl:param name="heading-level"/>
@@ -594,11 +594,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="heading-level" select="$heading-level"/>
     </xsl:apply-templates>
 
-    <!-- For a "worksheet" (only), we do it again, to generate -->
-    <!-- a standalone printable and editable version.          -->
-    <!-- NB we don't produce these for portable html.          -->
+    <!-- For a printout (worksheet or handout), we do it again,   -->
+    <!-- to generate a standalone printable and editable version. -->
+    <!-- NB we don't produce these for portable html.             -->
     <xsl:if test="(self::worksheet or self::handout) and not($b-portable-html)">
-        <xsl:apply-templates select="." mode="standalone-worksheet">
+        <xsl:apply-templates select="." mode="standalone-printout">
             <xsl:with-param name="heading-level" select="$heading-level"/>
         </xsl:apply-templates>
     </xsl:if>
@@ -631,7 +631,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:if>
         </xsl:attribute>
         <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <!-- page-margins-attribute will be empty unless in a worksheet's standalone page -->
+        <!-- page-margins-attribute will be empty unless in a printout's standalone page -->
         <xsl:apply-templates select="." mode="page-margins-attribute"/>
         <xsl:apply-templates select="." mode="section-heading">
             <xsl:with-param name="heading-level" select="$heading-level"/>
@@ -786,7 +786,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Worksheets generate one additional version     -->
 <!-- designed for printing, on Letter or A4 paper.  -->
-<xsl:template match="worksheet|handout" mode="standalone-worksheet">
+<xsl:template match="worksheet|handout" mode="standalone-printout">
     <xsl:param name="heading-level"/>
 
     <xsl:variable name="base-filename">
@@ -794,7 +794,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:apply-templates select="." mode="file-wrap">
         <xsl:with-param name="filename">
-            <xsl:apply-templates select="." mode="standalone-worksheet-filename"/>
+            <xsl:apply-templates select="." mode="standalone-printout-filename"/>
         </xsl:with-param>
         <xsl:with-param name="content">
             <xsl:apply-templates select="." mode="structural-division-content">
@@ -910,7 +910,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- (backmatter/references is a singleton).  Whether or not to   -->
 <!-- *display* a number at birth is therefore more complicated    -->
 <!-- than *having* a number or not.                               -->
-<!-- NB: We sneak in links for standalone versions of worksheets. -->
+<!-- NB: We sneak in links for standalone versions of printouts.  -->
 <xsl:template match="exercises|solutions|glossary|references|worksheet|handout|reading-questions" mode="heading-content">
     <span class="type">
         <xsl:apply-templates select="." mode="type-name"/>
@@ -930,25 +930,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="title-full" />
     </span>
     <!-- Links to the "printable" version(s), meant only for "viewable" -->
-    <!-- worksheet, so CSS can kill on the "printable" versions         -->
+    <!-- printout, so CSS can kill on the "printable" versions          -->
     <!-- $paper is LOWER CASE "a4" and "letter"                         -->
-    <!-- NB until worksheet printing can be done without extra files,   -->
+    <!-- NB until printout printing can be done without extra files,    -->
     <!-- we omit this for portable html.                                -->
     <xsl:if test="(self::worksheet or self::handout) and not($b-portable-html)">
-        <xsl:apply-templates select="." mode="standalone-worksheet-links"/>
+        <xsl:apply-templates select="." mode="standalone-printout-links"/>
     </xsl:if>
 </xsl:template>
 
 <!-- Links to the "printable" version(s), meant only for "viewable" -->
-<!-- worksheet, so CSS can kill on the "printable" versions         -->
+<!-- printout, so CSS can kill on the "printable" versions          -->
 <!-- As of 2025-05-31, this is changing to a single print button    -->
 <!-- and will later change to have the button to popout printable   -->
-<!-- worksheet instead of linking to separate file.                 -->
+<!-- printout instead of linking to separate file.                  -->
 <!-- We isolate link creation, so we can kill it simply in          -->
 <!-- derivative  conversions                                        -->
-<xsl:template match="worksheet|handout" mode="standalone-worksheet-links">
+<xsl:template match="worksheet|handout" mode="standalone-printout-links">
     <xsl:variable name="filename">
-        <xsl:apply-templates select="." mode="standalone-worksheet-filename"/>
+        <xsl:apply-templates select="." mode="standalone-printout-filename"/>
     </xsl:variable>
     <xsl:variable name="print-preview-text">
         <xsl:apply-templates select="." mode="type-name">
@@ -4459,11 +4459,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- All of the items matching the template two above (except perhaps  -->
-<!-- the WW exercises) can appear in a worksheet with some room to     -->
+<!-- the WW exercises) can appear in a printout with some room to      -->
 <!-- work a problem given by a @workspace attribute.  (But we are not  -->
 <!-- careful with the match, given the limited reach here.)  The "div" -->
 <!-- we drop here is controlled by the Javascript - on a "normal" page -->
-<!-- displaying a worksheet it is ineffective, and on a printable,     -->
+<!-- displaying a printout it is ineffective, and on a printable,      -->
 <!-- standalone page it produces space that is visually apparent, but  -->
 <!-- prints invisible.  No @workspace attribute, nothing is added.     -->
 <!-- We rely on a template in -common to error-check the value of      -->
@@ -5114,7 +5114,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates>
             <xsl:with-param name="b-original" select="$b-original" />
         </xsl:apply-templates>
-        <!-- Insert workspace (will only apply to p inside worksheet/handout -->
+        <!-- Insert workspace (will only apply to p inside worksheet or handout) -->
         <xsl:apply-templates select="." mode="workspace"/>
         <!-- Insert permalink -->
         <xsl:apply-templates select="." mode="permalink"/>
@@ -5209,7 +5209,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:for-each>
         <!-- INDENT ABOVE ON A WHITESPACE COMMIT -->
-    <!-- Insert workspace (will only apply to p inside worksheet/handout) -->
+    <!-- Insert workspace (will only apply to p inside worksheet or handout) -->
     <xsl:apply-templates select="." mode="workspace"/>
     <!-- Insert permalink -->
     <xsl:apply-templates select="." mode="permalink"/>
@@ -5314,7 +5314,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
                     </xsl:otherwise>
                 </xsl:choose>
-                <!-- Insert workspace (will only apply if in worksheet/handout) -->
+                <!-- Insert workspace (will only apply if in worksheet or handout) -->
                 <xsl:apply-templates select="." mode="workspace"/>
                 <!-- Insert permalink -->
                 <xsl:apply-templates select="." mode="permalink"/>
@@ -10991,9 +10991,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:call-template name="native-search-box-js" />
 </xsl:variable>
 
-<!-- Generate a version of file-wrap-full-head-cache customized for  -->
-<!-- use in printable worksheets. There does not seem to be a better -->
-<!-- (and straightforward) method other than duplicating above work. -->
+<!-- Generate a version of file-wrap-full-head-cache customized for use in -->
+<!-- printable worksheets and handouts. There does not seem to be a better -->
+<!-- (and straightforward) method other than duplicating above work.       -->
 <xsl:variable name="file-wrap-full-head-cache-printable">
     <!-- file-wrap-iframe-head-cache -->
     <xsl:call-template name="fonts"/>
@@ -13707,7 +13707,7 @@ TODO:
     </xsl:if>
 </xsl:template>
 
-<!-- The worksheet previews get their own css target that controls both screen and print styles -->
+<!-- The printout previews get their own css target that controls both screen and print styles -->
 <xsl:template name="css-printable">
     <xsl:if test="not($b-debug-react)">
         <link href="{$html.css.dir}/print-worksheet.css" rel="stylesheet" type="text/css"/>
@@ -13983,35 +13983,35 @@ TODO:
 <!-- Worksheet Margins and Pages -->
 <!-- ########################### -->
 
-<!-- We put page-margins-attributes only on worksheet sections -->
+<!-- We put page-margins-attributes only on printout sections -->
 <xsl:template match="*" mode="page-margins-attribute"/>
 
 <xsl:template match="worksheet|handout" mode="page-margins-attribute">
     <xsl:attribute name="data-margins">
         <!-- A space-separated list for top, right, bottom, and left margins -->
-        <xsl:apply-templates select="." mode="worksheet-margin">
+        <xsl:apply-templates select="." mode="printout-margin">
             <xsl:with-param name="author-side" select="@top"/>
             <xsl:with-param name="publisher-side" select="$ws-margin-top"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="worksheet-margin">
+        <xsl:apply-templates select="." mode="printout-margin">
             <xsl:with-param name="author-side" select="@right"/>
             <xsl:with-param name="publisher-side" select="$ws-margin-right"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="worksheet-margin">
+        <xsl:apply-templates select="." mode="printout-margin">
             <xsl:with-param name="author-side" select="@bottom"/>
             <xsl:with-param name="publisher-side" select="$ws-margin-bottom"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="worksheet-margin">
+        <xsl:apply-templates select="." mode="printout-margin">
             <xsl:with-param name="author-side" select="@left"/>
             <xsl:with-param name="publisher-side" select="$ws-margin-left"/>
         </xsl:apply-templates>
     </xsl:attribute>
 </xsl:template>
 
-<!-- A worksheet is (mostly) structured by "page", which translates    -->
+<!-- A printout is (mostly) structured by "page", which translates    -->
 <!-- into an HTML section.onepage.  Note that an "introduction" and    -->
 <!-- "objectives" can precede the first "page" as HTML output, and the -->
 <!-- final "page" may be followed by a "conclusion" and "outcomes"     -->
@@ -14024,7 +14024,7 @@ TODO:
 
 <!-- A template ensures standalone page creation, -->
 <!-- and links to same, are consistent            -->
-<xsl:template match="worksheet|handout" mode="standalone-worksheet-filename">
+<xsl:template match="worksheet|handout" mode="standalone-printout-filename">
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>-printable</xsl:text>
     <xsl:text>.html</xsl:text>

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -113,7 +113,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- a specialized division, but we would always like to have them as -->
     <!-- standalone worksheets, not matter the chunking level in effect.  -->
     <xsl:if test="self::worksheet">
-        <xsl:apply-templates select="." mode="standalone-worksheet"/>
+        <xsl:apply-templates select="." mode="standalone-printout"/>
     </xsl:if>
 </xsl:template>
 
@@ -196,7 +196,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Worksheets are a great feature for a Jupyter notebook.  But we need -->
 <!-- to adjust the page-oriented flavor of the base HTML (which exists   -->
-<!-- as part of accomodating printing from a web browser). All children  -->
+<!-- as part of accommodating printing from a web browser). All children  -->
 <!-- of a "page" get processed, and elsewhere get recognized as items    -->
 <!-- deserving of their own cells.                                       -->
 <xsl:template match="worksheet/page">
@@ -205,7 +205,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- A template ensures standalone page creation, -->
 <!-- and links to same, are consistent (*.ipynb)  -->
-<xsl:template match="worksheet" mode="standalone-worksheet-filename">
+<xsl:template match="worksheet" mode="standalone-printout-filename">
     <xsl:param name="paper"/>
 
     <xsl:apply-templates select="." mode="visible-id"/>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1333,7 +1333,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\hypertarget{#4}{}}, after upper={\notblank{#3}{\par\rule{\workspacestrutwidth}{#3}\par\vfill}{\par}}}&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="$document-root//@workspace">
-        <xsl:text>%% Worksheet exercises may have workspaces&#xa;</xsl:text>
+        <xsl:text>%% Worksheets and handouts children may have workspaces&#xa;</xsl:text>
         <xsl:text>\newlength{\workspacestrutwidth}&#xa;</xsl:text>
         <xsl:choose>
             <xsl:when test="$b-latex-draft-mode">
@@ -5509,8 +5509,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- A typical division has 5 arguments (below).  For specialized       -->
 <!-- divisions we need to adjust the environment name for numbered      -->
-<!-- v. unnumbered instances.  Worksheets are exception with a          -->
-<!-- page layout change.                                                -->
+<!-- v. unnumbered instances.  Worksheets and handouts are exception    -->
+<!-- with a page layout change.                                         -->
 <!--                                                                    -->
 <!--    1. title                                                        -->
 <!--    2. subtitle                                                     -->
@@ -5527,7 +5527,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- NB: could be obsoleted, see single use -->
     <xsl:variable name="b-is-specialized" select="boolean(self::exercises|self::solutions[not(parent::backmatter)]|self::reading-questions|self::glossary|self::references|self::worksheet|self::handout|self::index)"/>
 
-    <!-- change geometry if worksheet should be formatted -->
+    <!-- change geometry if worksheet or handout should be formatted -->
     <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
         <!-- \newgeometry includes a \clearpage -->
         <xsl:apply-templates select="." mode="new-geometry"/>
@@ -5597,7 +5597,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<!-- Exceptional, for a worksheet only, we clear the page  -->
+<!-- Exceptional, for a printouts only, we clear the page  -->
 <!-- at the start and provide many options for specifying  -->
 <!-- the four margins, in units LaTeX understands (such as -->
 <!-- cm, in, pt).  This only produces text, so could go in -->
@@ -5608,22 +5608,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- *really* override (worksheet.left, etc.) -->
     <xsl:text>\newgeometry{</xsl:text>
     <xsl:text>left=</xsl:text>
-    <xsl:apply-templates select="." mode="worksheet-margin">
+    <xsl:apply-templates select="." mode="printout-margin">
         <xsl:with-param name="author-side" select="@left"/>
         <xsl:with-param name="publisher-side" select="$ws-margin-left"/>
     </xsl:apply-templates>
     <xsl:text>, right=</xsl:text>
-    <xsl:apply-templates select="." mode="worksheet-margin">
+    <xsl:apply-templates select="." mode="printout-margin">
         <xsl:with-param name="author-side" select="@right"/>
         <xsl:with-param name="publisher-side" select="$ws-margin-right"/>
     </xsl:apply-templates>
     <xsl:text>, top=</xsl:text>
-    <xsl:apply-templates select="." mode="worksheet-margin">
+    <xsl:apply-templates select="." mode="printout-margin">
         <xsl:with-param name="author-side" select="@top"/>
         <xsl:with-param name="publisher-side" select="$ws-margin-top"/>
     </xsl:apply-templates>
     <xsl:text>, bottom=</xsl:text>
-    <xsl:apply-templates select="." mode="worksheet-margin">
+    <xsl:apply-templates select="." mode="printout-margin">
         <xsl:with-param name="author-side" select="@bottom"/>
         <xsl:with-param name="publisher-side" select="$ws-margin-bottom"/>
     </xsl:apply-templates>
@@ -5696,7 +5696,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="*"/>
 </xsl:template>
 
-<!-- Pages in a Worksheet -->
+<!-- Pages in a worksheet or handout-->
 <!-- Produce a  \clearpage  indicating the end -->
 <!-- of a page, but not for the last page.     -->
 

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -98,8 +98,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Specialized Divisions -->
-<!-- "exercises", "solutions", references,             -->
-<!-- "worksheet", "reading-questions", "glossary"      -->
+<!-- "exercises", "solutions", references, "worksheet",-->
+<!-- "handout", "reading-questions", "glossary"        -->
 <!-- This is the case of a "structured" division,      -->
 <!-- where we use the resulting number for the         -->
 <!-- division. (In the unstructured case, the number   -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -256,7 +256,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
-<!-- Worksheet margins.  Applies to both PDF and HTML. -->
+<!-- Printout margins.  Applies to both PDF and HTML. -->
 
 <xsl:variable name="ws-margin">
     <xsl:apply-templates select="$publisher-attribute-options/common/worksheet/pi:pub-attribute[@name='margin']" mode="set-pubfile-variable"/>


### PR DESCRIPTION
This is a purely cosmetic change to the code (some variable names, mostly comments).  I used "printout" as a stand-in for "worksheet or handout".  See how it reads.  Happy to change to something else if you prefer.  Can also split up into multiple commits if you think that is worth it.