### PR TITLE
Guide: cautionary tale of non-meaningful macros

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1596,6 +1596,182 @@
             </introduction>
 
             <subsubsection>
+                <title>A Cautionary Tale</title>
+
+                <p>For a memorable illustration of what can go wrong without meaningful macro names, consider the <latex/> macro <c>\be</c>.  David Farmer collected, from papers in the arXiv preprint server, sixty-six different definitions of <c>\be</c>.  Across that collection, <c>\be</c> stands for at least sixteen entirely distinct mathematical objects (and one for which it is a stretch to call the object mathematical at all).  Without the definition close at hand, a reader of the source has no way to know which is meant.  The original list is at <url href="https://aimath.org/~farmer/print/whatisbe.html" visual="aimath.org/~farmer/print/whatisbe.html"/>; we reproduce it below, grouped into sixteen equivalence classes, with each class given a short descriptive phrase that the macro name <c>\be</c> conspicuously fails to convey.</p>
+
+                <list>
+                    <title>Sixty-six definitions of <c>\be</c></title>
+
+                    <ol>
+                        <li>
+                            <p>the <c>equation</c> environment, or display math:</p>
+                            <ul>
+                                <li><c>\begin{equation}</c></li>
+                                <li><c>\begin {equation}</c></li>
+                                <li><c>\begin{equation*}</c></li>
+                                <li><c>\begin{equation}\begin{array}{l}</c></li>
+                                <li><c>\setcounter{equation}{\value{theorem}} \begin{equation}</c></li>
+                                <li><c>\begin{displaymath}</c></li>
+                                <li><c>\begin{equs}</c></li>
+                                <li><c>\protect\[</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the <c>eqnarray</c> environment:</p>
+                            <ul>
+                                <li><c>\begin{eqnarray}</c></li>
+                                <li><c>\begin{eqnarray*}</c></li>
+                                <li><c>\begin{eqnarray}\label{#1}</c></li>
+                                <li><c>\begin{eqnarray} \label{#1}</c></li>
+                                <li><c>\begin{eqnarray#1}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the <c>gather</c> environment:</p>
+                            <ul>
+                                <li><c>\begin{gather}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the <c>enumerate</c> environment:</p>
+                            <ul>
+                                <li><c>\begin{enumerate}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>an <c>example</c>-like environment:</p>
+                            <ul>
+                                <li><c>\begin{exmple}</c></li>
+                                <li><c>\begin{example}\rm\label{#1}</c></li>
+                                <li><c>\begin{Example}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the Greek letter beta, possibly decorated:</p>
+                            <ul>
+                                <li><c>\beta</c></li>
+                                <li><c>{\beta}</c></li>
+                                <li><c>\ensuremath{\beta}</c></li>
+                                <li><c>\overrightarrow{\beta}</c></li>
+                                <li><c>\boldsymbol \beta</c></li>
+                                <li><c>$\beta\text{ }$</c></li>
+                                <li><c>\beta_{\ep}</c></li>
+                                <li><c>{\bar \beta}</c></li>
+                                <li><c>\smash{\mkern2mu\overline{\mkern-2mu\phantom{\eta}}\mkern-9.583mu}\eta</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a bold lowercase letter:</p>
+                            <ul>
+                                <li><c>\mathbf{e}</c></li>
+                                <li><c>{\mathbf e}</c></li>
+                                <li><c>{\mathbf{e}}</c></li>
+                                <li><c>\boldsymbol b</c></li>
+                                <li><c>\boldsymbol e</c></li>
+                                <li><c>\boldsymbol{e}</c></li>
+                                <li><c>{\boldsymbol{e}}</c></li>
+                                <li><c>\mbox{\boldmath $e$}</c></li>
+                                <li><c>\bm{e}</c></li>
+                                <li><c>{\bf e}</c></li>
+                                <li><c>{\bf{e}}</c></li>
+                                <li><c>{\bf \textbf{e}}</c></li>
+                                <li><c>\mbox{\bf e}</c></li>
+                                <li><c>{\bold {\hat{e}}}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a bold or blackboard-bold uppercase E:</p>
+                            <ul>
+                                <li><c>\mathbb E</c></li>
+                                <li><c>\mathbb{E}</c></li>
+                                <li><c>\mathbf E</c></li>
+                                <li><c>\mbox{$\bf E$}</c></li>
+                                <li><c>\breve{E}</c></li>
+                                <li><c>\boldsymbol{\mathcal{E}}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a bold or barred digit:</p>
+                            <ul>
+                                <li><c>\mathbf{1}</c></li>
+                                <li><c>\bar{5}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a barred, fraktur, sans-serif, vector, or matrix lowercase letter:</p>
+                            <ul>
+                                <li><c>\bar e</c></li>
+                                <li><c>\bar{e}</c></li>
+                                <li><c>\bar{\e}</c></li>
+                                <li><c>\bar{\varepsilon}</c></li>
+                                <li><c>\mathfrak b</c></li>
+                                <li><c>\textfrak{B}</c></li>
+                                <li><c>\mathfrak{s}</c></li>
+                                <li><c>\mathsf{o}</c></li>
+                                <li><c>\vec{e}</c></li>
+                                <li><c>\mtx{e}</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>horizontal spacing:</p>
+                            <ul>
+                                <li><c>\mbox{}\hskip10pt</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a partial derivative:</p>
+                            <ul>
+                                <li><c>\partial B_\lambda</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>a specific functor:</p>
+                            <ul>
+                                <li><c>\Bord_n(H_n)</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the Greek letters alpha or gamma:</p>
+                            <ul>
+                                <li><c>\alpha</c></li>
+                                <li><c>\gamma</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the infinity symbol:</p>
+                            <ul>
+                                <li><c>\infty</c></li>
+                            </ul>
+                        </li>
+
+                        <li>
+                            <p>the phrase <q>broken ergodicity</q>:</p>
+                            <ul>
+                                <li><c>broken ergodicity</c></li>
+                            </ul>
+                        </li>
+                    </ol>
+                </list>
+
+                <p>Sixteen meanings, one name<mdash/>and that is just for one macro on one preprint server.  Now imagine reading source written by a colleague who has used <c>\be</c> consistently, but never told you which of the sixteen is meant.  The remedy is to use macro names that say what they mean: <c>\equation</c>, <c>\beta</c>, <c>\expectation</c>, and so on.  The remaining subsubsections of this section give specific advice for several common situations where a single piece of notation carries multiple mathematical meanings.</p>
+            </subsubsection>
+
+            <subsubsection>
                 <title>Vertical Bars</title>
 
                 <p>Vertical bars are used for a variety of mathematical objects.  Paired to create functions of expressions: absolute value, <m>\left\lvert x-1\right\rvert</m>; norm of a vector, <m>\left\lVert \mathbf{v}\right\rVert</m>; cardinality of a set, <m>\left\lvert X\right\rvert</m>; and the determinant of a matrix, <m>\left\lvert A^k\right\rvert</m>.  As relations:  division, <m>a\mid b</m>; parallel lines <m>L_1\parallel L_2</m>.  Sets are another use: <m>E=\left\{x\in{\mathbb Z}\,\middle\vert\, x\equiv 0\pmod 2\right\}</m>.</p>


### PR DESCRIPTION
## Summary

Adds an "A Cautionary Tale" subsubsection at the start of the Semantic
Macros subsection (Mathematics chapter) of the Guide. It reproduces
David Farmer's collection of sixty-six published definitions of the
LaTeX macro `\be` (https://aimath.org/~farmer/print/whatisbe.html),
partitioned into sixteen equivalence classes, each labeled with a
short phrase saying what `\be` was meant to denote.

The illustration gives concrete weight to the section's opening
claim — that a well-designed macro should convey mathematical
meaning without the reader consulting its definition.

(Farmer's page states 15 classes; we follow his visual blank-line
grouping, which yields 16.)

## Test plan

- [x] PDF build of `doc/guide/guide.xml` succeeds (431 pages); no new
  warnings introduced by this change.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*