### PR TITLE
Support @tag on a bare "md"

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1467,6 +1467,8 @@
             <title>One-Line Display Mathematics</title>
 
             <p>The <tag>md</tag> element can be used for longer expressions or a single equation.  Typically you will get vertical separation above and below, and the contents will be centered.  See below about concluding periods (and other punctuation), and alignment.  To number the expression, use the <attr>number</attr> attribute with the value set to <c>yes</c>.  And once numbered, the expression can be the target of a cross-reference (<tag>xref</tag>), if you also add a <attr>xml:id</attr> attribute.</p>
+
+            <p>A symbolic local tag may instead be requested with the <attr>tag</attr> attribute, using the same set of symbol names as on an <tag>mrow</tag>; see <xref ref="topic-display-math"/>.  Since a tag stands in for a number, the <attr>tag</attr> and <attr>number</attr> attributes are mutually exclusive on a one-line <tag>md</tag>.</p>
         </subsection>
 
         <subsection xml:id="topic-display-math">

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2325,7 +2325,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <p>If you are not writing a research monograph, maybe (a) you will not use many numbered equations, or do not like the looks of them, or feel they scare your readers, and (b) maybe your cross-references are always local-ish, like strictly within an <tag>example</tag> or a <tag>proof</tag>.  For this situation you can create, and employ, a <q>local</q> tag on a displayed equation.  Nothing enforces the idea of what constitutes local, and there is nothing to stop you from using the same symbols more than once.  With freedom comes responsibility.</p>
 
-                <p>Use the <attr>tag</attr> attribute on an <tag>mrow</tag>, only.  (Remember, you can have just one <tag>mrow</tag>.)  The value of the <attr>tag</attr> attribute is a symbol name.  The prefix <c>d</c> means <q>double</q>, and the prefix <c>t</c> means <q>triple</q>.  So allowed values are<cd>
+                <p>Use the <attr>tag</attr> attribute on an <tag>mrow</tag>, or directly on a single-line <tag>md</tag> (one with no <tag>mrow</tag> children).  The value of the <attr>tag</attr> attribute is a symbol name.  The prefix <c>d</c> means <q>double</q>, and the prefix <c>t</c> means <q>triple</q>.  So allowed values are<cd>
                     <cline>star, dstar, tstar</cline>
                     <cline>dagger, ddagger, tdagger</cline>
                     <cline>daggerdbl, ddaggerdbl, tdaggerdbl</cline>
@@ -2339,6 +2339,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <mrow xml:id="equation-local-maltese"   tag="dmaltese">c^2 \amp = a^2+b^2</mrow>
                     <mrow>z^2 \amp = x^2+y^2</mrow>
                 </md>Here are the local cross-references: <xref ref="equation-local-star"/>, <xref ref="equation-local-dagger"/>, <xref ref="equation-local-daggerdbl"/>, <xref ref="equation-local-hash"/>, <xref ref="equation-local-maltese"/>.  We test another farther away in <xref ref="section-cross-referencing" text="type-global"/>, contrary to our advice above.</p>
+
+                <p>When there is nothing to align, the <attr>tag</attr> attribute may live directly on a single-line <tag>md</tag>: <md xml:id="equation-tag-on-md" tag="star">c^2 = a^2 + b^2</md>.  This is equivalent to placing the content in a single <tag>mrow</tag> child carrying the <attr>tag</attr>.  A cross-reference to this equation looks like <xref ref="equation-tag-on-md"/>.  Note that <attr>tag</attr> and <attr>number</attr> are mutually exclusive on a single-line <tag>md</tag>.</p>
             </subsection>
 
             <subsection xml:id="commutative-diagrams">

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1637,16 +1637,17 @@
                 element m {
                     mixed {(FillInMath | WWVariable)*}
                 }
+            TagSymbol = "star" | "dstar" | "tstar" |
+                        "dagger" | "ddagger" | "tdagger" |
+                        "daggerdbl" | "ddaggerdbl" | "tdaggerdbl" |
+                        "hash" | "dhash" | "thash" |
+                        "maltese" | "dmaltese" | "tmaltese"
             MathRow =
                 element mrow {
                     MetaDataTarget,
                     (
                         attribute number {"yes" | "no"} |
-                        attribute tag {"star" | "dstar" | "tstar" |
-                                       "dagger" | "ddagger" | "tdagger" |
-                                       "daggerdbl" | "ddaggerdbl" | "tdaggerdbl" |
-                                       "hash" | "dhash" | "thash" |
-                                       "maltese" | "dmaltese" | "tmaltese" }
+                        attribute tag { TagSymbol }
                     )?,
                     attribute break {"yes" | "no"}?,
                     mixed {(Xref | FillInMath | WWVariable)*}
@@ -1654,20 +1655,27 @@
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
-                    # common to both forms; @number defaults to "no"
+                    # common to both forms
                     Component?,
                     Index*,
-                    attribute number {"yes" | "no"}?,
                     (
                         # single-line: text content, optional @xml:id
-                        # makes it a cross-reference target, no @label
+                        # makes it a cross-reference target, no @label;
+                        # @number and @tag are mutually exclusive,
+                        # @number defaults to "no"
                         (
                             UniqueID?,
+                            (
+                                attribute number {"yes" | "no"} |
+                                attribute tag { TagSymbol }
+                            )?,
                             mixed {(Xref | FillInMath | WWVariable)*}
                         ) |
                         # multi-line: "mrow" content, not itself a
-                        # cross-reference target, so no @xml:id, no @label
+                        # cross-reference target, so no @xml:id, no @label;
+                        # @number defaults to "no" and applies to each "mrow"
                         (
+                            attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
                             attribute alignment {text}?,
                             attribute alignat-columns {text}?,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4144,6 +4144,25 @@
       </mixed>
     </element>
   </define>
+  <define name="TagSymbol">
+    <choice>
+      <value>star</value>
+      <value>dstar</value>
+      <value>tstar</value>
+      <value>dagger</value>
+      <value>ddagger</value>
+      <value>tdagger</value>
+      <value>daggerdbl</value>
+      <value>ddaggerdbl</value>
+      <value>tdaggerdbl</value>
+      <value>hash</value>
+      <value>dhash</value>
+      <value>thash</value>
+      <value>maltese</value>
+      <value>dmaltese</value>
+      <value>tmaltese</value>
+    </choice>
+  </define>
   <define name="MathRow">
     <element name="mrow">
       <ref name="MetaDataTarget"/>
@@ -4156,23 +4175,7 @@
             </choice>
           </attribute>
           <attribute name="tag">
-            <choice>
-              <value>star</value>
-              <value>dstar</value>
-              <value>tstar</value>
-              <value>dagger</value>
-              <value>ddagger</value>
-              <value>tdagger</value>
-              <value>daggerdbl</value>
-              <value>ddaggerdbl</value>
-              <value>tdaggerdbl</value>
-              <value>hash</value>
-              <value>dhash</value>
-              <value>thash</value>
-              <value>maltese</value>
-              <value>dmaltese</value>
-              <value>tmaltese</value>
-            </choice>
+            <ref name="TagSymbol"/>
           </attribute>
         </choice>
       </optional>
@@ -4203,28 +4206,35 @@
   <define name="MathDisplay">
     <element name="md">
       <optional>
-        <!-- common to both forms; @number defaults to "no" -->
+        <!-- common to both forms -->
         <ref name="Component"/>
       </optional>
       <zeroOrMore>
         <ref name="Index"/>
       </zeroOrMore>
-      <optional>
-        <attribute name="number">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
       <choice>
         <!--
           single-line: text content, optional @xml:id
-          makes it a cross-reference target, no @label
+          makes it a cross-reference target, no @label;
+          @number and @tag are mutually exclusive,
+          @number defaults to "no"
         -->
         <group>
           <optional>
             <ref name="UniqueID"/>
+          </optional>
+          <optional>
+            <choice>
+              <attribute name="number">
+                <choice>
+                  <value>yes</value>
+                  <value>no</value>
+                </choice>
+              </attribute>
+              <attribute name="tag">
+                <ref name="TagSymbol"/>
+              </attribute>
+            </choice>
           </optional>
           <mixed>
             <zeroOrMore>
@@ -4238,9 +4248,18 @@
         </group>
         <!--
           multi-line: "mrow" content, not itself a
-          cross-reference target, so no @xml:id, no @label
+          cross-reference target, so no @xml:id, no @label;
+          @number defaults to "no" and applies to each "mrow"
         -->
         <group>
+          <optional>
+            <attribute name="number">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
           <optional>
             <attribute name="break">
               <choice>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -938,7 +938,7 @@
     <section>
         <title>Mathematics</title>
 
-        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, displayed mathematics, <c>md</c>, comes in two forms.  A single-line <c>md</c> has no <c>mrow</c> children and may carry an <attr>xml:id</attr> to be a cross-reference target; it does not use a <attr>label</attr>.  A multi-row <c>md</c> has <c>mrow</c> children and is not itself a target of cross-references, so takes neither an <attr>xml:id</attr> nor a <attr>label</attr>, though its rows can be targets.  Either form may carry a <attr>number</attr> attribute, defaulting to <q>no</q>; on a multi-row <c>md</c> it applies to each <c>mrow</c> that does not override it.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.</p>
+        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, displayed mathematics, <c>md</c>, comes in two forms.  A single-line <c>md</c> has no <c>mrow</c> children and may carry an <attr>xml:id</attr> to be a cross-reference target; it does not use a <attr>label</attr>.  A multi-row <c>md</c> has <c>mrow</c> children and is not itself a target of cross-references, so takes neither an <attr>xml:id</attr> nor a <attr>label</attr>, though its rows can be targets.  Either form may carry a <attr>number</attr> attribute, defaulting to <q>no</q>; on a multi-row <c>md</c> it applies to each <c>mrow</c> that does not override it.  A single-line <c>md</c> may carry a <attr>tag</attr> attribute as an alternative to <attr>number</attr>, supplying a symbolic local tag in place of a number; the two attributes are mutually exclusive.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.</p>
 
         <fragment xml:id="mathematics">
             <title>Mathematics</title>
@@ -951,16 +951,17 @@
                 element m {
                     mixed {(FillInMath | WWVariable)*}
                 }
+            TagSymbol = "star" | "dstar" | "tstar" |
+                        "dagger" | "ddagger" | "tdagger" |
+                        "daggerdbl" | "ddaggerdbl" | "tdaggerdbl" |
+                        "hash" | "dhash" | "thash" |
+                        "maltese" | "dmaltese" | "tmaltese"
             MathRow =
                 element mrow {
                     MetaDataTarget,
                     (
                         attribute number {"yes" | "no"} |
-                        attribute tag {"star" | "dstar" | "tstar" |
-                                       "dagger" | "ddagger" | "tdagger" |
-                                       "daggerdbl" | "ddaggerdbl" | "tdaggerdbl" |
-                                       "hash" | "dhash" | "thash" |
-                                       "maltese" | "dmaltese" | "tmaltese" }
+                        attribute tag { TagSymbol }
                     )?,
                     attribute break {"yes" | "no"}?,
                     mixed {(Xref | FillInMath | WWVariable)*}
@@ -968,20 +969,27 @@
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
-                    # common to both forms; @number defaults to "no"
+                    # common to both forms
                     Component?,
                     Index*,
-                    attribute number {"yes" | "no"}?,
                     (
                         # single-line: text content, optional @xml:id
-                        # makes it a cross-reference target, no @label
+                        # makes it a cross-reference target, no @label;
+                        # @number and @tag are mutually exclusive,
+                        # @number defaults to "no"
                         (
                             UniqueID?,
+                            (
+                                attribute number {"yes" | "no"} |
+                                attribute tag { TagSymbol }
+                            )?,
                             mixed {(Xref | FillInMath | WWVariable)*}
                         ) |
                         # multi-line: "mrow" content, not itself a
-                        # cross-reference target, so no @xml:id, no @label
+                        # cross-reference target, so no @xml:id, no @label;
+                        # @number defaults to "no" and applies to each "mrow"
                         (
+                            attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
                             attribute alignment {text}?,
                             attribute alignat-columns {text}?,

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1941,17 +1941,26 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Replace bare "md" by "md" with one "mrow"          -->
 <!--   - @xml:id will live on the "md" (new)            -->
 <!--   - md/@number  respected first                    -->
+<!--   - md/@tag  transferred to the manufactured       -->
+<!--       "mrow", where downstream processing expects  -->
+<!--       it; @tag and @number are mutually exclusive  -->
 <!--   - @pi:authored-one-line as empty sentinel, to    -->
 <!--       distinguish from an *authored* single "mrow" -->
 <xsl:template match="md[not(mrow)]" mode="repair">
     <xsl:copy>
-        <xsl:apply-templates select="@*" mode="repair"/>
+        <xsl:apply-templates select="@*[not(local-name(.) = 'tag')]" mode="repair"/>
         <!-- note origin as single-line display math -->
         <xsl:attribute name="pi:authored-one-line"/>
         <!-- manufacture an "mrow" to hold content -->
         <xsl:element name="mrow">
+            <!-- a @tag on the bare "md" is transferred to the "mrow" -->
+            <xsl:copy-of select="@tag"/>
             <xsl:attribute name="pi:numbered">
                 <xsl:choose>
+                    <!-- a local @tag precludes a number -->
+                    <xsl:when test="@tag">
+                        <xsl:text>no</xsl:text>
+                    </xsl:when>
                     <!-- possibly authored with @number -->
                     <xsl:when test="@number = 'yes'">
                         <xsl:text>yes</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8376,6 +8376,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="@tag" mode="tag-symbol" />
 </xsl:template>
 
+<!-- Same for a bare "md" whose manufactured "mrow" carries a @tag -->
+<xsl:template match="md[@pi:authored-one-line and mrow/@tag]" mode="xref-number">
+    <xsl:apply-templates select="mrow/@tag" mode="tag-symbol" />
+</xsl:template>
+
 <!-- The second abstract template, we condition   -->
 <!-- on if the link is rendered as a knowl or not -->
 <!-- and then condition on the location of the    -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -7453,9 +7453,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="label" />
 </xsl:template>
 
-<!-- When tagging the manufactured "mrow" of a bare "md" we -->
-<!-- get the identification from the containing parent "md" -->
+<!-- When tagging the manufactured "mrow" of a bare "md" we  -->
+<!-- get the identification from the containing parent "md"; -->
+<!-- a @tag transferred from the bare "md" still emits the   -->
+<!-- symbol via the usual \tag{} mechanism                   -->
 <xsl:template match="mrow[parent::md/@pi:authored-one-line]" mode="tag">
+    <xsl:if test="@tag">
+        <xsl:text>\tag{</xsl:text>
+        <xsl:apply-templates select="@tag" mode="tag-symbol" />
+        <xsl:text>}</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="parent::md" mode="label" />
 </xsl:template>
 

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -10751,6 +10751,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}}</xsl:text>
 </xsl:template>
 
+<!-- Same for a bare "md" whose manufactured "mrow" carries a @tag; -->
+<!-- the \label{} lives on the "md", so \ref{} resolves to its \tag -->
+<xsl:template match="md[@pi:authored-one-line and mrow/@tag]" mode="xref-number">
+    <xsl:text>{\xreffont\ref{</xsl:text>
+    <xsl:apply-templates select="." mode="unique-id" />
+    <xsl:text>}}</xsl:text>
+</xsl:template>
+
 <!-- These exceptions are unnumbered, and are just handled explicitly, -->
 <!-- along with a check, the template produces *nothing*               -->
 <xsl:template match="p|paragraphs|blockquote|contributor|colophon|book|article" mode="xref-number">


### PR DESCRIPTION
A single-line `"md"` (one with no `"mrow"` children) may now carry a `@tag` attribute as an alternative to `@number`, supplying a symbolic local tag in place of a number.  The assembly repair pass transfers the attribute to the manufactured `"mrow"`, and small LaTeX and HTML adjustments ensure both the display and the cross-reference text render the symbol.  `@tag` and `@number` are mutually exclusive on a single-line `"md"`.

Commits, in order:

- `Assembly:` transfer `@tag` from a bare `"md"` to the manufactured `"mrow"`
- `LaTeX:` emit `\tag{}` for a `@tag` transferred to a manufactured `"mrow"`
- `LaTeX:` cross-reference to a tagged bare `"md"` renders the symbol
- `HTML:` cross-reference to a tagged bare `"md"` renders the symbol
- `Schema:` allow `@tag` on a bare `"md"`, mutually exclusive with `@number` (also factors a shared `TagSymbol` pattern out of the duplicated enumeration in `MathRow` and `MathDisplay`)
- `Sample article:` demonstrate `@tag` on a single-line `"md"` (with a cross-reference)
- `Guide:` document `@tag` on a one-line `"md"`

Verified by a before/after sample-article build (HTML + LaTeX); all diff content is the new example, the deliberate prose update, mechanical paragraph-id renumbering from inserting the new paragraph, or build timestamps.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*