### PR TITLE
Fix for bug with runestone webwork

### DIFF
--- a/js/pretext-webwork/2.20/pretext-webwork.js
+++ b/js/pretext-webwork/2.20/pretext-webwork.js
@@ -16,7 +16,7 @@ async function handleWW(ww_id, action) {
     const ww_processing = 'webwork2';
     const ww_origin = ww_container.dataset.origin;
     const ww_problemSource = ww_container.dataset.problemsource;
-    const ww_baseCourse = ww_container.dataset.documentid;
+    let ww_baseCourse = ww_container.dataset.documentid;
     const ww_sourceFilePath = ww_container.dataset.sourcefilepath;
     const ww_course_id = ww_container.dataset.courseid;
     const ww_user_id = ww_container.dataset.userid;
@@ -81,12 +81,13 @@ async function handleWW(ww_id, action) {
     let generatedPG = 'generated/webwork/pg/';
     // For Runestone, we specify where to find the generated problems.
     if (runestone_logged_in) {
-        if (!ww_baseCourse) {
-            // WeBWorK generated after 2025/10/15-ish should have a baseCourse specified. We fall back to parsing the baseCourse from ww_id, which *should* always start with the base course prior to the first underscore (although this is not guaranteed). If no underscore is found, we fall back to eBookConfig.basecourse.
+        if (ww_problemSource && !ww_baseCourse) {
+            // WeBWorK authored in source, generated after 2025/10/15-ish, should have a baseCourse specified. We fall back to parsing the baseCourse from ww_id, which *should* always start with the base course prior to the first underscore (although this is not guaranteed). If no underscore is found, we fall back to eBookConfig.basecourse.
+            // This is only needed for webwork problems authored in source, not OPL problems, so we only check when ww_problemSource is set.
             const parts = ww_id.split('_');
             ww_baseCourse = parts.length > 1 ? parts[0] : eBookConfig.basecourse;
+            console.log("using the base course " + ww_baseCourse);
         }
-        console.log("using the base course " + ww_baseCourse);
         generatedPG = `/ns/books/published/${ww_baseCourse}/${generatedPG}`;
     }
 


### PR DESCRIPTION
I introduced a bug in 6c1038110537da4f681c8b8b8b1dafe7428cc45b that caused webwork problems that are NOT authored in source to not activate when in runestone.  This popped up just now with the release of 2.30 of the CLI.  

This PR fixes that bug as well as makes the checking for a basecourse for runestone webwork more robust (only checking for for the base course when `ww_problemSource` is set, which is the only time that we also define `ww_baseCourse` using the `documentId`).

@rbeezer, if you can merge this relatively quickly, I can release a patch for the CLI so that runestone can have the latest pretext features without its books breaking.