### PR TITLE
HTML: add textmacros extension, enforce LaTeX escaping in text mode

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2389,6 +2389,58 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
             </subsection>
 
+            <subsection xml:id="subsection-special-characters-text-mode" label="subsection-special-characters-text-mode">
+                <title>Special Characters in Text Mode</title>
+
+                <p><latex/> designates ten characters as <term>special</term> because they carry syntactic meaning.  When these characters appear inside text-mode macros (such as <c>\text{}</c>) within mathematics, they must be escaped to produce their literal glyph.  Seven of the ten have simple single-character escapes and are demonstrated in the following table.  The remaining three (<c>~</c>, <c>^</c>, <c>\</c>) require macros from <latex/>'s <c>textcomp</c> package (<c>\textasciitilde</c>, <c>\textasciicircum</c>, <c>\textbackslash</c>) which are not available in MathJax's text mode as of 2026-04-03.</p>
+
+                <tabular halign="center">
+                    <row header="yes" bottom="major">
+                        <cell>Character</cell>
+                        <cell>Escaped form</cell>
+                        <cell>Rendered</cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Hash <c>#</c></cell>
+                        <cell><c>\#</c></cell>
+                        <cell><m>\text{5\#}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Ampersand <c>&amp;</c></cell>
+                        <cell><c>\&amp;</c></cell>
+                        <cell><m>\text{P \&amp; Q}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Percent <c>%</c></cell>
+                        <cell><c>\%</c></cell>
+                        <cell><m>\text{5\%}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Dollar <c>$</c></cell>
+                        <cell><c>\$</c></cell>
+                        <cell><m>\text{\$3}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Underscore <c>_</c></cell>
+                        <cell><c>\_</c></cell>
+                        <cell><m>\text{x\_1}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Left brace <c>{</c></cell>
+                        <cell><c>\{</c></cell>
+                        <cell><m>\text{\{a, b\}}</m></cell>
+                    </row>
+                    <row bottom="minor">
+                        <cell>Right brace <c>}</c></cell>
+                        <cell><c>\}</c></cell>
+                        <cell><m>\text{\{a, b\}}</m></cell>
+                    </row>
+                </tabular>
+
+                <p>The hash character also requires escaping within the <c>\tag{}</c> macro.  See <xref ref="equation-local-hash"/> for an example where the <c>tag="dhash"</c> attribute produces a double hash as an equation tag.</p>
+
+            </subsection>
+
             <subsection xml:id="miscellaneous-math">
                 <title>Miscellaneous</title>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -703,7 +703,64 @@ Book (with parts), "section" at level 3
 
 <!-- $debug.displaystyle defaults to yes for testing -->
 
+<!-- Warn about bare special characters inside \text{} in math.      -->
+<!-- The textmacros extension treats # % &amp; as special, so they   -->
+<!-- must be escaped as \# \% \&amp; to produce literal glyphs.      -->
+<!-- We walk through each \text{...} segment via recursion and check -->
+<!-- the content up to the next } for bare special characters.       -->
+<!-- Imperfect with nested braces, but catches common cases.         -->
+<xsl:template name="warn-text-special-characters">
+    <xsl:variable name="math-text" select="string(.)"/>
+    <xsl:if test="contains($math-text, '\text{')">
+        <xsl:call-template name="check-text-segments">
+            <xsl:with-param name="remaining" select="$math-text"/>
+        </xsl:call-template>
+    </xsl:if>
+</xsl:template>
+
+<!-- Recursive walk through \text{...} segments of a LaTeX string -->
+<xsl:template name="check-text-segments">
+    <xsl:param name="remaining"/>
+    <xsl:if test="contains($remaining, '\text{')">
+        <!-- content after \text{ up to next } -->
+        <xsl:variable name="after-text" select="substring-after($remaining, '\text{')"/>
+        <xsl:variable name="inside" select="substring-before($after-text, '}')"/>
+        <!-- check for bare # (present but \# is not) -->
+        <xsl:if test="contains($inside, '#') and not(contains($inside, '\#'))">
+            <xsl:message>
+                <xsl:text>PTX:WARNING:   a bare "#" inside \text{} in math must be escaped as "\#"</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:text>               </xsl:text>
+                <xsl:apply-templates select="." mode="location-report"/>
+            </xsl:message>
+        </xsl:if>
+        <!-- check for bare % -->
+        <xsl:if test="contains($inside, '%') and not(contains($inside, '\%'))">
+            <xsl:message>
+                <xsl:text>PTX:WARNING:   a bare "%" inside \text{} in math must be escaped as "\%"</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:text>               </xsl:text>
+                <xsl:apply-templates select="." mode="location-report"/>
+            </xsl:message>
+        </xsl:if>
+        <!-- check for bare & -->
+        <xsl:if test="contains($inside, '&amp;') and not(contains($inside, '\&amp;'))">
+            <xsl:message>
+                <xsl:text>PTX:WARNING:   a bare "&amp;" inside \text{} in math must be escaped as "\&amp;"</xsl:text>
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:text>               </xsl:text>
+                <xsl:apply-templates select="." mode="location-report"/>
+            </xsl:message>
+        </xsl:if>
+        <!-- recurse on remainder after this \text{...} -->
+        <xsl:call-template name="check-text-segments">
+            <xsl:with-param name="remaining" select="$after-text"/>
+        </xsl:call-template>
+    </xsl:if>
+</xsl:template>
+
 <xsl:template match="m">
+    <xsl:call-template name="warn-text-special-characters"/>
     <!-- wrap in math delimiters -->
     <xsl:call-template name="inline-math-wrapper">
         <xsl:with-param name="math">
@@ -934,6 +991,7 @@ Book (with parts), "section" at level 3
     <xsl:param name="b-original" select="true()" />
     <xsl:param name="b-top-level" select="false()" />
     <xsl:param name="b-needs-tags" />
+    <xsl:call-template name="warn-text-special-characters"/>
     <!-- Build a textual version of the latex,       -->
     <!-- applying the rare templates allowed,        -->
     <!-- save for minor manipulation later.          -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8551,9 +8551,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#x2021;</xsl:text>
 </xsl:template>
 
-<!-- 'NUMBER SIGN' (U+0023) -->
+<!-- 'NUMBER SIGN' (U+0023), identical to LaTeX -->
 <xsl:template name="tag-hash">
-    <xsl:text>&#x0023;</xsl:text>
+    <xsl:text>\#</xsl:text>
 </xsl:template>
 
 <!-- 'MALTESE CROSS' (U+2720) -->
@@ -13188,6 +13188,8 @@ TODO:
                                 <string>amscd</string>
                                 <string>color</string>
                                 <string>newcommand</string>
+                                <!-- necessary for \text{} in math -->
+                                <string>textmacros</string>
                                 <string>knowl</string>
                             </array>
                         </map>
@@ -13227,6 +13229,8 @@ TODO:
                             <string>[tex]/amscd</string>
                             <string>[tex]/color</string>
                             <string>[tex]/newcommand</string>
+                            <!-- necessary for \text{} in math -->
+                            <string>[tex]/textmacros</string>
                             <string>[pretext]/mathjaxknowl3.js</string>
                         </array>
                         <map key="paths">


### PR DESCRIPTION
## Summary

- Add the MathJax `textmacros` extension to the MathJax 3 configuration for HTML output. This enforces LaTeX escaping rules for special characters (`# & % $ _ { }`) inside `\text{}` within math.
- Change the `tag-hash` template in `pretext-html.xsl` to output `\#` instead of a bare `#`, matching the existing LaTeX override.
- Add build-time warnings in `pretext-common.xsl` for bare `#`, `%`, or `&` detected inside `\text{}` in `m` and `mrow` elements.
- Add a subsection to the sample article demonstrating correct usage of all seven escapable special characters in text mode.

## Motivation

MathJax 4 includes the `textmacros` extension by default. Adding it now under MathJax 3 separates the author-facing escaping change from the upcoming MathJax 4 upgrade, giving authors time to fix their source. Bare special characters in `\text{}` were never valid LaTeX; MathJax 3 accepted them only because it did not process text-mode content. Authors building PDF output are unlikely to be affected.

## Test plan

- [ ] Build HTML sample article, verify seven-character table renders on the Mathematics page
- [ ] Build PDF sample article, verify same table renders
- [ ] Verify `\tag{##}` renders correctly on the Mathematics page (equation with `tag="dhash"`)
- [ ] Run with `-vv`, confirm no spurious warnings from the sample article
- [ ] Test a document with bare `#` in `\text{}`, confirm warning appears and MathJax shows an error

*Claude Opus 4.6, acting as a coding assistant for Rob Beezer*