### PR TITLE
Preview: thread heading level for interactive standalone pages

### DIFF
--- a/xsl/extract-interactive.xsl
+++ b/xsl/extract-interactive.xsl
@@ -63,9 +63,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="visible-id" />
     <xsl:text>&#xa;</xsl:text>
     <!-- (2) Identical content, but now isolated on a reader-friendly page -->
+    <!-- The standalone page has its own masthead h1, so headings inside   -->
+    <!-- start fresh at h2.  Mirrors the standalone-page invocation in     -->
+    <!-- the "interactive" template of pretext-html.xsl.                   -->
     <xsl:apply-templates select="." mode="standalone-page" >
         <xsl:with-param name="content">
-            <xsl:apply-templates select="." mode="interactive-core" />
+            <xsl:apply-templates select="." mode="interactive-core">
+                <xsl:with-param name="is-standalone" select="true()"/>
+                <xsl:with-param name="heading-level" select="2"/>
+            </xsl:apply-templates>
         </xsl:with-param>
     </xsl:apply-templates>
     <!-- (3) A simple page that can be used in an iframe construction -->


### PR DESCRIPTION
The `preview` component reuses `interactive-core` (via `extract-interactive.xsl`) to build the standalone HTML page for each `<interactive>`, but the call omitted the parameters that the parallel invocation in `pretext-html.xsl` supplies. As a result:

1. **Primary bug.** `$heading-level` was never initialized, so an `<interactive>` containing `<instructions>` triggered the `PTX:BUG: "hN" template reached without a $heading-level parameter` diagnostic from `pretext-html.xsl`. The heading defaulted to `h2` — coincidentally correct here, but only because the standalone page's masthead `h1` already implies `h2` next.

2. **Secondary bug, same omission.** `$is-standalone` defaulted to `false()`, so the standalone page erroneously included an "open in new tab" link to itself.

Fix: thread `heading-level="2"` and `is-standalone="true()"` through the `interactive-core` call, mirroring `pretext-html.xsl:10007-10010`.

Reproducer: any document with `<interactive>...<instructions>...</instructions></interactive>` built with `-c preview`. Tested against a minimal article and verified the `PTX:BUG` message no longer fires and the redundant opener link is gone.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*