### PR TITLE
Guide: how to spell check HTML output

### DIFF
--- a/doc/guide/appendices/editors.xml
+++ b/doc/guide/appendices/editors.xml
@@ -919,5 +919,26 @@
             </subsubsection>
         </subsection>
     </section>
-
+    <section xml:id="subsection-spellchecking-output">
+        <title>Spell Checking Output</title>
+        <p>
+            While browsing your HTML output, it is possible to have the web browser's native
+            spell checker highlight spelling errors. Create a bookmark with the following for
+            its URL:
+            <cd>
+                <cline>javascript:document.body.contentEditable=!document.body.isContentEditable; document.designMode=(document.designMode === 'on') ? 'off' : 'on'; void 0</cline>
+            </cd>
+            Now when viewing a page and you click this bookmarklet, javascript will change
+            browser settings so that the native spell checker highlights spelling errors. This
+            is done by making the text content of the page editable, which is normally what is
+            needed for the browser's spell checker to kick in. While this is active, you will
+            not be able to click most links and buttons. Click the bookmarklet again to toggle
+            things back to how they were.
+        </p>
+        <p>
+            Some browsers may have extensions that you can install for spell checking the
+            content of a page. For example, Chrome has
+            <url href="https://chromewebstore.google.com/detail/webpage-spell-check/mgdhaoimpabdhmacaclbbjddhngchjik">Webpage Spell-Check</url>.
+        </p>
+    </section>
 </appendix>


### PR DESCRIPTION
While I could have spell checkers in my editors, I haven't put in the time to configure them for XML. Let alone for chunks of other code like latex-image or pg-code. Instead I use what's described here in Firefox, which makes a quick-and-dirty spell checker on the output pages. If I'm reviewing something in final stages, I run this on each page as I review. I thought this might be of some general interest for the guide.