### PR TITLE
WeBWorK: clean up diagnostics after switch to per-exercise files

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -39,8 +39,8 @@
 <!-- project. This ephemeral tree also has some global publisher variable  -->
 <!-- data for how PG should be processed. This tree will be used by        -->
 <!-- pretext.py in conjuction with some form of renderer (webwork2, local  -->
-<!-- PG, or the standalone renderer) to create an XML file called          -->
-<!-- webwork-representations.xml with various representations of each      -->
+<!-- PG, or the standalone renderer) to write, for each webwork exercise,  -->
+<!-- a file of representations of that problem (named by @assembly-id).    -->
 
 <!-- The top of the ephemeral XML tree has some global attributes.         -->
 
@@ -58,15 +58,14 @@
 <!-- 4.  pghuman: human readable PG (for generated exercises only)         -->
 <!-- 5.  PG that is somewhat minimized (and less human-readable)           -->
 
-<!-- The pretext/pretext script (-c webwork) uses all this to build a      -->
-<!-- single XML file (called webwork-representations.xml) containing       -->
-<!-- multiple representations of each webwork problem. The pretext/pretext -->
-<!-- script must be re-run whenever something changes with author source   -->
-<!-- within a webwork element. Or if something changes with a .pg file.    -->
-<!-- Or if some configuration changes.                                     -->
+<!-- The pretext/pretext script (-c webwork) uses all this to write, for   -->
+<!-- each webwork exercise, an XML file of representations of that problem -->
+<!-- (named by @assembly-id). The script must be re-run whenever the       -->
+<!-- author source for a webwork exercise, a .pg file, or some             -->
+<!-- configuration changes.                                                -->
 
-<!-- Then other translation sheets' assembly phase will factor in          -->
-<!-- webwork-representations.xml                                           -->
+<!-- Then other translation sheets' assembly phase will read the per-      -->
+<!-- exercise representation file for each webwork exercise.               -->
 
 <!-- Standard conversion groundwork -->
 <xsl:import href="./publisher-variables.xsl"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3252,24 +3252,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:copy>
                         <xsl:apply-templates select="node()|@*" mode="representations"/>
                     </xsl:copy>
-                    <xsl:message>PTX:ERROR:    There is a WeBWorK exercise with @assembly-id "<xsl:value-of select="@assembly-id"/>"</xsl:message>
-                    <xsl:message>              but your publication file does not indicate the directory</xsl:message>
-                    <xsl:message>              of problem representations created by a WeBWorK server.</xsl:message>
-                    <xsl:message>              Your WeBWorK exercises will all, at best, be empty.</xsl:message>
+                    <xsl:message>PTX:ERROR:   no WeBWorK representations directory configured in the publication file; WeBWorK exercise with @assembly-id "<xsl:value-of select="@assembly-id"/>" will be empty.</xsl:message>
                 </xsl:when>
                 <!-- This should only fail if the file is missing or stale.  Repeatedly. -->
                 <xsl:when test="not($the-webwork-rep)">
                     <xsl:copy>
                         <xsl:apply-templates select="node()|@*" mode="representations"/>
                     </xsl:copy>
-                    <xsl:message>PTX:ERROR:    The WeBWorK problem with @assembly-id "<xsl:value-of select="@assembly-id"/>"</xsl:message>
-                    <xsl:message>              could not be located at "<xsl:value-of select="$webwork-rep-uri"/>". </xsl:message>
-                    <xsl:message>              If the WeBWorK files were built with an older version of PreTeXt,</xsl:message>
-                    <xsl:message>              they need to be regenerated.  A "webwork-representations.xml"</xsl:message>
-                    <xsl:message>              in that directory is a sign of this old single-file format.</xsl:message>
-                    <xsl:message>              If there are many messages like this, then likely your directory is missing.</xsl:message>
-                    <xsl:message>              But if this is an isolated error message, then it may indicate a bug,</xsl:message>
-                    <xsl:message>              which should be reported.</xsl:message>
+                    <xsl:message>PTX:ERROR:   could not load WeBWorK representation file "<xsl:value-of select="$webwork-rep-uri"/>" for @assembly-id "<xsl:value-of select="@assembly-id"/>"; re-generate the WeBWorK representations.  A "webwork-representations.xml" in that directory indicates old-format files that need replacing.</xsl:message>
                 </xsl:when>
                 <xsl:otherwise>
                     <!-- The representation file may record a server failure   -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10880,14 +10880,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
-<!-- Fail if WeBWorK extraction and merging has not been done -->
-<xsl:template match="webwork[*]">
-    <xsl:message>PTX:ERROR: A document that uses WeBWorK nees to incorporate a file</xsl:message>
-    <xsl:message>of representations of WW problems.  These can be created with the</xsl:message>
-    <xsl:message>"pretext" Python script and specified in a publisher file.</xsl:message>
-    <xsl:message>See the documentation for details.</xsl:message>
-</xsl:template>
-
 <!-- The guts of a WeBWorK problem realized in HTML -->
 <!-- This is heart of an external knowl version, or -->
 <!-- what is born visible under control of a switch -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1384,7 +1384,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <xsl:when test="$publication/source/@webwork-problems">
                 <xsl:value-of select="str:replace($publication/source/@webwork-problems, '&#x20;', '%20')"/>
-                <xsl:message>PTX:WARNING: the publication file entry  source/@webwork-problems  is</xsl:message>
+                <xsl:message>PTX:ERROR:   the publication file entry  source/@webwork-problems  is</xsl:message>
                 <xsl:message>             deprecated, please move to using managed directories</xsl:message>
             </xsl:when>
             <!-- no specification, so empty string for filename -->


### PR DESCRIPTION
A small audit-and-cleanup pass over WeBWorK-related diagnostics and comments that had not caught up with #2809 (per-exercise representation files) and #2855 (placeholder file written on server failure). Four focused commits:

- **WeBWorK: extract-pg.xsl comments describe per-exercise representation files** — three documentation-comment blocks in `xsl/extract-pg.xsl` still described the pipeline as building "a single XML file (called `webwork-representations.xml`)". Rewritten to describe the per-exercise format (one file per exercise, named by `@assembly-id`).

- **Assembly: condense WeBWorK file-loading error messages** — in `xsl/pretext-assembly.xsl`, the two `xsl:when` branches that handle "no representations directory configured" and "representation file could not be loaded" emitted 4-line and 8-line `xsl:message` blocks. Each collapses to a single line. Structure (the two branches, the hollow-copy body) unchanged. The hint that a `webwork-representations.xml` in the directory indicates old-format files is kept, in shortened form.

- **HTML: remove redundant error template for unprocessed WeBWorK exercises** — `xsl/pretext-html.xsl` had a `<xsl:template match="webwork[*]">` emitting 4 message lines (with a "nees"→"needs" typo) when an unprocessed `<webwork>` survived into HTML conversion. That condition is already diagnosed at assembly time by the messages above, so this template is redundant and is dropped.

- **Publisher: error on deprecated source/@webwork-problems entry** — promote the `PTX:WARNING` for `source/@webwork-problems` in `xsl/publisher-variables.xsl` to `PTX:ERROR`. Managed directories are the expected configuration now.

A small adjacent fallback in `xsl/pretext-html.xsl` (three-way choice on `rendering-data/@passwd` / `@password` / `@course-password` for backward compatibility with old representation files) is intentionally left alone for this pass.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*