### PR TITLE
Remove @xml:base from PreTeXt source and schema

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1415,7 +1415,6 @@
                 element plaintitle {text}
             Creator =
                 element creator {TextShort}
-            XMLBase = attribute xml:base {text}
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,
@@ -1426,7 +1425,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 Index*
@@ -1434,7 +1432,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 ShortTitle?,
@@ -1444,7 +1441,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
                 ShortTitle?,
@@ -1454,7 +1450,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 Subtitle?,
@@ -1465,7 +1460,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
                 (Subtitle | LinedSubtitle)?,
@@ -1476,7 +1470,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Index*
@@ -1484,7 +1477,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title, ShortTitle?, PlainTitle?)?,
                 Index*
@@ -1492,7 +1484,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Creator?,
@@ -1501,7 +1492,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Caption,
@@ -1887,7 +1877,6 @@
             
             DocInfo =
                 element docinfo {
-                    XMLBase?,
                     XMLLang?,
                     Configuration+
                 }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -3633,9 +3633,6 @@
       <ref name="TextShort"/>
     </element>
   </define>
-  <define name="XMLBase">
-    <attribute name="xml:base"/>
-  </define>
   <define name="XMLLang">
     <attribute name="xml:lang"/>
   </define>
@@ -3664,9 +3661,6 @@
       <ref name="Component"/>
     </optional>
     <optional>
-      <ref name="XMLBase"/>
-    </optional>
-    <optional>
       <ref name="XMLLang"/>
     </optional>
     <ref name="Title"/>
@@ -3683,9 +3677,6 @@
     </optional>
     <optional>
       <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLBase"/>
     </optional>
     <optional>
       <ref name="XMLLang"/>
@@ -3710,9 +3701,6 @@
     </optional>
     <optional>
       <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLBase"/>
     </optional>
     <optional>
       <ref name="XMLLang"/>
@@ -3742,9 +3730,6 @@
       <ref name="Component"/>
     </optional>
     <optional>
-      <ref name="XMLBase"/>
-    </optional>
-    <optional>
       <ref name="XMLLang"/>
     </optional>
     <ref name="Title"/>
@@ -3770,9 +3755,6 @@
     </optional>
     <optional>
       <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLBase"/>
     </optional>
     <optional>
       <ref name="XMLLang"/>
@@ -3808,9 +3790,6 @@
       <ref name="Component"/>
     </optional>
     <optional>
-      <ref name="XMLBase"/>
-    </optional>
-    <optional>
       <ref name="XMLLang"/>
     </optional>
     <optional>
@@ -3829,9 +3808,6 @@
     </optional>
     <optional>
       <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLBase"/>
     </optional>
     <optional>
       <ref name="XMLLang"/>
@@ -3860,9 +3836,6 @@
       <ref name="Component"/>
     </optional>
     <optional>
-      <ref name="XMLBase"/>
-    </optional>
-    <optional>
       <ref name="XMLLang"/>
     </optional>
     <optional>
@@ -3884,9 +3857,6 @@
     </optional>
     <optional>
       <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLBase"/>
     </optional>
     <optional>
       <ref name="XMLLang"/>
@@ -4843,9 +4813,6 @@
   </define>
   <define name="DocInfo">
     <element name="docinfo">
-      <optional>
-        <ref name="XMLBase"/>
-      </optional>
       <optional>
         <ref name="XMLLang"/>
       </optional>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2888,7 +2888,6 @@
         <p>Notes: <ul>
             <li>Language tags go on the root element to affect variants of names of objects, like theorems.</li>
             <li>The <c>xinlude</c> mechanism may pass language tags down through the root element of included files to make them universally available.</li>
-            <li>The <c>xinclude</c> mechanism inserts a <c>@xml:base</c> attribute on the root element of an included file.  So we allow this attribute on any element that allows a title.</li>
             <li>The <c>component</c> attribute allows versions to be controlled by a publisher file.</li>
             <li>These are not unordered specifications since they contain several attributes, and we enforce a <c>title</c>, <c>subtitle</c>, <tag>shorttitle</tag>, <tag>plaintitle</tag>, <c>creator</c>, <c>caption</c>, <c>idx</c> order.</li>
             <li><c>MetaDataTarget</c> is for items that are targets of cross-references, but without even optional titles.  Since they will be knowled, they can appear in an index.  But without the potential to be titled, we do not set them up as possible root elements of a file to <c>xinclude</c>.</li>
@@ -2924,7 +2923,6 @@
                 element plaintitle {text}
             Creator =
                 element creator {TextShort}
-            XMLBase = attribute xml:base {text}
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,
@@ -2935,7 +2933,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 Index*
@@ -2943,7 +2940,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 ShortTitle?,
@@ -2953,7 +2949,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
                 ShortTitle?,
@@ -2963,7 +2958,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title,
                 Subtitle?,
@@ -2974,7 +2968,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title | LinedTitle),
                 (Subtitle | LinedSubtitle)?,
@@ -2985,7 +2978,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Index*
@@ -2993,7 +2985,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 (Title, ShortTitle?, PlainTitle?)?,
                 Index*
@@ -3001,7 +2992,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Creator?,
@@ -3010,7 +3000,6 @@
                 UniqueID?,
                 LabelID?,
                 Component?,
-                XMLBase?,
                 XMLLang?,
                 Title?,
                 Caption,
@@ -3347,7 +3336,6 @@
             <code>
             DocInfo =
                 element docinfo {
-                    XMLBase?,
                     XMLLang?,
                     Configuration+
                 }

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -883,6 +883,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="pi:*" mode="version"/>
 <xsl:template match="@pi:*" mode="version"/>
 
+<!-- The xinclude mechanism stamps an @xml:base attribute onto the  -->
+<!-- root element of every included file.  We drop it during the    -->
+<!-- version pass, so the assembled source carries none, and the    -->
+<!-- schema need not permit it.  To retain the originating file URI -->
+<!-- (say, for diagnostics) mint a @pi:source-uri here instead,     -->
+<!-- consistent with the other "pi:" provenance attributes.         -->
+<xsl:template match="@xml:base" mode="version"/>
+
 <!-- The "custom" element, with a @name in an auxiliary file,     -->
 <!-- and a @ref in a source file, allows for custom substitutions -->
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11039,6 +11039,10 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:message>
             <xsl:text>PTX:DEBUG:   </xsl:text>
             <xsl:text>f: </xsl:text>
+            <!-- On assembled source the version pass has stripped @xml:base,  -->
+            <!-- so this yields nothing; to restore the originating file URI,  -->
+            <!-- mint a @pi:source-uri there (with the other "pi:" provenance) -->
+            <!-- and consume it here.                                          -->
             <xsl:choose>
                 <xsl:when test="@xml:base">
                     <xsl:value-of select="@xml:base" />


### PR DESCRIPTION
## Remove `@xml:base` from PreTeXt source and schema

XInclude stamps an `@xml:base` attribute onto the root element of every included file. The schema permitted `@xml:base` only where it permits a `<title>` (the `MetaData*` groups), so any fragment whose root is an untitled element (`<p>`, `<md>`, `<ol>`, `<image>`, …) produced a spurious schema error once XIncludes were resolved — nothing wrong in the source.

Rather than *widen* the schema to tolerate `@xml:base` everywhere, this removes the attribute during assembly's **version pass**, so it never reaches a validator — and then drops the `@xml:base` allowance from the schema entirely.

### Commit 1 — `Assembly: remove "@xml:base" during the version pass`
- `xsl/pretext-assembly.xsl`: a one-line `mode="version"` strip (`<xsl:template match="@xml:base" mode="version"/>`), beside the existing `@pi:*` strips. The assembled tree is now free of `@xml:base`.
- A comment notes the upgrade path: if the originating file URI is ever wanted (e.g. for diagnostics), mint a `@pi:source-uri` provenance attribute here instead, alongside the other `pi:*` markers.
- `xsl/pretext-common.xsl`: the only reader of `@xml:base` (`mode="debug-location"`) keeps working on un-assembled trees and falls back to empty otherwise; a comment records the same `@pi:source-uri` option.

### Commit 2 — `Schema: remove the "@xml:base" allowance`
- Removes the `XMLBase` definition, all ten `XMLBase?,` references in the `MetaData*` groups, and the explanatory note; regenerates `pretext.rnc`/`pretext.rng`. (Dev overlay unchanged — the groups live in the base schema.)

### Testing
Built the version-form (`assembly-version`) of `sample-book`:
- `@xml:base` occurrences: **14 → 0**; the assembled tree validates against the new schema with **0** errors.
- The pre-change (un-stripped) form validated against the new schema yields **14** `xml:base "not allowed"` errors — confirming validation must run on the version tree.
- A normal LaTeX build is unaffected (the lone consumer has a fallback).

### Follow-up: make the "version" tree easier to reach
Schema validation now accepts only the **post-version-pass** tree — for `@xml:base` here, as was already the case for `@component` singletons. Today that tree is reachable only through the developer-oriented `assembly-version` build format. A natural next step is to make it easier to obtain and validate against — for instance, having the validate command run the version pass before invoking `jing`. That is **not** part of this PR.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
