### PR TITLE
WeBWorK examples: meaningful @label on each exercise

### DIFF
--- a/examples/showcase/source/webwork.ptx
+++ b/examples/showcase/source/webwork.ptx
@@ -13,7 +13,7 @@
   </p>
   <!-- TODO: Add an array answer once the current WW distribution is returning PTX content for that. -->
 
-  <exercise>
+  <exercise label="answer-type-variety">
     <title>Answer Type Variety</title>
     <idx><h><webwork/></h><h>answer types</h></idx>
     <introduction>
@@ -92,7 +92,7 @@
     </webwork>
   </exercise>
 
-  <exercise>
+  <exercise label="special-feedback">
     <title>Special Feedback</title>
     <idx><h><webwork/></h><h>custom feedback</h></idx>
     <idx><h><webwork/></h><h>hint</h></idx>
@@ -156,7 +156,7 @@
     </webwork>
   </exercise>
 
-  <exercise>
+  <exercise label="string-answers">
     <title>String Answers</title>
     <idx><h><webwork/></h><h>string answers</h></idx>
     <idx><h><webwork/></h><h>algorithmic image</h></idx>
@@ -202,7 +202,7 @@
     </webwork>
   </exercise>
 
-  <exercise>
+  <exercise label="open-problem-library">
     <title>Open Problem Library</title>
     <idx><h><webwork/></h><h>Open Problem Library</h></idx>
     <introduction>
@@ -215,7 +215,7 @@
     <webwork source="Library/PCC/BasicAlgebra/NumberBasics/FactorInteger10.pg"/>
   </exercise>
 
-  <exercise>
+  <exercise label="structured-with-tasks">
     <title>Structured with Tasks</title>
     <idx><h><webwork/></h><h>tasks</h></idx>
     <idx><h><webwork/></h><h>flexible answer syntax</h></idx>
@@ -283,7 +283,7 @@
     </webwork>
   </exercise>
 
-  <exercise>
+  <exercise label="units-in-answers">
     <title>Units in Answers</title>
     <idx><h><webwork/></h><h>unit answers</h></idx>
     <introduction>

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -39,7 +39,7 @@
     <section>
       <title><webwork /> Minimal Section</title>
       <!-- An exercise "generated" from PTX source -->
-      <exercise>
+      <exercise label="add-integers">
         <webwork>
           <pg-code>
             $a = Compute(random(1, 9, 1));
@@ -68,12 +68,12 @@
       </exercise>
       <!-- An exercise with source from a "webwork2" server           -->
       <!-- The path is relative to the host course's templates folder -->
-      <exercise>
+      <exercise label="cylinder-volume">
         <webwork source="Library/PCC/BasicAlgebra/Geometry/CylinderVolume10.pg"/>
       </exercise>
       <!-- An exercise with source from a pg file. This is the default new problem file template -->
       <!-- from a webwork2 server. The path is relative to this current file we are in.          -->
-      <exercise>
+      <exercise label="value-of-pi">
         <webwork><xi:include parse="text" href="pg/newProblem.pg"/></webwork>
       </exercise>
     </section>

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -808,7 +808,7 @@ ENDDOCUMENT();
                             </p>
                         </introduction>
 
-                        <exercise>
+                        <exercise label="antiderivative-sin">
                             <webwork>
                                 <pg-code>
                                     $answer = FormulaUpToConstant("-cos(x)");
@@ -824,7 +824,7 @@ ENDDOCUMENT();
                             </webwork>
                         </exercise>
 
-                        <exercise>
+                        <exercise label="antiderivative-exp">
                             <webwork>
                                 <pg-code>
                                     $answer = FormulaUpToConstant("e^x");
@@ -1444,7 +1444,7 @@ ENDDOCUMENT();
                               </latex-image>
                             </image>
                         </introduction>
-                        <exercise>
+                        <exercise label="box-diagonal-five">
                             <webwork>
                                 <statement>
                                     <p>
@@ -1465,7 +1465,7 @@ ENDDOCUMENT();
                                 </solution>
                             </webwork>
                         </exercise>
-                        <exercise>
+                        <exercise label="box-diagonal-thirteen">
                             <webwork>
                                 <statement>
                                     <p>
@@ -1572,7 +1572,7 @@ ENDDOCUMENT();
 
                 <p>Here we make MathObject String answers to see how they turn out in answer elements.</p>
 
-                <exercise>
+                <exercise label="mathobject-string-answers">
                     <webwork>
                         <pg-code>
                             $xmlchars = q(&lt;>&amp;'";);
@@ -1632,7 +1632,7 @@ ENDDOCUMENT();
                     use <c>data="pgml"</c>. (This is not in the <pretext/> schema as of 3/26/2020, and is subject to change.)
                 </p>
 
-                <exercise>
+                <exercise label="pgml-data-attribute">
                     <webwork>
                         <pg-code>
                             $statement = 'some PGML math: [`\frac{1}{2}+\frac{3}{2}=2`]; and some *bold text*';
@@ -1764,7 +1764,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="radio-buttons-with-math">
                     <webwork>
                         <pg-code>
                               $expressions = RadioButtons(['\(x\)','\(x^2\)','\(2^x\)'], 2);
@@ -1844,7 +1844,7 @@ ENDDOCUMENT();
 
                 </exercise>
 
-                <exercise>
+                <exercise label="answer-arrays">
                     <title>Answer Arrays</title>
                     <webwork>
                       <pg-code>
@@ -1880,7 +1880,7 @@ ENDDOCUMENT();
             <section>
                 <title>Stress Tests</title>
 
-                <exercise>
+                <exercise label="ptx-source-with-server-images">
                     <title>PTX problem source with server-generated images</title>
                     <webwork>
                         <pg-code>
@@ -1919,7 +1919,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="list-indentation">
                     <title>Checking Proper Indentation In Lists</title>
                     <introduction>
                         <p>One long exercise, where ordered sublists test the specification of their labels.</p>
@@ -2186,7 +2186,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="list-indentation-with-images-and-tables">
                     <title>Checking Proper Indentation In Lists with Images and Tables</title>
                     <webwork>
                         <pg-code>
@@ -2269,7 +2269,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="deep-nested-lists">
                     <title>Deep-nested lists</title>
                     <webwork>
                         <statement>
@@ -2313,7 +2313,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="empty-statement">
                     <introduction>
                         <p>
                             This exercise has no content in its statement.
@@ -2326,7 +2326,7 @@ ENDDOCUMENT();
                     </webwork>
                 </exercise>
 
-                <exercise>
+                <exercise label="single-quote-in-table-cell">
                     <introduction>
                         <p>
                             This exercise has a single quote in it.
@@ -2357,14 +2357,14 @@ ENDDOCUMENT();
                 <subsection>
                     <title>Inline Exercises</title>
                     <p>Some <q>inline</q> exercises, as distinguished from the <q>divisional</q> exercises below.</p>
-                    <exercise>
+                    <exercise label="inline-bare">
                         <webwork>
                             <statement>
                                 <p><m>1+1=2</m></p>
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-title">
                         <title>Has a Title</title>
                         <webwork>
                             <statement>
@@ -2372,7 +2372,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-introduction">
                         <introduction>
                             <p>Has an introduction.</p>
                         </introduction>
@@ -2382,7 +2382,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-title-introduction">
                         <title>Has a Title</title>
                         <introduction>
                             <p>Has an introduction.</p>
@@ -2393,7 +2393,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-conclusion">
                         <webwork>
                             <statement>
                                 <p><m>1+1=2</m></p>
@@ -2403,7 +2403,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-title-conclusion">
                         <title>Has a Title</title>
                         <webwork>
                             <statement>
@@ -2414,7 +2414,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-introduction-conclusion">
                         <introduction>
                             <p>Has an introduction.</p>
                         </introduction>
@@ -2427,7 +2427,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="inline-title-introduction-conclusion">
                         <title>Has a Title</title>
                         <introduction>
                             <p>Has an introduction.</p>
@@ -2445,14 +2445,14 @@ ENDDOCUMENT();
 
                 <exercises>
                     <title>Divisional Exercises</title>
-                    <exercise>
+                    <exercise label="divisional-bare">
                         <webwork>
                             <statement>
                                 <p><m>1+1=2</m></p>
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-title">
                         <title>Has a Title</title>
                         <webwork>
                             <statement>
@@ -2460,7 +2460,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-introduction">
                         <introduction>
                             <p>Has an introduction.</p>
                         </introduction>
@@ -2470,7 +2470,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-title-introduction">
                         <title>Has a Title</title>
                         <introduction>
                             <p>Has an introduction.</p>
@@ -2481,7 +2481,7 @@ ENDDOCUMENT();
                             </statement>
                         </webwork>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-conclusion">
                         <webwork>
                             <statement>
                                 <p><m>1+1=2</m></p>
@@ -2491,7 +2491,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-title-conclusion">
                         <title>Has a Title</title>
                         <webwork>
                             <statement>
@@ -2502,7 +2502,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-introduction-conclusion">
                         <introduction>
                             <p>Has an introduction.</p>
                         </introduction>
@@ -2515,7 +2515,7 @@ ENDDOCUMENT();
                             <p>Has a conclusion.</p>
                         </conclusion>
                     </exercise>
-                    <exercise>
+                    <exercise label="divisional-title-introduction-conclusion">
                         <title>Has a Title</title>
                         <introduction>
                             <p>Has an introduction.</p>
@@ -2533,14 +2533,14 @@ ENDDOCUMENT();
                         <introduction>
                             <p>These are inside an exercisegroup.</p>
                         </introduction>
-                        <exercise>
+                        <exercise label="exercisegroup-bare">
                             <webwork>
                                 <statement>
                                     <p><m>1+1=2</m></p>
                                 </statement>
                             </webwork>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-title">
                             <title>Has a Title</title>
                             <webwork>
                                 <statement>
@@ -2548,7 +2548,7 @@ ENDDOCUMENT();
                                 </statement>
                             </webwork>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-introduction">
                             <introduction>
                                 <p>Has an introduction.</p>
                             </introduction>
@@ -2558,7 +2558,7 @@ ENDDOCUMENT();
                                 </statement>
                             </webwork>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-title-introduction">
                             <title>Has a Title</title>
                             <introduction>
                                 <p>Has an introduction.</p>
@@ -2569,7 +2569,7 @@ ENDDOCUMENT();
                                 </statement>
                             </webwork>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-conclusion">
                             <webwork>
                                 <statement>
                                     <p><m>1+1=2</m></p>
@@ -2579,7 +2579,7 @@ ENDDOCUMENT();
                                 <p>Has a conclusion.</p>
                             </conclusion>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-title-conclusion">
                             <title>Has a Title</title>
                             <webwork>
                                 <statement>
@@ -2590,7 +2590,7 @@ ENDDOCUMENT();
                                 <p>Has a conclusion.</p>
                             </conclusion>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-introduction-conclusion">
                             <introduction>
                                 <p>Has an introduction.</p>
                             </introduction>
@@ -2603,7 +2603,7 @@ ENDDOCUMENT();
                                 <p>Has a conclusion.</p>
                             </conclusion>
                         </exercise>
-                        <exercise>
+                        <exercise label="exercisegroup-title-introduction-conclusion">
                             <title>Has a Title</title>
                             <introduction>
                                 <p>Has an introduction.</p>


### PR DESCRIPTION
Companion to #2809. Adds a meaningful `@label` to every `<exercise>` containing a `<webwork>` in the three example projects with WeBWorK content (`minimal`, `sample-chapter`, `showcase`). One commit per example. These labels become the per-exercise representation filenames via `@assembly-id`.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*