### PR TITLE
Inline "exercise": recognize "appendix" as a parent

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17529,6 +17529,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <p>This is some notation introduced in the article.  <pretext/> allows the <q>notation list</q> generator anywhere, so we have this paragraph to test spacing above and below the table.  We'll say that again.</p>
 
                 <p>This is some notation introduced in the article.  <pretext/> allows the <q>notation list</q> generator anywhere, so we have this paragraph to test spacing above and below the table.  We'll say that again.</p>
+
+                <!-- Regression test: inline exercise as child of appendix. -->
+                <exercise xml:id="appendix-inline-checkpoint">
+                    <statement>
+                        <p>List two pieces of notation that appear in this appendix.</p>
+                    </statement>
+                </exercise>
             </appendix>
 
             <solutions xml:id="solutions-backmatter" label="solutions-backmatter" inline="hint solution answer" divisional="hint solution answer" project="answer" worksheet="hint" reading="answer">

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -144,4 +144,4 @@
 <!-- true. We are positive, so as new locations of "exercise"          -->
 <!-- are added, then this need not change                              -->
 <!-- Typical use: self::exercise and boolean(&INLINE-EXERCISE-FILTER;) -->
-<!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::section|parent::subsection|parent::subsubsection|parent::handout">
+<!ENTITY INLINE-EXERCISE-FILTER "parent::article|parent::paragraphs|parent::chapter|parent::appendix|parent::section|parent::subsection|parent::subsubsection|parent::handout">


### PR DESCRIPTION
An inline `<exercise>` whose parent was `<appendix>` matched no branch
of `INLINE-EXERCISE-FILTER` in `xsl/entities.ent`, so the downstream
LaTeX, HTML, and Braille templates fell through to a bare statement
rendering — no environment, no label, no number, no working `<xref>`.
Adding `parent::appendix` to the filter restores normal inline-exercise
behavior across all output formats.

Surfaced by an upcoming numbering test document. A regression test
(one inline exercise in `appendix-notation`) is included in the sample
article.

*Claude Opus 4.7, acting as a coding assistant for Rob Beezer*