### PR TITLE
CSS: Add custom styling/theming project to examples

### DIFF
--- a/examples/custom-theming/README.md
+++ b/examples/custom-theming/README.md
@@ -1,0 +1,24 @@
+#  Styling/Theming Samples for PreTeXt
+
+This project has samples to illustrate how the HTML output of PreTeXt can be customized. The `projects.ptx` file defines the following build targets:
+
+* `web` - Default styling
+* `web-custom-colors` - Specifying custom colors for a theme
+* `web-extra-css` - Adding extra CSS files with custom styles
+* `web-salem` - Specifying the "salem" theme with a specific color palette
+* `web-salem-extra-css` - Demonstrates additional tricks using extra CSS to use or modify the colors defined for a theme
+* `web-custom-theme` - Demonstrates how to create a custom theme by providing an SCSS file as a build target
+
+To build any of these targets using the PreTeXt CLI use a command like:
+
+```bash
+pretext build web-custom-colors
+```
+
+See the `project.ptx` file for more details about each target.
+
+If you are experimenting with `web-custom-theme`, and want to just rebuild the theme, you can add the `-t` flag. Doing so will leave the HTML in place and just rebuild the `theme.css` file from your SCSS.
+
+```bash
+pretext build web-custom-theme -t
+```

--- a/examples/custom-theming/assets/css/more-styles.css
+++ b/examples/custom-theming/assets/css/more-styles.css
@@ -1,0 +1,3 @@
+.ptx-content-footer .button {
+    border-radius: 10px 5px;
+}

--- a/examples/custom-theming/assets/css/my-styles.css
+++ b/examples/custom-theming/assets/css/my-styles.css
@@ -1,0 +1,10 @@
+.ptx-masthead {
+    background-color: #e4e5e6;
+}
+
+/* styles to apply in dark mode */
+:root.dark-mode {
+    .ptx-masthead {
+        background-color: #000000;
+    }
+}

--- a/examples/custom-theming/assets/css/salem-color-vars.css
+++ b/examples/custom-theming/assets/css/salem-color-vars.css
@@ -1,0 +1,36 @@
+/* Many colors in your output are controlled by CSS variables.
+   You can override these variables to override the appearance 
+   of all items that use that color.
+   You need to define the colors in a container that is at least
+   as specific as the default definition.
+   The default definitions for light mode are in 
+   :root:not(.dark-mode) { ... }
+   The default definitions for dark mode are in
+   :root.dark-mode { ... }
+   */
+:root:not(.dark-mode) {
+    --body-title-color: #573c13;
+}
+
+section>.heading {
+    /* you can use color variables defined in themes in your own rules to match existing colors */
+    background: var(--primary-color-white-95);
+    color: var(--primary-color);
+}
+
+/* Normally, all remark-likes are the same color in salem. Let's customize some. */
+/* observations are the classname used for the renamed "danger" blocks */
+.remark-like.observation {
+    border-color: #c72a36;
+    background-color: #f9d6d5;
+}
+
+.remark-like.convention {
+    border-color: #4CAF50;
+    background-color: #edfcee;
+}
+
+.remark-like.warning {
+    border-color: #e7d322;
+    background-color: #fbf8e6;
+}

--- a/examples/custom-theming/mytheme/_chunks-customized.scss
+++ b/examples/custom-theming/mytheme/_chunks-customized.scss
@@ -1,0 +1,19 @@
+// Grab everything from tacoma's chunks but tell it to use 0 border radius
+@use 'targets/html/tacoma/chunks-minimal' with (
+  $border-radius: 0
+);
+
+// Now add to that
+// @use statements must come before any actual CSS rules
+@use 'components/chunks/helpers/heading-box-mixin';
+
+.project-like {
+  @include heading-box-mixin.box;
+}
+
+.remark-like
+{
+  > .heading {
+    color: var(--primary-color);
+  }
+}

--- a/examples/custom-theming/mytheme/mytheme.scss
+++ b/examples/custom-theming/mytheme/mytheme.scss
@@ -1,0 +1,50 @@
+// A custom theme that is a modified version of the tacoma theme
+
+// This will get compiled into "theme.css" and placed into the output directory
+// of your project
+
+$primary-color: #2a5ea4 !default;
+$primary-color-dark: #829ab1 !default;
+$background-color-dark: #23241f !default;
+
+@use "sass:map";
+
+// Any @use path is checked relative to this file first, then
+// relative to the css directory in the pretext core.
+// https://github.com/PreTeXtBook/pretext/tree/master/css
+@use "colors/color-helpers" as colorHelpers;
+
+// ---------------------------------------------
+// components
+
+// To borrow a file from tacoma, we must do an @use with the
+// full path from the css directory:
+@use 'targets/html/tacoma/_parts-tacoma' as parts;
+
+// Underscores indicate files designed to be included in other files
+// you do not need to include the underscore in the filename in the @use
+// chunks-customized exists in the same directory as this file, so that
+// will be found/used.
+@use 'chunks-customized';
+
+
+@use 'components/pretext';
+
+// ---------------------------------------------
+// fonts and colors
+@use 'fonts/fonts-google';
+
+@use 'colors/palette-single-muted' as palette-light with (
+  $primary-color: $primary-color,
+);
+
+@use 'colors/palette-dark' as palette-dark with (
+  $primary-color: $primary-color-dark,
+  $background-color: $background-color-dark,
+);
+
+// ---------------------------------------------
+// concrete rules / includes that generate CSS
+
+// render the actual colors
+@include colorHelpers.set-root-colors(palette-light.$colors, palette-dark.$colors);

--- a/examples/custom-theming/project.ptx
+++ b/examples/custom-theming/project.ptx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<project ptx-version="2">
+    <targets>
+        <!-- default web styling -->
+        <target name="web" format="html"/>
+
+        <!-- customized colors for a theme -->
+        <target name="web-custom-colors" format="html" publication="publication-custom-colors.ptx"/>
+
+        <!-- use custom css files -->
+        <target name="web-extra-css" format="html">
+            <!-- stringparams must be specified per build target                                  -->
+            <!-- html.css.extra can have multiple file names, space separated                     -->
+            <!-- css files should be placed in the assets/external folder so                      -->
+            <!-- are copied to the output directory on build.                                     -->
+            <!-- see: https://pretextbook.org/doc/guide/html/processing-directory-management.html -->
+            <stringparams html.css.extra="external/css/my-styles.css external/css/more-styles.css" />
+        </target>
+
+        <!-- use the salem theme with the leaves color palette -->
+        <target name="web-salem" format="html" publication="publication-salem.ptx"/>
+        
+        <!-- use the salem theme with the leaves color palette and custom css -->
+        <target name="web-salem-extra-css" format="html" publication="publication-salem.ptx">
+            <stringparams html.css.extra="external/css/salem-color-vars.css" />
+        </target>
+
+        <!-- use a custom theme -->
+        <target name="web-custom-theme" format="html" publication="publication-custom-theme.ptx"/>
+
+
+    </targets>
+</project>

--- a/examples/custom-theming/publication/publication-custom-colors.ptx
+++ b/examples/custom-theming/publication/publication-custom-colors.ptx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<publication>
+  <!-- Set where external assets and generated assets will be   -->
+  <!-- stored or created.  Directories are relative to the main -->
+  <!-- source PreTeXt file                                      -->
+  <source>
+    <!-- Paths to folders containing external assets and generated assets -->
+    <!-- relative to your main source file.                               -->
+    <!-- the @external value is where any file specified by               -->
+    <!--  html.css.extra CSS should be                                    -->
+    <directories external="../assets" generated="../generated-assets" />
+  </source>
+
+  <html>
+    <!-- specify custom colors to use in the theme as described here: -->
+    <!-- https://pretextbook.org/doc/guide/html/publication-file-online.html#online-style-options -->
+    <css theme="default-modern" primary-color="#361c65" secondary-color="#904619" primary-color-dark="#f2a0c2"/>
+  </html>
+
+</publication>

--- a/examples/custom-theming/publication/publication-custom-theme.ptx
+++ b/examples/custom-theming/publication/publication-custom-theme.ptx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<publication>
+  <!-- Set where external assets and generated assets will be   -->
+  <!-- stored or created.  Directories are relative to the main -->
+  <!-- source PreTeXt file                                      -->
+  <source>
+    <!-- Paths to folders containing external assets and generated assets -->
+    <!-- relative to your main source file.                               -->
+    <directories external="../assets" generated="../generated-assets" />
+  </source>
+
+  <html>
+    <!-- specify building a custom theme                    -->
+    <!-- entry-point must be relative to your document root -->
+    <css theme="custom" entry-point="../mytheme/mytheme.scss"/>
+  </html>
+
+</publication>

--- a/examples/custom-theming/publication/publication-salem.ptx
+++ b/examples/custom-theming/publication/publication-salem.ptx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<publication>
+  <!-- Set where external assets and generated assets will be   -->
+  <!-- stored or created.  Directories are relative to the main -->
+  <!-- source PreTeXt file                                      -->
+  <source>
+    <!-- Paths to folders containing external assets and generated assets -->
+    <!-- relative to your main source file.                               -->
+    <!-- the @external value is where any file specified by               -->
+    <!--  html.css.extra CSS should be                                    -->
+    <directories external="../assets" generated="../generated-assets" />
+  </source>
+
+  <html>
+    <css theme="salem" palette="leaves"/>
+  </html>
+
+</publication>

--- a/examples/custom-theming/publication/publication.ptx
+++ b/examples/custom-theming/publication/publication.ptx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<publication>
+  <!-- Set where external assets and generated assets will be   -->
+  <!-- stored or created.  Directories are relative to the main -->
+  <!-- source PreTeXt file                                      -->
+  <source>
+    <!-- Paths to folders containing external assets and generated assets -->
+    <!-- relative to your main source file.                               -->
+    <!-- the @external value is where any file specified by               -->
+    <!--  html.css.extra CSS should be                                    -->
+    <directories external="../assets" generated="../generated-assets" />
+
+    <!-- If not specified, theme will default to "default-modern" -->
+    <!-- <theme name="default-modern" /> -->
+  </source>
+
+</publication>

--- a/examples/custom-theming/source/ch-chapter-title.ptx
+++ b/examples/custom-theming/source/ch-chapter-title.ptx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<chapter xml:id="ch-chapter-title" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>Chapter Title</title>
+    
+    <introduction>
+        <p> Text before the first section. </p>
+    </introduction>
+    
+    <!-- include sections -->
+    <xi:include href="sec-section-name.ptx" />
+    
+</chapter>

--- a/examples/custom-theming/source/docinfo.ptx
+++ b/examples/custom-theming/source/docinfo.ptx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- The docinfo block is the analogue to the latex preamble -->
+<!-- This is where you can define macros and other book-wide -->
+<!-- settings. -->
+<docinfo xmlns:xi="http://www.w3.org/2001/XInclude">
+
+
+  <!-- brandlogo is the image that may appear next to the title in the banner -->
+  <!-- <brandlogo url="" source="images/cover.png"/> -->
+
+  <!-- It is possible to rename elements: -->
+  <rename element="observation" xml:lang="en-US">Danger</rename>
+
+</docinfo>

--- a/examples/custom-theming/source/frontmatter.ptx
+++ b/examples/custom-theming/source/frontmatter.ptx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This frontmatter division will contain all content before the -->
+<!-- first chapter. Fill in and comment/uncomment to see how this -->
+<!-- works. -->
+
+<frontmatter xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="frontmatter">
+    <bibinfo>
+        
+        <author>
+            <personname>You</personname>
+            <department>Your department</department>
+            <institution>Your institution</institution>
+        </author>
+        <date>
+            <today />
+        </date>
+        
+        <website>
+            <url href="https://pretextbook.org">My Website</url>
+        </website>
+        
+        <copyright>
+            <year>2020<ndash />2024</year>
+            <holder>You</holder>
+            <shortlicense> This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit <url href="http://creativecommons.org/licenses/by-sa/4.0/" visual="creativecommons.org/licenses/by-sa/4.0"> CreativeCommons.org</url>
+            </shortlicense>
+        </copyright>
+        
+    </bibinfo>
+    
+    <titlepage>
+        <titlepage-items/>
+    </titlepage>
+    
+    <colophon xml:id="front-colophon">
+        <colophon-items/>
+    </colophon>
+</frontmatter>

--- a/examples/custom-theming/source/main.ptx
+++ b/examples/custom-theming/source/main.ptx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<pretext xml:lang="en-US" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <!-- we first include a file which contains the docinfo element: -->
+    <xi:include href="./docinfo.ptx" />
+
+    <book xml:id="my-great-book">
+        <title>My Great Book</title>
+        <subtitle>An example to get you started</subtitle>
+
+        <!-- Include frontmatter -->
+        <xi:include href="./frontmatter.ptx" />
+
+        <!-- Include chapters -->
+        <xi:include href="./ch-chapter-title.ptx" />
+    </book>
+</pretext>

--- a/examples/custom-theming/source/sec-section-name.ptx
+++ b/examples/custom-theming/source/sec-section-name.ptx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="sec-section-name" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>Section Title</title>
+
+    <activity><p>Here is an activity.</p></activity>
+
+    <project><p>Here is a project.</p></project>
+
+    <p> Text of section. </p>
+
+    <convention><p>Here is a note.</p></convention>
+
+    <warning><p>Here is a warning.</p></warning>
+
+    <observation><p>Here is an observation that was renamed into a <q>danger</q>.</p></observation>
+</section>


### PR DESCRIPTION
Two purposes:

1) We don't encourage customizing CSS, but just about everyone "in the know" does it. And many not in the know yet ask about it. So this has simplified examples of how to add custom CSS and how to do it in a way that interacts well with the theme (e.g. making use of the "primary-color" defined by the theme). No more needing to point to @oscarlevin's book as a sample. 😄 

2) There probably should be an in-house example of a fully custom theme. @trshemanske did a great exploration of creating a `tacoma-crc` (https://github.com/trshemanske/tacoma-crc) that I have pointed to in the past. But this gives us a sample of how to do so that can be kept up to date with any future changes.