### PR TITLE
CSS: Salem. Suppress conclusion styling inside RS exercises

### DIFF
--- a/css/targets/html/salem/_chunks-salem.scss
+++ b/css/targets/html/salem/_chunks-salem.scss
@@ -57,8 +57,9 @@ $border-radius: 2px !default;
 
 // get rid of this wrapper when print worksheet styles are fixed
 .ptx-content:not(:has(>.worksheet)) {
-  .conclusion,
-  .goal-like {
+  // avoid styling inside runestone containers
+  .conclusion:not(.ptx-runestone-container *),
+  .goal-like:not(.ptx-runestone-container *) {
     @include heading-box-mixin.box(
       $background-color: var(--goal-like-body-background),
       $border-color: var(--goal-like-border-color),
@@ -67,6 +68,7 @@ $border-radius: 2px !default;
     );
   }
 }
+
 .ptx-content:has(>.worksheet) {
   .goal-like {
     margin-top: 1.5em;


### PR DESCRIPTION
Removes styling for conclusion in project-like inside RS exercises when using Salem theme. (See https://groups.google.com/g/pretext-dev/c/K96i-x24aAE/m/X_bHOW7NCQAJ?utm_medium=email&utm_source=footer)

@bnmnetp

We likely need some follow up work to differentiate the conclusion from contents of any particular task. But that cuts across themes and likely belongs in RS codebase as it will be styling the HTML RS injects.

I'm planning on doing a spacing pass over break for PTX content dropped into RS exercises. There are many small instances of too much or too little margin/padding when the styles are blended. Will look at follow up as part of that.