### PR TITLE
HTML: ensure introductions in printout page get correct structure

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1174,7 +1174,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Not knowlable as a component of bigger things, a      -->
 <!-- pure container.  This is the component of a division. -->
 <!-- Tunnel the duplication flag, drop id if duplicate     -->
-<xsl:template match="introduction[parent::*[&STRUCTURAL-FILTER;]]|conclusion[parent::*[&STRUCTURAL-FILTER;]]">
+<!-- NB: self::page for inside printouts -->
+<xsl:template match="introduction[parent::*[&STRUCTURAL-FILTER; or self::page]]|conclusion[parent::*[&STRUCTURAL-FILTER; or self::page]]">
     <xsl:param name="b-original" select="true()" />
     <!-- newline inserted to encourage formatted output -->
     <xsl:text>&#xa;</xsl:text>
@@ -5505,7 +5506,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Introductions and Conclusions -->
 <!-- As components of blocks.      -->
-<xsl:template match="introduction[not(parent::*[&STRUCTURAL-FILTER;])]|conclusion[not(parent::*[&STRUCTURAL-FILTER;])]">
+<!-- NB: self::page for inside printouts -->
+<xsl:template match="introduction[not(parent::*[&STRUCTURAL-FILTER; or self::page])]|conclusion[not(parent::*[&STRUCTURAL-FILTER; or self::page])]">
     <xsl:param name="b-original" select="true()" />
     <!-- newline inserted to encourage formatted output -->
     <xsl:text>&#xa;</xsl:text>


### PR DESCRIPTION
If an author writes a worksheet or handout with an `<introduction>` but wants that on its own page (like a cover page for an exam), it seems natural to put the introduction in a `<page>` element.  However, the xsl for introduction only places it in an html `<section>` if the introduction lives inside `STRUCTURAL`.  This simply adds `self:page` to the filters for structural to get the expected html in this case.