### PR TITLE
Fixed-order rendering for Parsons problems

### DIFF
--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3346,6 +3346,43 @@ TEST_CASE( "Test the add function" ) {
                 </block>
             </blocks>
         </exercise>
+
+        <exercise label="number-theory-proof-fixed-order" adaptive="yes">
+            <title>Parsons Problem, Mathematical Proof, Fixed Order</title>
+            <idx>even numbers</idx>
+            <statement>
+                <p>Create a proof of the theorem: If <m>n</m> is an even number, then <m>n\equiv 0\mod 2</m>. [Ed.  This version is a copy of the first Parsons problem in this section, now with <attr>randomize</attr> set to <c>no</c> on the <tag>blocks</tag>, so the blocks always appear in the fixed order given by the <attr>order</attr> attributes, instead of being shuffled.]</p>
+            </statement>
+            <blocks randomize="no">
+                <block order="2">
+                    <p>Suppose <m>n</m> is even.</p>
+                </block>
+                <block order="3">
+                    <choice><p>Then <m>n</m> is a prime number.</p></choice>
+                    <choice correct="yes"><p>Then there exists an <m>m</m> so that <m>n = 2m</m>.</p></choice>
+                    <choice><p>Then there exists an <m>m</m> so that <m>n = 2m + 1</m>.</p></choice>
+                </block>
+                <block order="1" correct="no">
+                    <p>Click the heels of your ruby slippers together three times.</p>
+                </block>
+                <block order="5">
+                    <p>So <m>n = 2m + 0</m>.</p>
+                    <p>This is a superfluous second paragraph in this block.</p>
+                </block>
+                <block order="4">
+                    <p>Thus <m>n\equiv 0\mod 2</m>.</p>
+                </block>
+                <block order="6" correct="no">
+                    <p>And a little bit of irrelevant multi-line math
+                        <md>
+                            <mrow>c^2&amp;a^2+b^2</mrow>
+                            <mrow>&amp;x^2+y^2</mrow>
+                        </md>.
+                    </p>
+                </block>
+            </blocks>
+            <hint><p>Dorothy will not be much help with this proof.</p></hint>
+        </exercise>
     </exercises>
 
     <exercises xml:id="horizontal-parsons-exercises">

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -234,7 +234,7 @@
                     element blocks {
                         attribute layout {"horizontal"}?,
                         attribute randomize {"yes"|"no"}?,
-                        Block+
+                        ( BlockOrdered+ | BlockUnordered+ )
                     },
                     Hint*, Answer*, Solution*,
                     (
@@ -248,19 +248,25 @@
                             text
                         }?
                     )?
-            Block =
-                element block {
-                    attribute order {xsd:integer}?,
-                    ((
+            BlockBody =
+                ((
+                    attribute correct {"yes"|"no"}?,
+                    mixed {BlockText?, CodeLine?}+
+                ) |
+                (
+                    element choice {
                         attribute correct {"yes"|"no"}?,
                         mixed {BlockText?, CodeLine?}+
-                    ) |
-                    (
-                        element choice {
-                            attribute correct {"yes"|"no"}?,
-                            mixed {BlockText?, CodeLine?}+
-                        }+
-                    ))
+                    }+
+                ))
+            BlockOrdered =
+                element block {
+                    attribute order {xsd:integer},
+                    BlockBody
+                }
+            BlockUnordered =
+                element block {
+                    BlockBody
                 }
             Matching =
                 MetaDataTitleOptional,

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -531,9 +531,14 @@
           </choice>
         </attribute>
       </optional>
-      <oneOrMore>
-        <ref name="Block"/>
-      </oneOrMore>
+      <choice>
+        <oneOrMore>
+          <ref name="BlockOrdered"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="BlockUnordered"/>
+        </oneOrMore>
+      </choice>
     </element>
     <zeroOrMore>
       <ref name="Hint"/>
@@ -564,15 +569,30 @@
       </optional>
     </optional>
   </define>
-  <define name="Block">
-    <element name="block">
-      <optional>
-        <attribute name="order">
-          <data type="integer"/>
-        </attribute>
-      </optional>
-      <choice>
-        <group>
+  <define name="BlockBody">
+    <choice>
+      <group>
+        <optional>
+          <attribute name="correct">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+        <oneOrMore>
+          <mixed>
+            <optional>
+              <ref name="BlockText"/>
+            </optional>
+            <optional>
+              <ref name="CodeLine"/>
+            </optional>
+          </mixed>
+        </oneOrMore>
+      </group>
+      <oneOrMore>
+        <element name="choice">
           <optional>
             <attribute name="correct">
               <choice>
@@ -591,30 +611,21 @@
               </optional>
             </mixed>
           </oneOrMore>
-        </group>
-        <oneOrMore>
-          <element name="choice">
-            <optional>
-              <attribute name="correct">
-                <choice>
-                  <value>yes</value>
-                  <value>no</value>
-                </choice>
-              </attribute>
-            </optional>
-            <oneOrMore>
-              <mixed>
-                <optional>
-                  <ref name="BlockText"/>
-                </optional>
-                <optional>
-                  <ref name="CodeLine"/>
-                </optional>
-              </mixed>
-            </oneOrMore>
-          </element>
-        </oneOrMore>
-      </choice>
+        </element>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="BlockOrdered">
+    <element name="block">
+      <attribute name="order">
+        <data type="integer"/>
+      </attribute>
+      <ref name="BlockBody"/>
+    </element>
+  </define>
+  <define name="BlockUnordered">
+    <element name="block">
+      <ref name="BlockBody"/>
     </element>
   </define>
   <define name="Matching">

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -259,6 +259,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- A Parsons blocks/@randomize="no" without any @order on  -->
+<!-- the child "block" elements is meaningless: the fixed    -->
+<!-- order would just match the authored order.  Warn so the -->
+<!-- author either supplies @order values or drops the       -->
+<!-- @randomize attribute.                                   -->
+<xsl:template match="blocks[@randomize = 'no']">
+    <xsl:if test="not(block/@order)">
+        <xsl:apply-templates select="." mode="messaging">
+            <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message">
+                <xsl:text>A &lt;blocks&gt; element with @randomize="no" has no &lt;block&gt; carrying @order.&#xa;</xsl:text>
+                <xsl:text>The fixed rendering order will just be the authored order.&#xa;</xsl:text>
+                <xsl:text>Either add @order to each &lt;block&gt;, or remove @randomize.</xsl:text>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- recurse further -->
+    <xsl:apply-templates/>
+</xsl:template>
+
 
 <!-- ####### -->
 <!-- WeBWorK -->

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2332,7 +2332,7 @@
                     element blocks {
                         attribute layout {"horizontal"}?,
                         attribute randomize {"yes"|"no"}?,
-                        Block+
+                        ( BlockOrdered+ | BlockUnordered+ )
                     },
                     Hint*, Answer*, Solution*,
                     (
@@ -2346,19 +2346,25 @@
                             text
                         }?
                     )?
-            Block =
-                element block {
-                    attribute order {xsd:integer}?,
-                    ((
+            BlockBody =
+                ((
+                    attribute correct {"yes"|"no"}?,
+                    mixed {BlockText?, CodeLine?}+
+                ) |
+                (
+                    element choice {
                         attribute correct {"yes"|"no"}?,
                         mixed {BlockText?, CodeLine?}+
-                    ) |
-                    (
-                        element choice {
-                            attribute correct {"yes"|"no"}?,
-                            mixed {BlockText?, CodeLine?}+
-                        }+
-                    ))
+                    }+
+                ))
+            BlockOrdered =
+                element block {
+                    attribute order {xsd:integer},
+                    BlockBody
+                }
+            BlockUnordered =
+                element block {
+                    BlockBody
                 }
             Matching =
                 MetaDataTitleOptional,

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1178,6 +1178,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:text>dag</xsl:text>
                         </xsl:attribute>
                     </xsl:if>
+                    <!-- Fixed-order rendering, gated by blocks/@randomize='no' -->
+                    <xsl:if test="blocks/@randomize = 'no'">
+                        <xsl:attribute name="data-order">
+                            <xsl:apply-templates select="blocks" mode="parsons-data-order"/>
+                        </xsl:attribute>
+                    </xsl:if>
                     <!-- author asks student to provide indentation via  -->
                     <!-- the indentation-enabled "drop" text window      -->
                     <!-- (not relevant for natural language)             -->
@@ -1249,6 +1255,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:if>
         </div>
     </div>
+</xsl:template>
+
+<!-- Helper: build the @data-order list (comma-separated, -->
+<!-- 0-based) in the order specified by @order on each    -->
+<!-- block.  A block containing "choice" children does    -->
+<!-- not get an index; each choice gets one in its place. -->
+<xsl:template match="blocks" mode="parsons-data-order">
+    <xsl:for-each select="block">
+        <xsl:sort select="@order" data-type="number"/>
+        <xsl:if test="position() &gt; 1">
+            <xsl:text>,</xsl:text>
+        </xsl:if>
+        <xsl:choose>
+            <xsl:when test="choice">
+                <xsl:for-each select="choice">
+                    <xsl:if test="position() &gt; 1">
+                        <xsl:text>,</xsl:text>
+                    </xsl:if>
+                    <!-- This choice is a leaf.  Its 0-based index is the count  -->
+                    <!-- of leaves preceding it: choice-less blocks and choices  -->
+                    <!-- of blocks before its parent, plus its earlier siblings. -->
+                    <xsl:value-of select="count(../preceding-sibling::block[not(choice)])
+                                          + count(../preceding-sibling::block/choice)
+                                          + count(preceding-sibling::choice)"/>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- This choice-less block is a leaf.  Its 0-based index   -->
+                <!-- is the count of leaves preceding it: choice-less       -->
+                <!-- blocks, plus choices belonging to blocks-with-choices. -->
+                <xsl:value-of select="count(preceding-sibling::block[not(choice)])
+                                      + count(preceding-sibling::block/choice)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:for-each>
 </xsl:template>
 
 <xsl:template match="blocks/block" mode="vertical-blocks">


### PR DESCRIPTION
## Summary

Adds a way to render a Parsons problem's blocks in a fixed,
author-specified order in HTML output, instead of the usual shuffle.
The order is described by the existing `@order` attributes on each
`<block>`, and is activated by `randomize="no"` on the enclosing
`<blocks>`.

When `<blocks randomize="no">` is set, the HTML build emits a
`data-order` attribute on the `parsonsblocks` element: a
comma-separated list of 0-based indices giving the blocks (and, where
a block has `<choice>` children, those choices) in `@order` sequence.
The Runestone JavaScript already interprets `data-order`, so no
client-side change is needed.

## Index numbering

Blocks are indexed 0-based in document order. A block with `<choice>`
children does not take an index itself; instead each of its choices
takes one, in place of the parent. `@order` lives on `<block>`, not on
`<choice>`, so the choices inside a block always render in their
authored order — only the surrounding blocks (and the choice-bearing
block as a unit) move. The blocks are then walked in `@order` order to
produce the `data-order` list. For the new sample-book exercise this
yields `data-order="4,0,1,2,3,6,5,7"`.

## Changes

- **Runestone (HTML):** emit `data-order` on the vertical Parsons
  template, computed by a new moded helper template.
- **Schema:** the `<block>` production is split so that either every
  block carries `@order` or none does — a mixed state is no longer
  schema-valid. (Parsons lives in the dev overlay, so only
  `pretext-dev.rnc`/`.rng` regenerate.)
- **Validation-plus:** advisory when `<blocks randomize="no">` has no
  `@order` anywhere — that configuration renders in authored order
  and conveys nothing, so the author should supply `@order` values or
  drop `@randomize`.
- **Sample book:** a new `number-theory-proof-fixed-order` exercise
  in `rune.xml` demonstrates the feature.

## Scope

This covers the vertical Parsons template
(`@exercise-interactive='parson'`). The horizontal Parsons template
is a separate code path and is not addressed here.

## Test plan

- [ ] Build the sample book HTML with
      `publication-runestone-academy.xml`; confirm the new
      `number-theory-proof-fixed-order` exercise carries
      `data-order="4,0,1,2,3,6,5,7"` and no other Parsons problem
      gains the attribute.
- [ ] Confirm validation-plus is silent on a fully-`@order`ed
      `<blocks randomize="no">` and warns on one with no `@order`.
- [ ] Regenerate `pretext-dev.rnc`/`.rng` and confirm a mixed
      some-`@order`/some-not `<blocks>` is rejected.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*