### PR TITLE
Schema: tighten attribute value enumerations, prune dead XSL checks

### DIFF
--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -18,7 +18,9 @@
                     attribute version { text }?,
                     attribute circuitjs { text }?,
                     attribute calcplot3d { text }?,
-                    attribute variant { text }?,
+                    # currently only consumed by the CalcPlot3D flavor;
+                    # widen this enum if another flavor adopts "@variant"
+                    attribute variant { "application" | "controls" | "minimal" }?,
                     attribute dark-mode-enabled { text }?,
                     attribute resize-behavior { text }?,
                     (

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -40,7 +40,17 @@
         <attribute name="calcplot3d"/>
       </optional>
       <optional>
-        <attribute name="variant"/>
+        <!--
+          currently only consumed by the CalcPlot3D flavor;
+          widen this enum if another flavor adopts "@variant"
+        -->
+        <attribute name="variant">
+          <choice>
+            <value>application</value>
+            <value>controls</value>
+            <value>minimal</value>
+          </choice>
+        </attribute>
       </optional>
       <optional>
         <attribute name="dark-mode-enabled"/>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -893,7 +893,10 @@
                 Component?,
                 attribute margins {text}?,
                 (attribute width {text} | attribute widths {text})?,
-                (AlignmentVertical | attribute valigns {text})?
+                (
+                    AlignmentVertical |
+                    attribute valigns { list { ("top" | "middle" | "bottom")+ } }
+                )?
             SideBySide =
                 element sidebyside {
                     SidebySideAttributes,

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1680,7 +1680,7 @@
                         (
                             attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
-                            attribute alignment {text}?,
+                            attribute alignment {"align" | "gather" | "alignat"}?,
                             attribute alignat-columns {text}?,
                             MathRow, (MathRow | (MathIntertext, MathRow))*
                         )

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1149,7 +1149,7 @@
             
             ExerciseOrderedList =
                 element ol {
-                    attribute cols {text}?,
+                    attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
                     ExerciseListItem+
                 }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2394,7 +2394,17 @@
     <optional>
       <choice>
         <ref name="AlignmentVertical"/>
-        <attribute name="valigns"/>
+        <attribute name="valigns">
+          <list>
+            <oneOrMore>
+              <choice>
+                <value>top</value>
+                <value>middle</value>
+                <value>bottom</value>
+              </choice>
+            </oneOrMore>
+          </list>
+        </attribute>
       </choice>
     </optional>
   </define>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4272,7 +4272,13 @@
             </attribute>
           </optional>
           <optional>
-            <attribute name="alignment"/>
+            <attribute name="alignment">
+              <choice>
+                <value>align</value>
+                <value>gather</value>
+                <value>alignat</value>
+              </choice>
+            </attribute>
           </optional>
           <optional>
             <attribute name="alignat-columns"/>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2995,7 +2995,15 @@
   <define name="ExerciseOrderedList">
     <element name="ol">
       <optional>
-        <attribute name="cols"/>
+        <attribute name="cols">
+          <choice>
+            <value>2</value>
+            <value>3</value>
+            <value>4</value>
+            <value>5</value>
+            <value>6</value>
+          </choice>
+        </attribute>
       </optional>
       <optional>
         <attribute name="marker"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -994,7 +994,7 @@
                         (
                             attribute number {"yes" | "no"}?,
                             attribute break {"yes" | "no"}?,
-                            attribute alignment {text}?,
+                            attribute alignment {"align" | "gather" | "alignat"}?,
                             attribute alignat-columns {text}?,
                             MathRow, (MathRow | (MathIntertext, MathRow))*
                         )

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1818,7 +1818,10 @@
                 Component?,
                 attribute margins {text}?,
                 (attribute width {text} | attribute widths {text})?,
-                (AlignmentVertical | attribute valigns {text})?
+                (
+                    AlignmentVertical |
+                    attribute valigns { list { ("top" | "middle" | "bottom")+ } }
+                )?
             SideBySide =
                 element sidebyside {
                     SidebySideAttributes,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2241,7 +2241,7 @@
             <code>
             ExerciseOrderedList =
                 element ol {
-                    attribute cols {text}?,
+                    attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
                     ExerciseListItem+
                 }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2039,7 +2039,9 @@
                     attribute version { text }?,
                     attribute circuitjs { text }?,
                     attribute calcplot3d { text }?,
-                    attribute variant { text }?,
+                    # currently only consumed by the CalcPlot3D flavor;
+                    # widen this enum if another flavor adopts "@variant"
+                    attribute variant { "application" | "controls" | "minimal" }?,
                     attribute dark-mode-enabled { text }?,
                     attribute resize-behavior { text }?,
                     (

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8278,11 +8278,14 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
-<!-- Translate horizontal alignment to CSS short name    -->
-<!-- HTML:  makes portion of CSS class names for cells   -->
-<!-- LaTeX: provides standard LaTeX horizontal alignment -->
-<!-- PG: provide LaTeX-style alignment string for        -->
-<!-- DataTable macro from niceTable.pl                   -->
+<!-- Translate horizontal alignment to CSS short name.            -->
+<!-- HTML:  makes portion of CSS class names for cells.           -->
+<!-- LaTeX: provides standard LaTeX horizontal alignment.         -->
+<!-- PG: provide LaTeX-style alignment string for the             -->
+<!-- DataTable macro from niceTable.pl.                           -->
+<!-- The schema restricts callers' @halign (on "tabular", "row",  -->
+<!-- "col", "cell") to these four values, so no defensive         -->
+<!-- otherwise is needed.                                         -->
 <xsl:template name="halign-specification">
     <xsl:param name="align" />
     <xsl:choose>
@@ -8295,17 +8298,16 @@ Book (with parts), "section" at level 3
         <xsl:when test="$align='right'">
             <xsl:text>r</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular horizontal alignment attribute not recognized: use left, center, right, justify</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
-<!-- Translate vertical alignment to CSS short name         -->
-<!-- HTML:  makes portion of CSS class names for cells      -->
-<!-- LaTeX: provides one standard LaTeX vertical alignment  -->
-<!-- PG: provide LaTeX-style alignment string for           -->
-<!-- DataTable macro from niceTable.pl                      -->
+<!-- Translate vertical alignment to CSS short name.              -->
+<!-- HTML:  makes portion of CSS class names for cells.           -->
+<!-- LaTeX: provides one standard LaTeX vertical alignment.       -->
+<!-- PG: provide LaTeX-style alignment string for the             -->
+<!-- DataTable macro from niceTable.pl.                           -->
+<!-- The schema restricts callers' @valign (on "tabular", "row")  -->
+<!-- to these three values, so no defensive otherwise is needed.  -->
 <xsl:template name="valign-specification">
     <xsl:param name="align" />
     <xsl:choose>
@@ -8318,9 +8320,6 @@ Book (with parts), "section" at level 3
         <xsl:when test="$align='bottom'">
             <xsl:text>b</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular vertical alignment attribute not recognized: use top, middle, bottom</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5788,24 +5788,14 @@ Book (with parts), "section" at level 3
 <!-- SidebySide Layout Utilities -->
 <!-- ########################### -->
 
-<!-- From a space-separated list of vertical alignments -->
-<!-- create error-checked result tree fragment          -->
+<!-- From a space-separated list of vertical alignments       -->
+<!-- create a result tree fragment.  The schema enforces      -->
+<!-- "top" | "middle" | "bottom" on each list item, so no     -->
+<!-- defensive value check is needed here.                    -->
 <xsl:template name="decompose-valigns">
     <xsl:param name="valigns" />
     <xsl:variable name="the-valign" select="substring-before($valigns, ' ')" />
     <xsl:if test="not($the-valign = '')">
-        <!-- error-check, since list bypasses schema -->
-        <!-- "top" is default, so check first        -->
-        <xsl:choose>
-            <xsl:when test="$the-valign = 'top'" />
-            <xsl:when test="$the-valign = 'bottom'" />
-            <xsl:when test="$the-valign = 'middle'" />
-            <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   @valign(s) ("<xsl:value-of select="$the-valign" />") in &lt;sidebyside&gt; or &lt;sbsgroup&gt; is not "top," "middle" or "bottom"</xsl:message>
-                <xsl:apply-templates select="." mode="location-report" />
-            </xsl:otherwise>
-        </xsl:choose>
-        <!-- okay, output element -->
         <valign>
             <xsl:value-of select="$the-valign" />
         </valign>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6152,27 +6152,20 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
-<!-- CSS class for multi-column lists -->
-<!-- Context is element with potential "cols" attribute -->
-<!-- Return value is "colsN" with 2 <= N <= 6           -->
-<!-- @cols absent produces no result (i.e. classless)   -->
-<!-- @cols = 1 produces no result (i.e. classless)      -->
-<!-- Error message if out-of-range, could be made fatal -->
-<!-- Schema should enforce this restriction also        -->
+<!-- CSS class for multi-column lists.  Context is an element with -->
+<!-- a potential "cols" attribute.  Return value is "colsN" with   -->
+<!-- 2 <= N <= 6, or empty when @cols is absent.                   -->
+<!-- Schema enforces @cols to be one of "2", "3", "4", "5", "6"    -->
+<!-- on each of "ol", "ul", and "exercisegroup" (and on the        -->
+<!-- variant of "ol" used inside exercise statements), so this     -->
+<!-- template just emits the class string whenever @cols is        -->
+<!-- present.                                                      -->
 <xsl:template match="ol|ul|exercisegroup" mode="number-cols-CSS-class">
-    <xsl:choose>
-        <xsl:when test="not(@cols)"/>
-        <xsl:when test="@cols = 1"/>
-        <xsl:when test="(@cols = 2) or (@cols = 3) or (@cols = 4) or (@cols = 5) or (@cols = 6)">
-            <xsl:text>cols</xsl:text>
-            <xsl:value-of select="@cols" />
-            <xsl:text> multicolumn</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:ERROR:   @cols attribute of lists or exercise groups, must be between 1 and 6 (inclusive), not "cols=<xsl:value-of select="@cols" />"</xsl:message>
-            <xsl:apply-templates select="." mode="location-report" />
-        </xsl:otherwise>
-    </xsl:choose>
+    <xsl:if test="@cols">
+        <xsl:text>cols</xsl:text>
+        <xsl:value-of select="@cols" />
+        <xsl:text> multicolumn</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- ################## -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8253,10 +8253,13 @@ Book (with parts), "section" at level 3
 <!-- functions for the construction of tables.    -->
 <!-- Document uses carefully when newly employed. -->
 
-<!-- Translate thickness attribute value to integer short name -->
-<!-- HTML: makes portion of CSS class names for cells          -->
-<!-- PG: makes portion of optional parameter for DataTable     -->
-<!-- macro from niceTable.pl for thickness of table cells      -->
+<!-- Translate thickness attribute value to integer short name.  -->
+<!-- HTML: makes portion of CSS class names for cells.           -->
+<!-- PG: makes portion of optional parameter for DataTable       -->
+<!-- macro from niceTable.pl for thickness of table cells.       -->
+<!-- The schema restricts callers' @top, @bottom, @left, @right  -->
+<!-- (on "tabular", "row", "col", "cell") to these four values,  -->
+<!-- so no defensive otherwise is needed.                        -->
 <xsl:template name="thickness-specification">
     <xsl:param name="width" />
     <xsl:choose>
@@ -8272,9 +8275,6 @@ Book (with parts), "section" at level 3
         <xsl:when test="$width='major'">
             <xsl:text>3</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular rule thickness not recognized: use none, minor, medium, major</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1166,7 +1166,12 @@ Book (with parts), "section" at level 3
 <xsl:template match="md[mrow]" mode="displaymath-alignment">
     <xsl:param name="b-needs-tags" select="true()" />
     <xsl:choose>
-        <!-- look for @alignment override, possibly bad -->
+        <!-- Honor the @alignment override.  The schema restricts the   -->
+        <!-- value to one of these three.  The trailing "@alignment"    -->
+        <!-- catch-all is reached only by schema-bypassed input; it     -->
+        <!-- emits a literal token so LaTeX (or MathJax) errors out on  -->
+        <!-- an unknown environment rather than silently falling        -->
+        <!-- through to the ampersand-sniff branch.                     -->
         <xsl:when test="@alignment='gather'">
             <xsl:text>gather</xsl:text>
         </xsl:when>
@@ -1177,8 +1182,6 @@ Book (with parts), "section" at level 3
             <xsl:text>align</xsl:text>
         </xsl:when>
         <xsl:when test="@alignment">
-            <xsl:message>PTX:ERROR: display math @alignment attribute "<xsl:value-of select="@alignment" />" is not recognized (should be "align", "gather", "alignat")</xsl:message>
-            <xsl:apply-templates select="." mode="location-report" />
             <xsl:text>bad-alignment-choice</xsl:text>
         </xsl:when>
         <!-- perhaps authored as obviously one-line (no alignment) -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10138,7 +10138,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- is a query string of a URL, and we can specify -->
 <!-- the style of the interface through @variant    -->
 <xsl:template match="interactive[@calcplot3d]" mode="iframe-interactive">
-    <!-- Use @variant to pick an endpoint/view/infrastructure -->
+    <!-- Use @variant to pick an endpoint/view/infrastructure. -->
+    <!-- The schema restricts @variant on "interactive" to one -->
+    <!-- of these three, so no defensive otherwise is needed.  -->
     <xsl:variable name="cp3d-endpoint">
         <xsl:choose>
             <xsl:when test="@variant='application'">
@@ -10150,12 +10152,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:when test="@variant='minimal'">
                 <xsl:text>https://c3d.libretexts.org/CalcPlot3D/dynamicFigure/index.html</xsl:text>
             </xsl:when>
-            <xsl:otherwise>
-                <!-- just a silly domain so something none-too-crazy happens -->
-                <xsl:text>http://www.example.com/</xsl:text>
-                <xsl:message>PTX:ERROR:  @variant="<xsl:value-of select="@variant" />" is not recognized for a CalcPlot3D &lt;interactive&gt;</xsl:message>
-                <xsl:apply-templates select="." mode="location-report" />
-            </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
     <!-- load 'em up and go -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -10375,6 +10375,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- paragraph halign-specifications (left, center, right, justify) -->
 <!-- converted to \raggedright, \centering, \raggedleft, <empty>    -->
 
+<!-- The five "*-specification" translators below all receive       -->
+<!-- their "$align" or "$width" from tabular attributes whose       -->
+<!-- values are schema-restricted: @halign and @valign to their     -->
+<!-- alignment vocabularies, and @top / @bottom / @left / @right    -->
+<!-- to "none", "minor", "medium", "major", on "tabular", "row",    -->
+<!-- "col", "cell".  No defensive otherwise is needed in any.       -->
+
 <xsl:template name="paragraph-valign-specification">
     <xsl:param name="align" />
     <xsl:choose>
@@ -10387,9 +10394,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$align='bottom'">
             <xsl:text>b</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: vertical alignment attribute not recognized: use top, middle, bottom</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -10408,9 +10412,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$align='right'">
             <xsl:text>\raggedleft</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: horizontal alignment attribute not recognized: use left, center, right, justify</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -10430,9 +10431,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$width='major'">
             <xsl:text>C</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular left or right attribute not recognized: use none, minor, medium, major</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -10452,9 +10450,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$width='major'">
             <xsl:text>\hrulethick</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular top or bottom attribute not recognized: use none, minor, medium, major</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -10477,9 +10472,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$width='major'">
             <xsl:text>\crulethick</xsl:text>
         </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>PTX:WARNING: tabular top or bottom attribute not recognized: use none, minor, medium, major</xsl:message>
-        </xsl:otherwise>
     </xsl:choose>
     <!-- span -->
     <xsl:if test="not($width='none')">


### PR DESCRIPTION
## Goal

Move the source-of-truth for attribute-value rules into the schema and
remove the corresponding runtime checks in XSL. The driving idea is that
when the schema can express a constraint, the XSL check is redundant
duplication that drifts out of sync; the conversion can then either rely
on the value space being correct (because the source validated) or — for
the rare schema-bypass case — emit a deliberately-broken token and let
the downstream tool (LaTeX, MathJax, the browser) raise its own native
error with its own file/line context.

Net effect across the branch:

- Five attributes that were `text` in the schema gain proper value
  enumerations (`md/@alignment`, `sidebyside/@valigns`, an exercise-
  statement `ol/@cols`, `interactive/@variant`).
- Eight `xsl:otherwise` branches in named templates that translated
  schema-enforced values to short tokens (`halign-specification`,
  `valign-specification`, `thickness-specification`, plus five LaTeX-
  side `*-specification` siblings) lose their unreachable
  `PTX:WARNING`/`PTX:ERROR` arm.

## Commits

1. **`Schema: enumerate "md" "@alignment" values, drop runtime check`** —
   schema restricts `@alignment` to `"align"|"gather"|"alignat"`; the XSL
   keeps a `bad-alignment-choice` literal as a deliberately-broken
   downstream-tool tripwire.
2. **`Schema: enumerate items of "sidebyside" "@valigns" list, drop runtime
   check`** — schema types `@valigns` as a whitespace-separated list of
   `"top"|"middle"|"bottom"`; the recursive `decompose-valigns` template
   sheds its per-item value check.
3. **`Schema: enumerate "@cols" on the exercise-statement "ol", simplify
   XSL`** — the last `text`-typed `@cols` in scope gets the same
   `"2"|…|"6"` enum the other three `ol`/`ul`/`exercisegroup` `@cols`
   already use; `number-cols-CSS-class` collapses from a 13-line `choose`
   to a 5-line `if`.
4. **`Common: drop unreachable "otherwise" in "thickness-specification"`** —
   `BorderThickness`-typed callers mean the `none|minor|medium|major`
   translator's otherwise was already dead.
5. **`Common: drop unreachable "otherwise" in "halign-" and
   "valign-specification"`** — same story for the two alignment
   translators called only from cell/row/col/tabular attributes.
6. **`Schema: enumerate "interactive" "@variant" for CalcPlot3D, drop
   runtime check`** — `interactive/@variant` typed to the three
   CalcPlot3D endpoints; the fallback `http://www.example.com/` URL goes
   away.
7. **`LaTeX: drop unreachable "otherwise" in five tabular "*-specification"
   templates`** — same cleanup as #4/#5, applied to the LaTeX-only
   variants (`paragraph-valign-`, `paragraph-halign-`, `vrule-`,
   `hrule-`, `crule-specification`).

## Two related cases deliberately left alone

- `ol/@marker` — values are decorated format codes (`"1."`, `"(a)"`,
  `"++A"`); a clean enum would reject existing valid usage. Best handled
  with a regex pattern or left as-is.
- `solutions/@scope` — an IDREF whose runtime check inspects the target
  element's type, not the attribute's value; RNG can't express that
  rule. A candidate for `pretext-validation-plus.xsl` rather than the
  base schema.

## Verification

`jing pretext-dev.rng` error counts on `examples/sample-article/`,
`examples/sample-book/`, and `doc/guide/`: **201 / 277 / 9** — identical
before and after every commit. None of the residual errors mention the
attributes touched here. No content build was exercised on this branch;
the schema changes are validation-only and the XSL changes only remove
unreachable branches.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*