### PR TITLE
Search box accessibility update

### DIFF
--- a/css/components/_pretext-search.scss
+++ b/css/components/_pretext-search.scss
@@ -1,35 +1,31 @@
 
 @use 'components/helpers/buttons-default' as buttons;
+@use 'components/helpers/accessibility' as accessibility;
 
-.searchbox {
+.ptx-search-box {
 
-  .searchwidget {
+  .ptx-search-widget {
     height: 100%;
   }
   
-  .searchresultsplaceholder {
-    position: fixed;
-    top: 5vh;
-    bottom: 5vh;
-    padding: 1em;
-    left: max(10vw, calc(100vw - 800px) / 2);
+  .ptx-search-dialog[open] {
     width: 80vw;
+    height: 100%;
     max-width: 800px;
     border: 2px solid var(--body-text-color);
     background: var(--knowl-background, #eaf0f6);
-    z-index: 5000;
     display: flex;
     flex-direction: column;
   }
 
-  .searchresultsplaceholder article {
+  .ptx-search-dialog article {
     width: 60%;
     margin-left: auto;
     margin-right: auto;
     font-family: sans-serif;
   }
 
-  .search-results-controls {
+  .ptx-search-dialog-controls {
     display: flex;
     justify-content: space-between;
     align-items: stretch;
@@ -38,26 +34,30 @@
     height: 35px;
   }
 
-  .ptxsearch {
+  .ptx-search-terms {
     flex: 1 1;
   }
   
 
-  .closesearchresults {
+  .ptx-search-close {
     @include buttons.ptx-button;
   }
 
-  .detailed_result {
+  .ptx-search-detailed-result {
     margin-bottom: 10px;
   }
 
-  .searchresults a:hover {
+  .ptx-search-results a:hover {
     text-decoration: underline;
     background: var(--link-active-background);
   }
 
+  .ptx-search-status {
+    @include accessibility.sr-only;
+  }
 
-  .searchresults {
+
+  .ptx-search-results {
     padding-left: 10px;
     margin-top: 0;
     overflow-y: auto;
@@ -66,72 +66,64 @@
     border: 1px solid var(--page-border-color, #ccc);
   }
 
-  .searchresults:empty {
+  .ptx-search-results:empty {
     display: none;
   }
   
-  .search-result-bullet {
+  .ptx-search-result-bullet {
     list-style-type: none;
   }
 
-  .search-result-score {
+  .ptx-search-result-score {
     display: none;
   }
 
   //result qualities
-  .no_result {
+  .ptx-search-result-none {
     font-size: 90%;
     font-weight: 200;
   }
 
-  .low_result {
+  .ptx-search-result-low {
     font-weight: 200;
   }
 
-  .medium_result {
+  .ptx-search-result-medium {
     font-weight: 500;
   }
-  .high_result {
+  .ptx-search-result-high {
     font-weight: 700;
   }
 
-  .searchempty {
+  .ptx-search-empty {
     display: none;
     padding-left: 10px;
     padding-top: 5px;
   }
 
-  .search-results-unshown-count {
-    margin-top: 0.6em;
+  .ptx-search-result-clip-highlight {
+    background: var(--ptx-search-resultshighlight);
   }
 
-  .search-result-clip-highlight {
-    background: var(--searchresultshighlight);
-  }
-
-  .searchresultsbackground {
-    position: fixed;
-    top: 0;
-    background: var(--searchresultsbackground, white);
-    width: 100vw;
-    height: 100%;
-    left: 0;
-    z-index: 4999;
+  .ptx-search-dialog::backdrop {
+    background: var(--ptx-search-resultsbackground, white);
   }
 
   @media screen and (max-width: 800px) {
-    .searchresultsplaceholder {
-      bottom: 10vh;
+    // max within browser default
+    .ptx-search-dialog[open] {
+      max-width: revert;
+      width: 100vw;
     }
   }
 }
 
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }

--- a/css/components/helpers/_accessibility.scss
+++ b/css/components/helpers/_accessibility.scss
@@ -1,0 +1,14 @@
+
+// Accessibility helper classes
+
+// Visually hide an element but make it available to screen readers
+@mixin sr-only {
+   clip: rect(1px, 1px, 1px, 1px);
+   clip-path: inset(50%);
+   height: 1px;
+   width: 1px;
+   margin: -1px;
+   overflow: hidden;
+   padding: 0;
+   position: absolute;
+}

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -6,6 +6,8 @@ $border-width: 1px !default;
 $navbar-breakpoint: 800px !default;
 $center-content: true !default;
 
+@use 'components/helpers/accessibility' as accessibility;
+
 @use 'components/helpers/buttons-default' as buttons;
 
 @use 'components/page-parts/extras/navbar-btn-borders';
@@ -108,8 +110,8 @@ $center-content: true !default;
     display: none;
   }
 
-  :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-    display: none;
+  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+    @include accessibility.sr-only;
   }
 
   .index-button {

--- a/css/dist/theme-boulder.css
+++ b/css/dist/theme-boulder.css
@@ -1449,30 +1449,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -1480,10 +1475,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -1503,33 +1498,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -1537,60 +1542,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;
@@ -2417,8 +2414,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;

--- a/css/dist/theme-crc-legacy.css
+++ b/css/dist/theme-crc-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -3882,7 +3882,7 @@ body.pretext {
     z-index: 100;
   }
 }
-.ptx-masthead .searchbox {
+.ptx-masthead .ptx-search-box {
   bottom: 2px;
   margin-right: -19px;
 }
@@ -4320,8 +4320,8 @@ body.pretext {
   padding: 0px 0px 0px 0px;
   justify-self: stretch;
 }
-.searchbox {
-  grid-area: ptx-searchbox;
+.ptx-search-box {
+  grid-area: ptx-search-box;
 }
 .ptx-navbar .treebuttons .next-button,
 .ptx-navbar .treebuttons .up-button,
@@ -4376,7 +4376,7 @@ nav.ptx-navbar {
   display: grid;
   grid-column-gap: 0em;
   grid-template-columns: auto auto auto 1fr 1fr auto;
-  grid-template-areas: "MH-toc-area MH-extras-area1 ptx-searchbox MH-extras-area2 MH-page-navigation-area MH-preferences-area";
+  grid-template-areas: "MH-toc-area MH-extras-area1 ptx-search-box MH-extras-area2 MH-page-navigation-area MH-preferences-area";
   background-color: #fff;
   align-items: start;
   border: 2px solid #ddd;
@@ -4470,12 +4470,12 @@ nav.ptx-navbar::after {
   cursor: pointer;
   box-sizing: border-box;
 }
-.ptx-navbar .searchbutton {
+.ptx-navbar .ptx-search-button {
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   left: calc(50vw - 300px);
 }
 @media only screen and (max-width: 800px) {
@@ -4505,7 +4505,7 @@ nav.ptx-navbar::after {
   .pretext .ptx-navbar :is(.calculator-toggle, .index-button) .icon {
     display: inline-block;
   }
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     left: 10vw;
   }
 }
@@ -4562,7 +4562,7 @@ nav.ptx-navbar::after {
 .ptx-navbar .name {
   display: inline-block;
 }
-.ptx-navbar .searchbutton .name {
+.ptx-navbar .ptx-search-button .name {
   display: none;
   position: relative;
   bottom: 0;
@@ -5157,7 +5157,7 @@ summary.knowl__link {
     position: absolute;
   }
 }
-.searchbox .searchresultsplaceholder {
+.ptx-search-box .ptx-search-dialog {
   background: #eaf0f6;
 }
 :root[data-legacy-colorscheme=blue_green] {

--- a/css/dist/theme-default-legacy.css
+++ b/css/dist/theme-default-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4196,7 +4196,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 .ptx-navbar .index-button {
@@ -4823,7 +4823,7 @@ summary.knowl__link {
     position: absolute;
   }
 }
-.searchbox .searchresultsplaceholder {
+.ptx-search-box .ptx-search-dialog {
   background: #eaf0f6;
 }
 :root[data-legacy-colorscheme=blue_green] {

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -341,8 +341,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;
@@ -2690,30 +2697,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -2721,10 +2723,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -2744,33 +2746,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -2778,60 +2790,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;

--- a/css/dist/theme-denver.css
+++ b/css/dist/theme-denver.css
@@ -345,8 +345,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;
@@ -3019,30 +3026,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -3050,10 +3052,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -3073,33 +3075,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -3107,60 +3119,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;

--- a/css/dist/theme-greeley.css
+++ b/css/dist/theme-greeley.css
@@ -1449,30 +1449,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -1480,10 +1475,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -1503,33 +1498,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -1537,60 +1542,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;
@@ -2417,8 +2414,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;

--- a/css/dist/theme-min-legacy.css
+++ b/css/dist/theme-min-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4216,7 +4216,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 .ptx-navbar .index-button {
@@ -4760,7 +4760,7 @@ summary.knowl__link {
     position: absolute;
   }
 }
-.searchbox .searchresultsplaceholder {
+.ptx-search-box .ptx-search-dialog {
   background: #eaf0f6;
 }
 :root[data-legacy-colorscheme=blue_green] {

--- a/css/dist/theme-oscarlevin-legacy.css
+++ b/css/dist/theme-oscarlevin-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4196,7 +4196,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 .ptx-navbar .index-button {

--- a/css/dist/theme-salem.css
+++ b/css/dist/theme-salem.css
@@ -345,8 +345,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;
@@ -2816,30 +2823,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -2847,10 +2849,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -2870,33 +2872,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -2904,60 +2916,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;

--- a/css/dist/theme-soundwriting-legacy.css
+++ b/css/dist/theme-soundwriting-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4196,7 +4196,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 .ptx-navbar .index-button {

--- a/css/dist/theme-tacoma.css
+++ b/css/dist/theme-tacoma.css
@@ -345,8 +345,15 @@ body.standalone-page .ptx-page {
 .ptx-navbar :is(.index-button) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton, .calculator-toggle, .light-dark-button, .embed-button) .name {
-  display: none;
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 .ptx-navbar .index-button {
   min-width: 70px;
@@ -2536,30 +2543,25 @@ article.theorem-like .emphasis {
 .searchwrapper .gsc-control-cse {
   padding: 5px;
 }
-.searchbox .searchwidget {
+.ptx-search-box .ptx-search-widget {
   height: 100%;
 }
-.searchbox .searchresultsplaceholder {
-  position: fixed;
-  top: 5vh;
-  bottom: 5vh;
-  padding: 1em;
-  left: max(10vw, (100vw - 800px) / 2);
+.ptx-search-box .ptx-search-dialog[open] {
   width: 80vw;
+  height: 100%;
   max-width: 800px;
   border: 2px solid var(--body-text-color);
   background: var(--knowl-background, #eaf0f6);
-  z-index: 5000;
   display: flex;
   flex-direction: column;
 }
-.searchbox .searchresultsplaceholder article {
+.ptx-search-box .ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox .search-results-controls {
+.ptx-search-box .ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
@@ -2567,10 +2569,10 @@ article.theorem-like .emphasis {
   margin-bottom: 1em;
   height: 35px;
 }
-.searchbox .ptxsearch {
+.ptx-search-box .ptx-search-terms {
   flex: 1 1;
 }
-.searchbox .closesearchresults {
+.ptx-search-box .ptx-search-close {
   font: inherit;
   display: flex;
   justify-content: center;
@@ -2590,33 +2592,43 @@ article.theorem-like .emphasis {
   cursor: pointer;
   user-select: none;
 }
-.searchbox .closesearchresults:hover:not(.disabled) {
+.ptx-search-box .ptx-search-close:hover:not(.disabled) {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .closesearchresults:focus-visible {
+.ptx-search-box .ptx-search-close:focus-visible {
   outline: 2px solid var(--button-text-color);
   outline-offset: -2px;
 }
-.searchbox .closesearchresults.disabled {
+.ptx-search-box .ptx-search-close.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.searchbox .closesearchresults.hidden {
+.ptx-search-box .ptx-search-close.hidden {
   display: none;
 }
-.searchbox .closesearchresults.open {
+.ptx-search-box .ptx-search-close.open {
   color: var(--button-hover-text-color);
   background-color: var(--button-hover-background);
 }
-.searchbox .detailed_result {
+.ptx-search-box .ptx-search-detailed-result {
   margin-bottom: 10px;
 }
-.searchbox .searchresults a:hover {
+.ptx-search-box .ptx-search-results a:hover {
   text-decoration: underline;
   background: var(--link-active-background);
 }
-.searchbox .searchresults {
+.ptx-search-box .ptx-search-status {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+.ptx-search-box .ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
@@ -2624,60 +2636,52 @@ article.theorem-like .emphasis {
   background: var(--content-background, white);
   border: 1px solid var(--page-border-color, #ccc);
 }
-.searchbox .searchresults:empty {
+.ptx-search-box .ptx-search-results:empty {
   display: none;
 }
-.searchbox .search-result-bullet {
+.ptx-search-box .ptx-search-result-bullet {
   list-style-type: none;
 }
-.searchbox .search-result-score {
+.ptx-search-box .ptx-search-result-score {
   display: none;
 }
-.searchbox .no_result {
+.ptx-search-box .ptx-search-result-none {
   font-size: 90%;
   font-weight: 200;
 }
-.searchbox .low_result {
+.ptx-search-box .ptx-search-result-low {
   font-weight: 200;
 }
-.searchbox .medium_result {
+.ptx-search-box .ptx-search-result-medium {
   font-weight: 500;
 }
-.searchbox .high_result {
+.ptx-search-box .ptx-search-result-high {
   font-weight: 700;
 }
-.searchbox .searchempty {
+.ptx-search-box .ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.searchbox .search-results-unshown-count {
-  margin-top: 0.6em;
+.ptx-search-box .ptx-search-result-clip-highlight {
+  background: var(--ptx-search-resultshighlight);
 }
-.searchbox .search-result-clip-highlight {
-  background: var(--searchresultshighlight);
-}
-.searchbox .searchresultsbackground {
-  position: fixed;
-  top: 0;
-  background: var(--searchresultsbackground, white);
-  width: 100vw;
-  height: 100%;
-  left: 0;
-  z-index: 4999;
+.ptx-search-box .ptx-search-dialog::backdrop {
+  background: var(--ptx-search-resultsbackground, white);
 }
 @media screen and (max-width: 800px) {
-  .searchbox .searchresultsplaceholder {
-    bottom: 10vh;
+  .ptx-search-box .ptx-search-dialog[open] {
+    max-width: revert;
+    width: 100vw;
   }
 }
 :root {
-  --searchresultsbackground: #fff8;
-  --searchresultshighlight: rgba(255, 255, 0, 50%);
+  --ptx-search-resultsbackground: #fff8;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 50%);
 }
 :root.dark-mode {
-  --searchresultsbackground: #0008;
-  --searchresultshighlight: rgba(255, 255, 0, 15%);
+  --ptx-search-resultsbackground: #0008;
+  --ptx-search-resultshighlight: rgba(255, 255, 0, 15%);
 }
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;

--- a/css/dist/theme-wide-legacy.css
+++ b/css/dist/theme-wide-legacy.css
@@ -3664,30 +3664,30 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
   border-color: #600;
   border-color: var(--sectiontoctext);
 }
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
   width: 60%;
   margin-left: auto;
   margin-right: auto;
   font-family: sans-serif;
 }
-.searchbox {
+.ptx-search-box {
 }
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
-.searchwidget {
+.ptx-search-widget {
   text-align: right;
 }
-.searchwidget input {
+.ptx-search-widget input {
 }
 .helpbox {
   display: none;
 }
-.detailed_result {
+.ptx-search-detailed-result {
   margin-bottom: 10px;
 }
 .all_results a:link {
@@ -3697,49 +3697,49 @@ article.exercise-like > .heading + div.ptx-runestone-container > div.runestone {
 .all_results a:hover {
   background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   background-color: #eee;
 }
-.searchresults a {
+.ptx-search-results a {
   text-decoration: none;
   color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
   text-decoration: underline;
   color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
   list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
   padding-left: 10px;
   margin-top: 0;
   overflow-y: auto;
   flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
   list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
   display: none;
 }
-.high_result {
+.ptx-search-result-high {
   font-weight: 700;
 }
-.medium_result {
+.ptx-search-result-medium {
   font-weight: 500;
 }
-.low_result {
+.ptx-search-result-low {
   font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
   font-weight: 200;
   color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
   font-size: 90%;
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   position: fixed;
   top: 5vh;
   bottom: 5vh;
@@ -3752,39 +3752,39 @@ ol.searchresults > li {
   display: flex;
   flex-direction: column;
 }
-.search-results-heading {
+.ptx-search-results-heading {
   border-bottom: 1px solid rgba(0, 0, 125, 0.5);
 }
-.search-results-controls {
+.ptx-search-dialog-controls {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   gap: 10px;
   margin-bottom: 1em;
 }
-.closesearchresults {
+.ptx-search-close {
   display: flex;
   justify-content: space-between;
   align-items: center;
   border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
   color: #c00;
   background-color: #fee;
   border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
   margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
   display: none;
   padding-left: 10px;
   padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
   margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
   font-size: 80%;
   font-style: italic;
   color: #444;
@@ -3793,11 +3793,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
   margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
   background: rgba(255, 255, 0, 0.5);
 }
 @media screen and (max-width: 800px) {
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4005,7 +4005,7 @@ body.pretext {
   background: var(--page-color);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
 }
-.searchresultsplaceholder {
+.ptx-search-dialog {
   left: calc(50vw - 300px);
 }
 .pretext .ptx-page .ptx-main {
@@ -4172,7 +4172,7 @@ body.pretext {
   .ptx-content .ptx-runestone-container .parsons .sortable-code:first-of-type {
     padding: 0 25px;
   }
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;
@@ -4424,7 +4424,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle) .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 .ptx-navbar .index-button {
@@ -5114,7 +5114,7 @@ summary.knowl__link {
     position: absolute;
   }
 }
-.searchbox .searchresultsplaceholder {
+.ptx-search-box .ptx-search-dialog {
   background: #eaf0f6;
 }
 .ptx-content article:is(.theorem-like, .definition-like, .example-like, .project-like, .remark-like, .openproblem-like, .computation-like) {

--- a/css/legacy/pretext_search.css
+++ b/css/legacy/pretext_search.css
@@ -1,11 +1,11 @@
-.searchresultsplaceholder article {
+.ptx-search-dialog article {
     width: 60%;
     margin-left: auto;
     margin-right: auto;
     font-family: sans-serif;
 }
 
-.searchbox {
+.ptx-search-box {
 /*
     height: 60px;
     border: solid;
@@ -17,16 +17,16 @@
   right: 0; */
 }
 
-.ptxsearch {
+.ptx-search-terms {
   height: 35px;
   flex: 1 1;
 }
 
-.searchbutton .name {
+.ptx-search-button .name {
   display: none;
 }
 
-.searchwidget {
+.ptx-search-widget {
 /*
     padding-top: 15px;
     padding-left: 20px;
@@ -35,7 +35,7 @@
     text-align: right;
 }
 
-.searchwidget input {
+.ptx-search-widget input {
 /*
     font-size: larger;
 */
@@ -45,7 +45,7 @@
     display: none;
 }
 
-.detailed_result {
+.ptx-search-detailed-result {
     margin-bottom: 10px;
 }
 
@@ -57,54 +57,54 @@
 .all_results a:hover {
     background-color: lightgray;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
     background-color: #eee;
 }
 
-.searchresults a {
+.ptx-search-results a {
     text-decoration: none;
     color: #222;
 }
-.searchresults a:hover {
+.ptx-search-results a:hover {
     text-decoration: underline;
     color: #33f;
 }
-.searchresults ul li {
+.ptx-search-results ul li {
     list-style-type: none;
 }
-ol.searchresults {
+ol.ptx-search-results {
     padding-left: 10px;
     margin-top: 0;
     overflow-y: auto;
     flex: 1 1;
 }
-ol.searchresults > li {
+ol.ptx-search-results > li {
     list-style-type: none;
 }
-.search-result-score {
+.ptx-search-result-score {
     display: none;
 }
-.high_result {
+.ptx-search-result-high {
     font-weight: 700;
 }
 
-.medium_result {
+.ptx-search-result-medium {
     font-weight: 500;
 }
 
 
-.low_result {
+.ptx-search-result-low {
     font-weight: 200;
 }
-.no_result {
+.ptx-search-result-none {
     font-weight: 200;
     color: #444;
 }
-.detailed_result .no_result {
+.ptx-search-detailed-result .ptx-search-result-none {
     font-size: 90%;
 }
 
-.searchresultsplaceholder {
+.ptx-search-dialog {
     position: fixed;
     top: 5vh;
     bottom: 5vh;
@@ -118,11 +118,11 @@ ol.searchresults > li {
     flex-direction: column;
 }
 
-.search-results-heading {
+.ptx-search-results-heading {
     border-bottom: 1px solid rgba(0,0,125,0.5);
 }
 
-.search-results-controls {
+.ptx-search-dialog-controls {
     display:flex;
     justify-content: space-between;
     align-items: stretch;
@@ -130,29 +130,29 @@ ol.searchresults > li {
     margin-bottom: 1em;
 }
 
-.closesearchresults {
+.ptx-search-close {
     display: flex;
     justify-content: space-between;
     align-items: center;
     border: 1px solid black;
 }
-.closesearchresults:hover {
+.ptx-search-close:hover {
     color: #c00;
     background-color: #fee;
     border-color: #f00;
 }
-.closesearchresults + h2 {
+.ptx-search-close + h2 {
     margin-top: -1em;
 }
-.searchempty {
+.ptx-search-empty {
     display: none;
     padding-left: 10px;
     padding-top: 5px;
 }
-.search-result-bullet {
+.ptx-search-result-bullet {
     margin-top: 0.3em;
 }
-.search-result-clip {
+.ptx-search-result-clip {
     font-size: 80%;
     font-style: italic;
     color: #444;
@@ -161,11 +161,11 @@ ol.searchresults > li {
 .search-results-unshown-count {
     margin-top: 0.6em;
 }
-.search-result-clip-highlight {
+.ptx-search-result-clip-highlight {
     background: rgba(255,255,0,0.5);
 }
 @media screen and (max-width: 800px) {
-    .searchresultsplaceholder {
+    .ptx-search-dialog {
         width: 80vw;
         left: 10vw;
         bottom: 10vh;

--- a/css/targets/html/legacy/crc/banner_crc.css
+++ b/css/targets/html/legacy/crc/banner_crc.css
@@ -330,7 +330,7 @@
     justify-self: stretch;
 }
 
-/* ptx-searchbox */
-.searchbox {
-    grid-area: ptx-searchbox;
+/* ptx-search-box */
+.ptx-search-box {
+    grid-area: ptx-search-box;
 }

--- a/css/targets/html/legacy/crc/navbar_crc.css
+++ b/css/targets/html/legacy/crc/navbar_crc.css
@@ -28,7 +28,7 @@
 
 
 /* Generic and large screen layout */
-.ptx-navbar .toc-toggle, .ptx-navbar .index-button, .ptx-navbar .searchbox
+.ptx-navbar .toc-toggle, .ptx-navbar .index-button, .ptx-navbar .ptx-search-box
 {
 }
 
@@ -66,7 +66,7 @@ nav.ptx-navbar {
 
     grid-template-columns: auto auto auto 1fr 1fr auto; 
     grid-template-areas:
-    "MH-toc-area MH-extras-area1 ptx-searchbox MH-extras-area2 MH-page-navigation-area MH-preferences-area";
+    "MH-toc-area MH-extras-area1 ptx-search-box MH-extras-area2 MH-page-navigation-area MH-preferences-area";
     background-color: #fff;
 /*
     padding: 20px 0px 0px 0px;
@@ -183,13 +183,13 @@ nav.ptx-navbar::after {
     box-sizing: border-box;
 }
 
-.ptx-navbar .searchbutton {
+.ptx-navbar .ptx-search-button {
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.searchresultsplaceholder {
+.ptx-search-dialog {
     left: calc(50vw - 300px);
 }
 
@@ -244,7 +244,7 @@ nav.ptx-navbar::after {
         display: inline-block;
     }
 
-    .searchresultsplaceholder {
+    .ptx-search-dialog {
         left: 10vw;
     }
 }
@@ -315,7 +315,7 @@ nav.ptx-navbar::after {
 .ptx-navbar .name {
     display: inline-block;
 }
-.ptx-navbar .searchbutton .name {
+.ptx-navbar .ptx-search-button .name {
     display: none;
     position: relative;
     bottom: 0;

--- a/css/targets/html/legacy/crc/shell_crc.css
+++ b/css/targets/html/legacy/crc/shell_crc.css
@@ -126,7 +126,7 @@ body.pretext {
         z-index: 100;
     }
 }
-.ptx-masthead .searchbox {
+.ptx-masthead .ptx-search-box {
    bottom: 2px;
    margin-right: -19px;
 }

--- a/css/targets/html/legacy/default/navbar_default.css
+++ b/css/targets/html/legacy/default/navbar_default.css
@@ -117,7 +117,7 @@ nav.ptx-navbar {
 .ptx-navbar :is(.index-button, .calculator-toggle)  .icon {
   display: none;
 }
-.ptx-navbar :is(.runestone-profile, .activecode-toggle, .searchbutton) .name {
+.ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
   display: none;
 }
 

--- a/css/targets/html/legacy/default/style_default.css
+++ b/css/targets/html/legacy/default/style_default.css
@@ -331,6 +331,6 @@
 }
 }
 
-.searchbox .searchresultsplaceholder {
+.ptx-search-box .ptx-search-dialog {
   background: #eaf0f6;
 }

--- a/css/targets/html/legacy/wide/shell_wide.scss
+++ b/css/targets/html/legacy/wide/shell_wide.scss
@@ -44,7 +44,7 @@ body.pretext {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
 }
 
-.searchresultsplaceholder {
+.ptx-search-dialog {
   left: calc(50vw - 300px);
 }
 
@@ -298,7 +298,7 @@ body.pretext {
     padding: 0 25px;
   }
 
-  .searchresultsplaceholder {
+  .ptx-search-dialog {
     width: 80vw;
     left: 10vw;
     bottom: 10vh;

--- a/js/pretext_search.js
+++ b/js/pretext_search.js
@@ -5,35 +5,34 @@
 //   or
 // var ptx_lunr_search_style = "reference";
 
-// since there is only one search box now, this can be simplified
-function doSearch(searchlocation="A") {
-    // Get the search terms from the input text box
-    var terms;
-    if(searchlocation == "A") {
-        terms = document.getElementById("ptxsearch").value;
-    } else {
-        terms = document.getElementById("ptxsearchB").value;
+// stub for i18next to future-proof the code. We don't actually use it for 
+// anything right now, but it will be needed if we want to localize the
+// accessibility search status messages.
+const i18next = window.i18next || class {
+    static t(key, params) {
+        for (const param in params) {
+            key = key.replace(`{{${param}}}`, params[param]);
+        }
+        return key;
     }
-    
-    localStorage.setItem('last-search-terms', JSON.stringify({terms: terms, time: Date.now()}));
-    
-    // Where do we want to put the results?
-    let resultArea = document.getElementById("searchresults")
-    resultArea.innerHTML = "";  // clear out any previous results
-    // assume AND for multiple words
-    var searchterms = terms;
-    if(searchlocation == "B") {
-        document.getElementById("ptxsearch").value = searchterms
-        console.log("ptxsearch value", document.getElementById("ptxsearch").value);
-    } else {
-        searchterms = terms;
-    }
+}
 
-    searchterms = searchterms.toLowerCase().trim();
+
+function doSearch() {
+    // Get the search terms from the input text box
+    const terms = document.getElementById("ptx-search-terms").value;
+    localStorage.setItem('last-search-terms', JSON.stringify({terms: terms, time: Date.now()}));
+
+    // Where do we want to put the results?
+    let resultArea = document.getElementById("ptx-search-results")
+    resultArea.innerHTML = "";  // clear out any previous results
+
+    // assume AND for multiple words 
+    const searchTerms = terms.toLowerCase().trim();
     let pageResult = [];
-    if(searchterms != "") {
+    if(searchTerms != "") {
         pageResult = ptx_lunr_idx.query((q) => {
-            for(let term of searchterms.split(' ')) {
+            for(let term of searchTerms.split(' ')) {
                 q.term(term, { fields: ["title"], boost: 20 }); //exact title match with 20x weight
                 q.term(term, { wildcard: lunr.Query.wildcard.TRAILING, fields: ["title"], boost: 10 }); //inexact title 10x weight
                 q.term(term, { fields: ["body"], boost: 5 }); //exact body 5x weight
@@ -102,7 +101,7 @@ function augmentResults(result, docs) {
                     const startClipInd = positionData[0];
                     const endClipInd = positionData[0] + positionData[1];
                     res.title = res.title.substring(0, endClipInd) + '</span>' + res.title.substring(endClipInd);
-                    res.title = res.title.substring(0, startClipInd) + '<span class="search-result-clip-highlight">' + res.title.substring(startClipInd);
+                    res.title = res.title.substring(0, startClipInd) + '<span class="ptx-search-result-clip-highlight">' + res.title.substring(startClipInd);
                     titleMarked = true;
                 }
             } else if (res.matchData.metadata[hit].body) {
@@ -115,7 +114,7 @@ function augmentResults(result, docs) {
                 const startClipInd = positionData[0];
                 const endClipInd = positionData[0] + positionData[1];
                 let resultSnippet = (startInd > 0 ? '...' : '' ) + bodyContent.substring(startInd, startClipInd);
-                resultSnippet += '<span class="search-result-clip-highlight">' + bodyContent.substring(startClipInd, endClipInd) + '</span>';
+                resultSnippet += '<span class="ptx-search-result-clip-highlight">' + bodyContent.substring(startClipInd, endClipInd) + '</span>';
                 resultSnippet += bodyContent.substring(endClipInd, endInd) + (endInd < bodyContent.length ? '...' : '' ) + '<br/>';
                 res.body += resultSnippet;
             }
@@ -180,36 +179,23 @@ function compareScoreDesc(a, b) {
 }
 
 function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
-    /* backward compatibility for old html */
-    if (document.getElementById("searchempty")) {
-        document.getElementById("searchempty").style.display = "none";
-    }
     let len = result.length;
-    console.log("first result", result[0]);
+
+    const searchStatus = document.getElementById("ptx-search-status");
+
     if (len == 0) {
-        if (document.getElementById("searchempty")) {
-            document.getElementById("searchempty").style.display = "block";
-        } else {
-            let noresults = document.createElement("div");
-            noresults.classList.add("noresults");
-            search_no_results_string = "No results were found"
-            noresults.innerHTML = search_no_results_string + ".";
-   //     console.log("the new variable", search_results_heading_string);
-            resultArea.appendChild(noresults);
-        }
-        document.getElementById("searchresultsplaceholder").style.display = null;
-        return
+        document.getElementById("ptx-search-empty").style.display = "block";
+        document.getElementById("ptx-search-dialog").style.display = null;
+        searchStatus.innerHTML = i18next.t('No results found for "{{terms}}".', { terms: searchterms });
+        return;
     }
-// console.log("result",result);
+    document.getElementById("ptx-search-empty").style.display = "none";
+    searchStatus.innerHTML = i18next.t('{{count}} results found.', { count: len });
+
     let allScores = result.map(function (r) { return r.score });
-// console.log(typeof allScores[0], "allScores",allScores);
     allScores.sort((a,b) => (a - b));
     allScores.reverse();
-// console.log("allScores, sorted",allScores);
 
-//    let high = result[Math.floor(len*0.25)].score;
-//    let med = result[Math.floor(len*0.5)].score;
-//    let low = result[Math.floor(len*0.75)].score;
     // sort the results by their position in the book, not their score
     let high = allScores[Math.floor(len*0.20)];
     let med = allScores[Math.floor(len*0.40)];
@@ -226,19 +212,19 @@ function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
         // add a class so we can colorize the results based on their rank in terms
         // of search score.
         if (res.score >= high) {
-            link.classList.add("high_result")
+            link.classList.add("ptx-search-result-high")
         } else if (res.score >= med) {
-            link.classList.add("medium_result")
+            link.classList.add("ptx-search-result-medium")
         } else if (res.score >= low) {
-            link.classList.add("low_result")
+            link.classList.add("ptx-search-result-low")
         } else { 
-            link.classList.add("no_result")
+            link.classList.add("ptx-search-result-none")
         }
         currIndent = res.level;
         if (currIndent > indent) {
             indent = currIndent;
             let ilist = document.createElement("ul")
-            ilist.classList.add("detailed_result");
+            ilist.classList.add("ptx-search-detailed-result");
             resultArea.appendChild(ilist);
             resultArea = ilist;
         } else if (currIndent < indent) {
@@ -248,14 +234,14 @@ function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
         link.href = `${res.url}`;
         link.innerHTML = `${res.type} ${res.number} ${res.title}`;
         let clip = document.createElement("div");
-        clip.classList.add("search-result-clip");
+        clip.classList.add("ptx-search-result-clip");
         clip.innerHTML = `${res.body}`;
         let bullet = document.createElement("li");
-        bullet.classList.add('search-result-bullet');
+        bullet.classList.add('ptx-search-result-bullet');
         bullet.appendChild(link);
         bullet.appendChild(clip);
         let p = document.createElement("text");
-        p.classList.add('search-result-score');
+        p.classList.add('ptx-search-result-score');
         p.innerHTML = `  (${res.score.toFixed(2)})`;
         bullet.appendChild(p);
         resultArea.appendChild(bullet);
@@ -263,53 +249,46 @@ function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
 
     // Auto-close search results when a result is clicked in case result is on
     // the same page search started from
-    const resultsDiv = document.getElementById('searchresultsplaceholder');
-    const backDiv = document.querySelector('.searchresultsbackground');
+    const resultsDialog = document.getElementById('ptx-search-dialog');
     resultArea.querySelectorAll("a").forEach((link) => {
         link.addEventListener('click', (e) => {
-            backDiv.style.display = 'none';
-            resultsDiv.style.display = 'none';
+            resultsDialog.close()
         });
     });
-    //Could print message about how many results are not shown. No way to localize it though...
-    // if(numUnshown > 0) {
-    //     let bullet = document.createElement("li");
-    //     bullet.classList.add('search-results-bullet');
-    //     bullet.classList.add('search-results-unshown-count');
-    //     let p = document.createElement("text");
-    //     p.innerHTML = `${parseInt(numUnshown)} unshown results...`;
-    //     bullet.appendChild(p);
-    //     resultArea.appendChild(bullet);
-    // }
-    document.getElementById("searchresultsplaceholder").style.display = null;
+    document.getElementById("ptx-search-dialog").style.display = null;
     MathJax.typesetPromise();
 }
 
 window.addEventListener("load", function (event) {
-    const resultsDiv = document.getElementById('searchresultsplaceholder');
+    const resultsDiv = document.getElementById('ptx-search-dialog');
+    const hasNativeInvokers = 'commandFor' in HTMLButtonElement.prototype;
 
-    //insert a div to be backgroud behind searchresultsplaceholder
-    const backDiv = document.createElement("div");
-    backDiv.classList.add("searchresultsbackground");
-    backDiv.style.display = 'none';
-    resultsDiv.parentNode.appendChild(backDiv);
+    document.getElementById("ptx-search-button").addEventListener('click', (e) => {
+        const dialog = document.getElementById("ptx-search-dialog");
+        if (!hasNativeInvokers && dialog && typeof dialog.showModal === "function" && !dialog.open) {
+            dialog.showModal();
+        }
 
-    document.getElementById("searchbutton").addEventListener('click', (e) => {
-        resultsDiv.style.display = null;
-        backDiv.style.display = null;
-        let searchInput = document.getElementById("ptxsearch");
-        searchInput.value = JSON.parse(localStorage.getItem("last-search-terms")).terms;
+        const lastSearch = localStorage.getItem("last-search-terms");
+        let searchInput = document.getElementById("ptx-search-terms");
+        searchInput.value = lastSearch ? (JSON.parse(lastSearch)?.terms || "") : "";
         searchInput.select();
-        doSearch();
+        if(searchInput.value) {
+            doSearch();
+        }
     });
 
-    document.getElementById("ptxsearch").addEventListener('input', (e) => {
-        doSearch();
-    });
+    const closeBtn = document.getElementById("ptx-search-close");
+    if (closeBtn && !hasNativeInvokers) {
+        closeBtn.addEventListener('click', (e) => {
+            const dialog = document.getElementById("ptx-search-dialog");
+            if (dialog && typeof dialog.close === "function" && dialog.open) {
+                dialog.close();
+            }
+        });
+    }
 
-    document.getElementById("closesearchresults").addEventListener('click', (e) => {
-        resultsDiv.style.display = 'none';
-        backDiv.style.display = 'none';
-        document.getElementById('searchbutton').focus();
+    document.getElementById("ptx-search-terms").addEventListener('input', (e) => {
+        doSearch();
     });
 });

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11128,7 +11128,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:variable name="reserved-html-ids">
         <xsl:text>ptx-masthead ptx-content ptx-content-footer ptx-page-footer </xsl:text>
         <xsl:text>ptx-navbar ptx-sidebar ptx-toc mainmatter logo-link latex-macros </xsl:text>
-        <xsl:text>ptxsearch searchbutton searchresults searchresultsplaceholder searchempty closesearchresults </xsl:text>
+        <xsl:text>ptx-search-button ptx-search-results ptx-search-dialog ptx-search-terms ptx-search-status ptx-search-empty ptx-search-close</xsl:text>
         <xsl:text>light-dark-button papersize-select highlight-workspace-checkbox </xsl:text>
         <xsl:text>hide-hint-checkbox hide-answer-checkbox hide-solution-checkbox </xsl:text>
         <xsl:text>print-first-page-header-checkbox print-running-header-checkbox </xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -14046,9 +14046,9 @@ TODO:
 <!-- Div for native search -->
 <xsl:template name="native-search-box">
     <xsl:if test="$has-native-search">
-        <div class="searchbox">
-            <div class="searchwidget">
-                <button id="searchbutton" class="searchbutton button" type="button" title="Search book">
+        <div class="ptx-search-box">
+            <div class="ptx-search-widget">
+                <button id="ptx-search-button" type="button" class="ptx-search-button button" title="Search book" commandfor="ptx-search-dialog" command="show-modal" >
                     <xsl:call-template name="insert-symbol">
                         <xsl:with-param name="name" select="'search'"/>
                     </xsl:call-template>
@@ -14063,19 +14063,22 @@ TODO:
 <!-- Div for native search results -->
 <xsl:template name="native-search-results">
     <xsl:if test="$has-native-search">
-        <div id="searchresultsplaceholder" class="searchresultsplaceholder" style="display: none">
-            <div class="search-results-controls">
-                <input aria-label="Search term" id="ptxsearch" class="ptxsearch" type="text" name="terms" placeholder="Search term"/>
-                <button title="Close search" id="closesearchresults" class="closesearchresults"><span class="material-symbols-outlined">close</span></button>
+        <dialog id="ptx-search-dialog" class="ptx-search-dialog" closedby="closerequest">
+            <div class="ptx-search-dialog-controls">
+                <input aria-label="Search term" id="ptx-search-terms" class="ptx-search-terms" type="text" name="terms" placeholder="Search terms"/>
+                <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close" commandfor="ptx-search-dialog"  command="close"><span class="material-symbols-outlined">close</span></button>
             </div>
-            <h2 class="search-results-heading">
+            <!-- Will contain notice about how many results there are for screen readers to announce-->
+            <div id="ptx-search-status" class="ptx-search-status" aria-live="polite" aria-atomic="true">
+            </div>
+            <h2 class="ptx-search-results-heading">
                 <xsl:apply-templates select="." mode="type-name">
                     <xsl:with-param name="string-id" select="'search-results-heading'"/>
                 </xsl:apply-templates>
                 <xsl:text>: </xsl:text>
             </h2>
-            <!-- div#searchempty is not visible when there are results -->
-            <div id="searchempty" class="searchempty">
+            <!-- div#ptx-search-empty is not visible when there are results -->
+            <div id="ptx-search-empty" class="ptx-search-empty">
                 <span>
                     <xsl:apply-templates select="." mode="type-name">
                         <xsl:with-param name="string-id" select="'no-search-results'"/>
@@ -14083,9 +14086,9 @@ TODO:
                     <xsl:text>.</xsl:text>
                 </span>
             </div>
-            <ol id="searchresults" class="searchresults">
+            <ol id="ptx-search-results" class="ptx-search-results">
             </ol>
-        </div>
+        </dialog>
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
A start on:
https://github.com/PreTeXtBook/pretext/issues/2794

Moves the search dialog to a standard `<dialog>` element and thus provides standard keyboard navigation:
https://webaim.org/techniques/keyboard/
 
Also improves screen reader behavior for the search button and to announce search results. While searching, an invisible to the eye div gets updated to text like`"32 results found"`. This div is marked `aria-live` so that screen readers will announce it, giving the user some idea of what is happening down in the results panel without trying to announce all of the results.

@rbeezer I'm planning on making a number of small PRs as I get to various parts of the UI. This one is split into the usual CSS/JS/HTML commits. For a small commit that touches 2 or 3 files but all in a minor way, (add an `aria-XXX` to HTML and touch up a style or two) do you still want separate commits? Or just one `HTML: accessibility improvements for X`?