### PR TITLE
HTML: thread "heading-level" through WeBWorK "task" rendering

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -3828,6 +3828,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- interior, of such an exercise.                                  -->
 <xsl:template match="exercise|&PROJECT-LIKE;" mode="webwork-core">
     <xsl:param name="b-original"/>
+    <xsl:param name="heading-level"/>
 
     <xsl:choose>
         <xsl:when test="$b-host-runestone">
@@ -3841,6 +3842,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </xsl:attribute>
                     <xsl:apply-templates select="introduction|webwork-reps|conclusion">
                         <xsl:with-param name="b-original" select="$b-original" />
+                        <xsl:with-param name="heading-level" select="$heading-level"/>
                     </xsl:apply-templates>
                 </div>
             </div>
@@ -3848,6 +3850,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:otherwise>
             <xsl:apply-templates select="introduction|webwork-reps|conclusion">
                 <xsl:with-param name="b-original" select="$b-original" />
+                <xsl:with-param name="heading-level" select="$heading-level"/>
             </xsl:apply-templates>
         </xsl:otherwise>
     </xsl:choose>
@@ -3870,6 +3873,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="webwork-reps">
             <xsl:apply-templates select="." mode="webwork-core">
                 <xsl:with-param name="b-original" select="$b-original" />
+                <xsl:with-param name="heading-level" select="$heading-level"/>
             </xsl:apply-templates>
         </xsl:when>
         <!-- MyOpenMath case -->
@@ -4032,6 +4036,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="webwork-reps">
             <xsl:apply-templates select="." mode="webwork-core">
                 <xsl:with-param name="b-original" select="$b-original" />
+                <xsl:with-param name="heading-level" select="$heading-level"/>
             </xsl:apply-templates>
         </xsl:when>
         <xsl:when test="task">
@@ -11192,6 +11197,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- what is born visible under control of a switch -->
 <xsl:template match="webwork-reps">
     <xsl:param name="b-original" select="true()"/>
+    <xsl:param name="heading-level"/>
     <!-- TODO: simplify these variables, much like for LaTeX -->
     <xsl:variable name="b-has-hint" select="(ancestor::*[&PROJECT-FILTER;] and $b-has-project-hint) or
                                             (ancestor::exercises and $b-has-divisional-hint) or
@@ -11218,6 +11224,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-static">
             <xsl:apply-templates select="static" mode="exercise-components">
                 <xsl:with-param name="b-original"      select="$b-original"/>
+                <xsl:with-param name="heading-level"   select="$heading-level"/>
                 <xsl:with-param name="b-has-statement" select="true()"/>
                 <xsl:with-param name="b-has-hint"      select="$b-has-hint"/>
                 <xsl:with-param name="b-has-answer"    select="$b-has-answer"/>
@@ -11227,6 +11234,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:otherwise>
             <xsl:apply-templates select="." mode="webwork-interactive-div">
                 <xsl:with-param name="b-original"     select="$b-original"/>
+                <xsl:with-param name="heading-level"  select="$heading-level"/>
                 <xsl:with-param name="b-has-hint"     select="$b-has-hint"/>
                 <xsl:with-param name="b-has-answer"   select="$b-has-answer"/>
                 <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
@@ -11239,6 +11247,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- replace the div content with a live, interactive problem -->
 <xsl:template match="webwork-reps" mode="webwork-interactive-div">
     <xsl:param name="b-original"/>
+    <xsl:param name="heading-level"/>
     <xsl:param name="b-has-hint"/>
     <xsl:param name="b-has-answer"/>
     <xsl:param name="b-has-solution"/>
@@ -11377,6 +11386,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <div class="problem-contents">
             <xsl:apply-templates select="static" mode="exercise-components">
                 <xsl:with-param name="b-original"      select="$b-original"/>
+                <xsl:with-param name="heading-level"   select="$heading-level"/>
                 <xsl:with-param name="b-has-statement" select="true()"/>
                 <xsl:with-param name="b-has-hint"      select="$b-has-hint"/>
                 <xsl:with-param name="b-has-answer"    select="$b-has-answer"/>


### PR DESCRIPTION
## Problem

Building `examples/webwork/sample-chapter/` as HTML produced 13 `PTX:BUG`
messages of the form:

```
"hN" template reached without a $heading-level parameter on element <task>
at pretext/book/chapter/section/exercise/webwork-reps/static/task;
defaulting to h2
```

Every task heading inside the WeBWorK static representation (the
always-present fallback content, even on the dynamic/interactive path)
rendered as `<h2>` regardless of nesting depth.

## Fix

`xsl/pretext-html.xsl` — declare and thread `$heading-level` in four spots
on the `webwork-reps` chain:

- `webwork-core` template — add `<xsl:param name="heading-level"/>` and pass
  it through to `introduction|webwork-reps|conclusion`.
- Two callers of `webwork-core` (`exercise` and `&PROJECT-LIKE;` in
  `mode="wrapped-content"`) — pass `heading-level`.
- `webwork-reps` template — add the param and thread it on both branches
  (`static` for the static path, `webwork-interactive-div` for the dynamic
  path).
- `webwork-interactive-div` mode — add the param and pass it to its
  `select="static" mode="exercise-components"` apply.

## Verification

Built the WW sample chapter as HTML, before/after diff:

- `PTX:BUG` count: 13 → 0.
- Task headings now render at the correct depth: section page → exercise=h3,
  task=h4, nested task=h5; xref knowls → h3. Previously all rendered as h2.
- 4 files differ (1 is the build timestamp in `index.html`); no unintended
  changes elsewhere.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*