### PR TITLE
HTML: no permalinks in multiple choice statements

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11666,6 +11666,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- appear at  https://github.com/PreTeXtBook/pretext/pull/2534    -->
 <xsl:template match="feedback/p" mode="permalink"/>
 
+<!-- 2025-10-19: "p" in the label vor a multiple choice option overlaps -->
+<!-- the label itself, obscuring the content                            -->
+<xsl:template match="exercise/choices/choice/statement/p" mode="permalink"/>
+
 
 <!--                     -->
 <!-- Navigation Sections -->


### PR DESCRIPTION
Trying to render permalinks in multiple-choice problems ends up obscuring and preventing interaction with the label that should be a clickable way to select the desired option.

<img width="358" height="104" alt="2025-10-19 09_46_18-doctest-1b cpp - welcomeprogramming - Visual Studio Code" src="https://github.com/user-attachments/assets/6133c940-311f-441a-aba7-666f91ce503a" />

Rather than try to do some special rendering logic, it seems better to just not render permalinks in that context.