### PR TITLE
Add appendix contents to runestone manifest

### DIFF
--- a/examples/sample-book/backmatter.xml
+++ b/examples/sample-book/backmatter.xml
@@ -81,6 +81,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </section>
     </appendix>
 
+    <appendix>
+        <title>Some Runestone Elements</title>
+        <p>These elements should end up in the Runestone manifest.</p>
+        <datafile filename="datafile-appendix.txt" xml:id="datafile-appendix" label="datafile-appendix">
+            <pre>
+            Ipsum lorem...
+            </pre>
+        </datafile>
+
+        <program language="py" xml:id="program-appendix" label="program-appendix">
+            print("Hello from the appendix!")
+        </program>
+    </appendix>
+
     <xi:include href="./gfdl-mathbook.xml" />           <!-- GFDL License text -->
 
     <!-- Index follows appendices, preceded only colophon -->

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -308,7 +308,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </exercise>
 
-        <p>Exact same exercise again, but now we include <em>two</em> programs.  We first get the simple <q>Hello, world!</q> program at <xref ref="program-activecode-python"/> and then the same program defining the variables with lists of statistics at <xref ref="listing-python-included"/>.  So the output just includes the extra result from the <c>print()</c> statement.</p>
+        <p>Exact same exercise again, but now we include <em>three</em> programs.  We first get the simple <q>Hello, world!</q> program at <xref ref="program-activecode-python"/>, then the program defining the variables with lists of statistics at <xref ref="listing-python-included"/>, and finally the program from the appendix just to test linking to material there.</p>
 
         <p>This program also makes use of <attr>hidecode</attr> to initially keep the code hidden and <attr>download</attr> to enable a file download of the program (that includes all the included code).</p>
 
@@ -317,7 +317,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <statement>
                 <p>Compute the total amount of money loaned and store it in the variable <c>loan_total</c>.</p>
             </statement>
-            <program xml:id="python-summation-two" interactive='activecode' language="python" label="python-sum-total-two" include="python-hello-world python-statistics " hidecode="yes" download="yes">
+            <program xml:id="python-summation-two" interactive='activecode' language="python" label="python-sum-total-two" include="python-hello-world python-statistics program-appendix" hidecode="yes" download="yes">
                 <code>
                 loan_total = 0
                 for loan in loan_amount:

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -957,7 +957,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Appendix is currently not allowed to have "questions" as Runestone  -->
 <!-- requires those to have a chapter with an integer number             -->
 <!-- But look for code and datafiles that should go in source_code table --> 
-<xsl:template match="appendix" mode="runestone-manifest">
+<xsl:template match="appendix[.//program or .//datafile]" mode="runestone-manifest">
     <appendix>
         <!-- Check for programs that have been included elsewhere.           -->
         <xsl:apply-templates select=".//program[@xml:id = $linked-programs-list]" mode="runestone-manifest-source"/>
@@ -965,6 +965,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select=".//datafile" mode="runestone-manifest"/>
     </appendix>
 </xsl:template>
+<!-- If no programs or datafiles, do nothing -->
+<xsl:template match="appendix" mode="runestone-manifest"/>
 
 <!-- Traverse the tree,looking for things to do          -->
 <!-- http://stackoverflow.com/questions/3776333/         -->


### PR DESCRIPTION
This adds `appendix` items to the RS manifest. They can contain:
* datafiles
* source elements for programs that are linked to from elsewhere (same items that are written as `<source>` in chapters)

They do not contain any `<questions>` as those require a chapter with an integer chapter number. An appendix with exercises etc... would require reworking data assumptions in RS.