### PR TITLE
Deprecate "me", "men", "mdn" math elements; refactor deprecation-report cap

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -12184,11 +12184,20 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the temporary &quot;@runestone&quot; attribute was used to temporarily specify a raw HTML version of a Runestone problem.  That device is now obsolete.  The exercise remains, but its contents have been neutered to form an informational message.  Consider authoring the exercise using supported PreTeXt syntax.'"/>
     </xsl:call-template>
     <!--  -->
-    <!-- 2025-11-14  bare "mdn" construction was only ever temporary/transitional -->
+    <!-- 2026-05-11  "me" and "men" deprecated in favor of bare "md" -->
     <xsl:call-template name="deprecation-message">
-        <xsl:with-param name="occurrences" select="&quot;$document-root//mdn[not(mrow)]&quot;" />
-        <xsl:with-param name="date-string" select="'2025-11-14'" />
-        <xsl:with-param name="message" select="'an &quot;mdn&quot; element without any &quot;mrow&quot; children (&quot;bare&quot;) was only implemented briefly and was never supported.  Your instance is being ignored and will not be visible in output.  You can switch it to the supported bare &quot;md&quot; element with a &quot;@number&quot; attribute set to &quot;yes&quot;.'"/>
+        <xsl:with-param name="occurrences" select="&quot;$document-root//me|$document-root//men&quot;" />
+        <xsl:with-param name="date-string" select="'2026-05-11'" />
+        <xsl:with-param name="max-reports" select="'8'" />
+        <xsl:with-param name="message" select="'the &quot;me&quot; and &quot;men&quot; elements have been deprecated.  The replacement is an &quot;md&quot; with no &quot;mrow&quot; children, and numbering is controlled by the &quot;@number&quot; attribute, or a global setting in &quot;docinfo&quot;.'"/>
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2026-05-11  "mdn" deprecated in favor of "md" -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//mdn&quot;" />
+        <xsl:with-param name="date-string" select="'2026-05-11'" />
+        <xsl:with-param name="max-reports" select="'8'" />
+        <xsl:with-param name="message" select="'the &quot;mdn&quot; element has been deprecated.  The replacement is an &quot;md&quot;, and numbering is controlled by the &quot;@number&quot; attribute, or a global setting in &quot;docinfo&quot;.'"/>
     </xsl:call-template>
     <!--  -->
 </xsl:template>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11306,7 +11306,6 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:param name="occurrences" />
     <xsl:param name="date-string" />
     <xsl:param name="message" />
-    <xsl:param name="b-bulk" select="false()"/>
     <!-- "max-reports" caps the per-occurrence location reports.    -->
     <!-- An empty string (the default) imposes no cap; "0" silences -->
     <!-- the per-location reports entirely (the count line still    -->
@@ -12128,11 +12127,11 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'PDF front and back covers via a &quot;docinfo/covers&quot; element has moved to the publication file with some small changes.  Specification in &quot;docinfo&quot; is now being ignored.'"/>
     </xsl:call-template>
     <!--  -->
-    <!-- 2024-07-24 @permid abolished (bulk message added 2025-11-03) -->
+    <!-- 2024-07-24 @permid abolished -->
     <xsl:call-template name="deprecation-message">
         <xsl:with-param name="occurrences" select="&quot;$document-root//@permid&quot;"/>
         <xsl:with-param name="date-string" select="'2024-07-24'" />
-        <xsl:with-param name="b-bulk" select="true()" />
+        <xsl:with-param name="max-reports" select="'0'" />
         <xsl:with-param name="message" select="'Experiments using the @permid attribute have concluded, and the attribute is now being ignored.  You can safely remove them all and then this message will stop.'"/>
     </xsl:call-template>
     <!--  -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11307,6 +11307,11 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:param name="date-string" />
     <xsl:param name="message" />
     <xsl:param name="b-bulk" select="false()"/>
+    <!-- "max-reports" caps the per-occurrence location reports.    -->
+    <!-- An empty string (the default) imposes no cap; "0" silences -->
+    <!-- the per-location reports entirely (the count line still    -->
+    <!-- appears); a positive integer caps the number of reports.   -->
+    <xsl:param name="max-reports" select="''"/>
 
     <!-- These apparent re-definitions are local to this template -->
     <!-- Reasons are historical, so to be a convenience           -->
@@ -11341,7 +11346,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
                 <!-- <xsl:text>, set log.level to see more details</xsl:text> -->
             </xsl:message>
             <xsl:for-each select="$occurrences-rtf">
-                <xsl:apply-templates select="." mode="location-report" />
+                <xsl:if test="($max-reports = '') or (position() &lt;= number($max-reports))">
+                    <xsl:apply-templates select="." mode="location-report" />
+                </xsl:if>
             </xsl:for-each>
             <xsl:message>
                 <xsl:text>--------------</xsl:text>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11340,14 +11340,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
                 <!-- once verbosity is implemented -->
                 <!-- <xsl:text>, set log.level to see more details</xsl:text> -->
             </xsl:message>
-            <!-- Give location reports, except optionally, when the $occurences -->
-            <!-- are so pervasive, squelch a (useless) long list of instances   -->
-            <!-- that nobody would really want to see.                        . -->
-            <xsl:if test="not($b-bulk)">
-                <xsl:for-each select="$occurrences-rtf">
-                    <xsl:apply-templates select="." mode="location-report" />
-                </xsl:for-each>
-            </xsl:if>
+            <xsl:for-each select="$occurrences-rtf">
+                <xsl:apply-templates select="." mode="location-report" />
+            </xsl:for-each>
             <xsl:message>
                 <xsl:text>--------------</xsl:text>
             </xsl:message>


### PR DESCRIPTION
Adds deprecation messages for the math display elements `me`, `men`, and `mdn`, all of which the assembly pre-processor already rewrites to `md` (`pretext-assembly.xsl:1970, 1999`).

- `me` and `men` → use `md` with no `mrow` children; numbering controlled by `@number` or the global `docinfo/numbering/@equations` setting.
- `mdn` → use `md` with the same numbering controls.

To cap the location reports at 8 per message, the existing `b-bulk` (binary "show all reports / none") parameter on the `deprecation-message` template is replaced with a more flexible `max-reports`:

- empty string (default) — no cap, prior behavior;
- `0` — silence the per-location reports (the `b-bulk="true()"` use case);
- positive integer — cap at that many reports.

The lone `b-bulk` caller (`@permid` deprecation) is converted. The previously listed `mdn[not(mrow)]` deprecation (2025-11-14) is removed — it covered a transitional construct from a six-week window and is now superseded by the general `mdn` message.

**Sequence of commits**, in no-regression order:

1. Remove the `<xsl:if test="not($b-bulk)">` gate from the template (param stays declared as a no-op so callers don't break).
2. Add the `max-reports` parameter and gating logic alongside `b-bulk`.
3. Convert the `@permid` caller to `max-reports="'0'"`; remove the now-unused `b-bulk` parameter.
4. Add the `me`/`men` and `mdn` deprecation messages with `max-reports="'8'"`.

Verified that LaTeX conversion of the sample article emits no new messages (it doesn't use any of these elements). Tested the new messages on a synthetic source with 11 `me`/`men` and 2 `mdn` occurrences — counts are correct and the 8-cap is honored.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*