### PR TITLE
CSS: codelike blocks always get background color

### DIFF
--- a/css/colors/_color-vars.scss
+++ b/css/colors/_color-vars.scss
@@ -125,13 +125,17 @@ $colors: (
   "button-border-color": #ccc,
   "button-hover-background": #c7c7c7,
   "button-hover-text-color": var(--button-text-color),
-  "code-inline": #ededed,
 
   "dropdown-background": var(--content-background),
   "dropdown-border-color": var(--toc-border-color),
   "dropdown-text-color": var(--toc-text-color),
   "dropdown-hover-background": var(--tocitem-active-background),
   "dropdown-hover-text-color": var(--tocitem-active-text-color),
+
+  // ------------------------------------------------------------------------------
+  // Other
+  "code-background": #fdfdfd,
+  "code-inline-background": #ededed,
 );
 
 // ==============================================================================

--- a/css/colors/_palette-dark.scss
+++ b/css/colors/_palette-dark.scss
@@ -93,7 +93,11 @@ $colors: map.merge(
   "button-border-color": var(--background-color-white-25),
   "button-hover-background": var(--primary-color-black-50),
   "button-text-color": var(--body-text-color),
-  "code-inline": var(--background-color-gray-20),
+
+  // ------------------------------------------------------------------------------
+  // Other
+  "code-background": var(--background-color-gray-20),
+  "code-inline-background": var(--background-color-gray-20),
   )
 );
 

--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -1,5 +1,6 @@
 @mixin code-text {
   font-family: var(--font-monospace);
+  background: var(--code-background);
   font-size: .93rem;
   line-height: 1.2;
 }
@@ -26,8 +27,8 @@
   font-family: var(--font-monospace);
   white-space: pre;
   color: var(--body-text-color);
-  background: var(--code-inline);
-  border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
+  background: var(--code-inline-background);
+  border: 1px solid color-mix(in oklab, var(--code-inline-background) 50%, #888);
   border-radius: 0.2em;
   display: inline-block;
   overflow-x: auto;
@@ -46,6 +47,8 @@
   border-left: 1px solid #aaa;
   padding: 0 15px 5px;
   overflow-x: auto;
+  background: var(--code-background);
+  margin: 0;
   @include code-text();
 }
 

--- a/css/components/interactives/_runestone.scss
+++ b/css/components/interactives/_runestone.scss
@@ -52,8 +52,8 @@
 //Fixup datafile captions
 .runestone.datafile {
   .datafile_caption {
-    background: var(--code-inline);
-    border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
+    background: var(--code-inline-background);
+    border: 1px solid color-mix(in oklab, var(--code-inline-background) 50%, #888);
     display: block;
     width: fit-content;
     margin: 0 auto;
@@ -61,11 +61,11 @@
   img {
     margin: 0 auto;
     display: block;
-    border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
+    border: 1px solid color-mix(in oklab, var(--code-inline-background) 50%, #888);
   }
   pre, textarea {
     margin: 0 auto;
-    border: 1px solid color-mix(in oklab, var(--code-inline) 50%, #888);
+    border: 1px solid color-mix(in oklab, var(--code-inline-background) 50%, #888);
     background-color: var(--page-color);
   }
 }

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10982,6 +10982,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>Notice in the HTML version of the above example that when you highlight all, or a portion, of the listing for a cut-and-paste that the prompts are not included.</p>
 
+            <p>Now a test of some listings (and pre-formatted text) in a block that likely has a background color in an HTML version.</p>
+
+            <exercise>
+                <title>Code in a colored(?) container</title>
+                <statement>
+                <p>Not really much of an exercise, but it should force a colored box.</p>
+                <p>Running a program in a console:</p>
+                <console>
+                    <input>
+                    ./program
+                    </input>
+                </console>
+                <pre>
+                    A pre
+                </pre>
+                </statement>
+            </exercise>
+
             <p>The next listing is just absurdity, to check various characters from <latex/> that are otherwise employed by the code supporting consoles, and some Latin-1 characters.  We test each in a prompt, input, and output.  We use <c>(*</c> and <c>*)</c> as sequences used to escape embedded <latex/> commands, so we test those also.</p>
 
             <listing>


### PR DESCRIPTION
Add some kind of background color to all codelike elements.

Absence of a background color sometimes makes it hard to see the extent of the block (and what the copy to clipboard will apply to):
<img width="861" height="378" alt="image" src="https://github.com/user-attachments/assets/c222f6e4-07be-44ae-a280-d2259b8bf66f" />

And is sub-optimal when they are used in a container with a background color:
<img width="935" height="406" alt="image" src="https://github.com/user-attachments/assets/24be1df5-fedd-4f3f-989d-1712ff1e6730" />
