### PR TITLE
Fix issue with downloading required style files when specifying journal

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4632,8 +4632,11 @@ def get_web_asset(url):
         log.debug(msg)
         raise Exception(msg)
 
+    # Set a user-agent to mimic a browser. This is what chrome on windows sends as of 2025-11-19.
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'}
+
     try:
-        services_response = requests.get(url, timeout=(1,10))
+        services_response = requests.get(url, timeout=(1,10), headers=headers)
     except requests.exceptions.RequestException as e:
         msg = '\n'.join(['There was a network problem while trying to download "{}"',
                             'and the reported problem is:',


### PR DESCRIPTION
We recently discovered that when python requests tries to download the `bull-l.cls` file from the AMS website, we get back a 403 Forbidden error.  The solution seems to be to "spoof" the request by sending User-Agent headers.  This does that for the `get_web_asset()` function in the pretext script.  While this is used elsewhere too (currently just the runestone services bits; @bnmnetp I assume this won't mess anything up for runestone), this should only help avoid such errors (so prefixing future bugs).

Tested for the various journal names.  