### PR TITLE
Numbering rework: braille groundwork and a PDF back-matter equation fix

### DIFF
--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -122,18 +122,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:copy>
 </xsl:template>
 
-<!-- Convert to "real" XML, starting with "$augment" the   -->
-<!-- (current) final tree produced by the -assembly phase. -->
+<!-- An additional pass melds math markup, starting from $root, the  -->
+<!-- final tree from -assembly.  This stylesheet then works from the -->
+<!-- melded tree, $melded-root, for its $docinfo and $document-root. -->
 <xsl:variable name="math-meld-rtf">
-    <xsl:apply-templates select="$augment" mode="meld-math"/>
+    <xsl:apply-templates select="$root" mode="meld-math"/>
 </xsl:variable>
 <xsl:variable name="melded-math" select="exsl:node-set($math-meld-rtf)"/>
 
-<!-- Replace the "standard" key landmarks normally  -->
-<!-- produced by the -assembly stylesheet. -->
-<xsl:variable name="root" select="$melded-math/pretext"/>
-<xsl:variable name="docinfo" select="$root/docinfo"/>
-<xsl:variable name="document-root" select="$root/*[not(self::docinfo)]"/>
+<xsl:variable name="melded-root" select="$melded-math/pretext"/>
+<xsl:variable name="docinfo" select="$melded-root/docinfo"/>
+<xsl:variable name="document-root" select="$melded-root/*[not(self::docinfo)]"/>
 
 <!-- Source analysis -->
 
@@ -199,7 +198,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="segmented-rtf">
     <xsl:call-template name="warning-unimplemented"/>
     <xsl:call-template name="missing-warning"/>
-    <xsl:apply-templates select="$root"/>
+    <xsl:apply-templates select="$melded-root"/>
 </xsl:variable>
 
 <!-- And we sneak in a warning that this conversion is underway, but not complete. -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -5666,6 +5666,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="unique-id" />
     <xsl:text>}</xsl:text>
     <xsl:text>&#xa;</xsl:text>
+    <!-- A numberless division does not step a LaTeX counter, so     -->
+    <!-- \numberwithin never restarts its equations.  Reset here to  -->
+    <!-- match the assembly; with no number to show, serial is bare. -->
+    <xsl:if test="parent::backmatter and not($numbering-equations = 0)">
+        <xsl:variable name="numberless-suffix">
+            <xsl:apply-templates select="." mode="division-environment-name-suffix"/>
+        </xsl:variable>
+        <xsl:if test="$numberless-suffix = '-numberless'">
+            <xsl:text>\setcounter{equation}{0}%&#xa;</xsl:text>
+            <xsl:text>\renewcommand{\theequation}{\arabic{equation}}%&#xa;</xsl:text>
+        </xsl:if>
+    </xsl:if>
     <xsl:if test="$b-debug-numbering-check">
         <xsl:variable name="the-number">
             <xsl:apply-templates select="." mode="number"/>


### PR DESCRIPTION
This continues the numbering rework — equations and footnotes now, blocks later. A first, more independent batch of fixes landed in #2882; these two pieces are likewise self-contained and don't depend on the main rework, so they come next, with the rest of the numbering branch following right away.

- **Braille reads from the final assembled document.** Braille now takes its math from the fully assembled document instead of an earlier intermediate stage. No change to output today — it's groundwork, so the upcoming numbering changes reach braille too.

- **PDF restarts equations in an unnumbered back-matter division.** A `references` or `glossary` in the back matter that carries its own numbered equations was continuing the count from the preceding division. In the PDF those equations now restart from 1, so the division numbers its own equations, like the rest of the document already does.

**One caveat while the rest is in flight:** this PDF change runs ahead of the HTML side — PDF restarts those back-matter equation numbers while HTML still continues them, so the two formats can briefly disagree on equation numbers inside such a division. Bringing HTML into line is the next step on the numbering branch, so the gap is short.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
