### PR TITLE
Assembly: carry an @xml:id from audio|video|interactive[not(static)] …

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3539,6 +3539,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$exercise-style = 'static'">
             <!-- panel widths are experimental -->
             <sidebyside margins="7.5% 7.5%" widths="47% 21%" valign="top" halign="center">
+                <xsl:copy-of select="@xml:id"/>
                 <xsl:choose>
                     <!-- @preview present, so author provides a static image  -->
                     <!--                                                      -->


### PR DESCRIPTION
…over to its static sidebyside

This is discussed in #2618.

Among the PRs I expect to open and update this week, first to evaluate can be this one or #2739, in either order.