### PR TITLE
Guide: Add p to insight in Advice for Writing Image Descriptions

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -5317,7 +5317,9 @@
         </p>
 
         <insight>
-          VS Code, and presumably most modern text editors, will display the character count of selected text in the status bar.
+          <p>
+            VS Code, and presumably most modern text editors, will display the character count of selected text in the status bar.
+          </p>
         </insight>
 
         <p>


### PR DESCRIPTION
Discovered while reviewing this section to prepare for an MAA webinar that this `insight` (rendered as "Tip") had no content in HTML output because of missing `p`.