### PR TITLE
Enable publisher page breaks for subexercises

### DIFF
--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -141,14 +141,31 @@
             </cd>
             At time of writing, the allowable elements which may be preceded by a page break using
             this feature are divisions, numbered blocks, and the following unnumbered elements:
-            <tag>answer</tag>, <tag>aside</tag>, <tag>audio</tag>, <tag>biographical</tag>,
-            <tag>assemblage</tag>, <tag>blockquote</tag>, <tag>console</tag> (when not a child of a
-            <tag>sidebyside</tag>), <tag>exercisegroup</tag>, <tag>hint</tag>, <tag>historical</tag>, <tag>image</tag> (when
-            not a child of a <tag>sidebyside</tag>), <tag>interactive</tag>, <tag>list-of</tag>,
-            <tag>p</tag>, <tag>paragraphs</tag>, <tag>poem</tag>, <tag>pre</tag>, <tag>program</tag>
-            (when not a child of a <tag>sidebyside</tag>), <tag>sage</tag>, <tag>sbsgroup</tag>,
-            <tag>sidebyside</tag> (when not a child of a <tag>sidebyside</tag>), <tag>solution</tag>,
-            <tag>tabular</tag> (when not a child of a <tag>sidebyside</tag>), and <tag>video</tag>.
+            <tag>answer</tag>,
+            <tag>aside</tag>,
+            <tag>audio</tag>,
+            <tag>biographical</tag>,
+            <tag>assemblage</tag>,
+            <tag>blockquote</tag>,
+            <tag>console</tag> (when not a child of a <tag>sidebyside</tag>),
+            <tag>exercisegroup</tag>,
+            <tag>hint</tag>,
+            <tag>historical</tag>,
+            <tag>image</tag> (when not a child of a <tag>sidebyside</tag>),
+            <tag>interactive</tag>,
+            <tag>list-of</tag>,
+            <tag>p</tag>,
+            <tag>paragraphs</tag>,
+            <tag>poem</tag>,
+            <tag>pre</tag>,
+            <tag>program</tag> (when not a child of a <tag>sidebyside</tag>),
+            <tag>sage</tag>,
+            <tag>sbsgroup</tag>,
+            <tag>sidebyside</tag> (when not a child of a <tag>sidebyside</tag>),
+            <tag>solution</tag>,
+            <tag>subexercises</tag>,
+            <tag>tabular</tag> (when not a child of a <tag>sidebyside</tag>), and
+            <tag>video</tag>.
         </p>
         <p>
             Note that over time, the precise size of many things in your PDF output may change. This

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -6071,6 +6071,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="id">
         <xsl:apply-templates select="." mode="unique-id"/>
     </xsl:variable>
+    <xsl:apply-templates select="." mode="newpage"/>
     <xsl:text>\paragraph{</xsl:text>
     <xsl:apply-templates select="." mode="title-full"/>
     <xsl:text>}</xsl:text>


### PR DESCRIPTION
## Enable publisher page breaks for `subexercises`

`subexercises` was missing the `mode="newpage"` hook, so it couldn't be page-broken via `latex/insertions/@pagebreaks` — the same gap `exercisegroup` had in #2890. Adds the hook and lists `subexercises` in the allowable-elements documentation (reflowing that list one element per line so it stays readable).

This came out of a comprehensive sweep of the LaTeX templates for the same situation, prompted by #2890; `subexercises` was the only other element with the gap.

Two commits: the LaTeX hook, then the Guide entry. Verified by building the sample article with `subexercises` in `@pagebreaks`.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
