### PR TITLE
Schema: require "intertext" inside "md" to be followed by "mrow"

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1673,13 +1673,16 @@
                         ) |
                         # multi-line: "mrow" content, not itself a
                         # cross-reference target, so no @xml:id, no @label;
-                        # @number defaults to "no" and applies to each "mrow"
+                        # @number defaults to "no" and applies to each "mrow".
+                        # Each "intertext" must be sandwiched between "mrow":
+                        # it cannot lead, cannot trail, and two cannot be
+                        # adjacent.
                         (
                             attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
                             attribute alignment {text}?,
                             attribute alignat-columns {text}?,
-                            MathRow, (MathRow | MathIntertext)*
+                            MathRow, (MathRow | (MathIntertext, MathRow))*
                         )
                     )
                 }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4249,7 +4249,10 @@
         <!--
           multi-line: "mrow" content, not itself a
           cross-reference target, so no @xml:id, no @label;
-          @number defaults to "no" and applies to each "mrow"
+          @number defaults to "no" and applies to each "mrow".
+          Each "intertext" must be sandwiched between "mrow":
+          it cannot lead, cannot trail, and two cannot be
+          adjacent.
         -->
         <group>
           <optional>
@@ -4278,7 +4281,10 @@
           <zeroOrMore>
             <choice>
               <ref name="MathRow"/>
-              <ref name="MathIntertext"/>
+              <group>
+                <ref name="MathIntertext"/>
+                <ref name="MathRow"/>
+              </group>
             </choice>
           </zeroOrMore>
         </group>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -938,7 +938,7 @@
     <section>
         <title>Mathematics</title>
 
-        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, displayed mathematics, <c>md</c>, comes in two forms.  A single-line <c>md</c> has no <c>mrow</c> children and may carry an <attr>xml:id</attr> to be a cross-reference target; it does not use a <attr>label</attr>.  A multi-row <c>md</c> has <c>mrow</c> children and is not itself a target of cross-references, so takes neither an <attr>xml:id</attr> nor a <attr>label</attr>, though its rows can be targets.  Either form may carry a <attr>number</attr> attribute, defaulting to <q>no</q>; on a multi-row <c>md</c> it applies to each <c>mrow</c> that does not override it.  A single-line <c>md</c> may carry a <attr>tag</attr> attribute as an alternative to <attr>number</attr>, supplying a symbolic local tag in place of a number; the two attributes are mutually exclusive.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.</p>
+        <p>All mathematics appears inside paragraphs, and the syntax is that of <latex/>, as supported by MathJax, whose supported commands and macros are meant to be very similar to those of the AMSMath package.  Note that the content is typically unstructured, excepting <q>fill-in-the-blank</q>, <webwork/> variables (see variants), and internal cross-references in multi-row display mathematics. Also, displayed mathematics, <c>md</c>, comes in two forms.  A single-line <c>md</c> has no <c>mrow</c> children and may carry an <attr>xml:id</attr> to be a cross-reference target; it does not use a <attr>label</attr>.  A multi-row <c>md</c> has <c>mrow</c> children and is not itself a target of cross-references, so takes neither an <attr>xml:id</attr> nor a <attr>label</attr>, though its rows can be targets.  Either form may carry a <attr>number</attr> attribute, defaulting to <q>no</q>; on a multi-row <c>md</c> it applies to each <c>mrow</c> that does not override it.  A single-line <c>md</c> may carry a <attr>tag</attr> attribute as an alternative to <attr>number</attr>, supplying a symbolic local tag in place of a number; the two attributes are mutually exclusive.  Fill-in blanks have a variant attribute <attr>fill</attr> more suited for mathematics.  An <c>intertext</c> may appear between two <c>mrow</c>, but must always be sandwiched: it cannot be the first or last child of <c>md</c>, and two <c>intertext</c> may not be adjacent.</p>
 
         <fragment xml:id="mathematics">
             <title>Mathematics</title>
@@ -987,13 +987,16 @@
                         ) |
                         # multi-line: "mrow" content, not itself a
                         # cross-reference target, so no @xml:id, no @label;
-                        # @number defaults to "no" and applies to each "mrow"
+                        # @number defaults to "no" and applies to each "mrow".
+                        # Each "intertext" must be sandwiched between "mrow":
+                        # it cannot lead, cannot trail, and two cannot be
+                        # adjacent.
                         (
                             attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
                             attribute alignment {text}?,
                             attribute alignat-columns {text}?,
-                            MathRow, (MathRow | MathIntertext)*
+                            MathRow, (MathRow | (MathIntertext, MathRow))*
                         )
                     )
                 }

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -7429,6 +7429,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- *-form of the environment) is conveyed by an internal -->
 <!-- attribute placed by the pre-processor in the          -->
 <!-- "intertext" case.                                     -->
+<!-- The "intertext" sandwich rule (every "intertext" inside an "md"    -->
+<!-- must be followed by an "mrow") is enforced by the schema.          -->
+<!-- If the schema check were bypassed, the assembly explosion would    -->
+<!-- produce malformed LaTeX in either of two ways:                     -->
+<!--   *  a trailing "intertext" leaves an unclosed "\begin{align}"     -->
+<!--      with no matching "\end{align}".                               -->
+<!--   *  back-to-back "intertext" produce two consecutive              -->
+<!--      "\intertext{...}" with no math environment between them.      -->
+<!-- The schema check means this template can omit defensive checks.    -->
 <xsl:template match="md[mrow]">
     <xsl:apply-templates select="." mode="body">
         <xsl:with-param name="b-needs-open"  select="not(@pi:location) or @pi:location = 'first'"/>


### PR DESCRIPTION
## Context

The multi-row content model for `<md>` was:

```
MathRow, (MathRow | MathIntertext)*
```

That requires only that the first child be `<mrow>`, but permits an
`<intertext>` as the last child, and permits two `<intertext>`
back-to-back. The LaTeX un-explode in `xsl/pretext-latex-common.xsl`
(template `md[mrow]`) silently relies on every `<intertext>` being
sandwiched between two `<mrow>`. Violating that produces malformed
LaTeX (an unclosed `\begin{align}` for a trailing `intertext`, or two
consecutive `\intertext{...}` outside any math environment for
back-to-back `intertext`).

## Change

`schema/pretext.xml`:

- Tighten the multi-row content model to
  `MathRow, (MathRow | (MathIntertext, MathRow))*`, which forces every
  `<intertext>` to be both preceded and followed by an `<mrow>`.
- Add a brief mention in the Mathematics-section prose paragraph and an
  inline RNC-style comment next to the grammar.

`schema/pretext.rnc`, `schema/pretext.rng` regenerated via the standard
`xsltproc` + `trang` chain.

`xsl/pretext-latex-common.xsl`: add an aligned multi-line comment ahead
of the `md[mrow]` template recording that the sandwich rule is now
enforced by the schema and listing the two LaTeX failure modes the
check rules out. This is useful both for a future reader of the
template *and* for anyone investigating one of those failure modes who
might otherwise treat it as a bug to be fixed here — it is not; the
input bypassed schema validation.

## Verification

- `jing pretext-dev.rng` error counts on `examples/sample-article/`,
  `examples/sample-book/`, and `doc/guide/`: 201 / 277 / 9 — identical
  before and after. None of the pre-existing errors mention
  `intertext`.
- Source grep confirms every `<intertext>` in tracked sample documents
  (sample-article, showcase, sample-book/sets, webwork sample chapter)
  is already immediately followed by an `<mrow>`; no existing source
  is impacted by the tighter rule.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*