### PR TITLE
Schema: allow paragraphs within worksheet and page

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -420,7 +420,7 @@
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | PrintoutExercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment |
-                PrintoutSideBySide
+                PrintoutSideBySide | Paragraphs
 
             # Allow exercise in sidebyside
             PrintoutSideBySide =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1210,6 +1210,7 @@
       <ref name="ListGenerator"/>
       <ref name="Fragment"/>
       <ref name="PrintoutSideBySide"/>
+      <ref name="Paragraphs"/>
     </choice>
   </define>
   <!-- Allow exercise in sidebyside -->

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -426,7 +426,7 @@
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | PrintoutExercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment |
-                PrintoutSideBySide
+                PrintoutSideBySide | Paragraphs
 
             # Allow exercise in sidebyside
             PrintoutSideBySide =

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -983,6 +983,7 @@
       <xs:element ref="list-of"/>
       <xs:element ref="fragment"/>
       <xs:group ref="PrintoutSideBySide"/>
+      <xs:group ref="Paragraphs"/>
     </xs:choice>
   </xs:group>
   <!-- Allow exercise in sidebyside -->


### PR DESCRIPTION
Closes #2858. Adds the existing `paragraphs` element to `PrintoutBlock`, the content model shared by `page` children, a pageless `worksheet`, and `handout`. So `paragraphs` is allowable as a child of `page`, or — when there are no `page`s — directly in a `worksheet`, entirely similar to its use in ordinary divisions. Fully implemented in the processing layer already (per Oscar).

Literate `schema/pretext.xml` plus regenerated `pretext.rnc`/`.rng`/`.xsd`. `pretext-dev.*` is unchanged (it includes the base schema by reference).

**Testing (jing):** sample-article already used `paragraphs` inside worksheets, so no source change was needed. Validation goes 307 → 303 — resolving 3 pre-existing `paragraphs not allowed in worksheet` errors and 1 dependent cascade, with no new error kinds (subject-level comparison confirms zero regressions). Worksheet subtree builds to PDF cleanly.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*
