### PR TITLE
HTML: Move MathJax packages and macros to its configuration

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6888,8 +6888,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- this *must* be first for maximum utility -->
                 <xsl:call-template name="skip-to-content-link" />
                 <xsl:apply-templates select="." mode="primary-navigation"/>
-                <xsl:call-template name="latex-macros" />
-                 <header id="ptx-masthead" class="ptx-masthead">
+                <header id="ptx-masthead" class="ptx-masthead">
                     <div class="ptx-banner">
                         <xsl:call-template name="brand-logo" />
                         <div class="title-container">
@@ -9940,7 +9939,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- Some interactives use slates that are PreTeXt  -->
                 <!-- elements, hence could have math, hence need to -->
                 <!-- know globally available macros from the author -->
-                <xsl:call-template name="latex-macros"/>
                 <xsl:if test="slate|sidebyside|sbsgroup">
                     <div>
                         <!-- aspect ratio will force the proper height for wrapper div                           -->
@@ -11270,7 +11268,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </div>  <!-- banner -->
             </header>  <!-- masthead -->
             <xsl:apply-templates select="." mode="primary-navigation"/>
-            <xsl:call-template name="latex-macros"/>
             <div class="ptx-page">
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
@@ -13127,7 +13124,7 @@ TODO:
                                 <string>base</string>
                                 <!-- 2023-10-19: this provides backward-compatible behavior -->
                                 <!-- and could be removed at the first sign of trouble      -->
-                                <xsl:if test="not(contains($latex-packages-mathjax, '\require{extpfeil}'))">
+                                <xsl:if test="not($docinfo/math-package[@mathjax-name='extpfeil'])">
                                     <string>extpfeil</string>
                                 </xsl:if>
                                 <string>ams</string>
@@ -13135,6 +13132,9 @@ TODO:
                                 <string>color</string>
                                 <string>newcommand</string>
                                 <string>knowl</string>
+                                <xsl:for-each select="$docinfo/math-package[@mathjax-name and normalize-space(@mathjax-name) != '']">
+                                    <string><xsl:value-of select="@mathjax-name"/></string>
+                                </xsl:for-each>
                             </array>
                         </map>
                     </map>
@@ -13158,7 +13158,9 @@ TODO:
                                         <xsl:text>            });&#xa;</xsl:text>
                                         <xsl:text>        }</xsl:text>
                                     </raw>
-                                    <string></string>
+                                    <raw>
+                                        <xsl:text>() => {}</xsl:text>
+                                    </raw>
                                 </array>
                             </map>
                         </xsl:if>
@@ -13175,6 +13177,9 @@ TODO:
                             <string>[tex]/color</string>
                             <string>[tex]/newcommand</string>
                             <string>[pretext]/mathjaxknowl3.js</string>
+                            <xsl:for-each select="$docinfo/math-package[@mathjax-name and normalize-space(@mathjax-name) != '']">
+                                <string>[tex]/<xsl:value-of select="@mathjax-name"/></string>
+                            </xsl:for-each>
                         </array>
                         <map key="paths">
                             <string key="pretext">
@@ -13188,9 +13193,17 @@ TODO:
                                 <boolean key="typeset">false</boolean>
                             </xsl:when>
                             <xsl:otherwise>
-                                <!-- tell Runestone components that MathJax is all loaded -->
                                 <raw>
                                     <xsl:text>pageReady() {&#xa;</xsl:text>
+                                    <xsl:text>      MathJax.tex2mmlPromise(String.raw`&#xa;</xsl:text>
+                                    <xsl:value-of select="$latex-macros"/>
+                                    <xsl:call-template name="fillin-math"/>
+                                    <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
+                                    <xsl:if test="$b-has-sfrac">
+                                        <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
+                                    </xsl:if>
+                                    <xsl:text>      `);&#xa;</xsl:text>
+                                    <!-- tell Runestone components that MathJax is all loaded -->
                                     <xsl:text>      return MathJax.startup.defaultPageReady().then(function () {&#xa;</xsl:text>
                                     <xsl:text>      console.log("in ready function");&#xa;</xsl:text>
                                     <xsl:text>      rsMathReady();&#xa;</xsl:text>
@@ -13968,49 +13981,6 @@ TODO:
     <xsl:attribute name="dir">
         <xsl:value-of select="$document-language-direction"/>
     </xsl:attribute>
-</xsl:template>
-
-
-<!-- ############## -->
-<!-- LaTeX Preamble -->
-<!-- ############## -->
-
-<!-- First a variable to massage the author-supplied -->
-<!-- package list to the form MathJax expects        -->
-<xsl:variable name="latex-packages-mathjax">
-    <xsl:for-each select="$docinfo/math-package">
-        <!-- must be specified, but can be empty/null -->
-        <xsl:if test="not(normalize-space(@mathjax-name)) = ''">
-            <xsl:text>\require{</xsl:text>
-            <xsl:value-of select="@mathjax-name"/>
-            <xsl:apply-templates/>
-            <xsl:text>}</xsl:text>
-            <!-- all on one line, not very readable, but historical -->
-        </xsl:if>
-    </xsl:for-each>
-</xsl:variable>
-
-<!-- MathJax expects math wrapping, and we place in   -->
-<!-- a hidden div so not visible and take up no space -->
-<!-- Inline CSS added because a "flash" was visible   -->
-<!-- between HTML loading and CSS taking effect.      -->
-<!-- We could rename this properly, since we are      -->
-<!-- sneaking in packages, which load first, in       -->
-<!-- case authors want to build on these macros       -->
-<xsl:template name="latex-macros">
-    <div id="latex-macros" class="hidden-content process-math" style="display:none">
-        <xsl:call-template name="inline-math-wrapper">
-            <xsl:with-param name="math">
-                <xsl:value-of select="$latex-packages-mathjax"/>
-                <xsl:value-of select="$latex-macros"/>
-                <xsl:call-template name="fillin-math"/>
-                <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
-                <xsl:if test="$b-has-sfrac">
-                    <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
-                </xsl:if>
-            </xsl:with-param>
-        </xsl:call-template>
-    </div>
 </xsl:template>
 
 

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -375,22 +375,27 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:call-template>
 </xsl:template>
 
-<!-- This will override the HTML version, but is patterned -->
-<!-- after same.  Adjustments are: different overall       -->
-<!-- delimiters, and no enclosing div to hide content      -->
-<!-- (thereby avoiding the need for serialization).        -->
-<!-- We *remove* our defintion of \lt since MathJax does   -->
-<!-- it anyway and Jupyter adds it in as part of a         -->
-<!-- conversion to LateX.  Bad practice?  Maybe better to  -->
-<!-- go back to -common and rework the entire latex-macro  -->
-<!-- generation scheme?                                    -->
+<!-- Jupyter uses its own MathJax config, so we cannot load packages and define macros -->
+<!-- in the MJ config as we do in HTML. Instead, we load/define these inline here.     -->
+<!-- We *remove* our defintion of \lt since MathJax does it anyway and Jupyter adds it -->
+<!-- in as part of a conversion to LateX.  Bad practice?  Maybe better to go back to   -->
+<!-- -common and rework the entire latex-macro generation scheme?                      -->
 <xsl:template name="latex-macros">
     <xsl:call-template name="markdown-cell">
         <xsl:with-param name="content">
             <xsl:call-template name="begin-string" />
             <xsl:call-template name="inline-math-wrapper">
                 <xsl:with-param name="math">
-                    <xsl:value-of select="$latex-packages-mathjax" />
+                    <xsl:for-each select="$docinfo/math-package">
+                        <!-- must be specified, but can be empty/null -->
+                        <xsl:if test="not(normalize-space(@mathjax-name)) = ''">
+                            <xsl:text>\require{</xsl:text>
+                            <xsl:value-of select="@mathjax-name"/>
+                            <xsl:apply-templates/>
+                            <xsl:text>}</xsl:text>
+                            <!-- all on one line, not very readable, but historical -->
+                        </xsl:if>
+                    </xsl:for-each>
                     <!-- Sequence replacements if \gt and/or \amp need to go -->
                     <xsl:value-of select="str:replace($latex-macros,'\newcommand{\lt}{&lt;}&#xa;', '')"/>
                 </xsl:with-param>


### PR DESCRIPTION
We have long put author-demanded packages (cancel, etc) in a `\require{}` inside a block of math content. And long placed author-defined macros in the same block of math content.

This change moves all of that into the actual configuration block for MathJax. This was motivated by certain changes I'd like to make for WeBWorK, but just seems like the actual appropriate way to do all this. I don't believe it was possible with MJ2, so we did what we did. And held onto it. But with my testing of the sample article with both MJ3 and MJ4, this works.

This warrants lots of testing. I'll try other projects, other browsers, other devices, etc. But I wanted to post it here to see if there is interest in even more people testing. Marking this as draft until I can report more testing.