### PR TITLE
MathJax script load timing

### DIFF
--- a/examples/sample-article/media/code/jsxgraph/interactive-jsx-arc-graph.js
+++ b/examples/sample-article/media/code/jsxgraph/interactive-jsx-arc-graph.js
@@ -1,0 +1,89 @@
+JXG.Options.text.useMathJax = true;
+
+var board = JXG.JSXGraph.initBoard('jsx_1_5_arc_graph_fig', {
+    boundingbox: [-4, 4, 4, -4],
+    axis: true,
+    showCopyright: false
+});
+
+const fx = (x) => -(x - 1) * (x - 1) + 3;
+
+// small separation to enforce a < b
+const eps = 8e-2;
+
+var f = board.create('functiongraph', [
+    function (x) { return fx(x); }
+]);
+
+var xptx = board.create('glider', [0, 0, f], {
+    withLabel: false,
+    color: 'red',
+    size: 3
+});
+
+var bptx = board.create('glider', [2, 2, f], {
+    withLabel: false,
+    color: 'red',
+    size: 3
+});
+
+var xlabel = board.create('text', [0.12, 0.12, 'a'], {
+    anchor: xptx,
+    // useMathJax: true,
+    parse: false,
+    // display: 'html',
+    fixed: true,
+    fontSize: 14
+});
+
+var blabel = board.create('text', [0.12, 0.12, 'b'], {
+    anchor: bptx,
+    // useMathJax: true,
+    parse: false,
+    // display: 'html',
+    fixed: true,
+    fontSize: 14
+});
+
+
+// enforce strict ordering a < b with epsilon separation
+xptx.on('drag', function () {
+    let a = xptx.X();
+    let b = bptx.X();
+
+    if (a >= b - eps) {
+        a = b - eps;
+        xptx.moveTo([a, fx(a)]);
+    }
+});
+
+bptx.on('drag', function () {
+    let a = xptx.X();
+    let b = bptx.X();
+
+    if (b <= a + eps) {
+        b = a + eps;
+        bptx.moveTo([b, fx(b)]);
+    }
+});
+
+var arcline = board.create('line', [xptx, bptx], {
+    straightFirst: false,
+    straightLast: false
+});
+
+var arcfun = function () {
+    const a = xptx.X();
+    const b = bptx.X();
+    const arc = (fx(b) - fx(a)) / (b - a);
+    const arcround= arc.toFixed(2);
+    return `\\(\\text{ARC} = \\frac{f(b)-f(a)}{b-a} = ${arcround}\\)`;
+};
+
+var arcformula = board.create('text', [-4, 3, arcfun
+], {
+    parse: false,
+    fixed: true,
+    fontSize: 14,
+cssStyle: 'background-color: rgb(255,255,255)'
+});

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13523,18 +13523,6 @@ TODO:
 <!-- Autobold extension is critical for captions (bold'ed) that -->
 <!-- have mathematics in them (suggested by P. Krautzberger)    -->
 <xsl:template name="mathjax">
-    <!-- MathJax 4 configuration via JavaScript module -->
-    <script type="module">
-        <xsl:text>import { startMathJax } from './</xsl:text>
-        <xsl:value-of select="$html.js.dir"/>
-        <xsl:text>/mathjax_startup.js';&#xa;</xsl:text>
-        <xsl:text>startMathJax({&#xa;</xsl:text>
-            <xsl:text>hasWebworkReps: </xsl:text><xsl:value-of select="$b-has-webwork-reps"/><xsl:text>,&#xa;</xsl:text>
-            <xsl:text>hasSage: </xsl:text><xsl:value-of select="$b-has-sage"/><xsl:text>,&#xa;</xsl:text>
-            <xsl:text>isReact: </xsl:text><xsl:value-of select="$b-debug-react"/><xsl:text>,&#xa;</xsl:text>
-            <xsl:text>htmlPresentation: </xsl:text><xsl:value-of select="$b-html-presentation"/><xsl:text>,&#xa;</xsl:text>
-        <xsl:text>});&#xa;</xsl:text>
-    </script>
     <!-- MathJax 4 CDN -->
     <script defer="true">
         <xsl:attribute name="src">
@@ -13548,6 +13536,18 @@ TODO:
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:attribute>
+    </script>
+    <!-- MathJax 4 configuration via JavaScript module -->
+    <script type="module">
+        <xsl:text>import { startMathJax } from './</xsl:text>
+        <xsl:value-of select="$html.js.dir"/>
+        <xsl:text>/mathjax_startup.js';&#xa;</xsl:text>
+        <xsl:text>startMathJax({&#xa;</xsl:text>
+            <xsl:text>hasWebworkReps: </xsl:text><xsl:value-of select="$b-has-webwork-reps"/><xsl:text>,&#xa;</xsl:text>
+            <xsl:text>hasSage: </xsl:text><xsl:value-of select="$b-has-sage"/><xsl:text>,&#xa;</xsl:text>
+            <xsl:text>isReact: </xsl:text><xsl:value-of select="$b-debug-react"/><xsl:text>,&#xa;</xsl:text>
+            <xsl:text>htmlPresentation: </xsl:text><xsl:value-of select="$b-html-presentation"/><xsl:text>,&#xa;</xsl:text>
+        <xsl:text>});&#xa;</xsl:text>
     </script>
 </xsl:template>
 


### PR DESCRIPTION
Addresses issue described here:
https://groups.google.com/g/pretext-support/c/6WPUi-lfsLM/m/weEOxubjAQAJ?utm_medium=email&utm_source=footer

`<script type="module"` is implicitly deferred and run in order with other `deferred` scripts. 

So we want to first include the `<script defer ...` that loads MathJax into the HTML, then include the `<script type="module"` that calls the startup.

Solution makes sense, and seems to reliably fix the reported issue. I just am not sure why the ordering issue does not break more things.