### PR TITLE
HTML: Mermaid diagrams do not get white background in dark mode

### DIFF
--- a/css/components/elements/_media.scss
+++ b/css/components/elements/_media.scss
@@ -27,6 +27,10 @@ img.contained {
   // as most transparent images will assume that the background is white
   background: var(--ptx-image-bg);
 }
+// but mermaid svg should always have a transparent background
+.mermaid > svg {
+  background: none;
+}
 
 .image-description {
   summary {


### PR DESCRIPTION
Most svg's get white background in dark mode... too many existing diagrams assume there is a light background and always render blank text on transparent fill. Mermaid diagrams handle dark mode, so they should not.

Testing note: you have to refresh the page after changing light/dark mode to get mermaid diagrams to rerender.