### PR TITLE
Schema: allow bare md in stable schema

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1628,18 +1628,17 @@
                     attribute break {"yes" | "no"}?,
                     attribute alignment {text}?,
                     attribute alignat-columns {text}?,
-                    MathRow,
-                    (MathRow | MathIntertext)*
+                    (
+                    (mixed {(FillInMath | WWVariable)*}) |
+                    (MathRow, (MathRow | MathIntertext)*)
+                    )
                 } |
                 element mdn {
                     attribute number {"yes" | "no"}?,
                     attribute break {"yes" | "no"}?,
                     attribute alignment {text}?,
                     attribute alignat-columns {text}?,
-                    (
-                    (mixed {(FillInMath | WWVariable)*}) |
-                    (MathRow, (MathRow | MathIntertext)*)
-                    )
+                    MathRow, (MathRow | MathIntertext)*
                 }
             
             Verbatim =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4157,13 +4157,25 @@
         <optional>
           <attribute name="alignat-columns"/>
         </optional>
-        <ref name="MathRow"/>
-        <zeroOrMore>
-          <choice>
+        <choice>
+          <mixed>
+            <zeroOrMore>
+              <choice>
+                <ref name="FillInMath"/>
+                <ref name="WWVariable"/>
+              </choice>
+            </zeroOrMore>
+          </mixed>
+          <group>
             <ref name="MathRow"/>
-            <ref name="MathIntertext"/>
-          </choice>
-        </zeroOrMore>
+            <zeroOrMore>
+              <choice>
+                <ref name="MathRow"/>
+                <ref name="MathIntertext"/>
+              </choice>
+            </zeroOrMore>
+          </group>
+        </choice>
       </element>
       <element name="mdn">
         <optional>
@@ -4188,25 +4200,13 @@
         <optional>
           <attribute name="alignat-columns"/>
         </optional>
-        <choice>
-          <mixed>
-            <zeroOrMore>
-              <choice>
-                <ref name="FillInMath"/>
-                <ref name="WWVariable"/>
-              </choice>
-            </zeroOrMore>
-          </mixed>
-          <group>
+        <ref name="MathRow"/>
+        <zeroOrMore>
+          <choice>
             <ref name="MathRow"/>
-            <zeroOrMore>
-              <choice>
-                <ref name="MathRow"/>
-                <ref name="MathIntertext"/>
-              </choice>
-            </zeroOrMore>
-          </group>
-        </choice>
+            <ref name="MathIntertext"/>
+          </choice>
+        </zeroOrMore>
       </element>
     </choice>
   </define>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -977,18 +977,17 @@
                     attribute break {"yes" | "no"}?,
                     attribute alignment {text}?,
                     attribute alignat-columns {text}?,
-                    MathRow,
-                    (MathRow | MathIntertext)*
+                    (
+                    (mixed {(FillInMath | WWVariable)*}) |
+                    (MathRow, (MathRow | MathIntertext)*)
+                    )
                 } |
                 element mdn {
                     attribute number {"yes" | "no"}?,
                     attribute break {"yes" | "no"}?,
                     attribute alignment {text}?,
                     attribute alignat-columns {text}?,
-                    (
-                    (mixed {(FillInMath | WWVariable)*}) |
-                    (MathRow, (MathRow | MathIntertext)*)
-                    )
+                    MathRow, (MathRow | MathIntertext)*
                 }
             </code>
         </fragment>

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -3510,14 +3510,20 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="md">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="mrow"/>
+    <xs:complexType mixed="true">
+      <xs:choice>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="mrow"/>
-          <xs:element ref="intertext"/>
+          <xs:group ref="FillInMath"/>
+          <xs:element ref="var"/>
         </xs:choice>
-      </xs:sequence>
+        <xs:sequence>
+          <xs:element ref="mrow"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="mrow"/>
+            <xs:element ref="intertext"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
       <xs:attribute name="number">
         <xs:simpleType>
           <xs:restriction base="xs:token">
@@ -3539,20 +3545,14 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="mdn">
-    <xs:complexType mixed="true">
-      <xs:choice>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="mrow"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:group ref="FillInMath"/>
-          <xs:element ref="var"/>
-        </xs:choice>
-        <xs:sequence>
           <xs:element ref="mrow"/>
-          <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="mrow"/>
-            <xs:element ref="intertext"/>
-          </xs:choice>
-        </xs:sequence>
-      </xs:choice>
+          <xs:element ref="intertext"/>
+        </xs:choice>
+      </xs:sequence>
       <xs:attribute name="number">
         <xs:simpleType>
           <xs:restriction base="xs:token">


### PR DESCRIPTION
I had intended that this fix would be part of #2783, but edited the wrong line in that pr: I allowed bare math in an `mdn`, not a `md`.  This fixes that error.