### PR TITLE
Sample book + Guide: modernize listing markup; add dev coding exercise

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -2279,6 +2279,7 @@
                 <p>To compare the reader's submitted response to the provided correct answer with <tag>mathcmp</tag>, use <attr>use-answer="yes"</attr>. To compare the submitted response to any other object, the <tag>mathcmp</tag> element should have a single evaluated math object as content, which could include a newly generated expression using <tag>de-expression</tag> that is based on the submitted responses. To compare two different math objects, the <tag>mathcmp</tag> should have two math objects. For convenience, there are some implicit representations available as well, illustrated in <xref ref="list-mathcmp-expressions-structure"/>.</p>
 
                 <listing xml:id="list-mathcmp-expressions-structure">
+                    <title>Possible structures for using <tag>mathcmp</tag> within a <tag>test</tag>. The <tag>de-expression</tag> would be replaced by any valid construction as described for the <tag>setup</tag>.</title>
                     <program>
                         <code><![CDATA[
                             <!-- Compare submitted response with fillin answer -->
@@ -2317,7 +2318,6 @@
                         ]]>
                         </code>
                     </program>
-                    <title>Possible structures for using <tag>mathcmp</tag> within a <tag>test</tag>. The <tag>de-expression</tag> would be replaced by any valid construction as described for the <tag>setup</tag>.</title>
                 </listing>
 
                 <p>Compound logical structures are created using the <tag>logic</tag> element in the place of a comparison. To specify which operation is being used, the <attr>op</attr> attribute is set to one of <attr>op="and"</attr>, <attr>op="or"</attr>, or <attr>op="not"</attr>. The operations are considered <m>n</m>-ary, meaning that the contents should be one or more comparison elements, which might include additional logic. The <attr>op="and"</attr> will evaluate as true when <em>all</em> of the children comparisons evaluate as true. The <attr>op="or"</attr> will evaluate as true when <em>at least one</em> of the children comparisons evaluates as true. The <attr>op="not"</attr> is technically implemented as the negation of <attr>op="and"</attr>, and so will evaluate as true when <em>at least one</em> of the children comparisons evaluates as <em>false</em>. In the absence of any <tag>logic</tag>, there is always an implicit <attr>op="and"</attr> so that any sequence of comparisons within a single <tag>test</tag>, all comparisons are required to evaluate as true.</p>

--- a/examples/sample-book/rune-examples/activecode-ambles.xml
+++ b/examples/sample-book/rune-examples/activecode-ambles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <listing>
-    <caption>A Python program with preamble/postamble</caption>
+    <title>A Python program with preamble/postamble</title>
     <program interactive='activecode' language="python" label="program-activecode-python-ambles" include-source="yes">
         <preamble>
         def add(a, b):

--- a/examples/sample-book/rune-examples/static-listing-java.xml
+++ b/examples/sample-book/rune-examples/static-listing-java.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <listing>
-  <caption>A static Java program with highlighted lines</caption>
+  <title>A static Java program with highlighted lines</title>
   <program language="java" line-numbers="yes" highlight-lines="2,6-8" include-source="yes">
       <title>"hi" in Java</title>
       <code>

--- a/examples/sample-book/rune-examples/static-listing-java.xml
+++ b/examples/sample-book/rune-examples/static-listing-java.xml
@@ -3,7 +3,6 @@
 <listing>
   <title>A static Java program with highlighted lines</title>
   <program language="java" line-numbers="yes" highlight-lines="2,6-8" include-source="yes">
-      <title>"hi" in Java</title>
       <code>
       import javax.swing.JFrame;  //Importing class JFrame
       import javax.swing.JLabel;  //Importing class JLabel

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -100,7 +100,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <p>A Java program will only be interactive if hosted on a Runestone server.</p>
 
         <listing xml:id="program-activecode-java">
-            <title>Informal Java <q>Hello, World</q></title>
             <title>A Java program, interactive on a <pubtitle>Runestone</pubtitle> server</title>
             <program xml:id="java-hello-world" interactive='activecode' language="java">
                 <code>

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -103,7 +103,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <title>Informal Java <q>Hello, World</q></title>
             <title>A Java program, interactive on a <pubtitle>Runestone</pubtitle> server</title>
             <program xml:id="java-hello-world" interactive='activecode' language="java">
-                <title>"hi" in Java</title>
                 <code>
                 public class HelloWorld {
                     public static void main(String[] args) {
@@ -270,7 +269,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <listing xml:id="program-activecode-java-flags">
             <title>A Java program, interactive on a <pubtitle>Runestone</pubtitle> server, with compiler and linker flags</title>
             <program xml:id="java-hello-world-flags" interactive='activecode' language="java" compiler-args="-g" linker-args="-s">
-                <title>"hi" in Java</title>
                 <code>
                 import javax.swing.JFrame;  //Importing class JFrame
                 import javax.swing.JLabel;  //Importing class JLabel

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -42,7 +42,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <p>Instead of specifying <attr>language</attr> on each program, a default can be specified at <c>docinfo/programs/@language</c>. That value will be used for any program that lacks a <attr>language</attr> attribute. This sample does not specify it's own <attr>language</attr> and is relying on the default set in this book.</p>
 
         <listing>
-            <caption>Python program, relying on default programs language</caption>
+            <title>Python program, relying on default programs language</title>
             <program line-numbers="yes" include-source="yes">
                 <code>
                 def say_hello():
@@ -228,7 +228,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <p>Here is the same Python program from the previous section, but now with a <tag>preamble</tag> and <tag>postamble</tag> that are invisible.  The user will not see the code that is added to their submission.  Not actually useful in this case, but it might be if you wanted to hide boilerplate setup from the reader.</p>
 
         <listing>
-            <caption>A Python program with invisible pre/post ambles</caption>
+            <title>A Python program with invisible pre/post ambles</title>
             <program interactive='activecode' language="python" label="program-activecode-python-ambles-invisible" include-source="yes">
                 <preamble visible="no">
                 def add(a, b):
@@ -375,11 +375,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>First, we have a <c>.h</c> file that defines an <attr>filename</attr>. It has an <attr>xml:id</attr> so other elements can reference it. It also has an <attr>label</attr> which is it's unique identifier in the Runestone database. (The label is intentionally different than the xml:id for demonstration purposes, but they can be the same.) The <attr>filename</attr> is used to indicate what to name to use when the contents of the element are written to a file on the server - other program code and/or tools on the server can look for it using this name. The <attr>filename</attr> need not be unique<mdash/>we could have multiple programs with <attr>filename="add.h"</attr>. As we will see below, the author specifies which <q>version</q> of a file should be used in any given location with its unique xml:id.</p>
 
-        <p>The <tag>program</tag> is inside of a <tag>listing</tag> so that we have a place to add a caption and so that we can reference the code sample, including that caption, with an <tag>xref</tag> from elsewhere. Note that the <tag>listing</tag> has both a <tag>caption</tag> and a <tag>title</tag>. The <tag>caption</tag> will be rendered with the program. The <tag>title</tag> will not appear locally. It will be used if an <tag>xref</tag> links to the <tag>listing</tag> using <attr>text="title"</attr></p>
+        <p>The <tag>program</tag> is inside of a <tag>listing</tag> so that we have a place to add a title and so that we can reference the code sample, including that title, with an <tag>xref</tag> from elsewhere. The <tag>title</tag> of the <tag>listing</tag> is rendered with the program. It is also used if an <tag>xref</tag> links to the <tag>listing</tag> using <attr>text="title"</attr>.</p>
 
         <listing xml:id="addh-v1-listing">
-            <title>add.h (version 1)</title>
-            <caption>add.h (version 1) - A very simple header file that lacks header guards.</caption>
+            <title>add.h (version 1) - A very simple header file that lacks header guards.</title>
             <program filename="add.h" xml:id="addh-v1" label="addh-v1-label" language="cpp" include-source="yes">
                 int add(int a, int b);
             </program>

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -473,6 +473,14 @@
                 }
             BlockStatement |= Query
 
+            # Coding exercise: an interactive program (typically
+            # activecode) whose "tests" hold unit tests
+            CodingExercise =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                Program,
+                Hint*, Answer*, Solution*
             # Include all exercise types in exercise and activity
             Exercise |=
                 element exercise {
@@ -485,7 +493,8 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
-                    Areas
+                    Areas |
+                    CodingExercise
                     )
                 }
             # STACK assessment exercise type

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1135,6 +1135,27 @@
   <define name="BlockStatement" combine="choice">
     <ref name="Query"/>
   </define>
+  <!--
+    Coding exercise: an interactive program (typically
+    activecode) whose "tests" hold unit tests
+  -->
+  <define name="CodingExercise">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <ref name="StatementExercise"/>
+    <ref name="Program"/>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
+  </define>
   <!-- Include all exercise types in exercise and activity -->
   <define name="Exercise" combine="choice">
     <element name="exercise">
@@ -1150,6 +1171,7 @@
         <ref name="FreeResponse"/>
         <ref name="FillInBlank"/>
         <ref name="Areas"/>
+        <ref name="CodingExercise"/>
       </choice>
     </element>
   </define>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2557,6 +2557,14 @@
                 }
             BlockStatement |= Query
 
+            # Coding exercise: an interactive program (typically
+            # activecode) whose "tests" hold unit tests
+            CodingExercise =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                Program,
+                Hint*, Answer*, Solution*
             # Include all exercise types in exercise and activity
             Exercise |=
                 element exercise {
@@ -2569,7 +2577,8 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
-                    Areas
+                    Areas |
+                    CodingExercise
                     )
                 }
             # STACK assessment exercise type


### PR DESCRIPTION
Cleans up deprecated/invalid listing markup that the Guide surfaced (it `xi:include`s sample-book examples), and adds the dev-overlay schema for the documented coding exercise. Validation target is `pretext-dev.rng` (the Guide documents experimental Runestone features).

**Sample book — source:**
- `Sample book: use listing title in place of deprecated caption` — 5 `listing/caption` → `title` (deprecated 2024-11-19); updates the `rune.xml` prose that taught the old caption/title split.
- `Sample book: remove unsupported title from program` — `program` has no `title`.
- `Sample book: remove duplicate listing title` — a `listing` had two `title`s.

**Guide — source:**
- `Guide: order listing title before program in mathcmp example` — `title` must precede `program` in a `listing`.

**Schema — dev overlay only:**
- `Schema: add coding exercise to dev overlay` — new dev-only `CodingExercise` (`statement`, a `program` with `tests`, optional `hint`/`answer`/`solution`), so the Guide's documented unit-tested coding-exercise example is schema-valid. `pretext-dev.*` only; base `pretext.rnc`/`.rng`/`.xsd` untouched.

**Testing (jing vs `pretext-dev.rng`):** Guide 12 → 3. sample-article 207 → 207 (no regression). sample-book 339 → 312 (no new error kinds). sample-book and Guide assembly builds clean, no deprecation warnings.

**Known / deferred:** the 3 remaining Guide errors are `@include-source` on `program` (×2) and `exercise` (×1). Allowing `include-source` there is intentionally **not** in this PR — to be settled in a separate developer discussion. (`datafile/@include-source` already lives in the dev overlay and is unchanged.)

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*
