### PR TITLE
CSS: fix spacing issues around para's in various containers

### DIFF
--- a/css/components/_spacing.scss
+++ b/css/components/_spacing.scss
@@ -1,6 +1,4 @@
-// Entry point for common web styling
-
-// Spacing for content
+// Basic spacing for content
 
 // Breakpoint at which the navbar moves to the bottom of the screen
 $navbar-breakpoint: 800px !default;
@@ -10,22 +8,30 @@ $navbar-breakpoint: 800px !default;
   box-sizing: border-box;
 }
 
-// minimal spacing around items in a section or article
-// unspecific selectors - just about anything will override them
-section > *:not(:first-child) {
-  margin-top: 1.5em;
-}
-article > *:not(:first-child):has(.heading) {
-  margin-top: 1.5em;
-}
-article > *:not(:first-child) {
-  margin-top: 1.5em;
-}
-.knowl__content > *:not(:first-child) {
-  margin-top: 1.5em;
-}
+//----------------------------------------------------------
+// Inter item vertical spacing
+//
+// Set some baseline minimal inter-item vertical spacings
+//
+// Individual items can override this with their own margin. The
+// user of @layer here forces these rules to all have less precedence
+// than any rules not in a layer.
+// Most spacing should be done with margin-top.
 
-// tighten up spacing slightly for adjacent paragraphs in a section
-:is(section, article, .knowl__content) > .para + .para {
-  margin-top: 1em;
+@layer spacing {
+  // inter-item spacing high level containers
+  :is(section, article, .knowl__content) > *:not(:first-child) {
+    margin-top: 1.5em;
+  }
+
+  // but tighten up spacing slightly for adjacent paragraphs in a section
+  :is(section, article, .knowl__content) > .para + .para {
+    margin-top: 1em;
+  }
+
+  // lower-level container elements that are expected to contain sequences of items
+  // tighter spacing here to avoid visually breaking up the minor container
+  .ptx-content :is(ul, td, li, dd, .blockquote, .sbspanel, .para.logical) > *:not(:first-child) {
+    margin-top: 0.5em;
+  }
 }


### PR DESCRIPTION
Fix for issues identified by Alex and David:
https://groups.google.com/g/pretext-dev/c/r5pzcXvda_A/m/0GeEbEBFAAAJ
And a few other spots (e.g. https://pretextbook.org/examples/sample-article/html/section-side-by-side.html#stacking-side-by-side-11-2-2-2)

Most of the identified In keeping with current spacing practice, the fix focuses on giving arbitrary children of particular elements a top margin rather than individually targeting the elements.

We want that default spacing between items in a container to be a baseline that items can override if necesary. To allow for overriding with minimal specificity shenanigans, I added an `@layers` wrapper to the baseline spacing rules. Because that layer is defined after the layerless rules, it will have lower precedence. i.e. ANY unlayered rule will override its styles regardless of specificity.
(see https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Cascade_layers).

