### PR TITLE
WeBWorK: write a representation file when server rendering fails

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1839,100 +1839,103 @@ def webwork_to_xml(
             static.set("source", path[problem])
 
         # If there is "badness"...
-        # Build 'shell' problems to indicate failures
+        # Build 'shell' problems to indicate failures.  Fall through (no
+        # "continue") so that rendering-data, pg, and the per-exercise file
+        # write below all execute — those sections have explicit "if badness"
+        # branches that produce a minimal faux problem, and assembly relies
+        # on the file existing for every WeBWorK exercise.
         if badness:
             log.error(badness_msg.format(path[problem], seed[problem], badness_tip))
             static.set("failure", badness_type)
             statement = ET.SubElement(static, "statement")
             p = ET.SubElement(statement, "p")
             p.text = badness_msg.format(path[problem], seed[problem], badness_tip)
-            continue
+        else:
+            # Start appending XML children
+            response_root = ET.fromstring(bytes(response_text, encoding='utf-8'))
 
-        # Start appending XML children
-        response_root = ET.fromstring(bytes(response_text, encoding='utf-8'))
+            # This recursive function is needed in the case of nested tasks.
+            # It is written in such a way to handle task with no nesting, and even an exercise without any task.
 
-        # This recursive function is needed in the case of nested tasks.
-        # It is written in such a way to handle task with no nesting, and even an exercise without any task.
+            def static_webwork_level(write, read):
+                # (tree we are building, tree we take from)
+                # since write is a tree and read is a tree, we use deepcopy to make sure
+                # that when we append nodes we are appending new ones, not intertwining the trees
 
-        def static_webwork_level(write, read):
-            # (tree we are building, tree we take from)
-            # since write is a tree and read is a tree, we use deepcopy to make sure
-            # that when we append nodes we are appending new ones, not intertwining the trees
+                tasks = read.findall("./task")
+                if tasks:
+                    titles = read.xpath("./title")
+                    if titles:
+                        for ttl in list(titles):
+                            title = copy.deepcopy(ttl)
+                            write.append(title)
+                    introductions = read.xpath(
+                        "./statement[following-sibling::task]|./statement[following-sibling::stage]"
+                    )
+                    if introductions:
+                        introduction = ET.SubElement(write, "introduction")
+                        for intro in list(introductions):
+                            for child in intro:
+                                chcopy = copy.deepcopy(child)
+                                introduction.append(chcopy)
+                    for tsk in list(tasks):
+                        task = ET.SubElement(write, "task")
+                        static_webwork_level(task, tsk)
+                    conclusions = read.xpath("./statement[preceding-sibling::task]")
+                    if conclusions:
+                        conclusion = ET.SubElement(write, "conclusion")
+                        for conc in list(conclusions):
+                            for child in conc:
+                                chcopy = copy.deepcopy(child)
+                                conclusion.append(chcopy)
+                else:
+                    titles = read.xpath("./title")
+                    if titles:
+                        for ttl in list(titles):
+                            title = copy.deepcopy(ttl)
+                            write.append(title)
+                    statements = read.xpath(
+                        "./statement[not(preceding-sibling::task or following-sibling::task)]"
+                    )
+                    if statements:
+                        statement = ET.SubElement(write, "statement")
+                        for stat in list(statements):
+                            for child in stat:
+                                chcopy = copy.deepcopy(child)
+                                statement.append(chcopy)
+                    hints = read.xpath("./hint")
+                    if hints:
+                        hint = ET.SubElement(write, "hint")
+                        for hnt in list(hints):
+                            for child in hnt:
+                                chcopy = copy.deepcopy(child)
+                                hint.append(chcopy)
+                    answer_names = read.xpath(".//fillin/@name|.//var/@name|.//ul/@name|.//ol/@name|.//dl/@name")
+                    answer_hashes = response_root.find("./answerhashes")
+                    if answer_hashes is not None:
+                        for ans in list(answer_hashes):
+                            if ans.get("ans_name") in list(answer_names):
+                                correct_ans = ans.get("correct_ans", "")
+                                correct_ans_latex_string = ans.get(
+                                    "correct_ans_latex_string", ""
+                                )
+                                if correct_ans != "" or correct_ans_latex_string != "":
+                                    answer = ET.SubElement(write, "answer")
+                                    p = ET.SubElement(answer, "p")
+                                    if correct_ans_latex_string:
+                                        m = ET.SubElement(p, "m")
+                                        m.text = correct_ans_latex_string
+                                    elif correct_ans:
+                                        p.text = correct_ans
+                    solutions = read.xpath("./solution")
+                    if solutions:
+                        solution = ET.SubElement(write, "solution")
+                        for sol in list(solutions):
+                            for child in sol:
+                                chcopy = copy.deepcopy(child)
+                                solution.append(chcopy)
 
-            tasks = read.findall("./task")
-            if tasks:
-                titles = read.xpath("./title")
-                if titles:
-                    for ttl in list(titles):
-                        title = copy.deepcopy(ttl)
-                        write.append(title)
-                introductions = read.xpath(
-                    "./statement[following-sibling::task]|./statement[following-sibling::stage]"
-                )
-                if introductions:
-                    introduction = ET.SubElement(write, "introduction")
-                    for intro in list(introductions):
-                        for child in intro:
-                            chcopy = copy.deepcopy(child)
-                            introduction.append(chcopy)
-                for tsk in list(tasks):
-                    task = ET.SubElement(write, "task")
-                    static_webwork_level(task, tsk)
-                conclusions = read.xpath("./statement[preceding-sibling::task]")
-                if conclusions:
-                    conclusion = ET.SubElement(write, "conclusion")
-                    for conc in list(conclusions):
-                        for child in conc:
-                            chcopy = copy.deepcopy(child)
-                            conclusion.append(chcopy)
-            else:
-                titles = read.xpath("./title")
-                if titles:
-                    for ttl in list(titles):
-                        title = copy.deepcopy(ttl)
-                        write.append(title)
-                statements = read.xpath(
-                    "./statement[not(preceding-sibling::task or following-sibling::task)]"
-                )
-                if statements:
-                    statement = ET.SubElement(write, "statement")
-                    for stat in list(statements):
-                        for child in stat:
-                            chcopy = copy.deepcopy(child)
-                            statement.append(chcopy)
-                hints = read.xpath("./hint")
-                if hints:
-                    hint = ET.SubElement(write, "hint")
-                    for hnt in list(hints):
-                        for child in hnt:
-                            chcopy = copy.deepcopy(child)
-                            hint.append(chcopy)
-                answer_names = read.xpath(".//fillin/@name|.//var/@name|.//ul/@name|.//ol/@name|.//dl/@name")
-                answer_hashes = response_root.find("./answerhashes")
-                if answer_hashes is not None:
-                    for ans in list(answer_hashes):
-                        if ans.get("ans_name") in list(answer_names):
-                            correct_ans = ans.get("correct_ans", "")
-                            correct_ans_latex_string = ans.get(
-                                "correct_ans_latex_string", ""
-                            )
-                            if correct_ans != "" or correct_ans_latex_string != "":
-                                answer = ET.SubElement(write, "answer")
-                                p = ET.SubElement(answer, "p")
-                                if correct_ans_latex_string:
-                                    m = ET.SubElement(p, "m")
-                                    m.text = correct_ans_latex_string
-                                elif correct_ans:
-                                    p.text = correct_ans
-                solutions = read.xpath("./solution")
-                if solutions:
-                    solution = ET.SubElement(write, "solution")
-                    for sol in list(solutions):
-                        for child in sol:
-                            chcopy = copy.deepcopy(child)
-                            solution.append(chcopy)
-
-        static_webwork_level(static, response_root)
+            static_webwork_level(static, response_root)
 
         # Add rendering-data element with attribute data for rendering a problem
         if (badness or origin[problem] == "generated" or (webwork2_minor_version < 19 and origin[problem] != "webwork2")):

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3272,6 +3272,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:message>              which should be reported.</xsl:message>
                 </xsl:when>
                 <xsl:otherwise>
+                    <!-- The representation file may record a server failure   -->
+                    <!-- from when the WeBWorK representations were generated. -->
+                    <!-- In that case the file holds a placeholder "faux       -->
+                    <!-- problem" (statement only) so assembly still proceeds, -->
+                    <!-- but warn the author so the failure does not go        -->
+                    <!-- unnoticed in later builds.                            -->
+                    <xsl:if test="$the-webwork-rep/static/@failure">
+                        <xsl:message>PTX:WARNING:   the WeBWorK problem with @assembly-id "<xsl:value-of select="@assembly-id"/>" has a stored "<xsl:value-of select="$the-webwork-rep/static/@failure"/>" failure recorded when the WeBWorK representations were last generated.  A placeholder is being rendered in its place.  Re-generate the WeBWorK representations (and watch for errors) to retry.</xsl:message>
+                    </xsl:if>
                     <!-- Build a temporary exercise with "webwork-reps" from the  -->
                     <!-- representations file substituted in place of "webwork".   -->
                     <!-- This preserves the parent-child relationship that         -->


### PR DESCRIPTION
Companion regression-fix to #2809 (per-exercise WeBWorK representation files).

Before #2809, when the WeBWorK server failed to render a problem (compile error, empty PG, malformed XML response, or missing `<statement>` — collectively "badness"), the script logged the error and built a minimal `<webwork-reps>` placeholder. Because that placeholder was a `SubElement` of a single shared `webwork-representations.xml` tree written once at the end of the loop, it always landed in the file, and assembly could still find a record for the failed problem.

After #2809, each `<webwork-reps>` is its own tree written from inside the loop. The leftover `continue` at the end of the badness block now skips the file write entirely. A failed problem produces no file, and assembly aborts with `PTX:ERROR: The WeBWorK problem with @assembly-id "..." could not be located` — with no useful diagnostic at the originating failure unless the author was watching the original generation log.

Two commits:

1. **Script** (`pretext/lib/pretext.py`) — replace the `continue` after badness detection with `else:` that scopes only the response-parsing block. The downstream rendering-data, `pg`, and per-exercise file-write blocks already contain `if badness:` branches that produce a base64-encoded shell PG with the failure message; those were unreachable before and now produce the intended "faux problem" file.

2. **Assembly** (`xsl/pretext-assembly.xsl`) — when a per-exercise representation file is loaded and its `static/@failure` is set, emit a `PTX:WARNING` naming the assembly-id and failure type, advising the author to re-generate the WeBWorK representations. Without this, a stored failure would be silently rendered as the placeholder in every later build.

### Test

Introduced a syntax error in `examples/webwork/sample-chapter/pg/Adding_SingleDigit_Integers.pg` (`xi:include`d by the `local-pg-file` exercise), re-generated representations against `https://webwork-ptx.aimath.org`. Confirmed extraction logs `PTX:ERROR: ...failed to compile`; `local-pg-file.xml` is now written with `<static seed="20" failure="compile">` plus a faux PG shell; assembly logs `PTX:WARNING: ...has a stored "compile" failure ... A placeholder is being rendered in its place. Re-generate the WeBWorK representations (and watch for errors) to retry.`

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*