### PR TITLE
Common: for "list-of" only match elements in the default namespace

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -15044,6 +15044,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <list-of elements="theorem" scope="section"/>
             </subsection>
 
+            <subsection xml:id="subsection-list-of-definitions" label="subsection-list-of-definitions">
+                <title>Definitions in This Article</title>
+
+                <p>Here is a similar list, but for <c>definition</c> elements across the whole article.  This list also serves as a regression test.  <xref ref="prefigure-diagrams"/> contains a <prefigure/> diagram whose source uses a <c>definition</c> element of its own, in the <prefigure/> XML namespace.  An earlier version of <tag>list-of</tag> matched descendants by local name only, ignoring namespaces, and so would catch <prefigure/> definitions and then fail to produce numbers for them.  The list below correctly contains only the <pretext/> definitions.</p>
+
+                <list-of elements="definition" empty="no"/>
+            </subsection>
+
             <subsection xml:id="subsection-with-an-exercise">
                 <title>A Title with ] a Right Bracket</title>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7981,7 +7981,8 @@ Book (with parts), "section" at level 3
     <xsl:param name="b-reading-questions"/>
 
     <!-- Check if we are at a divison that needs a heading                      -->
-    <xsl:variable name="b-division-element" select="local-name(.) = $divisions"/>
+    <!-- match only the default namespace                                       -->
+    <xsl:variable name="b-division-element" select="(local-name(.) = $divisions) and (namespace-uri(.) = '')"/>
     <xsl:choose>
         <xsl:when test="$b-division-element">
             <!-- handling a division element that *may* need a heading -->
@@ -7994,7 +7995,8 @@ Book (with parts), "section" at level 3
                     <!-- extensive searching for "exercise", but we hope the      -->
                     <!-- booleans passed in will short-circuit and result in no   -->
                     <!-- searching when it is not necessary                       -->
-                    <xsl:variable name="by-name-elements" select="boolean(.//*[local-name(.) = $elements])" />
+                    <!-- match only the default namespace                         -->
+                    <xsl:variable name="by-name-elements" select="boolean(.//*[(local-name(.) = $elements) and (namespace-uri(.) = '')])" />
                     <xsl:variable name="division-exercises" select="$b-division-exercises and .//exercise[ancestor::exercises]"/>
                     <xsl:variable name="worksheet-exercises" select="$b-worksheet-exercises and .//exercise[ancestor::worksheet]"/>
                     <xsl:variable name="reading-questions" select="$b-reading-questions and .//exercise[ancestor::reading-questions]"/>
@@ -8016,7 +8018,8 @@ Book (with parts), "section" at level 3
         </xsl:when>
         <xsl:otherwise>
             <!-- not at a division, so test element for inclusion -->
-            <xsl:if test="(local-name(.) = $elements)
+            <!-- match only the default namespace                 -->
+            <xsl:if test="((local-name(.) = $elements) and (namespace-uri(.) = ''))
                        or ($b-division-exercises and self::exercise and ancestor::exercises)
                        or ($b-worksheet-exercises and self::exercise and ancestor::worksheet)
                        or ($b-reading-questions and self::exercise and ancestor::reading-questions)


### PR DESCRIPTION
## Summary

Fixes the bug reported in #2838: a `<list-of>` would match elements by local name only, so foreign-namespace elements with the same local name as the requested PreTeXt element (e.g. a `<definition>` inside a `<prefigure>` diagram) were swept into the list and then triggered numbering errors (`[NUM]`/`[STRUCT]`).

## Changes

- `xsl/pretext-common.xsl` — three matching predicates inside the `list-of-content` template now also require `namespace-uri(.) = ''`, so only elements in the default (PreTeXt) namespace are considered.
- `examples/sample-article/sample-article.xml` — adds a new subsection with a `<list-of elements="definition" empty="no"/>`. The article already contains a `<prefigure>` diagram with a `<definition>` element of its own, so this list serves as a regression test in addition to demonstrating the feature.

## Test plan

- [x] `pretext/pretext -vv -c doc -f html …` on the sample article: clean build, no `[NUM]`/`[STRUCT]` errors.
- [x] The new `<list-of elements="definition">` lists the real PreTeXt definitions and excludes the prefigure-namespace `<definition>`.
- [x] The pre-existing `<list-of>` uses still produce the same output as before.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*