### PR TITLE
CSS: fix fillin styling for non-math, non-interactive fillin blanks in HTML

### DIFF
--- a/css/components/elements/_fillin.scss
+++ b/css/components/elements/_fillin.scss
@@ -1,36 +1,29 @@
 
 .fillin {
   display: inline-block;
-  border-bottom-style: solid;
+  border: none;
   border-width: 1px;
   margin-right: 0.1em;
+  margin-left: 0.1em;
   margin-bottom: -0.25em;
 
-  .underline {
-    display: inline-block;
+  &.underline {
     border-bottom-style: solid;
     border-width: 1px;
-    margin-right: 0.1em;
-    margin-bottom: -0.25em;
   }
 
-  .box {
-    display: inline-block;
-    border: none;
-    margin-left: 0.1em;
-    margin-right: 0.1em;
-    margin-bottom: -0.25em;
-    outline: 1px solid black;
+  &.box {
+    outline: 1px solid var(--body-text-color);
     height: 1.3em;
   }
   
-  .shade {
-    display: inline-block;
-    border: none;
-    margin-right: 0.1em;
-    margin-left: 0.1em;
-    margin-bottom: -0.25em;
-    background-color: #eee;
+  &.shade {
+    background-color: var(--fillin-background-color, #eee);
     height: 1.3em;
   }
+}
+
+
+:root.dark-mode {
+  --fillin-background-color: #444;
 }


### PR DESCRIPTION
I noticed that the style options for non-interactive, non-math filllin blanks are broken in HTML. Pretty sure this happened in the great CSS retooling and has gone unnoticed until now. Rendering is currently always underlined. This restores box/shaded renderings.

Look for it at 4.7 in SA for examples. Will have to change pub file `common/fillin/@textstyle` to see the issue.

@oscarlevin This is probably coming your way
