### PR TITLE
Fix publisher "@part-structure" name and inline-exercise structure numbers in introductions

### DIFF
--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -125,7 +125,7 @@
                 element divisions {
                     attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?,
                     attribute chapter-start { xsd:integer }?,
-                    attribute parts-structure { "decorative" | "structural" }?
+                    attribute part-structure { "decorative" | "structural" }?
                 }
 
             Blocks =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -325,7 +325,7 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="parts-structure">
+        <attribute name="part-structure">
           <choice>
             <value>decorative</value>
             <value>structural</value>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -256,7 +256,7 @@
                 element divisions {
                     attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?,
                     attribute chapter-start { xsd:integer }?,
-                    attribute parts-structure { "decorative" | "structural" }?
+                    attribute part-structure { "decorative" | "structural" }?
                 }
 
             Blocks =

--- a/schema/publication-schema.xsd
+++ b/schema/publication-schema.xsd
@@ -264,7 +264,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="chapter-start" type="xs:integer"/>
-      <xs:attribute name="parts-structure">
+      <xs:attribute name="part-structure">
         <xs:simpleType>
           <xs:restriction base="xs:token">
             <xs:enumeration value="decorative"/>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4674,8 +4674,11 @@ Book (with parts), "section" at level 3
 </xsl:template>
 
 <!-- Structure Numbers: Inline Exercises -->
-<!-- Follows the theorem/figure/etc scheme (can't poll parent) -->
-<xsl:template match="exercise[boolean(&INLINE-EXERCISE-FILTER;)]" mode="structure-number">
+<!-- Follows the theorem/figure/etc scheme.  The second alternative   -->
+<!-- adds an inline exercise in a division introduction or conclusion -->
+<!-- (its parent is not in the inline filter); divisional-container   -->
+<!-- exercises are handled by the next template instead.              -->
+<xsl:template match="exercise[boolean(&INLINE-EXERCISE-FILTER;)]|exercise[(parent::introduction or parent::conclusion) and not(ancestor::exercises or ancestor::worksheet or ancestor::reading-questions)]" mode="structure-number">
     <xsl:variable name="exercise-levels">
         <xsl:choose>
             <xsl:when test="$b-number-exercise-distinct">


### PR DESCRIPTION
Two small, pre-existing bugs uncovered while working on the assembly-time numbering rework. They are independent of that work and stand on their own.

## 1. Publisher file `numbering/divisions/@part-structure` attribute name

The publication-file schema declared this attribute as `@parts-structure`, but the XSL has always read `@part-structure` — the spelling documented and used in real publication files. So a publication file with the intended, working `<divisions part-structure="structural"/>` failed schema validation. This corrects the literate schema (and the regenerated `.rng`/`.xsd`) to `@part-structure`, matching the XSL and actual usage.

## 2. Structure number for an inline `exercise` in an `introduction`/`conclusion`

An inline `exercise` placed directly in a division's `introduction` or `conclusion` is schema-valid, but had no `structure-number` template and fell through to the error fallback — emitting a `PTX:ERROR` and rendering the literal placeholder `[STRUCT]` for its number. This adds that case to the inline-exercise `structure-number` template (excluding the `exercises`/`worksheet`/`reading-questions` containers, whose exercises are numbered as divisional), so such an exercise now takes its enclosing division's structure number.

## A pre-existing issue this surfaces

Fixing the structure number above exposes a separate, pre-existing problem in the **serial** number for these exercises: when two or more inline exercises sit in the same `introduction`/`conclusion`, they currently receive the *same* serial (e.g. both `3.4`), because today's block-serial computation does not count exercises in these positions. The `[STRUCT]` error had been masking this.

This is left for the in-progress assembly-time serial-numbering rework to resolve: the same `@serial` approach already shipped for equations and footnotes — where an item's serial is its position within a counting scope — will pool these exercises and give them distinct numbers. Until then the collision is rare (it needs two or more inline exercises in a single introduction or conclusion) and no worse than the prior placeholder.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
