### PR TITLE
HTML: add instructions class to prefigure diagcess details element

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6300,7 +6300,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Diagacess Instructions -->
 
 <xsl:template name="diagacess-instructions">
-    <details>
+    <details class="instructions diagcess__instructions">
         <summary>Diagram Exploration Keyboard Controls</summary>
         <div class="diagcess-navigation-controls">
             <table>


### PR DESCRIPTION
To address #2820, this adds classes to the details element for diagcess instructions `details` element.  Since printouts already hide `instructions` classes for other interactives, the keyboard instructions for prefigure will now also be hidden.  

I went ahead and added `diagcess__instructions` to mirror the class name for interactive instructions, although currently there is no special css rule for this.

One other place that `instructions` is targeted by css: inside an iframe version of an interactive.  I don't think this ever happens with prefigure, so there shouldn't be any side-effects.