### PR TITLE
Script: pass raw string as regex pattern

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2761,11 +2761,11 @@ def _stack_process_response(qdict):
     soltext = qdict["questionsamplesolutiontext"]
 
     # Strip validation and specific feedback
-    qtext = re.sub("\[\[validation:(\w+)\]\]", "", qtext)
-    qtext = re.sub("\[\[feedback:(\w+)\]\]", "", qtext)
+    qtext = re.sub(r"\[\[validation:(\w+)\]\]", "", qtext)
+    qtext = re.sub(r"\[\[feedback:(\w+)\]\]", "", qtext)
 
     # Iterate over inputs. For each input with ID ansid:
-    ansids = re.findall("\[\[input:(\w+)\]\]", qtext)
+    ansids = re.findall(r"\[\[input:(\w+)\]\]", qtext)
     answers = []
     for ansid in ansids:
         ansdata = qdict["questioninputs"][ansid]


### PR DESCRIPTION
My python version is 3.12.8. When I use the pretext script, I get these warnings:

```
/Users/alex.jordan/pretext/pretext/lib/pretext.py:2764: SyntaxWarning: invalid escape sequence '\['
  qtext = re.sub("\[\[validation:(\w+)\]\]", "", qtext)
/Users/alex.jordan/pretext/pretext/lib/pretext.py:2765: SyntaxWarning: invalid escape sequence '\['
  qtext = re.sub("\[\[feedback:(\w+)\]\]", "", qtext)
/Users/alex.jordan/pretext/pretext/lib/pretext.py:2768: SyntaxWarning: invalid escape sequence '\['
  ansids = re.findall("\[\[input:(\w+)\]\]", qtext)
```

The change here is so that a raw string, with literal backslash and literal bracket will be passed as the regex pattern. Then the regex itself will use the backslash to escape the bracket in pattern matching.