### PR TITLE
CSS: unify inline code spacing

### DIFF
--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -4,6 +4,11 @@
   line-height: 1.2;
 }
 
+@mixin code-inline-spacing {
+  line-height: normal;  //prevent extra "padding" based on line-height
+  padding: 0.0625em .15em;
+}
+
 // wide programs need to be scrollable
 .code-box {
   overflow-x: auto;
@@ -23,12 +28,12 @@
   color: var(--body-text-color);
   background: var(--code-inline);
   border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
-  padding: 0.0625em 0.125em;
   border-radius: 0.2em;
   display: inline-block;
   overflow-x: auto;
   max-width: 100%;
   vertical-align: middle;
+  @include code-inline-spacing();
 }
 
 

--- a/css/components/elements/_prism.scss
+++ b/css/components/elements/_prism.scss
@@ -1,3 +1,5 @@
+@use '../chunks/codelike';
+
 // Prism stylesheets built locally as default ones don't support light/dark switching
 // this is a merged version of the default and dark themes
 
@@ -30,12 +32,17 @@ pre[class*="language-"] {
   line-height: 1.2;
   tab-size: 4;
   hyphens: none;
-  
+
+  &.code-inline {
+    // unclobber some inline code styles
+    @include codelike.code-inline-spacing();
+  }
+
   &::selection,
   & ::selection {
     background: #b3d4fc;
   }
-  
+
   .token {
     
     &:is(.comment,


### PR DESCRIPTION
The prism styling currently overrides some of the spacing that `.code-inline` tries to set. This unifies the padding of `.code-inline` that is or is not getting language syntax highlighting.

You should currently notice a slight difference between highlighted and unhighlighted fragments here:
https://pretextbook.org/examples/sample-article/html/section-programs.html#section-programs-21

After applying those all have the same visual padding.