### PR TITLE
Make auto-permalinks not selectable for copy-paste

### DIFF
--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -29,6 +29,7 @@ dt,
   opacity: var(--permalink-opacity, $opacity);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 
 li > .autopermalink {

--- a/css/dist/epub.css
+++ b/css/dist/epub.css
@@ -1315,6 +1315,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/kindle.css
+++ b/css/dist/kindle.css
@@ -1315,6 +1315,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/print-worksheet.css
+++ b/css/dist/print-worksheet.css
@@ -1689,6 +1689,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;
@@ -2663,6 +2664,10 @@ section.handout {
 .onepage > .heading {
   margin-top: 0;
   font-size: 1.3em;
+}
+.onepage h4.heading {
+  font-size: 1.2em;
+  margin-top: 1em;
 }
 .onepage .instructions {
   display: none;

--- a/css/dist/theme-boulder.css
+++ b/css/dist/theme-boulder.css
@@ -1318,6 +1318,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -2559,6 +2559,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/theme-denver.css
+++ b/css/dist/theme-denver.css
@@ -2888,6 +2888,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/theme-greeley.css
+++ b/css/dist/theme-greeley.css
@@ -1318,6 +1318,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/theme-salem.css
+++ b/css/dist/theme-salem.css
@@ -2685,6 +2685,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;

--- a/css/dist/theme-tacoma.css
+++ b/css/dist/theme-tacoma.css
@@ -2405,6 +2405,7 @@ dt,
   opacity: var(--permalink-opacity, 0);
   transition: opacity 0.2s;
   margin-top: 0 !important;
+  user-select: none;
 }
 li > .autopermalink {
   left: -3.5em;


### PR DESCRIPTION
When a user tries to copy-paste text from a document, they should not also be copying the permalink symbols.