### PR TITLE
Fix PDF compilation for packages needing 3+ LaTeX passes

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5228,21 +5228,25 @@ def pdf(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir, method, outp
         # First pass always needed, second resolves cross-references.
         # Additional passes may be required by packages like nicematrix
         # (which uses TikZ "remember picture" for cell coloring) or
-        # tcolorbox.  We check the .log for "Rerun" requests, matching
-        # the same strategy used for standalone latex-image compilation.
+        # tcolorbox.  We check the .log for "Rerun to get" requests,
+        # matching the strategy used for standalone latex-image compilation.
         latex_cmd = latex_exec_cmd + ["-halt-on-error", sourcename]
         logname = basename + ".log"
         MAX_PASSES = 10
-        subprocess.run(latex_cmd)
-        for pass_num in range(2, MAX_PASSES + 1):
-            subprocess.run(latex_cmd)
+        result = subprocess.run(latex_cmd)
+        for _ in range(2, MAX_PASSES + 1):
+            result = subprocess.run(latex_cmd)
+            if result.returncode != 0:
+                break
             if os.path.isfile(logname):
                 with open(logname) as f:
                     log_contents = f.read()
-                if "Rerun" not in log_contents and "rerun" not in log_contents:
+                if "Rerun to get" not in log_contents:
                     break
             else:
                 break
+        else:
+            log.warning("LaTeX compilation of {} required {} passes and may not have converged.".format(sourcename, MAX_PASSES))
 
         # If we want all outputs, we copy the entire build directory now that the PDF is built
         # so we can get the *.log, *.aux, etc build files.

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5224,14 +5224,25 @@ def pdf(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir, method, outp
         # process with a  latex  engine
         latex_key = get_deprecated_tex_fallback(method)
         latex_exec_cmd = get_executable_cmd(latex_key)
-        # In flux during development, now nonstop
         # -halt-on-error will give an exit code to examine
-        # perhaps behavior depends on -v, -vv
-        # Two passes to resolve cross-references,
-        # we may need a third for tcolorbox adjustments
+        # First pass always needed, second resolves cross-references.
+        # Additional passes may be required by packages like nicematrix
+        # (which uses TikZ "remember picture" for cell coloring) or
+        # tcolorbox.  We check the .log for "Rerun" requests, matching
+        # the same strategy used for standalone latex-image compilation.
         latex_cmd = latex_exec_cmd + ["-halt-on-error", sourcename]
+        logname = basename + ".log"
+        MAX_PASSES = 10
         subprocess.run(latex_cmd)
-        subprocess.run(latex_cmd)
+        for pass_num in range(2, MAX_PASSES + 1):
+            subprocess.run(latex_cmd)
+            if os.path.isfile(logname):
+                with open(logname) as f:
+                    log_contents = f.read()
+                if "Rerun" not in log_contents and "rerun" not in log_contents:
+                    break
+            else:
+                break
 
         # If we want all outputs, we copy the entire build directory now that the PDF is built
         # so we can get the *.log, *.aux, etc build files.


### PR DESCRIPTION
## Summary

- Replace hardcoded 2-pass LaTeX compilation in `pdf()` with a log-checking rerun loop
- Fixes nicematrix `\cellcolor` overlay nodes expanding to fill the entire page in the sample article PDF (page 60, Figure 10.12)
- Documents needing only 2 passes are unaffected — the loop checks the log after pass 2 and breaks immediately if no rerun is requested

## Root cause

The `pdf()` function in `pretext/lib/pretext.py` ran exactly 2 LaTeX passes (`subprocess.run` called twice). The `nicematrix` package's `code-before` directive uses TikZ `remember picture, overlay` nodes internally to position colored cell backgrounds. These nodes require **3 passes** to resolve their final page coordinates. With only 2 passes, the overlay rectangles are mis-positioned and can cover the entire page.

The standalone `latex-image` extraction pipeline (`pretext/lib/pretext.py:696-707`) already had a proper rerun loop that checks for "Rerun" in the `.log` file, which is why the generated image files (`latex-three-pass.pdf/.svg/.png`) rendered correctly. The main document compilation was missing this same logic.

## Change

**`pretext/lib/pretext.py` — `pdf()` function (line ~5250)**

Before:
```python
subprocess.run(latex_cmd)
subprocess.run(latex_cmd)
```

After:
```python
subprocess.run(latex_cmd)
for pass_num in range(2, MAX_PASSES + 1):
    subprocess.run(latex_cmd)
    if os.path.isfile(logname):
        with open(logname) as f:
            log_contents = f.read()
        if "Rerun" not in log_contents and "rerun" not in log_contents:
            break
    else:
        break
```

The loop always runs at least 2 passes (matching previous behavior), then checks the `.log` for rerun requests before each additional pass, up to a maximum of 10. This matches the existing strategy used for standalone latex-image compilation.

## Test plan

- [x] Rebuild `examples/sample-article` PDF — page 60 (Figure 10.12, "A matrix with colored entries") now renders correctly with properly bounded colored cells
- [x] Verified the standalone image `gen/latex-image/latex-three-pass.pdf` was already correct (confirming the issue was isolated to main document compilation)
- [x] Documents without multi-pass packages still compile with exactly 2 passes (no performance regression)

Fixes #2825