### PR TITLE
Fixes for printouts

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -75,6 +75,17 @@
   display: none;
 }
 
+// Some elements don't make sense to print: 
+//   image descriptions
+//   webwork "activate" buttons
+//   buttons in general (to remove Runestone "Check Me" button)
+// We remove these here.
+details.image-description,
+.ptx-content .webwork-button,
+.ptx-runestone-container button.btn {
+  display: none;
+}
+
 
 // Set font appropriate for printing
 section.worksheet, section.handout {

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -151,8 +151,9 @@ summary {
   margin-top: 0;
 }
 
+// tasks might be "free-floating" articles, in which case they should get the same indenting as tasks inside exercises.
  section article.task {
-  margin-left: 0;
+  margin-left: 20px;
 }
 
 section.worksheet > .heading, section.handout > .heading {

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -671,8 +671,11 @@ function createPrintoutPages(margins) {
             // sidebyside could have tasks, but we don't want to dive further into them.
             rows.push(child);
         } else if (child.querySelector('.task')) {
-            for (const row of child.children) {
-                rows.push(row);
+            // Keep the child as a block, but put each task after the first one as its own row:
+            rows.push(child);
+            const tasks = child.querySelectorAll('.task');
+            for (let i = 1; i < tasks.length; i++) {
+                rows.push(tasks[i]);
             }
         // Skipping separate treatment of exercisegroups for now.
         //} else if (child.classList.contains('exercisegroup')) {


### PR DESCRIPTION
This PR addresses two issues with worksheets and handouts.

1. Some elements only make sense in the web version and should not be printed.  We hide image descriptions and webwork/runestone buttons (just in case one of these elements is included in a worksheet).
2. In a worksheet without authored pages, we were pulling out every child of an exercise that contains tasks (as long as it is not in a side-by-side, to allow pages to break in the middle of a set of tasks.  But this was causing strange sizing of the heading for the exercise.  Now we keep an exercise with a single task, and put every subsequent task as its own block.  Small change to the javascript and tweak to the css to indent tasks consistently.

Note there is currently not an example of a image `#description` in a worksheet in a sample article, so you shouldn't see any changes to the output when built.