### PR TITLE
Publisher pagebreaks

### DIFF
--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -168,7 +168,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <worksheet formatted="yes"/>
         <asymptote links="yes"/>
         <insertions pagebreaks="quotations exercises-section-multiple pre-roll-countdown-8"/>
-        <insertions pagebreaks="sidebyside-bully-pulpit"/>
+        <insertions pagebreaks="sidebyside-bully-pulpit sbsgroup-pagebreak-test"/>
     </latex>
 
 </publication>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -12695,6 +12695,50 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </sidebyside>
                 </sbsgroup>
 
+                <p>
+                    Now an <tag>sbsgroup</tag> that should start on a new page if this sample
+                    article is built to PDF using the distribution publisher file.
+                </p>
+
+                <sbsgroup xml:id="sbsgroup-pagebreak-test" width="20%">
+                    <sidebyside>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                    </sidebyside>
+                    <sidebyside>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                        <figure>
+                            <caption></caption>
+                            <image source="images/cross-rectangle.png"/>
+                        </figure>
+                    </sidebyside>
+                </sbsgroup>
+
                 <p>The following is a <tag>sbsgroup</tag> full of <q>operation</q> tables.  Once upon a time it was rather cramped vertically in HTML output, but Andrew Scholer improved the spacing at <url href="https://github.com/PreTeXtBook/pretext/pull/2387" visual="github.com/PreTeXtBook/pretext/pull/2387">GitHub #2387</url>.  The example is from Valerio Monti.</p>
 
                 <figure xml:id="tabelle_classi_di_resto">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5903,6 +5903,7 @@ Book (with parts), "section" at level 3
         </xsl:for-each>
     </xsl:variable>
 
+    <xsl:apply-templates select="." mode="pre-sidebyside"/>
     <!-- now collect components into output wrappers -->
     <xsl:apply-templates select="." mode="compose-panels">
         <xsl:with-param name="b-original" select="$b-original" />
@@ -5937,6 +5938,7 @@ Book (with parts), "section" at level 3
 
 <xsl:template match="sbsgroup">
     <xsl:variable name="data">
+        <xsl:apply-templates select="." mode="pre-sbsgroup"/>
         <xsl:apply-templates select="sidebyside" />
         <xsl:apply-templates select="." mode="post-sbsgroup"/>
     </xsl:variable>
@@ -5965,12 +5967,14 @@ Book (with parts), "section" at level 3
 <!-- Post-Layout Hooks -->
 <!-- ################# -->
 
-<!-- We may wish to add information below a "sidebyside"    -->
-<!-- or a "sbsgroup".  Motivation is keyboard shortcut help -->
-<!-- for interactive accessible diagrams out of PreFigure   -->
-<!-- code with the diagcess JS library.  See invocations    -->
-<!-- above, with no-op stubs here. -->
+<!-- We may wish to add information above or below a "sidebyside"  -->
+<!-- or a "sbsgroup".  Motivation is keyboard shortcut help for    -->
+<!-- interactive accessible diagrams out of PreFigure code with    -->
+<!-- the diagcess JS library.  See invocations above, with no-op   -->
+<!-- stubs here. -->
 
+<xsl:template match="sidebyside" mode="pre-sidebyside"/>
+<xsl:template match="sbsgroup" mode="pre-sbsgroup"/>
 <xsl:template match="sidebyside" mode="post-sidebyside"/>
 <xsl:template match="sbsgroup" mode="post-sbsgroup"/>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5874,7 +5874,7 @@ Book (with parts), "section" at level 3
     <!-- "paragraphs" deprecated within sidebyside, 2018-05-02 -->
     <!-- jsxgraph deprecated?  Check                           -->
 
-     <xsl:variable name="panels" select="p|pre|ol|ul|dl|program|console|poem|audio|video|interactive|slate|exercise|image|figure|table|listing|list|tabular|stack|jsxgraph|paragraphs" />
+    <xsl:variable name="panels" select="p|pre|ol|ul|dl|program|console|poem|audio|video|interactive|slate|exercise|image|figure|table|listing|list|tabular|stack|jsxgraph|paragraphs" />
 
     <!-- We build up lists of various parts of a panel      -->
     <!-- It has setup (LaTeX), headers (titles), panels,    -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -9230,17 +9230,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="pop-footnote-text"/>
 </xsl:template>
 
-<!-- Copied verbatim from pretext-common.xsl   -->
-<!-- except with the possibility for a newpage -->
-<xsl:template match="sbsgroup">
-    <xsl:variable name="data">
-        <xsl:apply-templates select="sidebyside" />
-        <xsl:apply-templates select="." mode="post-sbsgroup"/>
-    </xsl:variable>
+<!-- Possibility for a newpage -->
+<xsl:template match="sbsgroup" mode="pre-sbsgroup">
     <xsl:apply-templates select="." mode="newpage"/>
-    <xsl:call-template name="sbsgroup-wrapper">
-        <xsl:with-param name="sbsgroup-content" select="$data"/>
-    </xsl:call-template>
 </xsl:template>
 
 <!-- ###### -->


### PR DESCRIPTION
This follows up from #2618, making a `pre-sbsgroup` template that can be used as the mechanism to make a pagebreak right before an sbsgroup in PDF.

Also I saw a nearby bad space in the -common file.  I removed it on its own commit, but right before the other commit involving that file. So you could squash those two if that's better. Or if you just don't want that let me know and I'll force push without that commit.