### PR TITLE
Improve `dl @width` options

### DIFF
--- a/css/components/elements/_description-lists.scss
+++ b/css/components/elements/_description-lists.scss
@@ -69,33 +69,23 @@ dl.description-list {
     margin-left: 22ex;
   }
 
-  .narrow {
+  &.narrow {
     dt {
-      margin-top: 0;
-      width: unset;
-      max-width: 55ex;
-      text-align: left;
+      width: 11ex;
     }
 
     dd {
-      margin-left: 12ex;
-      margin-left: 0;
-      margin-top: 0;
-      width: 31em;
-      max-width: calc(100% - 12ex);
-      float: right;
-      clear: right;
+      margin-left: 15ex;
+    }
+  }
+
+  &.wide {
+    dt {
+      width: 25ex;
     }
 
-    dd::after {
-      content: "";
-      display: block;
-      height: 1em;
-      clear: left;
-    }
-
-    dd:last-child::after {
-      height: 0;
+    dd {
+      margin-left: 29ex;
     }
   }
 }
@@ -130,7 +120,8 @@ dl.description-list dl dd {
   }
 
   dl.description-list dd,
-  dl.description-list.narrow dd {
+  dl.description-list.narrow dd,
+  dl.description-list.wide dd {
     margin-top: 0.5em;
     margin-left: 3em;
     max-width: calc(100% - 3em);

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5738,7 +5738,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </li>
                 </dl></p>
 
-                <p>Some presentations can be assisted by a hint from the author about the lengths of the titles.  You can choose to provide a <c>width</c> attribute on a <c>dl</c> element with possible values <c>narrow</c> and <c>medium</c>. The value refers (somewhat confusingly) to the distance between the left margin and the description.  The default is <c>medium</c>, which is illustrated above. Conversion to <latex/> ignores the attribute.  An example with <c>narrow</c>:
+                <p>Some presentations can be assisted by a hint from the author about the lengths of the titles.  You can choose to provide a <c>width</c> attribute on a <c>dl</c> element with possible values <c>narrow</c>, <c>medium</c>, and <c>wide</c>. The value refers (somewhat confusingly) to the distance between the left margin and the description.  The default is <c>medium</c>, which is illustrated above.  An example with <c>narrow</c>:
                 <dl width="narrow">
                     <li>
                         <title>Red</title>
@@ -5810,7 +5810,81 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <title><c>main()</c> is a void function</title>
                         <p>A <c>dl</c> with <c>width="narrow"</c> might be a useful way to give commentary on a program listing.</p>
                     </li>
-                </dl></p>
+                </dl>
+                And the same example with <c>wide</c>:
+                <dl width="wide">
+                    <li>
+                        <title>Red</title>
+                        <p>The color of the sun at sunset.</p>
+                    </li>
+                    <li>
+                        <title>Blue</title>
+                        <p>The color of a clear sky. Also a synonym for <q>depressed or sad</q>, the title of a 1971 Joni Mitchell album (and more than a dozen other musical albums), the period of Picasso's work between 1901 and 1904, and much more!</p>
+                    </li>
+                    <li>
+                        <title>Aqua</title>
+                        <p>The color of shallow tropical waters.<fn>On a sunny day! (Testing footnotes in description lists for <latex/> output.)</fn></p>
+                    </li>
+                    <li xml:id="description-list-math-title-wide">
+                        <title>Math <m>x^2</m></title>
+                        <!-- this is a candidate for a "plaintitle" but the schema limits -->
+                        <!-- the element to divisions, figures and named lists            -->
+                        <p>Sorry, not a color but testing titles with math in them.</p>
+                    </li>
+                    <li>
+                       <title><q>i</q> before <q>e</q> except after <q>c,</q> unless it sounds like <q>a</q> as in <q>neighbor</q> and <q>weigh</q></title>
+                        <p>Get feisty about that weird counterfeit rule: seize the day and don't have a heifer, man.</p>
+                       </li>
+                    <li>
+                        <title>Avocado</title>
+                        <p>Avocado is the the color with hex code <c>#568203</c>, and also the main ingredient in guacamole.</p>
+                     </li>
+                    <li>
+                        <title>Magenta</title>
+                        <p>Magenta is a color, and a character in Rocky Horror.</p>
+                     </li>
+                    <li>
+                        <title>Zymurgist</title>
+                        <p>A scientist who studies the chemical process of fermentation in brewing and distilling.  Also the alphabetically last 9-letter word in the English language.</p>
+                     </li>
+                    <li>
+                        <title>Byzantium</title>
+                        <p>Byzantium is the the color with hex code <c>#702963</c>, and also an ancient Greek city which later became known as Constantinople, and today is called Istanbul.</p>
+                     </li>
+                    <li>
+                        <title>Convection</title>
+                        <p>Circulating motion in a fluid.</p>
+                     </li>
+                    <li>
+                        <title>Elementary</title>
+                        <p>No literary detective ever said <q>Elementary my dear Watson.</q>  In particular, Sherlock Holmes never said that.</p>
+                     </li>
+                    <li>
+                        <title>Understand</title>
+                        <p>Perceive the intended meaning of.</p>
+                     </li>
+                    <li>
+                        <title>Washington</title>
+                        <p>A state, a district, the man on the US $1 bill and on the US quarter. Did you ever notice that on the US dime, the value is stated as <q>one dime</q>? But how is one to know that a dime is worth 10 cents?</p>
+                     </li>
+                    <li>
+                        <title>Aquamarine</title>
+                        <p>Aquamarine is a color, and a mineral.</p>
+                    </li>
+                    <li>
+                        <title>Those who cannot remember the past are condemned to repeat it.</title>
+                        <p>George Santayana wrote those words in 1905.  A similar aphorism is misattributed to Winston Churchill.  The idea is embodied in the 4th principle: <pretext/> respects the good design practices which have been developed over the past centuries.</p>
+                    </li>
+                    <li>
+                        <title><m>\displaystyle \zeta(s) = \sum_{n=1}^\infty n^{-s} </m></title>
+                        <p>The Riemann <m>\zeta</m>-function is defined by a Dirichlet series, valid for <m> \Re(s) > 1</m>.</p>
+                     </li>
+                    <li>
+                        <title><c>main()</c> is a void function</title>
+                        <p>A <c>dl</c> with <c>width="narrow"</c> might be a useful way to give commentary on a program listing.</p>
+                    </li>
+                </dl>
+                </p>
 
                 <p>You can nest description lists, though items might get crowded horizontally.  We expand our computer list a bit.
                 <dl>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -5818,7 +5818,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:when test="@width = 'narrow'">
                     <xsl:text>description-list narrow</xsl:text>
                 </xsl:when>
-                <!-- 'medium', 'wide', and any typo (let DTD check) -->
+                <xsl:when test="@width = 'wide'">
+                    <xsl:text>description-list wide</xsl:text>
+                </xsl:when>
+                <!-- 'medium' and any typo (let DTD check) -->
                 <xsl:otherwise>
                     <xsl:text>description-list</xsl:text>
                 </xsl:otherwise>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1808,11 +1808,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newlength{\dlititlewidth}&#xa;</xsl:text>
         <xsl:text>\newlength{\dlimaxnarrowtitle}\setlength{\dlimaxnarrowtitle}{11ex}&#xa;</xsl:text>
         <xsl:text>\newlength{\dlimaxmediumtitle}\setlength{\dlimaxmediumtitle}{18ex}&#xa;</xsl:text>
+        <xsl:text>\newlength{\dlimaxwidetitle}\setlength{\dlimaxwidetitle}{25ex}&#xa;</xsl:text>
         <!-- "top seam" alignment works better for titles that are display math -->
         <!-- halign applies only to "upper", which is "right" in sidebyside     -->
         <xsl:text>\tcbset{ dlistyle/.style={sidebyside, sidebyside align=top seam, lower separated=false, bwminimalstyle, bottomtitle=0.75ex, after skip=1.5ex, boxsep=0pt, left=0pt, right=0pt, top=0pt, bottom=0pt, before lower app={\setparstyle\noindent}} }&#xa;</xsl:text>
         <xsl:text>\tcbset{ dlinarrowstyle/.style={dlistyle, lefthand width=\dlimaxnarrowtitle, sidebyside gap=1ex, halign=flush left, righttitle=10ex} }&#xa;</xsl:text>
         <xsl:text>\tcbset{ dlimediumstyle/.style={dlistyle, lefthand width=\dlimaxmediumtitle, sidebyside gap=4ex, halign=flush right} }&#xa;</xsl:text>
+        <xsl:text>\tcbset{ dliwidestyle/.style={dlistyle, lefthand width=\dlimaxwidetitle, sidebyside gap=4ex, halign=flush right} }&#xa;</xsl:text>
         <xsl:text>\NewDocumentEnvironment{descriptionlist}{}{\par\vspace*{1.5ex}}{\par\vspace*{1.5ex}}%&#xa;</xsl:text>
         <xsl:text>%% begin enviroment has an if/then to open the tcolorbox&#xa;</xsl:text>
         <xsl:text>\NewDocumentEnvironment{dlinarrow}{mm}{%&#xa;</xsl:text>
@@ -1825,6 +1827,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%% medium option is simpler&#xa;</xsl:text>
         <xsl:text>\NewDocumentEnvironment{dlimedium}{mm}%&#xa;</xsl:text>
         <xsl:text>{\begin{tcolorbox}[dlimediumstyle, phantom={\hypertarget{#2}{}}]\textbf{#1}\tcblower}%&#xa;</xsl:text>
+        <xsl:text>{\end{tcolorbox}}%&#xa;</xsl:text>
+        <xsl:text>%% wide option is similar&#xa;</xsl:text>
+        <xsl:text>\NewDocumentEnvironment{dliwide}{mm}%&#xa;</xsl:text>
+        <xsl:text>{\begin{tcolorbox}[dliwidestyle, phantom={\hypertarget{#2}{}}]\textbf{#1}\tcblower}%&#xa;</xsl:text>
         <xsl:text>{\end{tcolorbox}}%&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="$document-root//exercisegroup">
@@ -7687,6 +7693,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:choose>
             <xsl:when test="parent::dl/@width = 'narrow'">
                 <xsl:text>dlinarrow</xsl:text>
+            </xsl:when>
+            <xsl:when test="parent::dl/@width = 'wide'">
+                <xsl:text>dliwide</xsl:text>
             </xsl:when>
             <!-- the default (specified, or absent) -->
             <xsl:otherwise>


### PR DESCRIPTION
This started as a PR to just fix a bug in which `dl` with `@width="narrow"` didn't display correctly in HTML.  That is accomplished here.

The guide also claims that `@width` can have value "wide", but this never seems to have been implemented.  So I did that for LaTeX and HTML.  And then also added an example to the sample article.

There is a small inconsistency between LaTeX and HTML for narrow though: in LaTeX, a narrow `dl` that has a `dt` too big to fit in the allocated `11ex` will make the `dd` start on the next line.  I think this is how the narrow option was supposed to work for HTML, but the CSS that was there was broken so I simplified it to always keep the `dd` on the same line.  In HTML, the narrow `dt` is also flush right (same as the other widths), but this is not true for LaTeX.

There are other things to do for `dl`.  We have talked about a slightly different style for the nested terms.  And the nested terms in LaTeX have strange spacing (or at least, not consistent with HTML).  There is also still an issue with `dl` as the first child of a `<paragraphs>` that  needs work in LaTeX.  All this for another time.