### PR TITLE
Fix schema-validation errors in the Guide

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1603,8 +1603,7 @@
 
                     <ol>
                         <li>
-                            <p>the <c>equation</c> environment, or display math:</p>
-                            <ul>
+                            <p>the <c>equation</c> environment, or display math:<ul>
                                 <li><c>\begin{equation}</c></li>
                                 <li><c>\begin {equation}</c></li>
                                 <li><c>\begin{equation*}</c></li>
@@ -1613,46 +1612,41 @@
                                 <li><c>\begin{displaymath}</c></li>
                                 <li><c>\begin{equs}</c></li>
                                 <li><c>\protect\[</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the <c>eqnarray</c> environment:</p>
-                            <ul>
+                            <p>the <c>eqnarray</c> environment:<ul>
                                 <li><c>\begin{eqnarray}</c></li>
                                 <li><c>\begin{eqnarray*}</c></li>
                                 <li><c>\begin{eqnarray}\label{#1}</c></li>
                                 <li><c>\begin{eqnarray} \label{#1}</c></li>
                                 <li><c>\begin{eqnarray#1}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the <c>gather</c> environment:</p>
-                            <ul>
+                            <p>the <c>gather</c> environment:<ul>
                                 <li><c>\begin{gather}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the <c>enumerate</c> environment:</p>
-                            <ul>
+                            <p>the <c>enumerate</c> environment:<ul>
                                 <li><c>\begin{enumerate}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>an <c>example</c>-like environment:</p>
-                            <ul>
+                            <p>an <c>example</c>-like environment:<ul>
                                 <li><c>\begin{exmple}</c></li>
                                 <li><c>\begin{example}\rm\label{#1}</c></li>
                                 <li><c>\begin{Example}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the Greek letter beta, possibly decorated:</p>
-                            <ul>
+                            <p>the Greek letter beta, possibly decorated:<ul>
                                 <li><c>\beta</c></li>
                                 <li><c>{\beta}</c></li>
                                 <li><c>\ensuremath{\beta}</c></li>
@@ -1662,12 +1656,11 @@
                                 <li><c>\beta_{\ep}</c></li>
                                 <li><c>{\bar \beta}</c></li>
                                 <li><c>\smash{\mkern2mu\overline{\mkern-2mu\phantom{\eta}}\mkern-9.583mu}\eta</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a bold lowercase letter:</p>
-                            <ul>
+                            <p>a bold lowercase letter:<ul>
                                 <li><c>\mathbf{e}</c></li>
                                 <li><c>{\mathbf e}</c></li>
                                 <li><c>{\mathbf{e}}</c></li>
@@ -1682,32 +1675,29 @@
                                 <li><c>{\bf \textbf{e}}</c></li>
                                 <li><c>\mbox{\bf e}</c></li>
                                 <li><c>{\bold {\hat{e}}}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a bold or blackboard-bold uppercase E:</p>
-                            <ul>
+                            <p>a bold or blackboard-bold uppercase E:<ul>
                                 <li><c>\mathbb E</c></li>
                                 <li><c>\mathbb{E}</c></li>
                                 <li><c>\mathbf E</c></li>
                                 <li><c>\mbox{$\bf E$}</c></li>
                                 <li><c>\breve{E}</c></li>
                                 <li><c>\boldsymbol{\mathcal{E}}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a bold or barred digit:</p>
-                            <ul>
+                            <p>a bold or barred digit:<ul>
                                 <li><c>\mathbf{1}</c></li>
                                 <li><c>\bar{5}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a barred, fraktur, sans-serif, vector, or matrix lowercase letter:</p>
-                            <ul>
+                            <p>a barred, fraktur, sans-serif, vector, or matrix lowercase letter:<ul>
                                 <li><c>\bar e</c></li>
                                 <li><c>\bar{e}</c></li>
                                 <li><c>\bar{\e}</c></li>
@@ -1718,50 +1708,44 @@
                                 <li><c>\mathsf{o}</c></li>
                                 <li><c>\vec{e}</c></li>
                                 <li><c>\mtx{e}</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>horizontal spacing:</p>
-                            <ul>
+                            <p>horizontal spacing:<ul>
                                 <li><c>\mbox{}\hskip10pt</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a partial derivative:</p>
-                            <ul>
+                            <p>a partial derivative:<ul>
                                 <li><c>\partial B_\lambda</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>a specific functor:</p>
-                            <ul>
+                            <p>a specific functor:<ul>
                                 <li><c>\Bord_n(H_n)</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the Greek letters alpha or gamma:</p>
-                            <ul>
+                            <p>the Greek letters alpha or gamma:<ul>
                                 <li><c>\alpha</c></li>
                                 <li><c>\gamma</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the infinity symbol:</p>
-                            <ul>
+                            <p>the infinity symbol:<ul>
                                 <li><c>\infty</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
 
                         <li>
-                            <p>the phrase <q>broken ergodicity</q>:</p>
-                            <ul>
+                            <p>the phrase <q>broken ergodicity</q>:<ul>
                                 <li><c>broken ergodicity</c></li>
-                            </ul>
+                            </ul></p>
                         </li>
                     </ol>
                 </list>

--- a/doc/guide/developer/css.xml
+++ b/doc/guide/developer/css.xml
@@ -93,7 +93,7 @@
             If you want to add finer control over the colors used by a new feature, add a new color variable to <c>colors/_color-vars.scss</c>, and use it in your CSS. To do so, you would write something like:
         </p>
 
-        <program langauge="scss">
+        <program language="scss">
             "dropdown-background": var(--button-background),
         </program>
 
@@ -132,7 +132,7 @@
 
         <p>Icons for various buttons and controls are provided for by the <url ref="https://fonts.google.com/icons">Google Material Symbols</url> font. To use an icon from this font, add the classes <c>icon material-symbols-outlined</c> to an element (typically a <tag>span</tag> or <tag>i</tag>) and set its content to the name of the icon you want. For example, to get a magnifying glass icon, you would write:</p>
 
-        <program langage="html">
+        <program language="html">
             &lt;span class="icon material-symbols-outlined" aria-hidden="true">search&lt;/span>
         </program>
 

--- a/doc/guide/developer/css.xml
+++ b/doc/guide/developer/css.xml
@@ -126,7 +126,7 @@
             When writing new CSS, you can use these variables to ensure that your new feature uses the same fonts as the rest of the theme.
         </p>
 
-        <p>Icons for various buttons and controls are provided for by the <url ref="https://fonts.google.com/icons">Google Material Symbols</url> font. To use an icon from this font, add the classes <c>icon material-symbols-outlined</c> to an element (typically a <tag>span</tag> or <tag>i</tag>) and set its content to the name of the icon you want. For example, to get a magnifying glass icon, you would write:</p>
+        <p>Icons for various buttons and controls are provided for by the <url href="https://fonts.google.com/icons">Google Material Symbols</url> font. To use an icon from this font, add the classes <c>icon material-symbols-outlined</c> to an element (typically a <tag>span</tag> or <tag>i</tag>) and set its content to the name of the icon you want. For example, to get a magnifying glass icon, you would write:</p>
 
         <program language="html">
             &lt;span class="icon material-symbols-outlined" aria-hidden="true">search&lt;/span>

--- a/doc/guide/developer/css.xml
+++ b/doc/guide/developer/css.xml
@@ -98,12 +98,8 @@
         </program>
 
         <p>
-            This ensures that the new variable has a default value (the button background color). Any palatte that targets multiple colors or dark mode will already have a value for <c>--button-background</c>, so your new variable will automatically work with those. Then, to customize the new variable for a particular palette like <c>_palette-dual.scss</c>, you would add an entry to the palette file, such as:
+            This ensures that the new variable has a default value (the button background color). Any palatte that targets multiple colors or dark mode will already have a value for <c>--button-background</c>, so your new variable will automatically work with those. Then, to customize the new variable for a particular palette like <c>_palette-dual.scss</c>, you would add an entry to the palette file, such as:<cd>"dropdown-background": var(--secondary-color),</cd>
         </p>
-
-        <code>
-            "dropdown-background": var(--secondary-color),
-        </code>
 
         <p>
             In a theme that uses the dual palette (like <c>default-modern</c>), the dropdown background will now be the secondary color, which is a different color than the button background. In a theme that uses a palette that does not customize <c>--dropdown-background</c>, the dropdown background will be the same as the button background.
@@ -142,9 +138,7 @@
     <section xml:id="css-sizing" label="css-sizing">
         <title>Sizing and Positioning Elements</title>
 
-        <p>Elements that are placed or sized relative to the page or other top level structures of the page will likely need to leverage <init>SCSS</init> variables to work well across different themes. Many files have variables defined that look like this one from <c>css/components/page-parts/_body.scss</c>:</p>
-
-        <code>$content-width: 600px !default;</code>
+        <p>Elements that are placed or sized relative to the page or other top level structures of the page will likely need to leverage <init>SCSS</init> variables to work well across different themes. Many files have variables defined that look like this one from <c>css/components/page-parts/_body.scss</c>:<cd>$content-width: 600px !default;</cd></p>
 
         <p>That variable can be overridden by a file that <c>@use</c>s it, but otherwise will have a default value of 600px. That variable can be used in style rules:</p>
 


### PR DESCRIPTION
## Fix schema-validation errors in the Guide

Validating the assembled Guide against the RELAX-NG schema turned up several invalid constructs in the source — 22 errors in all, none caught before because the Guide was not being schema-validated. Each is a small, self-contained source fix; together they bring the Guide to a clean bill of health against the schema.

### Commit 1 — `Guide: fix "@language" typos on two "program" elements`
Two `<program>` elements in the CSS developer chapter carried a misspelled language attribute (`langauge`, `langage`); both corrected to `language`.

### Commit 2 — `Guide: fold bare "code" blocks into the prose as "cd"`
Two snippets used a bare `<code>` element as a section-level block, but `<code>` is only valid inside a `<program>`. Replaced each with a `<cd>` (code display) folded into its lead-in `<p>`, which is the idiomatic way to show a short inline code display.

### Commit 3 — `Guide: use "@href" not "@ref" on a "url"`
A `<url>` linking to the Google Material Symbols font used `@ref` instead of `@href` (which also left the required `@href` missing).

### Commit 4 — `Guide: nest sublists inside "p" in the sixty-six "\be" list`
Full disclosure: this "Sixty-six definitions of `\be`" list is content I added (as Rob's coding assistant) in an earlier change, and I did not schema-validate it at the time — so all 16 of its sublists went in as bare `<ul>` elements directly inside block-mode `<li>`s, which the schema does not allow. This corrects my own mistake: each sublist is moved inside its lead-in `<p>`, the standard pattern for a nested list.

### Testing
Built the Guide's assembled (version-pass) form and validated it against `schema/pretext-dev.rng`: **22 errors → 0**.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
