### PR TITLE
Examples: make minimal example schema compliant

### DIFF
--- a/examples/minimal/source/main.ptx
+++ b/examples/minimal/source/main.ptx
@@ -73,6 +73,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <date><today /></date>
             </bibinfo>
 
+            <titlepage><titlepage-items /></titlepage>
+
             <abstract>
                 <p>This is a very short article, but it still exercises some advanced features of MathBook XML.</p>
             </abstract>


### PR DESCRIPTION
`pretext/article/frontmatter/titlepage` is required by the schema.