### PR TITLE
Support description and short description for interactive[@platform]

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -8862,6 +8862,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <caption>Numerical integrals using the midpoint rule</caption>
 
                     <interactive dark-mode-enabled="yes" xml:id="interactive-numerical-integral" platform="sage" width="100%" aspect="4:5">
+                        <shortdescription>An interactive for numerical integration</shortdescription>
+                        <description>
+                            <p>An interactive element with a slider allowing the value of <m>m</m> for the number of rectangles, the function <m>f</m>, and start and stop values for the interval of integration. There is an image showing the graph of <m>f</m> on the interval along with <m>m</m> rectangles of equal base width along the interval of integration. The height of each rectangle is determined by the value of <m>f</m> at the midpoint of the base of the rectangle. Above the image, the numerical value of the integral reported by SageMath is provided as well as the sum of the areas of the rectangles as the midpoint estimate.
+                            </p>
+                        </description>
                         <!-- Changes: gave 3 input boxes widths -->
                         <!-- Changes: Escaped \ inside LaTeX -->
                         <!-- Changes: Added figsize=5 to show -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6315,7 +6315,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Utility template so "aria-describedby" values are consistent -->
-<xsl:template match="image" mode="describedby-id">
+<xsl:template match="image|interactive[@platform]" mode="describedby-id">
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>-description</xsl:text>
 </xsl:template>
@@ -9881,11 +9881,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="src">
             <xsl:apply-templates select="." mode="iframe-filename" />
         </xsl:attribute>
-        <xsl:if test="shortdescription">
-            <xsl:attribute name="title">
-                <xsl:value-of select="shortdescription"/>
-            </xsl:attribute>
-        </xsl:if>
+        <!-- title attribute for accessibility -->
+        <xsl:choose>
+            <xsl:when test="not(string(shortdescription) = '')">
+                <xsl:attribute name="title">
+                    <xsl:apply-templates select="shortdescription" />
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="title">
+                    <xsl:text>described in detail following the image</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
     <!-- possibly give a long description -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6295,7 +6295,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
-<xsl:template match="image" mode="description">
+<xsl:template match="image|interactive[@platform]" mode="description">
     <xsl:if test="description">
         <!-- @aria-live means screenreaders will make announcements -->
         <details class="image-description" aria-live="polite">
@@ -9881,8 +9881,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="src">
             <xsl:apply-templates select="." mode="iframe-filename" />
         </xsl:attribute>
+        <xsl:if test="shortdescription">
+            <xsl:attribute name="title">
+                <xsl:value-of select="shortdescription"/>
+            </xsl:attribute>
+        </xsl:if>
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
+    <!-- possibly give a long description -->
+    <xsl:apply-templates select="." mode="description"/>
 </xsl:template>
 
 <!-- ######################### -->


### PR DESCRIPTION
This contributes to resolving #2721 by adding accessibility information for `interactive[@platform]`. Since my primary use case is for `@platform="sage"`, I opted to add `description` and `shortdescription` to the example of a SageMath interact in the sample article.

This is all inspired by the work of @sean-fitzpatrick in #2569. Tagging in @davidaustinm because I think some of his interactives use `interactive[@iframe]` and it would probably be straightforward for him to build off this PR to add the accessibility info to those.