### PR TITLE
Deprecate the "@include-source" attribute

### DIFF
--- a/examples/sample-book/rune-examples/activecode-ambles.xml
+++ b/examples/sample-book/rune-examples/activecode-ambles.xml
@@ -2,7 +2,7 @@
 
 <listing>
     <title>A Python program with preamble/postamble</title>
-    <program interactive='activecode' language="python" label="program-activecode-python-ambles" include-source="yes">
+    <program interactive='activecode' language="python" label="program-activecode-python-ambles">
         <preamble>
         def add(a, b):
         </preamble>

--- a/examples/sample-book/rune-examples/activecode-unittest.xml
+++ b/examples/sample-book/rune-examples/activecode-unittest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<exercise xml:id="unit-test-example" label="coding-exercise-python-unit-test" include-source="yes">
+<exercise xml:id="unit-test-example" label="coding-exercise-python-unit-test">
   <title>Coding Exercise, with Unit Tests</title>
 
   <statement>

--- a/examples/sample-book/rune-examples/static-listing-java.xml
+++ b/examples/sample-book/rune-examples/static-listing-java.xml
@@ -2,7 +2,7 @@
 
 <listing>
   <title>A static Java program with highlighted lines</title>
-  <program language="java" line-numbers="yes" highlight-lines="2,6-8" include-source="yes">
+  <program language="java" line-numbers="yes" highlight-lines="2,6-8">
       <code>
       import javax.swing.JFrame;  //Importing class JFrame
       import javax.swing.JLabel;  //Importing class JLabel

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -43,7 +43,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing>
             <title>Python program, relying on default programs language</title>
-            <program line-numbers="yes" include-source="yes">
+            <program line-numbers="yes">
                 <code>
                 def say_hello():
                     print("Hello, World!")
@@ -128,7 +128,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <listing>
             <title>A C++ program with compiler-args and stdin</title>
             <p>It may be convenient to set <attr>compiler-args</attr> and <attr>linker-args</attr> at the book level in <tag>docinfo/programs</tag>. Values specified in that location will be used for any <tag>program</tag> that does not override the values by specifying its own attributes.</p>
-            <program interactive="activecode" label="hello-world-cpp" language="cpp" compiler-args="-std=c++17,-Wall,-g" linker-args="-g,-s" include-source="yes">
+            <program interactive="activecode" label="hello-world-cpp" language="cpp" compiler-args="-std=c++17,-Wall,-g" linker-args="-g,-s">
                 <code>
                     #include &lt;iostream&gt;
                     #include &lt;string&gt;
@@ -169,7 +169,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-octave">
             <title>A simple Octave program</title>
-            <program xml:id="octave-simple" interactive='activecode' language="octave" include-source="yes">
+            <program xml:id="octave-simple" interactive='activecode' language="octave">
                 <code>
                 x = 2 + 2
                 printf("%d\n", x)
@@ -181,7 +181,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-kotlin">
             <title>A simple Kotlin program</title>
-            <program xml:id="kotlin-hello-world" interactive='activecode' language="kotlin" include-source="yes">
+            <program xml:id="kotlin-hello-world" interactive='activecode' language="kotlin">
                 <code>
                 fun main() {
                     println("Hello, world!!")
@@ -194,7 +194,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-mistake-pascal">
             <title>A Pascal program that cannot be interactive on Runestone</title>
-            <program xml:id="pascal-mistake" interactive='activecode' language="pascal" include-source="yes">
+            <program xml:id="pascal-mistake" interactive='activecode' language="pascal">
                 <code>
                 program HelloWorld;
                 begin
@@ -206,7 +206,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>The <attr>highlight-lines</attr> works on ActiveCode programs, but the highlighted lines are only shown when viewing the initial code. Any version of the code that the reader has edited may have shifted lines of code and thus highlighting might affect the wrong lines, causing confusion.</p>
 
-        <program interactive='activecode' language="python" label="program-activecode-highlights" highlight-lines="1-2,5" include-source="yes">
+        <program interactive='activecode' language="python" label="program-activecode-highlights" highlight-lines="1-2,5">
             def add(a, b):
                 return a + b
 
@@ -227,7 +227,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing>
             <title>A Python program with invisible pre/post ambles</title>
-            <program interactive='activecode' language="python" label="program-activecode-python-ambles-invisible" include-source="yes">
+            <program interactive='activecode' language="python" label="program-activecode-python-ambles-invisible">
                 <preamble visible="no">
                 def add(a, b):
                 </preamble>
@@ -250,7 +250,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="listing-python-included">
             <title>A Python program that defines some statistics</title>
-            <program xml:id="python-statistics" interactive='activecode' label="statistics" include-source="yes">
+            <program xml:id="python-statistics" interactive='activecode' label="statistics">
                 <code>
                 loan_amount = [1250.0, 500.0, 1450.0, 200.0, 700.0, 100.0, 250.0, 225.0, 1200.0, 150.0, 600.0, 300.0, 700.0, 125.0, 650.0, 175.0, 1800.0, 1525.0, 575.0, 700.0, 1450.0, 400.0, 200.0, 1000.0, 350.0]
 
@@ -291,7 +291,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>This program also makes use of <attr>autorun</attr> to execute on page load and the <attr>codelens</attr>to disable the codelens feature.</p>
 
-        <exercise xml:id="exercise-python-including" include-source="yes">
+        <exercise xml:id="exercise-python-including">
             <title>A Python program, including another</title>
             <statement>
                 <p>Compute the total amount of money loaned and store it in the variable <c>loan_total</c>.</p>
@@ -322,7 +322,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>This program also makes use of <attr>hidecode</attr> to initially keep the code hidden and <attr>download</attr> to enable a file download of the program (that includes all the included code).</p>
 
-        <exercise xml:id="exercise-python-including-two" include-source="yes">
+        <exercise xml:id="exercise-python-including-two">
             <title>A Python program, including two others</title>
             <statement>
                 <p>Compute the total amount of money loaned and store it in the variable <c>loan_total</c>.</p>
@@ -351,7 +351,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>Here is an activecode with <attr>language</attr> set to <c>sql</c> uses the <attr>database</attr> to load a SQLite database file.</p>
 
-        <exercise xml:id="exercise-sql-using-db" include-source="yes">
+        <exercise xml:id="exercise-sql-using-db">
             <title>An SQL program that uses an SQLite database file</title>
             <statement>
                 <p>Select all the columns of all the rows in the <c>test</c> database table.</p>
@@ -376,7 +376,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="addh-v1-listing">
             <title>add.h (version 1) - A very simple header file that lacks header guards.</title>
-            <program filename="add.h" xml:id="addh-v1" label="addh-v1-label" language="cpp" include-source="yes">
+            <program filename="add.h" xml:id="addh-v1" label="addh-v1-label" language="cpp">
                 int add(int a, int b);
             </program>
         </listing>
@@ -389,7 +389,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <statement>
                 <p>You can leave this code as is or modify it. When you click <q>Run</q>, the code will be compiled. However, it will not be run as this is not a standalone program. To run it, use the full program below.</p>
             </statement>
-            <program filename="add.cpp" xml:id="addcpp-v1" extra-compiler-args="-c" interactive="activecode" language="cpp" include-source="yes">
+            <program filename="add.cpp" xml:id="addcpp-v1" extra-compiler-args="-c" interactive="activecode" language="cpp">
                 int add(int a, int b) {
                     return a + b;
                 }
@@ -398,7 +398,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>Finally, the core program. <attr>add-files</attr> is used to specify (by xml:id) the files that need to be added to the program directory. <attr>compile-also</attr> specifies files that must be compiled with this source file (they will be assumed to be also part of <attr>add-files</attr>). Notice that when using <attr>add-files</attr> to reference code we want to include, we use the xml:id of the target program - it has the contents we want to include. When making a textual reference with an <tag>xref</tag> we can't link to the program, as it lacks the contextual information required to create a valid reference. Instead, we should link to a listing (or some other container) that surrounds the code, like this: <xref ref="addh-v1-listing"/> or <xref ref="addh-v1-listing" text="title"/></p>
 
-        <program label="multiple-file-program" interactive="activecode" add-files="addh-v1" compile-also="addcpp-v1" include-source="yes" language="cpp">
+        <program label="multiple-file-program" interactive="activecode" add-files="addh-v1" compile-also="addcpp-v1" language="cpp">
             <![CDATA[
             #include "add.h"
             #include <iostream>
@@ -460,7 +460,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-codelens-python-questions">
             <title>A Python program, stepable with CodeLens, with questions</title>
-            <program label="python-code-lens-questions" interactive="codelens" language="python" include-source="yes">
+            <program label="python-code-lens-questions" interactive="codelens" language="python">
                 <code>
                 def foo(n):
                     n = n + 1
@@ -488,7 +488,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <exercise label="program-codelens-cpp-questions">
             <title>A C++ program as CodeLens exercise</title>
             <statement>Run the codelens and answer the questions it asks.</statement>
-            <program interactive="codelens" language="cpp" include-source="yes">
+            <program interactive="codelens" language="cpp">
                 <code><![CDATA[
                   int foo() {
                       int x = 2;
@@ -518,7 +518,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="sieve-python">
             <title><url href="https://www.tutorialspoint.com/python-program-for-sieve-of-eratosthenes" visual="www.tutorialspoint.com/python-program-for-sieve-of-eratosthenes">Sieve of Eratosthenes</url>, Java</title>
-            <program label="sieve-codelens-python" interactive="codelens" language="python" starting-step="73" include-source="yes">
+            <program label="sieve-codelens-python" interactive="codelens" language="python" starting-step="73">
                 <code><![CDATA[
                 def SieveOfEratosthenes(n):
                    # array of type boolean with True values in it
@@ -608,7 +608,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>Program listings can be more that just live demonstrations, they can be exercises.  The first two also occur in the sample article where they just get a static rendering, if at all.</p>
 
-        <exercise label="coding-exercise-blank" include-source="yes">
+        <exercise label="coding-exercise-blank">
             <title>Inline Coding Exercise, No Help</title>
 
             <statement>
@@ -620,7 +620,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <hint><p>We didn't really ask you to do anything.</p></hint>
         </exercise>
 
-        <exercise label="coding-exercise-partial-one" include-source="yes">
+        <exercise label="coding-exercise-partial-one">
             <title>Inline Coding Exercise, Partial</title>
 
             <statement>
@@ -645,7 +645,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </answer>
         </exercise>
 
-        <activity xml:id="coding-exercise-partial-two" include-source="yes">
+        <activity xml:id="coding-exercise-partial-two">
             <title>Activity Coding Exercise</title>
 
             <statement>
@@ -663,7 +663,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <answer><p>We're still not really sure.</p></answer>
         </activity>
 
-        <exercise include-source="yes">
+        <exercise>
             <title>An Exercise with a Static Program</title>
 
             <statement>
@@ -683,7 +683,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <xi:include href="./rune-examples/activecode-unittest.xml"/>
 
-        <exercise xml:id="unit-test-example-java" label="coding-exercise-java-unit-test" include-source="yes">
+        <exercise xml:id="unit-test-example-java" label="coding-exercise-java-unit-test">
             <title>Java Exercise, with Unit Tests</title>
             <statement>
                 <p>Unit tests for Java can be written using junit.</p>
@@ -723,7 +723,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </exercise>
 
-        <exercise xml:id="unit-test-example-cpp" label="coding-exercise-cpp-unit-test" include-source="yes">
+        <exercise xml:id="unit-test-example-cpp" label="coding-exercise-cpp-unit-test">
             <title>C++ Exercise, with Unit Tests</title>
             <statement>
                 <p>Unit tests for C++ can be written using doctest or catch. Doctest based tests build substantially faster than catch based ones.</p>
@@ -755,7 +755,7 @@ TEST_CASE( "Test the add function" ) {
 
         <p>For simple programs, or languages without an available unit testing framework, input-output testing can be done instead. IO testing can only be done on languages that are run on a Runestone server (Java/C/C++/Octave/Python3).</p>
 
-        <exercise xml:id="io-test-example-cpp" label="coding-exercise-cpp-io-tests" include-source="yes">
+        <exercise xml:id="io-test-example-cpp" label="coding-exercise-cpp-io-tests">
             <title>C++ Exercise, with IO Tests</title>
             <statement>
                 <p>Read in an integer <c>n</c>. Print out a n by n square of asterisks.</p>
@@ -811,7 +811,7 @@ TEST_CASE( "Test the add function" ) {
         <p>In the following file of climate data, the first column is Year, second column is Global Average Temperature (Celcius), and the third column is Global Emmisions C02 (Giga-tons).  [Normally you might place this inside a block with the <tag>datafile</tag>.]</p>
 
         <!-- # Section 11.4 Think Like a Computer Scientist, Runestone 2023-01-23 -->
-        <datafile label="file-global-climate-one" xml:id="file-global-climate-one" filename="ccdata1.txt" rows="18" cols="40" editable="yes" include-source="yes">
+        <datafile label="file-global-climate-one" xml:id="file-global-climate-one" filename="ccdata1.txt" rows="18" cols="40" editable="yes">
             <pre>
             1850    -0.37     2.24E-7
             1860    -0.34     3.94E-7
@@ -836,7 +836,7 @@ TEST_CASE( "Test the add function" ) {
 
         <p>Browser based programs are automatically given access to data files by their filename.</p>
 
-        <program label="python-average-climate" xml:id="python-average-climate" interactive='activecode' language="python" include-source="yes">
+        <program label="python-average-climate" xml:id="python-average-climate" interactive='activecode' language="python">
             <code>
             ccfile = open("ccdata1.txt", "r")
 
@@ -870,17 +870,17 @@ TEST_CASE( "Test the add function" ) {
                 <li>LanguageWorkedWith</li>
             </ol></p>
 
-            <datafile label="stack-overflow-survey" filename="so_survey.csv" rows="10" cols="65" editable="no" include-source="yes">
+            <datafile label="stack-overflow-survey" filename="so_survey.csv" rows="10" cols="65" editable="no">
                 <pre source="datafiles/stackoverflow.csv"/>
             </datafile>
         </data>
 
         <!-- 400px wide, so 400/600 = 66% -->
-        <datafile label="luther-bell" filename="luther-bell.jpg" include-source="yes">
+        <datafile label="luther-bell" filename="luther-bell.jpg">
             <image source="datafiles/LutherBellPic.jpg" width="66%"/>
         </datafile>
 
-        <program label="python-one-pixel" interactive='activecode' language="python" include-source="yes">
+        <program label="python-one-pixel" interactive='activecode' language="python">
             <code>
             import image
             img = image.Image("luther-bell.jpg")
@@ -901,13 +901,13 @@ TEST_CASE( "Test the add function" ) {
             <p>[Now a data file and a program to process it, all bundled up inside a <tag>computation</tag>, since an <tag>example</tag> gets knowled and the ActiveCode does not fill.]</p>
 
             <!-- 300px wide so 300/600 = 50% -->
-            <datafile label="golden-gate" filename="golden_gate.png" include-source="yes">
+            <datafile label="golden-gate" filename="golden_gate.png">
                 <image source="datafiles/golden-gate-bridge.png" width="50%"/>
             </datafile>
 
             <p>This program changes every pixel of the image.</p>
 
-            <program label="python-change-pixels" interactive='activecode' language="python" include-source="yes">
+            <program label="python-change-pixels" interactive='activecode' language="python">
                 <code>
                 import image
 
@@ -943,7 +943,7 @@ TEST_CASE( "Test the add function" ) {
 
         <p>The data file is an abbreviated version of the example above, just to be different.  And is not editable.</p>
 
-        <datafile label="file-global-climate-two" xml:id="file-global-climate-two" filename="ccdata2.txt" rows="4" cols="40" editable="no" include-source="yes">
+        <datafile label="file-global-climate-two" xml:id="file-global-climate-two" filename="ccdata2.txt" rows="4" cols="40" editable="no">
             <pre>
             1900    -0.2      2.38
             1910    -0.49     3.34
@@ -963,7 +963,7 @@ TEST_CASE( "Test the add function" ) {
 
         <p>The program is identical to the above, but we specify <c>python3</c> as the language, and use the smaller file.  So this example is only active when this content is hosted on a Runestone Academy server.</p>
 
-        <program label="python-average-climate-two" interactive='activecode' language="python3" add-files="file-global-climate-two" include-source="yes">
+        <program label="python-average-climate-two" interactive='activecode' language="python3" add-files="file-global-climate-two">
             <code>
             ccfile = open("ccdata2.txt", "r")
 
@@ -984,16 +984,16 @@ TEST_CASE( "Test the add function" ) {
 
             <!-- Images are 100 x 100.  So width are 100/600 = 17% -->
 
-            <datafile label="flower1-datafile" xml:id="flower1-datafile" filename="flower1.jpg" include-source="yes">
+            <datafile label="flower1-datafile" xml:id="flower1-datafile" filename="flower1.jpg">
                 <image source="datafiles/flower-one.jpeg" width="17%"/>
             </datafile>
 
-            <datafile label="flower2-datafile" xml:id="flower2-datafile" filename="flower2.jpg" include-source="yes">
+            <datafile label="flower2-datafile" xml:id="flower2-datafile" filename="flower2.jpg">
                 <image source="datafiles/flower-two.jpeg" width="17%"/>
             </datafile>
         </data>
 
-        <program label="java-flower-collage" interactive='activecode' language="java" add-files="file-picture-classes-jar, flower1-datafile, flower2-datafile" include-source="yes">
+        <program label="java-flower-collage" interactive='activecode' language="java" add-files="file-picture-classes-jar, flower1-datafile, flower2-datafile">
             <!-- About 10 XML characters, hence CDATA -->
             <code><![CDATA[
             import java.awt.*;
@@ -1183,11 +1183,11 @@ TEST_CASE( "Test the add function" ) {
         <!-- https://runestone.academy/ns/books/published/csawesome/Unit8-2DArray/pictureLabA5.html -->
         <!-- https://github.com/bhoffman0/CSAwesome/blob/master/_sources/Unit8-2DArray/pictureLabA5.rst -->
 
-        <datafile label="beach-datafile" xml:id="beach-datafile" filename="beach.jpg" include-source="yes">
+        <datafile label="beach-datafile" xml:id="beach-datafile" filename="beach.jpg">
             <image source="datafiles/beach.jpg" width="17%"/>
         </datafile>
 
-        <datafile label="file-picture-classes-jar" xml:id="file-picture-classes-jar" filename="pictureClasses1.jar" editable="no" hide="yes" include-source="yes">
+        <datafile label="file-picture-classes-jar" xml:id="file-picture-classes-jar" filename="pictureClasses1.jar" editable="no" hide="yes">
             <pre>
             <![CDATA[
             import java.awt.Image;
@@ -2292,7 +2292,7 @@ TEST_CASE( "Test the add function" ) {
             <!-- <pre source="datafiles/picture-classes-library.jar"/> -->
         </datafile>
 
-        <program label="java-only-blue" interactive='activecode' language="java" add-files="file-picture-classes-jar, beach-datafile" include-source="yes">
+        <program label="java-only-blue" interactive='activecode' language="java" add-files="file-picture-classes-jar, beach-datafile">
             <code>
                 <![CDATA[
                 import java.awt.*;
@@ -4392,7 +4392,7 @@ TEST_CASE( "Test the add function" ) {
                 <p>This is a test of accessing program resources across pages by relying on what is in the database.</p>
             </statement>
 
-            <program interactive="activecode" add-files="addh-v1 addcpp-v1" compile-also="addcpp-v1" language="cpp" include-source="yes">
+            <program interactive="activecode" add-files="addh-v1 addcpp-v1" compile-also="addcpp-v1" language="cpp">
                 <![CDATA[
                 #include "add.h"
                 #include <iostream>

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -450,7 +450,6 @@
                     attribute rows {xsd:integer}?,
                     attribute cols {xsd:integer}?,
                     attribute editable {"yes"|"no"}?,
-                    attribute include-source {"yes"|"no"}?,
                     (
                         element pre {
                             attribute source {text}?,

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1089,14 +1089,6 @@
           </choice>
         </attribute>
       </optional>
-      <optional>
-        <attribute name="include-source">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
       <choice>
         <element name="pre">
           <optional>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2542,7 +2542,6 @@
                     attribute rows {xsd:integer}?,
                     attribute cols {xsd:integer}?,
                     attribute editable {"yes"|"no"}?,
-                    attribute include-source {"yes"|"no"}?,
                     (
                         element pre {
                             attribute source {text}?,

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -12207,6 +12207,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the &quot;mdn&quot; element has been deprecated.  The replacement is an &quot;md&quot;, and numbering is controlled by the &quot;@number&quot; attribute, or a global setting in &quot;docinfo&quot;.'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2026-05-22  "@include-source" attribute deprecated -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//@include-source&quot;" />
+        <xsl:with-param name="date-string" select="'2026-05-22'" />
+        <xsl:with-param name="message" select="'the &quot;@include-source&quot; attribute has been deprecated and it will be ignored.  No replacement is planned.'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/pretext-view-source.xsl
+++ b/xsl/pretext-view-source.xsl
@@ -89,9 +89,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- kill them here.  Careful experiments suggest these are the  -->
     <!-- only elements without source.                               -->
     <xsl:variable name="b-banned" select="boolean(self::fn)"/>
-    <!-- Allow for annotations of select elements                    -->
-    <xsl:variable name="include-source" select="@include-source = 'yes'"/>
-    <xsl:if test="($b-view-source and not($b-banned)) or $include-source">
+    <xsl:if test="$b-view-source and not($b-banned)">
         <!-- Part 1: Serialize the source -->
         <!-- Save off the id of the element being annotated -->
         <xsl:variable name="the-element-id" select="@original-id"/>


### PR DESCRIPTION
## Summary

Deprecates `@include-source`, the per-element opt-in that forced an HTML
"View Source" widget regardless of the publisher's global `view-source`
setting.

- **Implementation removed** — the `view-source-widget` template now keys
  solely on the publisher's `view-source` option; `@include-source` is no
  longer honored.
- **Deprecation warning added** — any remaining use reports `PTX:DEPRECATE`
  and is ignored. No replacement is planned.
- **Schema updated** — the attribute is removed from `datafile` in
  `pretext.xml`, with the dev schema files regenerated.
- **Sample book cleaned** — 43 uses removed from the Runestone chapter.

The four commits mirror these steps.

## Testing

- Sample book HTML built before/after: the only change is the removal of
  44 "View Source" widgets in the Runestone chapter; no other differences.
- A minimal document with `@include-source` confirms the deprecation
  warning fires with the expected text.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*