### PR TITLE
Releasing temporary files

### DIFF
--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -540,12 +540,16 @@ def release_temporary_directories():
 
     # log.level is 10 for debug, greater for all other levels.
     if log.level > 10:
-        for td in __temps:
-            log.info("Removing temporary directory {}".format(td))
-            # conservatively, raise exception on errors
-            shutil.rmtree(td, ignore_errors=False)
-            # reset list of temp direcotries to empty, to avoid duplicate requests
+        try:
+            for td in __temps:
+                log.info("Removing temporary directory {}".format(td))
+                # conservatively, raise exception on errors
+                shutil.rmtree(td, ignore_errors=False)
+                log.warning("Removed temporary directory {}".format(td))
+            # reset list of temp directories to empty, to avoid duplicate requests
             __temps = []
+        except:
+            log.warning("Failed to remove temporary directories, starting with {} (and maybe some others)".format(td))
     else:
         log.debug("Temporary directories left behind for inspection: {}".format(__temps))
 

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -533,13 +533,17 @@ def get_output_filename(xml, out_file, dest_dir, suffix):
     return os.path.join(dest_dir, derivedname)
 
 
-def release_temporary_directories():
-    """Release scratch directories unless requesting debugging info"""
+def release_temporary_directories(any_log_level):
+    """
+    Release scratch directories unless requesting debugging info
+    - any_log_level: can be set to True by an external tool to force cleanup even if log level is set to debug (log.level == 10)
+    """
+
 
     global __temps
 
     # log.level is 10 for debug, greater for all other levels.
-    if log.level > 10:
+    if log.level > 10 or any_log_level:
         try:
             for td in __temps:
                 log.info("Removing temporary directory {}".format(td))

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -930,7 +930,8 @@ def main():
         )
 
     # Cleanup, if execution does not raise errors
-    ptx.release_temporary_directories()
+    # "any_log_level" is False, since we want to keep temporary directories if the log level is set to debug
+    ptx.release_temporary_directories(any_log_level=False)
 
 
 # Do it - lone top-level command


### PR DESCRIPTION
Two commits:

1. Wrap the releasing in a try/catch to avoid errors when Windows is being difficult.  I did also put the resetting of the list of temporary directories outside the for loop.  Don't think it actually matters, but looks better to me.
2. I added a parameter in the function that allows the CLI to always ask for the temporary directories to be released.  This is something @bnmnetp has wanted, since he uses debug-level logging when building in runestone, but doesn't want all the temporary directories to clutter up his build server.  Shouldn't make any difference when using the core pretext script.

Of course, it's up to you if you want to keep both or just the first one.