### PR TITLE
Common: disable xref @first @last order check

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8932,9 +8932,14 @@ Book (with parts), "section" at level 3
             </xsl:if>
             <!-- courtesy check that range is not out-of-order               -->
             <!-- NB: different schemes for "exercise" can make this look odd -->
+            <!-- Disabled but left as an idea to reimplement. Currenlty      -->
+            <!-- very inefficient due to preceeding:: counts (in SA,         -->
+            <!-- 7 instances account for ~6% total processing time).         -->
+            <!-- 
             <xsl:if test="count($target-one/preceding::*) > count($target-two/preceding::*)">
                 <xsl:message>PTX:WARNING: &lt;xref @first="<xsl:value-of select="@first" />" @last="<xsl:value-of select="@last" />" /&gt; references two elements that appear to be in the wrong order</xsl:message>
             </xsl:if>
+            -->
             <!-- Biblio check assumes targets are equal       -->
             <!-- If target is a bibliography item, generic    -->
             <!-- text template only makes numbers, we add     -->


### PR DESCRIPTION
Was doing some timing in SA. Noticed that the xref `@first/@last` order check is about 6% of total processing time (file writing disabled) even though there are only 7 items to check.

```
        %
[2]     5.94    0.214    0.114      7     xref[@firstand@last] [2]
```

Disabling that check results in:
```
        %
[381]   0.00    0.000    0.111      7     xref[@firstand@last] [381]
```

Time cost scales almost linearly. If I had another 7 xrefs with a `@first/@last`, the processing time for them is over 10% of total.

IMO, this is too expensive for a courtesy check.