### PR TITLE
LaTeX: publisher option to underline hyperlinks

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -5302,6 +5302,11 @@
             </li>
 
             <li>
+                <title>Hyperlink Underlining in <init>PDF</init></title>
+                <p>In an electronic <init>PDF</init>, hyperlinks are distinguished from surrounding text by color alone, which may be insufficient for readers with color vision deficiencies.  A publisher option can add an underline beneath all hyperlinks (<tag>xref</tag> and <tag>url</tag>), providing a second visual cue independent of color.  (A print <init>PDF</init> does not color links, but a publisher may still choose to underline them.)  See <xref ref="latex-link-highlight-options"/> for the publisher file syntax.</p>
+            </li>
+
+            <li>
                 <title>Commutative Diagrams</title>
                 <p>Whenever possible, author commutative diagrams using the syntax of the <c>amscd</c> <latex/> package.  Then online and braille output will be more accessible.  See <xref ref="commutative-diagrams"/> for more.</p>
             </li>

--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -176,6 +176,8 @@
         <p>In a print <init>PDF</init>, cross-references will not be active hyperlinks and will be the same color as the adjoining text.  The publication file entry controlling the use of numbers in cross-references (<xref ref="latex-xref-page-number-options"/>) is by default <c>yes</c> in this case, but may be set to <c>no</c> to not include the page number of the target in the cross-reference.</p>
 
         <p>See <xref ref="latex-xref-page-number-options"/> for the syntax of specifying the use of page numbers in cross-references.</p>
+
+        <p>For accessibility, an underline can be added beneath all hyperlinks (cross-references and <init>URL</init>s) to supplement color as a visual indicator.  See <xref ref="latex-link-highlight-options"/>.</p>
     </section>
 
     <section xml:id="latex-page-fidelity">

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -388,6 +388,16 @@
             </cd> to values <c>yes</c> or <c>no</c> to enable or disable the use of page numbers in cross-references (typically achieved with the <tag>xref</tag> element).  The default varies, as it is dependent on the print option (<xref ref="latex-print-options"/>).  See <xref ref="latex-xref-page-numbers"/> for more on the defaults.</p>
         </subsection>
 
+        <subsection xml:id="latex-link-highlight-options">
+            <title>Hyperlink Highlighting</title>
+            <idx><h>accessibility</h><h>hyperlink underlining, LaTeX</h></idx>
+            <idx><h>LaTeX</h><h>hyperlink highlighting</h></idx>
+
+            <p>Set<cd>
+                <cline>/publication/latex/@link-highlight</cline>
+            </cd>to <c>underline</c> to draw an underline beneath hyperlinks (<tag>xref</tag> and <tag>url</tag>) in the <init>PDF</init> output.  The default value is <c>none</c>.  This option requires no additional <latex/> packages.  See <xref ref="topic-accessibility"/> for accessibility motivation.</p>
+        </subsection>
+
         <subsection xml:id="latex-worksheet-options">
             <title><latex /> Worksheet Options</title>
             <p>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -158,6 +158,7 @@
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
                     attribute snapshow { "yes" | "no" }?,
+                    attribute link-highlight { "none" | "underline" }?,
                     ( Page? & Worksheet? & Cover? & Asymptote?)
                 }
 

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -463,6 +463,14 @@
           </choice>
         </attribute>
       </optional>
+      <optional>
+        <attribute name="link-highlight">
+          <choice>
+            <value>none</value>
+            <value>underline</value>
+          </choice>
+        </attribute>
+      </optional>
       <interleave>
         <optional>
           <ref name="Page"/>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -302,6 +302,7 @@
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
                     attribute snapshow { "yes" | "no" }?,
+                    attribute link-highlight { "none" | "underline" }?,
                     ( Page? &amp; Worksheet? &amp; Cover? &amp; Asymptote?)
                 }
 

--- a/schema/publication-schema.xsd
+++ b/schema/publication-schema.xsd
@@ -413,6 +413,14 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attribute name="link-highlight">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="underline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="page">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1112,6 +1112,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%% Always defined, even if there is no need, or if a specific tt font is not loaded&#xa;</xsl:text>
     <xsl:text>\newcommand{\mono}[1]{\texttt{#1}}&#xa;</xsl:text>
     <xsl:text>%%&#xa;</xsl:text>
+    <!-- \linkhilite macro for highlighting hyperlinks (xref, url) -->
+    <!-- Only defined when needed, i.e. when not "none"            -->
+    <!-- "underline": wraps with \underline                        -->
+    <xsl:if test="$latex-link-highlight != 'none'">
+        <xsl:text>%% \linkhilite macro: wraps hyperlink visible text for highlighting&#xa;</xsl:text>
+        <xsl:choose>
+            <xsl:when test="$latex-link-highlight = 'underline'">
+                <xsl:text>\newcommand{\linkhilite}[1]{\underline{#1}}&#xa;</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:if>
+    <xsl:text>%%&#xa;</xsl:text>
     <xsl:text>%% Following semantic macros are only defined here if their&#xa;</xsl:text>
     <xsl:text>%% use is required only in this specific document&#xa;</xsl:text>
     <xsl:text>%%&#xa;</xsl:text>
@@ -8097,7 +8109,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>}</xsl:text>
             <!-- the visible clickable -->
             <xsl:text>{</xsl:text>
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>\linkhilite{</xsl:text>
+            </xsl:if>
             <xsl:copy-of select="$visible-text"/>
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>}</xsl:text>
+            </xsl:if>
             <xsl:text>}</xsl:text>
             <!-- A content-full URL will have an authored @visual version,  -->
             <!-- or the pre-processor will have manufactured a reasonable   -->
@@ -10834,17 +10852,27 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$xref-as-ref='true'">
             <xsl:text>\hyperref[</xsl:text>
             <xsl:apply-templates select="$target" mode="unique-id" />
-            <xsl:text>]</xsl:text>
-            <xsl:text>{</xsl:text>
+            <xsl:text>]{</xsl:text>
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>\linkhilite{</xsl:text>
+            </xsl:if>
             <xsl:value-of select="$content" />
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>}</xsl:text>
+            </xsl:if>
             <xsl:text>}</xsl:text>
         </xsl:when>
         <xsl:otherwise>
             <xsl:text>\hyperlink{</xsl:text>
             <xsl:apply-templates select="$target" mode="unique-id" />
-            <xsl:text>}</xsl:text>
-            <xsl:text>{</xsl:text>
+            <xsl:text>}{</xsl:text>
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>\linkhilite{</xsl:text>
+            </xsl:if>
             <xsl:value-of select="$content" />
+            <xsl:if test="$latex-link-highlight != 'none'">
+                <xsl:text>}</xsl:text>
+            </xsl:if>
             <xsl:text>}</xsl:text>
         </xsl:otherwise>
     </xsl:choose>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2889,6 +2889,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/latex/pi:pub-attribute[@name='latex-style']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!-- "none" (default) or "underline": whether hyperlinks (xref, url) -->
+<!-- receive visual highlighting in the LaTeX/PDF output.            -->
+<xsl:variable name="latex-link-highlight">
+    <xsl:apply-templates select="$publisher-attribute-options/latex/pi:pub-attribute[@name='link-highlight']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
 <!-- LaTeX/Page -->
 
 <!-- Right Alignment -->
@@ -3458,6 +3464,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <pi:pub-attribute name="draft" default="no" options="yes" legacy-stringparam="latex.draft"/>
         <pi:pub-attribute name="open-odd" default="no" options="add-blanks skip-pages"/>
         <pi:pub-attribute name="latex-style" default="" options="AIM chaos CLP dyslexic-font guide texstyle"/>
+        <pi:pub-attribute name="link-highlight" default="none" options="underline"/>
         <page>
             <pi:pub-attribute name="bottom-alignment" default="ragged" options="flush"/>
         </page>


### PR DESCRIPTION
## Summary

- Adds `latex/@link-highlight` publisher option (`none` | `underline`; default `none`) to control visual highlighting of hyperlinks in LaTeX/PDF output
- Defines `\linkhilite` macro unconditionally in the semantic macros preamble section; with `none` it is an identity, with `underline` it wraps with `\underline` — no additional LaTeX packages required
- Applies `\linkhilite` to the visible text of all hyperlinks: cross-references (`\hyperref`, `\hyperlink`) and URLs (`\href`)
- Adds publisher guide documentation and an accessibility motivation entry in the topics guide

## Motivation

In an electronic PDF, hyperlinks are distinguished by color alone. For readers with color vision deficiencies this may be insufficient, and the `underline` option provides a second visual cue independent of color. Underlining can also be useful independent of color considerations. (Print PDFs do not color links, but a publisher may still choose to underline them.)

## Commits

- **Publication variables**: `latex/@link-highlight` entry in inline data and variable in `publisher-variables.xsl`; `attribute link-highlight { "none" | "underline" }?` in `publication-schema.xml` with derived `.rnc`, `.rng`, `.xsd` regenerated
- **LaTeX implementation**: `\linkhilite` macro defined in semantic macros section of `pretext-latex-common.xsl`; applied to visible text of `\hyperref`, `\hyperlink`, and `\href` calls
- **Guide documentation**: new subsection in publication file reference, new accessibility list item in topics guide, pointer paragraph in pdf-print xref section

## Testing

Built `examples/sample-article` with `publication-testing.xml` setting `link-highlight="underline"` via `pretext/pretext -vv -c doc -f pdf`. Confirmed all cross-references and URLs appear underlined in the PDF, and that `none` (default) produces output identical to baseline.

🤖 Assisted by [Claude](https://claude.ai) (claude-sonnet-4-6); changes reviewed and approved by Rob Beezer.