### PR TITLE
EPUB: add fillinmath and sfrac macro definitions for offline MathJax

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -14038,6 +14038,9 @@ TODO:
 <!-- We could rename this properly, since we are      -->
 <!-- sneaking in packages, which load first, in       -->
 <!-- case authors want to build on these macros       -->
+<!-- NB: "math support" macros (fillin-math, sfrac) must  -->
+<!-- be defined here AND in the "extraction-wrapper"      -->
+<!-- template in  support/extract-math.xsl                -->
 <xsl:template name="latex-macros">
     <div id="latex-macros" class="hidden-content process-math" style="display:none">
         <xsl:call-template name="inline-math-wrapper">

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -129,11 +129,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:variable name="latex-macros-html" select="str:replace($no-less-than, '\newcommand{\gt}{&gt;}&#xa;', '')"/>
             <!-- put macros and packages early for MJ to find         -->
             <!-- give the div an @id so we can trash it as a leftover -->
+            <!-- NB: "math support" macros (fillin-math, sfrac) must  -->
+            <!-- be defined here AND in the "latex-macros" named      -->
+            <!-- template in  pretext-html.xsl                        -->
             <div id="latex-macros">
                 <xsl:call-template name="inline-math-wrapper">
                     <xsl:with-param name="math">
                         <xsl:value-of select="$latex-packages-mathjax"/>
                         <xsl:value-of select="$latex-macros-html"/>
+                        <xsl:call-template name="fillin-math"/>
+                        <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
+                        <xsl:if test="$b-has-sfrac">
+                            <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
+                        </xsl:if>
                     </xsl:with-param>
                 </xsl:call-template>
             </div>


### PR DESCRIPTION
## Summary

- A `\fillinmath` macro inside math (e.g. `<m>\sin(<fillin/>)</m>`) was rendering as raw LaTeX in EPUB output because the macro definition was never provided to the offline MathJax process.
- The `extract-math.xsl` stylesheet builds a mock HTML page for MathJax to process, but only included author-defined macros (`$latex-macros`) and MathJax packages — it omitted the `\fillinmath` and `\sfrac` definitions that the HTML pathway provides via its `latex-macros` named template.
- Added both macro definitions to the extraction wrapper, matching what `pretext-html.xsl` already provides for online MathJax.
- Added cross-reference comments in both files so developers know these "math support" macros must be kept in sync.

## Test plan

- [x] Built sample article as EPUB (SVG math) and verified fillins inside math render correctly in Calibre

*Claude Opus 4.6 acting as a coding assistant for Rob Beezer*