### PR TITLE
Common: "location-report" prints structural ancestor chain

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11080,8 +11080,12 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
                 </xsl:if>
             </xsl:message>
         </xsl:when>
-        <xsl:when test="mathbook|pretext">
-            <!-- at root, fail with no action -->
+        <xsl:when test="self::mathbook or self::pretext">
+            <!-- at the document root, fail with no action.  Earlier  -->
+            <!-- this test used "mathbook|pretext", which matched any -->
+            <!-- ancestor that happened to *contain* a "pretext/" or  -->
+            <!-- "mathbook/" empty element (the project-name marker)  -->
+            <!-- and halted the walk prematurely.                     -->
         </xsl:when>
         <xsl:otherwise>
             <!-- pop up a level and try again -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11032,11 +11032,34 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     </xsl:choose>
 </xsl:template>
 
-<!-- We search up the tree, looking for something -->
-<!-- an author will recognize, and then report it -->
-<!-- Useful for warnings that do not contain any  -->
-<!-- identifying information themselves           -->
+<!-- Report the location of an element or attribute, for use after a   -->
+<!-- warning that does not itself contain identifying information.     -->
+<!-- Prints two lines: a structural path of element local-names from   -->
+<!-- the root, useful for diagnosing structural problems; then the     -->
+<!-- nearest @xml:id or "title" up the ancestor chain, useful for the  -->
+<!-- author to locate the issue in their source.                       -->
 <xsl:template match="*|@*" mode="location-report">
+    <!-- structural path: "pretext/book/chapter/.../element" -->
+    <!-- attributes display as a trailing "@name" step       -->
+    <xsl:message>
+        <xsl:text>             located at: </xsl:text>
+        <xsl:for-each select="ancestor::*">
+            <xsl:value-of select="local-name(.)"/>
+            <xsl:text>/</xsl:text>
+        </xsl:for-each>
+        <xsl:if test="not(self::*)">
+            <xsl:text>@</xsl:text>
+        </xsl:if>
+        <xsl:value-of select="local-name(.)"/>
+    </xsl:message>
+    <!-- nearest @xml:id or "title" for author orientation -->
+    <xsl:apply-templates select="." mode="named-ancestor-report"/>
+</xsl:template>
+
+<!-- Walk up the ancestor chain, looking for the first element with     -->
+<!-- @xml:id or "title", and report it.  Companion to "location-report" -->
+<!-- so the structural path is printed once while this walk continues.  -->
+<xsl:template match="*|@*" mode="named-ancestor-report">
     <xsl:choose>
         <xsl:when test="@xml:id or title">
             <!-- print information about location -->
@@ -11062,7 +11085,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         </xsl:when>
         <xsl:otherwise>
             <!-- pop up a level and try again -->
-            <xsl:apply-templates select="parent::*[1]" mode="location-report" />
+            <xsl:apply-templates select="parent::*[1]" mode="named-ancestor-report" />
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
Improves the `location-report` template (in `pretext-common.xsl`) used
by 20+ author-facing warnings/errors to point at the offending source.

## Change (commit 1)

Previously `location-report` printed only the nearest `@xml:id`/`<title>`
ancestor — useful for "where in my book", but silent on structural shape.
Now it always prints a `located at:` line first, showing the full ancestor
chain via `for-each select="ancestor::*"`.

Output before:
```
PTX:ERROR: display math @alignment attribute "bogus" is not recognized …
             located within: "Displayed Mathematics" (title)
```

Output after:
```
PTX:ERROR: display math @alignment attribute "bogus" is not recognized …
             located at: pretext/article/section/subsection/p/md
             located within: "Displayed Mathematics" (title)
```

For attributes, the path ends with a `@name` step.

The existing identifying-ancestor lookup is preserved by refactoring it
into a sibling mode `named-ancestor-report`, so the structural path is
printed once at the top while the recursive named-ancestor walk continues
beneath.

## Pre-existing bug also fixed (commit 2)

Discovered while testing: the old root-detection test was
`<xsl:when test="mathbook|pretext">`, which matches any ancestor that
*contains* a `<pretext/>` or `<mathbook/>` empty element. The PreTeXt
project-name marker `<pretext/>` is used widely (72 occurrences in
`examples/sample-article/sample-article.xml` alone), so paragraphs that
mention "PreTeXt" silently halted the walk and suppressed the
`located within:` line.

Fixed to `self::mathbook or self::pretext` so the walk stops at the real
document root.

## Verification

Temporarily set `<md alignment="bogus">` on one display-math element in
`examples/sample-article/sample-article.xml`, which fires the
`display math @alignment attribute … is not recognized` error
(`pretext-common.xsl:1180`). Built the sample article as HTML; the
new two-line output above appeared as expected. Revert restored a clean
build.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*