### PR TITLE
Script: add profiling checkpoints to html()

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -91,6 +91,8 @@ import re
 # contextmanager tools
 import contextlib
 
+import time
+
 # cleanup multiline strings used as source code
 import textwrap
 
@@ -4856,6 +4858,9 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     # to ensure provided stringparams aren't mutated unintentionally
     stringparams = stringparams.copy()
 
+    log_time_info = stringparams.get("debug.profile", False) == "yes"
+    time_logger = Stopwatch("html()", log_time_info)
+
     # Consult publisher file for locations of images
     generated_abs, external_abs = get_managed_directories(xml, pub_file)
     # Consult source for additional files
@@ -4866,6 +4871,7 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
 
     pub_vars = get_publisher_variable_report(xml, pub_file, stringparams)
     include_static_files = get_publisher_variable(pub_vars, 'portable-html') != "yes"
+    time_logger.log("pubvars loaded")
 
     if include_static_files:
         # interrogate Runestone server (or debugging switches) and populate
@@ -4875,6 +4881,7 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
         # even if we don't need static files, we need to set stringparams for
         # Runestone Services information.
         _cdn_runestone_services(stringparams, ext_rs_methods)
+    time_logger.log("runestone placed")
 
     # support publisher file, and subtree argument
     if pub_file:
@@ -4893,18 +4900,19 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     # place managed directories - some of these (Asymptote HTML) are
     # consulted during the XSL run and so need to be placed beforehand
     copy_managed_directories(tmp_dir, external_abs=external_abs, generated_abs=generated_abs, data_abs=data_dir)
+    time_logger.log("managed directories copied")
 
     if include_static_files:
         # Copy js and css, but only if not building portable html
         # place JS in scratch directory
         copy_html_js(tmp_dir)
-
-        # build or copy theme
         build_or_copy_theme(xml, pub_vars, tmp_dir)
+        time_logger.log("css/js copied")
 
     # Write output into temporary directory
     log.info("converting {} to HTML in {}".format(xml, tmp_dir))
     xsltproc(extraction_xslt, xml, None, tmp_dir, stringparams)
+    time_logger.log("xsltproc complete")
 
     if not(include_static_files):
         # remove latex-image generated directories for portable builds
@@ -4939,6 +4947,8 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
             log.info("zip file of HTML output deposited as {}".format(derivedname))
     else:
         raise ValueError("PTX:BUG: HTML file format not recognized")
+
+    time_logger.log("build completed")
 
 
 def revealjs(
@@ -6258,6 +6268,31 @@ def place_latex_package_files(dest_dir, journal_name, cache_dir):
         # Copy required resource to the destination directory
         shutil.copy2(file_path, dest_dir)
 
+
+class Stopwatch:
+    """A simple stopwatch class for measuring elapsed time.
+    
+    print_log controls whether log messages are printed when the log() is called
+    """
+
+    def __init__(self, name:str="", print_log:bool=True):
+        self.name = name
+        self.print_log = print_log
+        self.start_time = time.time()
+        self.last_log_time = self.start_time
+    
+    def reset(self):
+        """Reset the log timer to the current time."""
+        self.last_log_time = time.time()
+
+    def log(self, timepoint_description:str=""):
+        """Print a log message with the elapsed time since the last log event."""
+        if self.print_log:
+            cur_time = time.time()
+            elapsed_time = cur_time - self.start_time
+            since_last_log_time = cur_time - self.last_log_time
+            self.reset()
+            log.info(f"** Timing report from {self.name}: {timepoint_description}, {since_last_log_time:.2f}s since last watch reset. {elapsed_time:.2f}s total elapsed time.")
 
 
 ###########################


### PR DESCRIPTION
Pulled out from: https://github.com/PreTeXtBook/pretext/pull/2329

-------------------------

This pull request adds a lightweight timing and profiling utility to the `pretext/lib/pretext.py` module, enabling optional logging of elapsed time at key stages of the HTML build process. The main change is the introduction of a `Stopwatch` class and its integration into the `html()` function, allowing developers to profile and monitor build performance when needed.

**Profiling and Logging Enhancements:**

* Introduced a `Stopwatch` class for measuring and logging elapsed time between key events, with optional logging controlled by the `profile.py` string parameter. (`pretext/lib/pretext.py`)
* Integrated the `Stopwatch` into the `html()` function, adding time logs at major build steps such as loading publisher variables, placing Runestone services, copying managed directories, copying CSS/JS, running XSLT, and completing the build. (`pretext/lib/pretext.py`) [[1]](diffhunk://#diff-38443e70f3814e0da63a79b48ef5349fe85c5e598bf82a068c415c0190753b5cR4861-R4863) [[2]](diffhunk://#diff-38443e70f3814e0da63a79b48ef5349fe85c5e598bf82a068c415c0190753b5cR4874) [[3]](diffhunk://#diff-38443e70f3814e0da63a79b48ef5349fe85c5e598bf82a068c415c0190753b5cR4884) [[4]](diffhunk://#diff-38443e70f3814e0da63a79b48ef5349fe85c5e598bf82a068c415c0190753b5cR4903-R4915) [[5]](diffhunk://#diff-38443e70f3814e0da63a79b48ef5349fe85c5e598bf82a068c415c0190753b5cR4951-R4952)

**Dependency Update:**

* Added an import for the standard `time` module to support the new timing functionality. (`pretext/lib/pretext.py`)