### PR TITLE
Schema: restrict md to single-line and multi-row forms

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1654,14 +1654,25 @@
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
-                    MetaDataTarget,
+                    # common to both forms; @number defaults to "no"
+                    Component?,
+                    Index*,
                     attribute number {"yes" | "no"}?,
-                    attribute break {"yes" | "no"}?,
-                    attribute alignment {text}?,
-                    attribute alignat-columns {text}?,
                     (
-                    (mixed {(Xref | FillInMath | WWVariable)*}) |
-                    (MathRow, (MathRow | MathIntertext)*)
+                        # single-line: text content, optional @xml:id
+                        # makes it a cross-reference target, no @label
+                        (
+                            UniqueID?,
+                            mixed {(Xref | FillInMath | WWVariable)*}
+                        ) |
+                        # multi-line: "mrow" content, not itself a
+                        # cross-reference target, so no @xml:id, no @label
+                        (
+                            attribute break {"yes" | "no"}?,
+                            attribute alignment {text}?,
+                            attribute alignat-columns {text}?,
+                            MathRow, (MathRow | MathIntertext)*
+                        )
                     )
                 }
             

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4201,7 +4201,13 @@
   </define>
   <define name="MathDisplay">
     <element name="md">
-      <ref name="MetaDataTarget"/>
+      <optional>
+        <!-- common to both forms; @number defaults to "no" -->
+        <ref name="Component"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="Index"/>
+      </zeroOrMore>
       <optional>
         <attribute name="number">
           <choice>
@@ -4210,31 +4216,44 @@
           </choice>
         </attribute>
       </optional>
-      <optional>
-        <attribute name="break">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
-      <optional>
-        <attribute name="alignment"/>
-      </optional>
-      <optional>
-        <attribute name="alignat-columns"/>
-      </optional>
       <choice>
-        <mixed>
-          <zeroOrMore>
-            <choice>
-              <ref name="Xref"/>
-              <ref name="FillInMath"/>
-              <ref name="WWVariable"/>
-            </choice>
-          </zeroOrMore>
-        </mixed>
+        <!--
+          single-line: text content, optional @xml:id
+          makes it a cross-reference target, no @label
+        -->
         <group>
+          <optional>
+            <ref name="UniqueID"/>
+          </optional>
+          <mixed>
+            <zeroOrMore>
+              <choice>
+                <ref name="Xref"/>
+                <ref name="FillInMath"/>
+                <ref name="WWVariable"/>
+              </choice>
+            </zeroOrMore>
+          </mixed>
+        </group>
+        <!--
+          multi-line: "mrow" content, not itself a
+          cross-reference target, so no @xml:id, no @label
+        -->
+        <group>
+          <optional>
+            <attribute name="break">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="alignment"/>
+          </optional>
+          <optional>
+            <attribute name="alignat-columns"/>
+          </optional>
           <ref name="MathRow"/>
           <zeroOrMore>
             <choice>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -938,7 +938,7 @@
     <section>
         <title>Mathematics</title>
 
-        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, a multi-row <c>md</c> is not itself a target of cross-references, though its rows can be; a single-line <c>md</c> may carry an <attr>xml:id</attr> and be a cross-reference target.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.</p>
+        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, displayed mathematics, <c>md</c>, comes in two forms.  A single-line <c>md</c> has no <c>mrow</c> children and may carry an <attr>xml:id</attr> to be a cross-reference target; it does not use a <attr>label</attr>.  A multi-row <c>md</c> has <c>mrow</c> children and is not itself a target of cross-references, so takes neither an <attr>xml:id</attr> nor a <attr>label</attr>, though its rows can be targets.  Either form may carry a <attr>number</attr> attribute, defaulting to <q>no</q>; on a multi-row <c>md</c> it applies to each <c>mrow</c> that does not override it.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.</p>
 
         <fragment xml:id="mathematics">
             <title>Mathematics</title>
@@ -968,14 +968,25 @@
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
-                    MetaDataTarget,
+                    # common to both forms; @number defaults to "no"
+                    Component?,
+                    Index*,
                     attribute number {"yes" | "no"}?,
-                    attribute break {"yes" | "no"}?,
-                    attribute alignment {text}?,
-                    attribute alignat-columns {text}?,
                     (
-                    (mixed {(Xref | FillInMath | WWVariable)*}) |
-                    (MathRow, (MathRow | MathIntertext)*)
+                        # single-line: text content, optional @xml:id
+                        # makes it a cross-reference target, no @label
+                        (
+                            UniqueID?,
+                            mixed {(Xref | FillInMath | WWVariable)*}
+                        ) |
+                        # multi-line: "mrow" content, not itself a
+                        # cross-reference target, so no @xml:id, no @label
+                        (
+                            attribute break {"yes" | "no"}?,
+                            attribute alignment {text}?,
+                            attribute alignat-columns {text}?,
+                            MathRow, (MathRow | MathIntertext)*
+                        )
                     )
                 }
             </code>

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -3538,7 +3538,7 @@
   <xs:element name="md">
     <xs:complexType mixed="true">
       <xs:sequence>
-        <xs:group ref="MetaDataTarget"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="idx"/>
         <xs:choice>
           <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element ref="xref"/>
@@ -3554,7 +3554,7 @@
           </xs:sequence>
         </xs:choice>
       </xs:sequence>
-      <xs:attributeGroup ref="MetaDataTarget"/>
+      <xs:attribute name="component"/>
       <xs:attribute name="number">
         <xs:simpleType>
           <xs:restriction base="xs:token">
@@ -3563,6 +3563,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attribute ref="xml:id"/>
       <xs:attribute name="break">
         <xs:simpleType>
           <xs:restriction base="xs:token">


### PR DESCRIPTION
Follow-up to #2857. The consolidated `md` was permissive — `MetaDataTarget` gave every `md` an `@xml:id` and `@label`, and the multi-row attributes applied to single-line math where they do nothing. This tightens the schema to the two forms `md` actually has:

- **Single-line** (no `mrow`): text content; may carry `@xml:id` (cross-reference target); no `@label`; no `@break`/`@alignment`/`@alignat-columns` (those only affect `md[mrow]` in the XSL).
- **Multi-row** (`mrow` children): not itself a cross-reference target, so no `@xml:id` and no `@label`; keeps `@break`/`@alignment`/`@alignat-columns`; its rows remain targetable via `mrow/@xml:id`.

`@number` (default `no`) and `@component`/`idx` stay common to both. `@label` is now removed from `md` entirely. The single-line attribute layout leaves room for a future `md/@tag`.

Narrative in `schema/pretext.xml` updated to describe the two forms. Derived `pretext.rnc`/`.rng`/`.xsd` regenerated from the literate source. `pretext-dev.*` is unchanged (#2857 removed the math dev overlay, so `md` is base-only).

**Testing:** jing on sample-article, sample-book, and the guide — identical error sets before/after (no regressions; the existing single-line `md` with `@xml:id` in the sample article stays valid). Targeted positive/negative documents confirm the new rules reject `@label` on `md`, `@xml:id` on a multi-row `md`, and `@break`/`@alignment` on a single-line `md`, while accepting the valid single-line and multi-row forms.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*
