### PR TITLE
Knowls - avoid flash of content when revealing

### DIFF
--- a/js/knowl.js
+++ b/js/knowl.js
@@ -39,8 +39,30 @@ class SlideRevealer {
     // mid animation state tracking
     this.animation = null;
     this.animationState = SlideRevealer.STATE.INACTIVE;
+    this.animatedElementInlineStyle = null;
 
     this.triggerElement.addEventListener('click', (e) => this.onClick(e));
+  }
+
+  storeAnimatedElementInlineStyle() {
+    if (this.animatedElementInlineStyle !== null) return;
+
+    this.animatedElementInlineStyle = {
+      overflow: this.animatedElement.style.overflow,
+      height: this.animatedElement.style.height,
+      paddingTop: this.animatedElement.style.paddingTop,
+      paddingBottom: this.animatedElement.style.paddingBottom
+    };
+  }
+
+  restoreAnimatedElementInlineStyle() {
+    if (this.animatedElementInlineStyle === null) return;
+
+    this.animatedElement.style.overflow = this.animatedElementInlineStyle.overflow;
+    this.animatedElement.style.height = this.animatedElementInlineStyle.height;
+    this.animatedElement.style.paddingTop = this.animatedElementInlineStyle.paddingTop;
+    this.animatedElement.style.paddingBottom = this.animatedElementInlineStyle.paddingBottom;
+    this.animatedElementInlineStyle = null;
   }
 
   onClick(e) {
@@ -48,6 +70,7 @@ class SlideRevealer {
     if (e) e.preventDefault();
 
     // Add an overflow on the <details> to avoid content overflowing
+    this.storeAnimatedElementInlineStyle();
     this.animatedElement.style.overflow = 'hidden';
 
     // Check if the element is being closed or is already closed
@@ -56,29 +79,63 @@ class SlideRevealer {
       this.animatedElement.setAttribute("open","");
       this.triggerElement.setAttribute("open","");
       this.contentElement.style.display = '';
+      this.contentElement.style.visibility = 'hidden';
+
+      let closedHeight = 0;
+      if (this.animatedElement.contains(this.triggerElement))
+        closedHeight = this.triggerElement.offsetHeight;
+
+      const naturalStyle = window.getComputedStyle(this.animatedElement);
+      const naturalPaddingTop = naturalStyle.paddingTop;
+      const naturalPaddingBottom = naturalStyle.paddingBottom;
+
+      this.animatedElement.style.height = `${closedHeight}px`;
+      this.animatedElement.style.paddingTop = '0px';
+      this.animatedElement.style.paddingBottom = '0px';
+
       // Trigger the animation to expand or collapse the knowl.
       // Delay the MathJax typesetting until the knowl is visible to ensure proper measurements
       // are taken, but before the unrolling begins. This helps avoid layout shifts and ensures
       // smooth animation with correctly sized content.
-      MathJax.typesetPromise().then(() => window.requestAnimationFrame(() => this.toggle(true)));
+      MathJax.typesetPromise().then(() => window.requestAnimationFrame(() => {
+        const expandingMeasurements = {
+          fullHeight: this.contentElement === this.animatedElement
+            ? this.contentElement.scrollHeight
+            : closedHeight + this.contentElement.offsetHeight,
+          paddingTop: naturalPaddingTop,
+          paddingBottom: naturalPaddingBottom
+        };
+
+        window.requestAnimationFrame(() => {
+          this.contentElement.style.visibility = '';
+          this.toggle(true, expandingMeasurements);
+        });
+      }));
     } else if (this.animationState === SlideRevealer.STATE.EXPANDING || this.animatedElement.hasAttribute("open")) {
       this.toggle(false);
     }
   }
 
-  toggle(expanding) {
+  toggle(expanding, expandingMeasurements = null) {
     let closedHeight = 0;
     if (this.animatedElement.contains(this.triggerElement))
       closedHeight = this.triggerElement.offsetHeight;
-    const fullHeight = closedHeight + this.contentElement.offsetHeight;
 
-    const startHeight = `${expanding ? closedHeight : fullHeight}px`;
+    const computedStyle = window.getComputedStyle(this.animatedElement);
+    const fullHeight = expandingMeasurements?.fullHeight ?? closedHeight + this.contentElement.offsetHeight;
+
+    const startHeight = `${expanding ? closedHeight : this.animatedElement.offsetHeight}px`;
     const endHeight = `${expanding ? fullHeight : closedHeight}px`;
 
-    // Need to animate padding to avoid extra height for xref knowls
-    const padding = this.animatedElement.offsetHeight - this.animatedElement.clientHeight;
-    const startPad = `${expanding ? 0 : padding}px`;
-    const endPad = `${expanding ? padding : 0}px`;
+    const currentPaddingTop = computedStyle.paddingTop;
+    const currentPaddingBottom = computedStyle.paddingBottom;
+    const endPaddingTop = expandingMeasurements?.paddingTop ?? currentPaddingTop;
+    const endPaddingBottom = expandingMeasurements?.paddingBottom ?? currentPaddingBottom;
+
+    const startPadTop = expanding ? '0px' : currentPaddingTop;
+    const endPadTop = expanding ? endPaddingTop : '0px';
+    const startPadBottom = expanding ? '0px' : currentPaddingBottom;
+    const endPadBottom = expanding ? endPaddingBottom : '0px';
 
     // Cancel any existing animation
     if (this.animation) {
@@ -92,15 +149,18 @@ class SlideRevealer {
     this.animationState = expanding ? SlideRevealer.STATE.EXPANDING : SlideRevealer.STATE.CLOSING;
     this.animation = this.animatedElement.animate({
       height: [startHeight, endHeight],
-      paddingTop: [startPad, endPad],
-      paddingBottom: [startPad, endPad]
+      paddingTop: [startPadTop, endPadTop],
+      paddingBottom: [startPadBottom, endPadBottom]
     }, {
       duration: animDuration,
-      easing: 'ease'
+      easing: 'ease-out'
     });
 
     this.animation.onfinish = () => { this.onAnimationFinish(expanding); };
-    this.animation.oncancel = () => { this.animationState = SlideRevealer.STATE.INACTIVE; };
+    this.animation.oncancel = () => {
+      this.animationState = SlideRevealer.STATE.INACTIVE;
+      this.restoreAnimatedElementInlineStyle();
+    };
   }
 
   onAnimationFinish(isOpen) {
@@ -115,9 +175,10 @@ class SlideRevealer {
     }
 
     // Clear styles used in animation
-    this.animatedElement.style.overflow = '';
+    this.restoreAnimatedElementInlineStyle();
     if (!isOpen)
       this.contentElement.style.display = 'none';
+    this.contentElement.style.visibility = '';
 
     if (isOpen) {
       let hasCallback = this.contentElement.querySelectorAll("[data-knowl-callback]");

--- a/js/knowl.js
+++ b/js/knowl.js
@@ -44,6 +44,10 @@ class SlideRevealer {
     this.triggerElement.addEventListener('click', (e) => this.onClick(e));
   }
 
+  isBusy() {
+    return this.animationState !== SlideRevealer.STATE.INACTIVE || this.animatedElementInlineStyle !== null;
+  }
+
   storeAnimatedElementInlineStyle() {
     if (this.animatedElementInlineStyle !== null) return;
 
@@ -68,6 +72,8 @@ class SlideRevealer {
   onClick(e) {
     // Stop default behavior from the browser
     if (e) e.preventDefault();
+
+    if (this.isBusy()) return;
 
     // Add an overflow on the <details> to avoid content overflowing
     this.storeAnimatedElementInlineStyle();
@@ -209,6 +215,7 @@ class LinkKnowl {
   constructor(knowlLinkElement) {
     this.linkElement = knowlLinkElement;
     this.outputElement = null;
+    this.slideHandler = null;
     this.uid = LinkKnowl.xrefCount++;
     knowlLinkElement.setAttribute("data-knowl-uid", this.uid);
 
@@ -323,21 +330,25 @@ class LinkKnowl {
     // prevent navigation
     event.preventDefault();
 
+    if (this.slideHandler?.isBusy()) {
+      return;
+    }
+
     if (this.outputElement !== null) {
       // output already created, toggle visibility
       this.toggle();
     } else {
       this.createOutputElement();
 
-      const slideHandler = new SlideRevealer(this.linkElement, this.outputElement, this.outputElement);
+      this.slideHandler = new SlideRevealer(this.linkElement, this.outputElement, this.outputElement);
       //slideHandler is now responsible for handling clicks to this element
-      this.linkElement.addEventListener('click', slideHandler);
+      this.linkElement.addEventListener('click', this.slideHandler);
 
       // Wait up to a half second in hopes of avoiding double content change
       // then render to show loading message
       let loadingTimeout = setTimeout(() => {
         loadingTimeout = null;
-        slideHandler.onClick(); //fake initial click
+        this.slideHandler.onClick(); //fake initial click
         this.toggle();
       }, 500);
 
@@ -352,7 +363,7 @@ class LinkKnowl {
           }
           // Now give code that follows .1 seconds to render before making visible
           setTimeout(() => {
-            slideHandler.onClick(); //fake initial click
+            this.slideHandler.onClick(); //fake initial click
             this.toggle();
           }, 100);
 


### PR DESCRIPTION
Knowls currently can briefly flash the content before trying to shrink and then reveal it. This is most noticeable when the knowl contains complex content (e.g. MathJax) and has not been rendered yet.

This removes that flash of content and smooths the reveal process by better calculating the final height and padding of the element being revealed. There is still a brief hiccup as complex content is revealed as the content is loaded and rendered.

For issue identified by @siefkenj here: https://groups.google.com/g/pretext-dev/c/XgiX8KhH2Dw/m/eW9srLM8AQAJ?utm_medium=email&utm_source=footer

--------------------------------------

This pull request enhances the animation logic for revealing and hiding "knowl" content, focusing on smoother transitions and improved style management. The main improvements are the preservation and restoration of inline styles during animations, more accurate and visually consistent expand/collapse animations, and better handling of animation state to prevent conflicts.

Key changes include:

**Animation and Style Management Improvements:**

* Added methods to `SlideRevealer` to store and restore the inline styles (`overflow`, `height`, `paddingTop`, `paddingBottom`) of the animated element before and after animations, ensuring that original styles are not lost or corrupted during transitions. (`js/knowl.js` [[1]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R42-R79) [[2]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7L118-R187)
* Refined the expand/collapse animation to use the element's natural padding and height values for more accurate measurements, and to animate both `paddingTop` and `paddingBottom` independently. The animation now uses the `ease-out` easing for a smoother effect. (`js/knowl.js` [[1]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R88-R144) [[2]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7L95-R169)

**Animation State and Event Handling:**

* Introduced an `isBusy()` method in `SlideRevealer` to prevent overlapping animations or state conflicts, and updated event handlers in `LinkKnowl` to check this state before triggering actions. (`js/knowl.js` [[1]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R42-R79) [[2]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R333-R351)

**Code Structure and Consistency:**

* Updated `LinkKnowl` to store the `SlideRevealer` instance as a member variable (`slideHandler`), ensuring consistent access and preventing duplicate handlers. (`js/knowl.js` [[1]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R218) [[2]](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7R333-R351)
* Updated all usages of the slide handler in `LinkKnowl` to use the new member variable, ensuring correct behavior throughout the component. (`js/knowl.js` [js/knowl.jsL294-R366](diffhunk://#diff-6eecafd760dfec47f29caa1ee83a3ff5ac652dfeed3f1a3b84726cb9b1cda8d7L294-R366))

These changes collectively result in more robust, visually consistent, and user-friendly knowl reveal/hide animations.