### PR TITLE
Favor publisher value for HTML toc focused mode over theme value

### DIFF
--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2296,13 +2296,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Whether or not to tag TOC as focused -->
 <xsl:variable name="html-toc-focused_value">
     <xsl:choose>
-        <xsl:when test="$html-theme-name = 'custom' or $b-html-theme-legacy">
-            <!-- legacy/custom themes can pick whether to use a focused toc or not -->
+        <xsl:when test="$publication/html/tableofcontents/@focused != ''">
             <xsl:apply-templates select="$publisher-attribute-options/html/tableofcontents/pi:pub-attribute[@name='focused']" mode="set-pubfile-variable"/>
         </xsl:when>
         <xsl:otherwise>
-            <!-- newer ones determined by theme                                -->
-            <xsl:if test="$html-theme/@focused-toc"><xsl:value-of select="$html-theme/@focused-toc"/></xsl:if>
+            <!-- check the theme for a default  -->
+            <xsl:if test="$html-theme/@focused-toc">
+                <xsl:value-of select="$html-theme/@focused-toc"/>
+            </xsl:if>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2356,7 +2356,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$publication/html/css/@theme">
             <xsl:value-of select="$publication/html/css/@theme"/>
         </xsl:when>
-        <xsl:otherwise>
+        <xsl:when test="$publication/html/css/@style or $publication/html/css/@shell">
             <!-- legacy style detection and overriding -->
             <xsl:choose>
                 <!-- crc and min are best detected via @shell -->
@@ -2385,6 +2385,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                   <xsl:text>default-modern</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>default-modern</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>


### PR DESCRIPTION
Second commit addresses:
https://groups.google.com/g/pretext-dev/c/PqQfGGJXKYA/m/1JuWVrw1AQAJ?utm_medium=email&utm_source=footer

While testing noticed that not specifying any theme/style gives a warning that theme `""` is not supported and that default modern will be used. First commit fixes that.