### PR TITLE
CSS: avoid blank page after printouts

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -373,6 +373,11 @@ form.papersize-select {
       page-break-inside: avoid;
     }
 
+    // Avoid a blank page at the end if the last page fits on the previous page
+    .onepage:last-of-type {
+      page-break-after: avoid;
+    }
+
     .first-page-header, .running-header {
       border-bottom: none;
     }


### PR DESCRIPTION
Chrome for windows appears to have started respecting the `page-break-after: always` css for printing even if there is no content after.  This has resulted in all printouts getting an extra blank page (but only for chrome on windows, it appears).  Whether or not this is a bug in chrome, the current PR addresses this by adding a selector for the last `.onepage` element in a printout and specifying to avoid the page-break.