### PR TITLE
HTML: no permalinks in Parsons problem blocks

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11671,6 +11671,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- of the "choice", but not everything.                               -->
 <xsl:template match="exercise/choices/choice/statement/p" mode="permalink"/>
 
+<!-- 2025-11-1: "p" inside Parsons problem should not get permalinks -->
+<xsl:template match="exercise/blocks//p" mode="permalink"/>
 
 <!--                     -->
 <!-- Navigation Sections -->


### PR DESCRIPTION
Currently `<p>` tags in Parsons blocks get permalinks inserted. I don't see any good that can come of having them there. The Parsons rendering code prevents the permalinks from even appearing, so it is just cruft HTML.

Although I don't know of any issues currently, given all the downstream processing the blocks go through, adding a bunch of extra HTML is asking for trouble.