### PR TITLE
XSL: use &FIGURE-LIKE; entity where appropriate

### DIFF
--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -802,7 +802,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Other FIGURE-LIKE can be handled together -->
-<xsl:template match="figure|listing|table|list">
+<xsl:template match="&FIGURE-LIKE;">
     <block breakable="no" box="standard" lines-before="1" lines-after="1">
         <segment indentation="6" runover="4">
             <!-- [BANA, 2016, 11.17.1a] "Leave a blank line after the title." -->
@@ -821,7 +821,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Caption/title, with label, number, etc.  "caption" and -->
 <!-- "title" elements are metadata, killed in -common,      -->
 <!-- obtained as needed via modal templates.                -->
-<xsl:template match="figure|listing|table|list" mode="block-title">
+<xsl:template match="&FIGURE-LIKE;" mode="block-title">
     <xsl:apply-templates select="." mode="type-name"/>
     <!--  -->
     <xsl:variable name="the-number">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4274,14 +4274,14 @@ Book (with parts), "section" at level 3
 <!-- a lone sidebyside, not in a sbsgroup -->
 <xsl:template match="figure/sidebyside/figure | figure/sidebyside/table | figure/sidebyside/listing | figure/sidebyside/list" mode="serial-number">
     <xsl:text>(</xsl:text>
-    <xsl:number format="a" count="figure|table|listing|list"/>
+    <xsl:number format="a" count="&FIGURE-LIKE;"/>
     <xsl:text>)</xsl:text>
 </xsl:template>
 
 <!-- when inside a sbsgroup, subnumbers range across entire group -->
 <xsl:template match="figure/sbsgroup/sidebyside/figure | figure/sbsgroup/sidebyside/table | figure/sbsgroup/sidebyside/listing | figure/sbsgroup/sidebyside/list" mode="serial-number">
     <xsl:text>(</xsl:text>
-    <xsl:number format="a" count="figure|table|listing|list" level="any" from="sbsgroup"/>
+    <xsl:number format="a" count="&FIGURE-LIKE;" level="any" from="sbsgroup"/>
     <xsl:text>)</xsl:text>
 </xsl:template>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2057,7 +2057,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:element>
 </xsl:template>
 
-<xsl:template match="figure|listing|table|list" mode="figure-caption">
+<xsl:template match="&FIGURE-LIKE;" mode="figure-caption">
     <xsl:param name="b-original"/>
 
     <!-- Subnumbered panels of a "sidebyside" get a simpler caption/title -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -3276,7 +3276,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- end: options -->
 </xsl:template>
 
-<xsl:template match="figure|table|listing|list" mode="environment">
+<xsl:template match="&FIGURE-LIKE;" mode="environment">
     <xsl:variable name="fig-placement">
         <xsl:apply-templates select="." mode="figure-placement"/>
     </xsl:variable>
@@ -9023,7 +9023,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="figure|table|list|listing" mode="environment-name">
+<xsl:template match="&FIGURE-LIKE;" mode="environment-name">
     <xsl:variable name="fig-placement">
         <xsl:apply-templates select="." mode="figure-placement"/>
     </xsl:variable>


### PR DESCRIPTION
This takes the places where `"figure|table|listing|list"` appears in the XSL (except sometimes in other orders) and replaces it all with `&FIGURE-LIKE`.

Among the handful of PRs I will open/update this week, this one can be looked at first.