### PR TITLE
CSS: add decorations for objectives/outcomes/assemblages in printouts

### DIFF
--- a/css/components/chunks/helpers/_box-mixin.scss
+++ b/css/components/chunks/helpers/_box-mixin.scss
@@ -1,9 +1,10 @@
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 10px !default;
 $border-radius: 0px !default;
+$border-width: 2px !default;
 
 // Generate styles for a surrounding box
-@mixin box($border-width: 2px,
+@mixin box($border-width: $border-width,
   $style: solid,
   $background-color: var(--block-body-background),
   $border-color: var(--block-border-color),

--- a/css/targets/print-worksheet/_chunks-worksheet.scss
+++ b/css/targets/print-worksheet/_chunks-worksheet.scss
@@ -15,6 +15,8 @@ $border-radius: 8px !default;
 @use 'components/chunks/knowls' with ($border-radius: $border-radius);
 
 @use 'components/chunks/helpers/inline-heading-mixin';
+@use 'components/chunks/helpers/horizontal-bars-mixin';
+@use 'components/chunks/helpers/box-mixin' with ($border-radius: $border-radius);
 
 
 .theorem-like,
@@ -54,19 +56,24 @@ $border-radius: 8px !default;
 }
 
 
- .goal-like {
-  border: none;
-  padding: 0;
-}
-
-.goal-like > .heading {
-  margin-top: -0.5em;
-  padding: 0;
-  margin: 0;
-  font-size: 1.1em;
+.goal-like {
+  @include horizontal-bars-mixin.bars(
+    $border-width: 1px,
+    $padding: 0.5em
+    );
 }
 
 .paragraphs,
 article {
   @include inline-heading-mixin.heading;
+}
+
+.assemblage-like {
+  @include box-mixin.box(
+    $border-width: 1px,
+    $border-color: var(--assemblage-like-border-color),
+  );
+  > .heading {
+    font-size: 1.1em;
+  }
 }

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -29,13 +29,27 @@
 
 
 // Make sure we are including the root colors using simple black-and-white palette
+// Always use colors from the light mode palette, since the print preview and printed version will be light mode.
+@use "sass:map";
 @use "colors/color-helpers" as colorHelpers;
 @use 'colors/palette-single' as palette with (
   $primary-color: black,
 );
 
-// render the actual colors
-@include colorHelpers.set-root-colors(palette.$colors);
+$light-colors: map.merge(
+  palette.$colors,
+  (
+    "block-head-color": black,
+  )
+);
+
+// Print worksheets should always render with the light palette, even if the page
+// root still carries the site's dark-mode class.
+:root,
+:root.dark-mode {
+  color-scheme: light;
+  @include colorHelpers.scss-to-css($light-colors);
+}
 
 // ---------------------------------------------
 // concrete rules / includes that generate CSS


### PR DESCRIPTION
As suggested by @davidaustinm, printouts will now get some basic styling for objectives and outcomes.  I also went ahead and added a simple box for assemblages.

One change to scss outside of the printout targets, to the  `box-mixin` simply adds a default border width so the printout can override this.  Should not impact any other styles.