### PR TITLE
Runestone: add id to activecode div in runnable Parsons

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1206,41 +1206,46 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <xsl:text>-runnable</xsl:text>
                     </xsl:attribute>
                     <div data-component="parsons-runnable">
-                    <textarea data-lang="{$active-language}" data-audio="" data-coach="true" style="visibility: hidden;">
-                        <xsl:variable name="hosting">
-                            <xsl:apply-templates select="." mode="activecode-host"/>
-                        </xsl:variable>
-                        <!-- loop just to set context. program should be single -->
-                        <xsl:for-each select="program">
-                            <xsl:call-template name="runestone-activecode-editor-attributes">
-                                <xsl:with-param name="active-language" select="$active-language"/>
-                                <xsl:with-param name="hosting" select="$hosting"/>
+                        <xsl:attribute name="id">
+                            <xsl:apply-templates select="." mode="runestone-id"/>
+                            <xsl:text>-runnable-ac</xsl:text>
+                        </xsl:attribute>
+                        <textarea data-lang="{$active-language}" data-audio="" data-coach="true" style="visibility: hidden;">
+                            <xsl:variable name="hosting">
+                                <xsl:apply-templates select="." mode="activecode-host"/>
+                            </xsl:variable>
+                            <!-- loop just to set context. program should be single -->
+                            <xsl:for-each select="program">
+                                <xsl:call-template name="runestone-activecode-editor-attributes">
+                                    <xsl:with-param name="active-language" select="$active-language"/>
+                                    <xsl:with-param name="hosting" select="$hosting"/>
+                                </xsl:call-template>
+                            </xsl:for-each>
+                            <!-- the content -->
+                            <xsl:text>&#xa;</xsl:text>
+                            <xsl:call-template name="add-indentation">
+                                <xsl:with-param name="text">
+                                    <xsl:call-template name="sanitize-text">
+                                        <xsl:with-param name="text" select="program-preamble"/>
+                                        <xsl:with-param name="preserve-end" select="true()"/>
+                                    </xsl:call-template>
+                                </xsl:with-param>
+                                <xsl:with-param name="indent"><xsl:value-of select="program-preamble/@indent"/></xsl:with-param>
                             </xsl:call-template>
-                        </xsl:for-each>
-                        <!-- the content -->
-                        <xsl:text>&#xa;</xsl:text>
-                        <xsl:call-template name="add-indentation">
-                            <xsl:with-param name="text">
-                                <xsl:call-template name="sanitize-text">
-                                    <xsl:with-param name="text" select="program-preamble"/>
-                                    <xsl:with-param name="preserve-end" select="true()"/>
-                                </xsl:call-template>
-                            </xsl:with-param>
-                            <xsl:with-param name="indent"><xsl:value-of select="program-preamble/@indent"/></xsl:with-param>
-                        </xsl:call-template>
-                        <!-- placeholder for user code -->
-                        <xsl:text>==PARSONSCODE==&#xa;</xsl:text>
-                        <xsl:call-template name="add-indentation">
-                            <xsl:with-param name="text">
-                                <xsl:call-template name="sanitize-text">
-                                    <xsl:with-param name="text" select="program-postamble"/>
-                                    <xsl:with-param name="preserve-start" select="true()"/>
-                                </xsl:call-template>
-                            </xsl:with-param>
-                            <xsl:with-param name="indent"><xsl:value-of select="program-postamble/@indent"/></xsl:with-param>
-                        </xsl:call-template>
-                    </textarea>
-                </div></div>
+                            <!-- placeholder for user code -->
+                            <xsl:text>==PARSONSCODE==&#xa;</xsl:text>
+                            <xsl:call-template name="add-indentation">
+                                <xsl:with-param name="text">
+                                    <xsl:call-template name="sanitize-text">
+                                        <xsl:with-param name="text" select="program-postamble"/>
+                                        <xsl:with-param name="preserve-start" select="true()"/>
+                                    </xsl:call-template>
+                                </xsl:with-param>
+                                <xsl:with-param name="indent"><xsl:value-of select="program-postamble/@indent"/></xsl:with-param>
+                            </xsl:call-template>
+                        </textarea>
+                    </div>
+                </div>
             </xsl:if>
 
         </div>


### PR DESCRIPTION
The activecode that is created when a "runnable" Parsons is completed does not get an  `@id` on the div that becomes the activecode. This does not prevent the activecode from working, but it does mean its code gets persisted/restored from the DB using an id of `""`. Since all runnables share that same id, if the user modifies the code of any of them, it shows as a change to all.

Smaller change than it looks, really just adds an `@id` to the div that becomes the activecode when the Parsons is complete. The rest of the changes are just indentation cleanup.

Heads up for @bnmnetp - this requires no RS side changes.