### PR TITLE
XSL: provide enhansed source that includes assembly-id

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5011,6 +5011,8 @@ def assembly(xml, pub_file, stringparams, out_file, dest_dir, method):
         stringparams["debug.assembly.exercise"] = method
     elif method == "version":
         stringparams["assembly.version-only"] = "yes"
+    elif method == "assembly-id":
+        stringparams["assembly.assembly-id-only"] = "yes"
     else:
         log.error("assembly method {} not recognized".format(method))
     # "extra_xsl" would be silly in this context (?)
@@ -5044,6 +5046,8 @@ def assembly_internal(xml, pub_file, stringparams, method):
         stringparams["debug.assembly.exercise"] = method
     elif method == "version":
         stringparams["assembly.version-only"] = "yes"
+    elif method == "assembly-id":
+        stringparams["assembly.assembly-id-only"] = "yes"
     else:
         log.error("assembly method {} not recognized".format(method))
     # use the right xsl template

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -149,17 +149,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="exercise-style" select="'static'"/>
 
 <!-- Short-Circuit -->
-<!-- Sometimes we only want to convert to a "version" (valid PreTeXt) via -->
-<!-- the resolution of version support and customizations.  Examples are  -->
-<!-- determining publisher variables (for generating something like LaTeX -->
-<!-- images, when we do not process the whole source) or performiong      -->
-<!-- validation.  We control this with an internal variable, which is not -->
-<!-- documented as an author or publisher feature.  When we select only   -->
-<!-- the production of the "version" tree, the choice of "exercise-style" -->
-<!-- is irrelevant.                                                       -->
+<!-- Sometimes we only want to stop at an intermediate tree.  For example, -->
+<!-- we may convert only to a "version" (valid PreTeXt) via resolution of  -->
+<!-- version support and customizations, or stop at the tree that has       -->
+<!-- @assembly-id attributes but has not yet loaded exercise components.    -->
+<!-- We control this with internal variables, not documented as author or   -->
+<!-- publisher features.  When we stop this early, "exercise-style" is      -->
+<!-- irrelevant.                                                             -->
 
 <!-- default is empty, so we ccan detect non-use -->
 <xsl:param name="assembly.version-only" select="''"/>
+<xsl:param name="assembly.assembly-id-only" select="''"/>
 
 <!-- Set to 'yes' to enable diagnostic checks, such as   -->
 <!-- verifying coherence of @assembly-id and @unique-id. -->
@@ -185,6 +185,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 <xsl:variable name="b-version-only" select="$version-only = 'yes'"/>
+
+<!-- convert to a boolean, with error-checking -->
+<xsl:variable name="assembly-id-only">
+    <xsl:choose>
+        <xsl:when test="$assembly.assembly-id-only = ''">
+            <xsl:text>no</xsl:text>
+        </xsl:when>
+        <xsl:when test="$assembly.assembly-id-only = 'yes'">
+            <xsl:text>yes</xsl:text>
+        </xsl:when>
+        <xsl:when test="$assembly.assembly-id-only = 'no'">
+            <xsl:text>no</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:BUG:  the internal parameter  assembly.assembly-id-only  received an unrecognized value of "<xsl:value-of select="$assembly.assembly-id-only"/>" (possible values are "yes" and "no")</xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="b-assembly-id-only" select="$assembly-id-only = 'yes'"/>
 
 <!-- ################################################ -->
 <!-- Controlling Two-Pass Extraction and Substitution -->
@@ -506,7 +525,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="assembly-label" select="exsl:node-set($assembly-label-rtf)"/>
 
 <xsl:variable name="representations-rtf">
-    <xsl:apply-templates select="$assembly-label" mode="representations"/>
+    <xsl:choose>
+        <!-- short-circuit to stop after adding @assembly-id -->
+        <xsl:when test="$b-assembly-id-only"/>
+        <xsl:otherwise>
+            <xsl:apply-templates select="$assembly-label" mode="representations"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:variable>
 <xsl:variable name="representations" select="exsl:node-set($representations-rtf)"/>
 

--- a/xsl/utilities/pretext-enhanced-source.xsl
+++ b/xsl/utilities/pretext-enhanced-source.xsl
@@ -94,6 +94,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-version-only">
             <xsl:apply-templates select="$version" mode="showme"/>
         </xsl:when>
+        <xsl:when test="$b-assembly-id-only">
+            <xsl:apply-templates select="$assembly-label" mode="showme"/>
+        </xsl:when>
         <xsl:otherwise>
             <xsl:apply-templates select="$root" mode="showme"/>
         </xsl:otherwise>


### PR DESCRIPTION
To check whether all webwork representation files have been build, the CLI needs access to the `@assembly-id` of webwork elements.  These are in the assembled source, but not the "version" variant (that's too soon) and we cannot use the other representations since they embed the exercise representations that might not exist.  

This PR exposes a new version of "enhanced source" that includes the assembly-ids, but quits before loading the representations.

Adds this as an option to the assembly routines in python.