### PR TITLE
Equation numbering: part-level counter fix and document-root @level

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2717,6 +2717,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:copy>
 </xsl:template>
 
+<!-- The top-level division (book, article, ...) is the root of the   -->
+<!-- division tree, at level 0, which the catch-all does not record.  -->
+<!-- A level-0 numbering scheme counts continuously from the root.    -->
+<xsl:template match="book|article|slideshow|letter|memo" mode="augment">
+    <xsl:copy>
+        <xsl:attribute name="level">
+            <xsl:text>0</xsl:text>
+        </xsl:attribute>
+        <xsl:apply-templates select="node()|@*" mode="augment">
+            <xsl:with-param name="parent-struct" select="''"/>
+            <xsl:with-param name="level" select="0"/>
+            <xsl:with-param name="ordered-list-level" select="0"/>
+        </xsl:apply-templates>
+    </xsl:copy>
+</xsl:template>
+
 <!-- See the definitions of levels in -common.  For a book with parts   -->
 <!-- ($parts != 'absent') we consider parts as peers of frontmatter and -->
 <!-- backmatter.  So we need to increment the level in this case, only. -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1404,17 +1404,32 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- variant having numbers (we could be more careful, but it is not critical) -->
     <!-- NB: global numbering is level 0 and "level-to-name" is (a) incorrect,     -->
     <!-- and (b) not useful (\numberwithin will fail)                              -->
-    <!-- NB: perhaps the chngcntr package should/could be used here                -->
     <xsl:if test="$document-root//men|$document-root//mdn[mrow]|$document-root//md[mrow]">
         <xsl:text>%% Equation Numbering&#xa;</xsl:text>
         <xsl:text>%% Controlled by  numbering.equations.level  processing parameter&#xa;</xsl:text>
         <xsl:text>%% No adjustment here implies document-wide numbering&#xa;</xsl:text>
         <xsl:if test="not($numbering-equations = 0)">
+            <!-- When the reset target is "part" (numbering-equations + root-level = 0), -->
+            <!-- the LaTeX book class's default chapter reset of the equation counter   -->
+            <!-- must be removed first.  numberwithin only adds reset triggers, it does -->
+            <!-- not displace them, so without counterwithout the equation counter      -->
+            <!-- would still reset at every chapter and the part scoping would be lost. -->
+            <xsl:if test="$numbering-equations + $root-level = 0">
+                <xsl:text>\counterwithout{equation}{chapter}&#xa;</xsl:text>
+            </xsl:if>
             <xsl:text>\numberwithin{equation}{</xsl:text>
             <xsl:call-template name="level-to-name">
                 <xsl:with-param name="level" select="$numbering-equations" />
             </xsl:call-template>
             <xsl:text>}&#xa;</xsl:text>
+            <!-- numberwithin redefines \theequation to include the reset target's    -->
+            <!-- own number as a prefix.  For part scoping this would prepend the     -->
+            <!-- Roman part letter to every equation display; PreTeXt convention is   -->
+            <!-- to show the part letter only on cross-part cross-references, so we   -->
+            <!-- trim the prefix here.                                                -->
+            <xsl:if test="$numbering-equations + $root-level = 0">
+                <xsl:text>\renewcommand{\theequation}{\arabic{equation}}&#xa;</xsl:text>
+            </xsl:if>
         </xsl:if>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -4892,6 +4892,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="appendix|solutions">
         <xsl:text>%&#xa;</xsl:text>
         <xsl:text>\appendix%&#xa;</xsl:text>
+        <!-- When the equation counter is scoped to "part" (see the         -->
+        <!-- equation-numbering template), the LaTeX book class's chapter   -->
+        <!-- reset of "equation" has been removed, so \appendix no longer   -->
+        <!-- resets equations as a side-effect.  Force the reset here so    -->
+        <!-- the backmatter's equation counter starts at 1.                 -->
+        <xsl:if test="$numbering-equations + $root-level = 0">
+            <xsl:text>\setcounter{equation}{0}%&#xa;</xsl:text>
+        </xsl:if>
         <xsl:text>%&#xa;</xsl:text>
         <!-- A book without parts gets a ToC entry, which is functional, -->
         <!-- while a book with parts gets a full-fledged part that is a  -->


### PR DESCRIPTION
Two small, independent fixes to equation numbering, surfaced while preparing a larger rework of the numbering passes. Both stand alone and are safe to land ahead of that work.

**1. LaTeX: part-level equation numbering no longer duplicates** *(commits "scope … to part", "reset … at the backmatter boundary")*

For a book with structural parts whose equations are numbered at the part level, the LaTeX/PDF output numbered equations `(I.1), (I.2), …` and **restarted them in every chapter of the part** — genuine duplicate numbers. `\numberwithin{equation}{part}` adds the part-level reset and the Roman part prefix, but the book class's per-chapter reset of the `equation` counter stays in force, so the counter still restarts each chapter.

The fix removes the chapter reset in this configuration (`\counterwithout{equation}{chapter}`), keeps `\numberwithin{equation}{part}`, and strips the prefix to a bare serial, so equations run continuously within each part. Since removing the chapter reset also means `\appendix` no longer resets the counter, an explicit `\setcounter{equation}{0}` is added at the backmatter boundary so the appendices restart at 1. Affects only documents numbering equations at the part level; HTML was already correct.

**2. Assembly: record `@level` on the document root** *(commit "Assembly: record @level on the document root")*

The assembly pass records `@level` on every division except the top-level `book`/`article`/…, though the documented level scale puts the root at level 0. This records it. The sole consumer of the division `@level` attribute (`new-level` in `-common`) matches `part|chapter|…` and never the root, so the change is **output-neutral** for all current conversions; it completes the recorded information and is a prerequisite for whole-document (level 0) numbering in the upcoming rework.

Validated during the equation-numbering work via HTML and PDF output diffs on a parts stress test (plus a parts-removed variant and the sample article).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
