### PR TITLE
WeBWorK in Runestone: let books use generated ww from other books

### DIFF
--- a/js/pretext-webwork/2.20/pretext-webwork.js
+++ b/js/pretext-webwork/2.20/pretext-webwork.js
@@ -16,6 +16,7 @@ async function handleWW(ww_id, action) {
     const ww_processing = 'webwork2';
     const ww_origin = ww_container.dataset.origin;
     const ww_problemSource = ww_container.dataset.problemsource;
+    const ww_baseCourse = ww_container.dataset.basecourse;
     const ww_sourceFilePath = ww_container.dataset.sourcefilepath;
     const ww_course_id = ww_container.dataset.courseid;
     const ww_user_id = ww_container.dataset.userid;
@@ -79,7 +80,13 @@ async function handleWW(ww_id, action) {
     let formData = new FormData();
     let generatedPG = 'generated/webwork/pg/';
     if (runestone_logged_in) {
-        generatedPG = `/ns/books/published/${eBookConfig.basecourse}/${generatedPG}`;
+        if (!ww_baseCourse) {
+            // Try to parse the baseCourse from ww_id which has form <baseCourse>_*-ww-rs
+            const match = ww_id.match(/^([a-zA-Z0-9_\-]+?)_/);
+            ww_baseCourse = match ? match[1] : eBookConfig.basecourse;
+        }
+        console.log("using the base course " + ww_baseCourse);
+        generatedPG = `/ns/books/published/${ww_baseCourse}/${generatedPG}`;
     }
 
     if (action == 'check' || action =='reveal') {

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10754,6 +10754,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:attribute name="data-problemSource">
                     <xsl:value-of select="rendering-data/@problemSource"/>
                 </xsl:attribute>
+                <!-- When rendering a problem with problemSource, we want to know the base course id -->
+                <xsl:attribute name="data-baseCourse">
+                    <xsl:value-of select="$document-id"/>
+                </xsl:attribute>
             </xsl:when>
             <xsl:when test="rendering-data/@sourceFilePath">
                 <xsl:attribute name="data-sourceFilePath">


### PR DESCRIPTION
This adds a "baseCourse" data attribute to each webwork problem and then sets the javascript to use that if it can to specify the path to the .pg file for the problem when activating.  

The javascript should only have any effect if viewed in runestone.  The `data-baseCourse` is only added when `data-problemSource` is, which should only happen when there is local .pg files to be loaded.

Draft for now since I am not in a position to test this fully yet, but @Alex-Jordan, I'd love to get your thoughts when you have a chance.