### PR TITLE
Enable publisher page breaks for exercisegroup

### DIFF
--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -6163,6 +6163,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <!-- build it -->
+    <xsl:apply-templates select="." mode="newpage"/> 
     <xsl:text>\par\medskip\noindent%&#xa;</xsl:text>
     <xsl:text>\textbf{</xsl:text>
     <!-- title may be default title -->


### PR DESCRIPTION
Adds one line to the template for `exercisegroup` so that if the `xml:id` of an exercise group is listed in the publisher file in `latex/insersions/@pagebreak`, a page break is added before the title and introduction of an exercise group.

This is to avoid the situation where the title and introduction of an exercise group are at the bottom of one page, with all the exercises on the next page.