### PR TITLE
Runestone: improve spacing of injected PreTeXt elements

### DIFF
--- a/css/components/interactives/_runestone.scss
+++ b/css/components/interactives/_runestone.scss
@@ -88,3 +88,15 @@ ul[data-component="timedAssessment"] {
     background: hsl(0, 0%, 8%);
   }
 }
+
+// Similar to rules in _spacing.scss
+// <statments> exercise content divs that are hoisted into a RS interactive
+// should get one of these classes.
+@layer spacing {
+  .runestone :is(.exercise-statement, .exercise-content) > *:not(:first-child) {
+    margin-top: 1em;
+  }
+  .ptx-runestone-container + .solutions {
+    margin-top: 0.5em;
+  }
+}


### PR DESCRIPTION
This will help improve spacing of multi-element blocks of PTX injected into RS exercises in places like statements.

Should have immediate visible effect at Checkpoint 5.4.1 in SB. (Activecode statements already have the `exercise-statement` class that this keys off of.)

Will affect many other components/locations once a partner RS PR is in place.

Heads up to @bnmnetp 