### PR TITLE
Improve floating aside handling in lists and multi-col environments

### DIFF
--- a/css/components/chunks/_asides-floating.scss
+++ b/css/components/chunks/_asides-floating.scss
@@ -14,6 +14,16 @@ $min-float-width: 1280px !default;
     clear: right;
   }
 
+  /* disable in any multicolumn list/exercisegroup */
+  .multicolumn details.aside-like {
+    position: relative;
+    margin-left: inherit;
+    width: auto;
+    right: 0;
+    float: none;
+    clear: none;
+  }
+
   details.aside-like > .knowl__content {
     margin-left:0;
     margin-right:0;

--- a/css/components/elements/_lists.scss
+++ b/css/components/elements/_lists.scss
@@ -28,7 +28,7 @@
     //     margin-top: 0;
     // }
 
-    .title {
+    .li--heading-title {
       font-size: 100%;
       font-weight: normal;
       font-style: italic;

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5422,10 +5422,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <title>List Spacing, II</title>
 
                 <p>This is another short list that ends a subsection, so can be used to address the necessary spacing.<ul cols="2">
-                    <li>Uno item.</li>
-                    <li>Dos items.</li>
-                    <li>Tres item.</li>
-                    <li>Quattro items.</li>
+                    <li>
+                      <p>Uno item.</p>
+                      <aside>
+                          <title>List column test</title>
+                          <p>An aside in a multi-column list. We don't want this to float away from its context and/or break the layout. This also tests if list title formatting affects things inside the list.</p>
+                      </aside>
+                    </li>
+                    <li><p>Dos items.</p></li>
+                    <li><p>Tres item.</p></li>
+                    <li><p>Quattro items.</p></li>
                 </ul></p>
 
                 <p>And a paragraph after that list so that spacing can be checked.</p>
@@ -16206,6 +16212,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </introduction>
                     <exercise>
                         <statement>
+                            <aside>
+                                <title>Column test</title>
+                                <p>An aside in a multi-column container.</p>
+                            </aside>
                             <md alignment="alignat">
                                 <mrow>2x \amp {}+{} \amp  y \amp {}={} \amp 10</mrow>
                                 <mrow>x  \amp       \amp    \amp {}={} \amp 6</mrow>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6208,6 +6208,7 @@ Book (with parts), "section" at level 3
         <xsl:when test="(@cols = 2) or (@cols = 3) or (@cols = 4) or (@cols = 5) or (@cols = 6)">
             <xsl:text>cols</xsl:text>
             <xsl:value-of select="@cols" />
+            <xsl:text> multicolumn</xsl:text>
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>PTX:ERROR:   @cols attribute of lists or exercise groups, must be between 1 and 6 (inclusive), not "cols=<xsl:value-of select="@cols" />"</xsl:message>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5277,8 +5277,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:if>
                 <!-- "title" only possible for structured version of a list item -->
                 <xsl:if test="title">
-                    <span class="heading">
-                        <span class="title">
+                    <span class="heading li--heading">
+                        <span class="title li--heading-title">
                             <xsl:apply-templates select="." mode="title-full"/>
                         </span>
                     </span>


### PR DESCRIPTION
Addresses floating aside issues in trickier locations as identified by @jjrsylvestre on -dev.
* Disable floating behavior in multi-col environments
* Avoid list title bleed through to asides (or anything else with a `.title` in `li`s