### PR TITLE
HTML banner customization variables

### DIFF
--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -144,6 +144,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <feedback href="http://example.com/not-implemented.html"><!-- My Button Text --></feedback>
         <!-- A "portable" build is meant to be a single file that is transportable -->
         <!-- <platform portable="yes"/> -->
+        <!-- Banner options, these default to yes but can be set to "no" to -->
+        <!-- remove the indicated element from the top banner               -->
+        <banner byline="no" subtitle="no"/>
     </html>
 
     <!-- 10pt font is the default   -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6986,7 +6986,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                         <!-- which is much like cover of a book  -->
                                         <xsl:apply-templates select="$document-root" mode="title-simple" />
                                     </span>
-                                    <xsl:if test="$b-has-subtitle">
+                                    <xsl:if test="$b-has-subtitle and $b-html-banner-subtitle">
                                         <xsl:text> </xsl:text>
                                         <span class="subtitle">
                                             <xsl:apply-templates select="$document-root" mode="subtitle" />
@@ -6995,10 +6995,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                 </a>
                             </h1>
                             <!-- Serial list of authors/editors -->
-                            <p class="byline">
-                                <xsl:apply-templates select="$bibinfo/author" mode="name-list"/>
-                                <xsl:apply-templates select="$bibinfo/editor" mode="name-list"/>
-                            </p>
+                            <xsl:if test="$b-html-banner-byline">
+                                <p class="byline">
+                                    <xsl:apply-templates select="$bibinfo/author" mode="name-list"/>
+                                    <xsl:apply-templates select="$bibinfo/editor" mode="name-list"/>
+                                </p>
+                            </xsl:if>
                         </div>  <!-- title-container -->
                     </div> <!-- banner -->
                     <!-- This seemed to not be enough, until Google Search went away  -->
@@ -11175,7 +11177,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <!-- which is much like cover of a book  -->
                                     <xsl:apply-templates select="$document-root" mode="title-simple" />
                                 </span>
-                                <xsl:if test="$b-has-subtitle">
+                                <xsl:if test="$b-has-subtitle and $b-html-banner-subtitle">
                                     <xsl:text> </xsl:text>
                                     <span class="subtitle">
                                         <xsl:apply-templates select="$document-root" mode="subtitle" />
@@ -11184,10 +11186,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             </a>
                         </h1>
                         <!-- Serial list of authors/editors -->
-                        <p class="byline">
-                            <xsl:apply-templates select="$bibinfo/author" mode="name-list"/>
-                            <xsl:apply-templates select="$bibinfo/editor" mode="name-list"/>
-                        </p>
+                        <xsl:if test="$b-html-banner-byline">
+                            <p class="byline">
+                                <xsl:apply-templates select="$bibinfo/author" mode="name-list"/>
+                                <xsl:apply-templates select="$bibinfo/editor" mode="name-list"/>
+                            </p>
+                        </xsl:if>
                     </div>  <!-- title-container -->
                 </div>  <!-- banner -->
             </header>  <!-- masthead -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2718,6 +2718,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-has-embed-button" select="$embed-button = 'yes'"/>
 
 
+<!--                            -->
+<!-- HTML Banner options        -->
+<!--                            -->
+<xsl:variable name="html-banner-subtitle">
+    <xsl:apply-templates select="$publisher-attribute-options/html/banner/pi:pub-attribute[@name='subtitle']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-html-banner-subtitle" select="$html-banner-subtitle = 'yes'"/>
+
+<xsl:variable name="html-banner-byline">
+    <xsl:apply-templates select="$publisher-attribute-options/html/banner/pi:pub-attribute[@name='byline']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-html-banner-byline" select="$html-banner-byline = 'yes'"/>
+
+
 <!-- ##################### -->
 <!-- EPUB-Specific Options -->
 <!-- ##################### -->
@@ -3276,6 +3290,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <analytics>
             <pi:pub-attribute name="google-gst" freeform="yes"/>
         </analytics>
+        <banner>
+            <pi:pub-attribute name="byline" default="yes" options="no"/>
+            <pi:pub-attribute name="subtitle" default="yes" options="no"/>
+        </banner>
         <video>
             <pi:pub-attribute name="privacy" default="yes" options="no"/>
         </video>


### PR DESCRIPTION
Subtitle and byline may not always make sense to render in banner.

Sample reasons someone may want them off:
* Long subtitle
* Lots of authors (physical space issues)
* Book is more a collection of content than an authored work

This adds publisher variables to disable rendering of both items in the banner. And reduces by 2 the number of reasons for someone to ask about how to add custom CSS to their project. 😄 