### PR TITLE
Common: store proglang key context in variable

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8148,12 +8148,16 @@ Book (with parts), "section" at level 3
 
 <!-- Define the key for indexing into the data list -->
 <xsl:key name="proglang" match="language" use="@ptx" />
+<!-- And make a variable with the context for key lookups useing that key -->
+<!-- doing the 'document('')/*/mb:programming' repeatedly is expensive.   -->
+<!-- (Especially in program|pf[prism-language]                            -->
+<xsl:variable name="proglang-key-context" select="exsl:node-set(document('')/*/mb:programming)"/>
 
 <!-- Define variables for default active language - will be picked up by -->
 <!-- RS manifest and can be a different string than the raw language. -->
 <xsl:variable name="default-active-programming-language">
     <xsl:if test="$version-docinfo/programs/@language">
-        <xsl:for-each select="document('')/*/mb:programming">
+        <xsl:for-each select="$proglang-key-context">
             <xsl:value-of select="key('proglang', $version-docinfo/programs/@language)/@active" />
         </xsl:for-each>
     </xsl:if>
@@ -8190,7 +8194,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="document('')/*/mb:programming">
+    <xsl:for-each select="$proglang-key-context">
         <xsl:value-of select="key('proglang', $language)/@active" />
     </xsl:for-each>
 </xsl:template>
@@ -8201,7 +8205,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="document('')/*/mb:programming">
+    <xsl:for-each select="$proglang-key-context">
         <xsl:value-of select="key('proglang', $language)/@listings" />
     </xsl:for-each>
 </xsl:template>
@@ -8223,7 +8227,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="document('')/*/mb:programming">
+    <xsl:for-each select="$proglang-key-context">
         <xsl:value-of select="key('proglang', $language)/@prism" />
     </xsl:for-each>
 </xsl:template>


### PR DESCRIPTION
Context switch with `<for-each select='document('')/*/mb:programming'>` is surprisingly expensive. This stores that element into a variable to avoid redoing the work to get the right context.

On my C++ text with heavy use of programs/pfs:
Before: 8% of total processing time:
```
index % time    self  children    called     name
                0.014    0.300   5107/5964      pf [38]
                0.008    0.325    857/5964      program[code-inclusion] [56]
[1]     8.07    0.300    0.002   5964     program|pf[prism-language] [1]
                0.002    0.020   5964/5964      program|pf[get-programming-language] [126]
```

After: 0.4%:
```
index % time    self  children    called     name
                0.012    0.015   5107/5964      pf [47]
                0.007    0.040    857/5964      program[code-inclusion] [59]
[37]    0.42    0.015    0.001   5964     program|pf[prism-language] [37]
                0.001    0.019   5964/5964      program|pf[get-programming-language] [149]
```