### PR TITLE
Script: all non-kindle epubs get epub.css

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4063,7 +4063,7 @@ def epub(xml_source, pub_file, out_file, dest_dir, file_format, math_format, str
     if math_format == "kindle":
         css = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "kindle.css")
         shutil.copy2(css, css_dir)
-    if math_format == "svg":
+    else:
         css = os.path.join(get_ptx_xsl_path(), "..", "css", "dist", "epub.css")
         shutil.copy2(css, css_dir)
 


### PR DESCRIPTION
Fix for bug found while looking at https://github.com/PreTeXtBook/pretext/pull/2836

`epub-mml` or `epub-speech` don't currently get CSS

--------------------

This pull request updates the logic for selecting the CSS file used during EPUB generation in the `pretext/lib/pretext.py` script. The main change ensures that the `epub.css` stylesheet is used as the default for all math formats except "kindle", which continues to use `kindle.css`.

**EPUB CSS selection logic:**

* Updated the conditional so that `epub.css` is used for all math formats except "kindle", instead of only for "svg". This makes the EPUB styling more consistent across different math formats.