### PR TITLE
WeBWorK: only match image pattern on nonempty strings

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1734,7 +1734,7 @@ def webwork_to_xml(
         #
         #   <image source="relative-path-to-temporary-image-on-server"
         #
-        graphics_pattern = re.compile(r'<image.*?source="([^"]*)"')
+        graphics_pattern = re.compile(r'<image.*?source="([^"]+)"')
 
         # replace filenames, download images with new filenames
         count = 0


### PR DESCRIPTION
As reported in on pretext-support, if something is out of sorts with a webwork2 server, the static PTX rendering of an exercise might have `<image source=""/>` with an empty source attribute. Normally when something is actually there, we capture what is there so we can download the webwork2 server's cached image file, and then we replace what is in `@source` with an appropriate generated image file path. But if we've captured the empty string, bad things happen when we try to replace all instances of the empty string...

So this change ensures the match only happens on nonempty source attributes.