### PR TITLE
Apply the @xml:id character-set check to @label

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11146,6 +11146,19 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
             </xsl:message>
         </xsl:if>
     </xsl:for-each>
+    <!-- The same limited character set applies to @label, which serves      -->
+    <!-- similar identifier-like purposes.  The reserved-id and "index"      -->
+    <!-- checks above stay specific to @xml:id, since only it is an HTML id. -->
+    <xsl:for-each select=".//@label">
+        <xsl:if test="not(translate(., $identifier-characters, '') = '')">
+            <xsl:message>
+                <xsl:text>PTX:ERROR:      </xsl:text>
+                <xsl:text>The @label "</xsl:text>
+                <xsl:value-of select="." />
+                <xsl:text>" is invalid.  Use only letters, numbers, hyphens and underscores.</xsl:text>
+            </xsl:message>
+        </xsl:if>
+    </xsl:for-each>
 </xsl:template>
 
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11110,9 +11110,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <!-- TODO: Added 2016-10-29, make into a fatal error later -->
 <!-- Unique UI id's added 2017-09-25 as fatal error -->
 <xsl:template match="mathbook|pretext" mode="identifier-warning">
-    <xsl:variable name="xmlid-characters" select="concat('-_', &SIMPLECHAR;)" />
+    <xsl:variable name="identifier-characters" select="concat('-_', &SIMPLECHAR;)" />
     <xsl:for-each select=".//@xml:id">
-        <xsl:if test="not(translate(., $xmlid-characters, '') = '')">
+        <xsl:if test="not(translate(., $identifier-characters, '') = '')">
             <xsl:message>
                 <xsl:text>PTX:ERROR:      </xsl:text>
                 <xsl:text>The @xml:id "</xsl:text>


### PR DESCRIPTION
The `identifier-warning` template already errors on an `@xml:id` containing anything outside letters, digits, hyphen, and underscore. This extends that same check to `@label`, which serves similar identifier-like purposes where the same restriction is appropriate.

Two commits:

1. **Rename** the `$xmlid-characters` variable to `$identifier-characters` (cosmetic, no behavior change) so the character set reads naturally when shared between the two attributes.
2. **Add** a parallel `@label` check reusing that variable, emitting `PTX:ERROR: The @label "…" is invalid. Use only letters, numbers, hyphens and underscores.`

Notes:
- The reserved-id (`masthead`, `toc`, …) and `index` checks are intentionally **not** copied — those are specific to `@xml:id`, since only it becomes an HTML id.
- Plain `.//@label`: in the current schema `@label` is the `LabelID` cross-reference label plus `pf:prefigure`'s `@label` (used to build image filenames) — the restriction suits both. Like the `@xml:id` check, this is a non-fatal `PTX:ERROR`.

Tested by temporarily setting a sample-article `@label` to `bad.label` and confirming the error fires (and valid labels do not).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
