### PR TITLE
CSS: restore normal weight for summary links font

### DIFF
--- a/css/components/elements/_summary-links.scss
+++ b/css/components/elements/_summary-links.scss
@@ -16,6 +16,7 @@
     border-radius: 3px;
     position: relative;
     display: block;
+    font-weight: unset;
 
     .title{
       font-style: normal;


### PR DESCRIPTION
Some recent commit has modified the font weight for text in the "summary links"; the buttons on the chapter page when there are chunked sections.  This restores that to the normal font that was previously there (and is shown on hover).

That is, unless @ascholerChemeketa, this was an intentional change?