### PR TITLE
Improve keyboard navigation for embed button

### DIFF
--- a/css/components/_pretext-search.scss
+++ b/css/components/_pretext-search.scss
@@ -1,28 +1,19 @@
 
 @use 'components/helpers/buttons-default' as buttons;
+@use 'components/helpers/dialogs' as dialogs;
 @use 'components/helpers/accessibility' as accessibility;
 
 .ptx-search-box {
-
-  .ptx-search-widget {
-    height: 100%;
+  .ptx-search-dialog {
+    @include dialogs.ptx-dialog-modal;
   }
-  
+
   .ptx-search-dialog[open] {
-    width: 80vw;
-    height: 100%;
-    max-width: 800px;
-    border: 2px solid var(--body-text-color);
-    background: var(--knowl-background, #eaf0f6);
     display: flex;
     flex-direction: column;
-  }
-
-  .ptx-search-dialog article {
-    width: 60%;
-    margin-left: auto;
-    margin-right: auto;
-    font-family: sans-serif;
+    max-width: 800px;
+    width: 80vw;
+    height: 100%;
   }
 
   .ptx-search-dialog-controls {
@@ -37,10 +28,11 @@
   .ptx-search-terms {
     flex: 1 1;
   }
-  
 
   .ptx-search-close {
-    @include buttons.ptx-button;
+    @include buttons.ptx-button(
+      $border-width: 0
+    );
   }
 
   .ptx-search-detailed-result {
@@ -56,7 +48,6 @@
     @include accessibility.sr-only;
   }
 
-
   .ptx-search-results {
     padding-left: 10px;
     margin-top: 0;
@@ -64,6 +55,11 @@
     flex: 1 1;
     background: var(--content-background, white);
     border: 1px solid var(--page-border-color, #ccc);
+    color: var(--body-text-color, black);
+  }
+
+  .ptx-search-results-heading {
+    margin-top: 0;
   }
 
   .ptx-search-results:empty {
@@ -103,10 +99,6 @@
 
   .ptx-search-result-clip-highlight {
     background: var(--ptx-search-resultshighlight);
-  }
-
-  .ptx-search-dialog::backdrop {
-    background: var(--ptx-search-resultsbackground, white);
   }
 
   @media screen and (max-width: 800px) {

--- a/css/components/helpers/_buttons-default.scss
+++ b/css/components/helpers/_buttons-default.scss
@@ -1,7 +1,9 @@
 $border-radius: 0 !default;
+$border-width: 1px !default;
 
 @mixin ptx-button(
-  $border-radius: $border-radius
+  $border-radius: $border-radius,
+  $border-width: $border-width
 ) {
   font: inherit;
   display: flex;
@@ -12,7 +14,7 @@ $border-radius: 0 !default;
   min-height: 34px;
   color: var(--button-text-color);
   background-color: var(--button-background);
-  border-width: 1px;
+  border-width: $border-width;
   border-color: var(--button-border-color);
   border-style: solid;
   border-radius: $border-radius;

--- a/css/components/helpers/_dialogs.scss
+++ b/css/components/helpers/_dialogs.scss
@@ -1,0 +1,39 @@
+@use "components/helpers/buttons-default" as buttons;
+
+$border-radius: 0 !default;
+
+// see also, related logic in ptx-dialog in pretext_add_on.js
+
+@mixin ptx-dialog {
+  border: 1px solid var(--dialog-border-color);
+  border-radius: $border-radius;
+  background: var(--dialog-background);
+  box-shadow: 0 0 5px var(--dialog-shadow-color);
+  color: var(--dialog-text-color);
+
+  & .ptx-dialog-close-button {
+    @include buttons.ptx-button(
+      $border-width: 0
+    );
+  }
+}
+
+@mixin ptx-dialog-modal {
+  @include ptx-dialog;
+
+  &::backdrop {
+    background: var(--dialog-background);
+    opacity: 0.6;
+  }
+}
+
+:root {
+  --dialog-border-color: var(--page-border-color);
+  --dialog-background: var(--navbar-background);
+  --dialog-shadow-color: var(--primary-color-gray-80);
+  --dialog-text-color: var(--button-text-color);
+}
+
+:root.dark-mode {
+  --dialog-shadow-color: var(--primary-color-black-80);
+}

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -9,6 +9,7 @@ $center-content: true !default;
 @use 'components/helpers/accessibility' as accessibility;
 
 @use 'components/helpers/buttons-default' as buttons;
+@use 'components/helpers/dialogs' as dialogs;
 
 @use 'components/page-parts/extras/navbar-btn-borders';
 
@@ -74,24 +75,22 @@ $center-content: true !default;
     height: 34px;
   }
 
-  .embed-popup {
+  .ptx-embed-popup {
     padding: 10px;
-    background-color: var(--navbar-background);
-    position: absolute;
     margin-top: $nav-height;
-    border: 1px solid var(--page-border-color);
-    border-radius: 3px;
-    box-shadow: 0 0 5px var(--primary-color-gray-80);
-    color: var(--button-text-color);
 
-    .embed-code-container {
-      width: "100%";
-      padding:5px;
-      .embed-code-textbox {
+    @include dialogs.ptx-dialog-modal;
+
+    .ptx-embed-popup-controls {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+    }
+
+    .ptx-embed-code-textbox {
         width: 100%;
         padding: 10px;
         height: 5em;
-      }
     }
   }
 
@@ -110,7 +109,7 @@ $center-content: true !default;
     display: none;
   }
 
-  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .embed-button) .name {
+  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .ptx-embed-button) .name {
     @include accessibility.sr-only;
   }
 
@@ -180,8 +179,10 @@ $center-content: true !default;
       display: none;
     }
 
-    .embed-popup {
+    .ptx-embed-popup {
       margin-top: unset;
+      margin-bottom: 0;
+      top: auto;
       bottom: $nav-height;
     }
 
@@ -190,7 +191,7 @@ $center-content: true !default;
       bottom: $nav-height;
     }
 
-    :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button, .embed-button) .name {
+    :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button, .ptx-embed-button) .name {
       display: none;
     }
   }

--- a/css/components/page-parts/extras/_navbar-btn-borders.scss
+++ b/css/components/page-parts/extras/_navbar-btn-borders.scss
@@ -2,8 +2,9 @@
 $border-width: 1px !default;
 
 @mixin navbar-btn-borders {
-  .ptx-navbar {
-    .button {
+  .ptx-navbar-contents {
+    & > .button,
+    & > :not(dialog) > .button {
       border-left-width: $border-width;
       border-right-width: $border-width;
       border-color: var(--page-border-color);

--- a/css/targets/html/denver/_customizations.scss
+++ b/css/targets/html/denver/_customizations.scss
@@ -13,7 +13,7 @@ $text-color: white !default;
 .ptx-navbar {
     background: linear-gradient(to bottom, var(--banner-background), var(--navbar-background));
 
-    .button:not(.copy-embed-button) {
+    .button:not(.ptx-embed-copy-button, .ptx-embed-close-button) {
         background: linear-gradient(to bottom, var(--banner-background), var(--navbar-background));
 
         // Turn off background-image (linear gradient) on hover so it behaves like a solid color button

--- a/css/targets/html/greeley/_customization.scss
+++ b/css/targets/html/greeley/_customization.scss
@@ -30,3 +30,8 @@
 //  margin-top: 0.5em;
 //}
 
+// Override default navbar based colors for any PTX dialogs
+:root {
+  --dialog-background: var(--knowl-background);
+  --dialog-text-color: var(--body-text-color);
+}

--- a/css/targets/html/salem/_parts-salem.scss
+++ b/css/targets/html/salem/_parts-salem.scss
@@ -37,8 +37,18 @@ $sidebar-breakpoint: $content-width + $sidebar-width + $content-side-padding * 2
   $navbar-breakpoint: $navbar-breakpoint,
 );
 
+.ptx-dialog {
+  --button-text-color: var(--dialog-text-color);
+  --button-background: var(--dialog-background);
+}
+
 :root {
   --page-width: 1100px;
+  --dialog-background: var(--primary-color-white-96);
+  --dialog-text-color: var(--body-text-color);
+}
+:root.dark-mode {
+  --dialog-background: var(--content-background);
 }
 
 .standalone-page {

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -11,9 +11,17 @@
  *******************************************************************************
  */
 
-/*
-console.log("thisbrowser.userAgent", window.navigator.userAgent);
-*/
+// stub for i18next to future-proof the code. We don't actually use it for
+// anything right now, but it will be needed if we want to localize the
+// accessibility search status messages.
+window.i18next = window.i18next || {
+    t(key, params = {}) {
+        for (const param in params) {
+            key = key.replace(`{{${param}}}`, params[param]);
+        }
+        return key;
+    }
+};
 
 /* scrollbar width from https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript */
 function getScrollbarWidth() {
@@ -1244,7 +1252,7 @@ function setDarkMode(isDark) {
     const modeButton = document.getElementById("light-dark-button");
     if (modeButton) {
         modeButton.querySelector('.icon').innerText = isDark ? "light_mode" : "dark_mode";
-        modeButton.querySelector('.name').innerText = isDark ? "Light Mode" : "Dark Mode";
+        modeButton.querySelector('.name').innerText = isDark ? window.i18next.t("Light Mode") : window.i18next.t("Dark Mode");
     }
 }
 

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1273,6 +1273,130 @@ window.addEventListener("DOMContentLoaded", function(event) {
     });
 });
 
+
+class PTXDialog {
+    static hasNativeCommandInvokers() {
+        return 'commandForElement' in HTMLButtonElement.prototype;
+    }
+    // dialogElement: should be a <dialog> element
+    // openButton: is an optional element that triggers the dialog to open and will receive focus again when the dialog closes
+    //             if provided, will automatically have an event listener added to open the dialog on click
+    // options can include:
+    // - kind: whether the dialog is "modal" (the default), "light-close" or "non-modal"
+    //   - "modal" traps focus and must be dismissed with the close button or escape
+    //   - "light-close" are model, but close if the user clicks outside the dialog
+    //   - "non-modal" do not trap focus and can be interacted with while open
+    // - closeButton: button element that should close the dialog when clicked
+    //                If not provided for a modal dialog, one will be added.
+    constructor(dialogElement, openButton = null, options = {}) {
+        this.dialog = dialogElement;
+        this.controlElement = openButton;
+        this.kind = options.kind || "modal";
+        this.isModal = this.kind === "modal" || this.kind === "light-close";
+
+        this.openButton = openButton;
+        if (this.openButton && !PTXDialog.hasNativeCommandInvokers()) {
+            this.openButton.addEventListener("click", () => this.open());
+        }
+
+        this.closeButton = options.closeButton;
+        // add a close button unless the dialog already has one as identified in options
+        if (!this.closeButton && this.isModal) {
+            const topBar = document.createElement("div");
+            topBar.classList.add("ptx-dialog-topbar");
+            this.dialog.prepend(topBar);
+            this.closeButton = document.createElement("button");
+            this.closeButton.classList.add("ptx-dialog-close-button");
+            this.closeButton.setAttribute("aria-label", "Close dialog");
+            this.closeButton.innerHTML = `<span class="material-symbols-outlined">close</span>`;
+            topBar.appendChild(this.closeButton);
+        }
+        if (this.closeButton) {
+            this.closeButton.addEventListener("click", () => this.close());
+        }
+
+        if (PTXDialog.hasNativeCommandInvokers()) {
+            // If the browser supports command invokers, we can just use the native dialog element and its showModal and close methods.
+            this.open = () => {
+              if(this.isModal) {
+                this.dialog.showModal();
+              } else {
+                this.dialog.show();
+              }
+            };
+            this.close = () => {
+                this.dialog.close();
+                if (this.controlElement) {
+                    this.controlElement.focus();
+                }
+            };
+            this.toggle = () => {
+                if (this.dialog.open) {
+                    this.close();
+                } else {
+                    this.open();
+                }
+            };
+        } else {
+            // Otherwise, we use the fallback functions defined above to manage the dialog state.
+            this.open = () => this.openDialogFallback();
+            this.close = () => this.closeDialogFallback();
+            this.toggle = () => this.toggleDialogFallback();
+        }
+
+        if (this.kind === "light-close") {
+            // Add event listener to close the dialog if the user clicks outside of it
+            this.dialog.addEventListener("click", (event) => {
+                if (event.target === this.dialog) {
+                    // need to ask for bounding rext and do manual check
+                    // to include border and padding area of the dialog
+                    const rect = this.dialog.getBoundingClientRect();
+                    const isInDialog = (
+                        rect.top <= event.clientY &&
+                        event.clientY <= rect.top + rect.height &&
+                        rect.left <= event.clientX &&
+                        event.clientX <= rect.left + rect.width
+                    );
+                    if (!isInDialog) {
+                        this.close();
+                    }
+                }
+            });
+        }
+    }
+
+    openDialogFallback() {
+        if (this.dialog && typeof this.dialog.showModal === "function" && !this.dialog.open) {
+            if(this.isModal) {
+              this.dialog.showModal();
+            } else {
+              this.dialog.show();
+            }
+        }
+    }
+
+    closeDialogFallback() {
+        if (this.dialog && typeof this.dialog.close === "function" && this.dialog.open) {
+            this.dialog.close();
+        }
+        if (this.controlElement) {
+            this.controlElement.focus();
+        }
+    }
+
+    toggleDialogFallback() {
+        if (!this.dialog) {
+            return;
+        }
+        if (this.dialog.open) {
+            this.closeDialogFallback();
+        } else {
+            this.openDialogFallback();
+        }
+    }
+}
+
+
 // Share button and embed in LMS code
 window.addEventListener("DOMContentLoaded", function(event) {
     const shareButton = document.getElementById("embed-button");

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1399,36 +1399,55 @@ class PTXDialog {
 
 // Share button and embed in LMS code
 window.addEventListener("DOMContentLoaded", function(event) {
-    const shareButton = document.getElementById("embed-button");
-    if (shareButton) {
-        const sharePopup = document.getElementById("embed-popup");
-        const embedCode = "<iframe src='" + window.location.href + "?embed' width='100%' height='1000px' frameborder='0'></iframe>";
-        const embedTextbox = document.getElementById("embed-code-textbox");
-        if (embedTextbox) {
-            embedTextbox.value = embedCode;
+    const shareButton = document.getElementById("ptx-embed-button");
+    const sharePopupElement = document.getElementById("ptx-embed-popup");
+    if (!shareButton || !sharePopupElement) {
+        return;
+    }
+    const closeBtn = document.getElementById("ptx-embed-close-button");
+
+    const sharePopup = new PTXDialog(
+        sharePopupElement, 
+        shareButton, 
+        {
+            kind: "light-close",
+            closeButton: closeBtn
         }
-        shareButton.addEventListener("click", function() {
-            sharePopup.classList.toggle("hidden");
-        });
-        const copyButton = document.getElementById("copy-embed-button");
-        if (copyButton) {
+    );
+
+    const embedCode = "<iframe src='" + window.location.href + "?embed' width='100%' height='1000px' frameborder='0'></iframe>";
+    const embedTextbox = document.getElementById("ptx-embed-code-textbox");
+    if (embedTextbox) {
+        embedTextbox.value = embedCode;
+    }
+    
+    const copyButton = document.getElementById("ptx-embed-copy-button");
+    if (copyButton) {
+        if (navigator.clipboard) {
             copyButton.addEventListener("click", function() {
-                const embedTextbox = document.getElementById("embed-code-textbox");
+                const embedTextbox = document.getElementById("ptx-embed-code-textbox");
                 if (embedTextbox) {
-                    navigator.clipboard.writeText(embedCode).then(() => {
-                        console.log("Embed code copied to clipboard!");
-                    }).catch(err => {
-                        console.error("Failed to copy embed code: ", err);
-                    });
-                    //copyButton.innerHTML = "✓✓";
-                    // show confirmation for 2 seconds:
-                    copyButton.querySelector('.icon').innerText = "library_add_check";
-                    setTimeout(function() {
-                        copyButton.querySelector('.icon').innerText = "content_copy";
-                        sharePopup.classList.add("hidden");
-                    }, 450);
+                    if (navigator.clipboard) {
+                        navigator.clipboard.writeText(embedCode).then(() => {
+                            console.log("Embed code copied to clipboard!");
+                            copyButton.querySelector('.icon').innerText = "library_add_check";
+                            setTimeout(function() {
+                                copyButton.querySelector('.icon').innerText = "content_copy";
+                                sharePopup.close();
+                                shareButton.focus();
+                            }, 450);
+                        }).catch(err => {
+                            console.error("Failed to copy embed code: ", err);
+                        });
+                    } else {
+                        console.warn("Clipboard API not supported, falling back to manual copy.");
+                    }
                 }
             });
+        } else {
+            // If clipboard API is not supported, hide the copy button and
+            // rely on users to manually copy from the textbox
+            copyButton.style.display = "none";
         }
     }
 });

--- a/js/pretext_search.js
+++ b/js/pretext_search.js
@@ -8,14 +8,14 @@
 // stub for i18next to future-proof the code. We don't actually use it for
 // anything right now, but it will be needed if we want to localize the
 // accessibility search status messages.
-const i18next = window.i18next || class {
-    static t(key, params) {
+window.i18next = window.i18next || {
+    t(key, params = {}) {
         for (const param in params) {
             key = key.replace(`{{${param}}}`, params[param]);
         }
         return key;
     }
-}
+};
 
 
 function doSearch() {
@@ -186,11 +186,11 @@ function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
     if (len == 0) {
         document.getElementById("ptx-search-empty").style.display = "block";
         document.getElementById("ptx-search-dialog").style.display = null;
-        searchStatus.innerHTML = i18next.t('No results found for "{{terms}}".', { terms: searchterms });
+        searchStatus.innerHTML = window.i18next.t('No results found for "{{terms}}".', { terms: searchterms });
         return;
     }
     document.getElementById("ptx-search-empty").style.display = "none";
-    searchStatus.innerHTML = i18next.t('{{count}} results found.', { count: len });
+    searchStatus.innerHTML = window.i18next.t('{{count}} results found.', { count: len });
 
     let allScores = result.map(function (r) { return r.score });
     allScores.sort((a,b) => (a - b));

--- a/js/pretext_search.js
+++ b/js/pretext_search.js
@@ -260,15 +260,15 @@ function addResultToPage(searchterms, result, docs, numUnshown, resultArea) {
 }
 
 window.addEventListener("load", function (event) {
-    const resultsDiv = document.getElementById('ptx-search-dialog');
-    const hasNativeInvokers = 'commandFor' in HTMLButtonElement.prototype;
+    const searchDialogElement = document.getElementById('ptx-search-dialog');
+    const searchButtonElement = document.getElementById('ptx-search-button');
+    const closeBtn = document.getElementById("ptx-search-close");
+    const searchDialog = new PTXDialog(searchDialogElement, searchButtonElement, {
+        closeButton: closeBtn,
+    });
 
-    document.getElementById("ptx-search-button").addEventListener('click', (e) => {
-        const dialog = document.getElementById("ptx-search-dialog");
-        if (!hasNativeInvokers && dialog && typeof dialog.showModal === "function" && !dialog.open) {
-            dialog.showModal();
-        }
-
+    searchButtonElement.addEventListener('click', (e) => {
+        // Attempt to restore last search
         const lastSearch = localStorage.getItem("last-search-terms");
         let searchInput = document.getElementById("ptx-search-terms");
         searchInput.value = lastSearch ? (JSON.parse(lastSearch)?.terms || "") : "";
@@ -277,16 +277,6 @@ window.addEventListener("load", function (event) {
             doSearch();
         }
     });
-
-    const closeBtn = document.getElementById("ptx-search-close");
-    if (closeBtn && !hasNativeInvokers) {
-        closeBtn.addEventListener('click', (e) => {
-            const dialog = document.getElementById("ptx-search-dialog");
-            if (dialog && typeof dialog.close === "function" && dialog.open) {
-                dialog.close();
-            }
-        });
-    }
 
     document.getElementById("ptx-search-terms").addEventListener('input', (e) => {
         doSearch();

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11134,7 +11134,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:text>print-first-page-header-checkbox print-running-header-checkbox </xsl:text>
         <xsl:text>print-first-page-footer-checkbox print-running-footer-checkbox </xsl:text>
         <xsl:text>calculator-toggle calculator-container geogebra-calculator </xsl:text>
-        <xsl:text>embed-button embed-popup embed-code-textbox copy-embed-button </xsl:text>
+        <xsl:text>ptx-embed-button ptx-embed-popup ptx-embed-close-button ptx-embed-code-textbox ptx-embed-copy-button </xsl:text>
         <!-- Runestone Services ids, banned always: these components can appear -->
         <!-- even on a non-hosted build.  (When actually hosted on Runestone the -->
         <!-- HTML ids are mangled, so the collision risk there is small.)        -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12501,27 +12501,32 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template name="embed-button">
-    <button id="embed-button" class="embed-button button" title="Embed this page">
+    <button id="ptx-embed-button" class="ptx-embed-button button" title="Embed this page" commandfor="ptx-embed-popup" command="show-modal">
         <xsl:call-template name="insert-symbol">
             <xsl:with-param name="name" select="'code'"/>
         </xsl:call-template>
         <span class="name">Embed</span>
 
     </button>
-    <div class="embed-popup hidden" id="embed-popup">
-        <p>Copy the code below to embed this page in your own website or LMS page.</p>
-        <div class="embed-code-container">
-            <textarea class="embed-code-textbox" id="embed-code-textbox" readonly="true" aria-label="textbox">
+    <dialog class="ptx-dialog ptx-embed-popup" id="ptx-embed-popup" closedby="closerequest">
+        <div class="ptx-embed-popup-controls">
+            <p>Copy the code below to embed this page in your own website or LMS page.</p>
+            <button class="ptx-embed-close-button button" id="ptx-embed-close-button" title="Close embed popup">
+                <span class="material-symbols-outlined">close</span>
+            </button>
+        </div>
+        <div class="ptx-embed-code-container">
+            <textarea class="ptx-embed-code-textbox" id="ptx-embed-code-textbox" readonly="true" aria-label="textbox">
                 <iframe src="https://example.com/embed" width="100%" height="1000"></iframe>
             </textarea>
-            <button class="copy-embed-button button" id="copy-embed-button" title="Copy embed code">
+            <button autofocus="autofocus" class="ptx-embed-copy-button button" id="ptx-embed-copy-button" title="Copy embed code">
                 <xsl:call-template name="insert-symbol">
                     <xsl:with-param name="name" select="'content_copy'"/>
                 </xsl:call-template>
                 <span class="name">Copy</span>
             </button>
         </div>
-    </div>
+    </dialog>
 </xsl:template>
 
 <xsl:template match="*" mode="print-button">
@@ -14063,7 +14068,7 @@ TODO:
 <!-- Div for native search results -->
 <xsl:template name="native-search-results">
     <xsl:if test="$has-native-search">
-        <dialog id="ptx-search-dialog" class="ptx-search-dialog" closedby="closerequest">
+        <dialog id="ptx-search-dialog" class="ptx-dialog ptx-search-dialog" closedby="closerequest">
             <div class="ptx-search-dialog-controls">
                 <input aria-label="Search term" id="ptx-search-terms" class="ptx-search-terms" type="text" name="terms" placeholder="Search terms"/>
                 <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close" commandfor="ptx-search-dialog"  command="close"><span class="material-symbols-outlined">close</span></button>


### PR DESCRIPTION
Change the embed nav button to native dialog and improves keyboard navigation handling.

Updates the id's for the HTML components to be `ptx-` prefixed. This potentially breaks after market styling, but that seems low likely hood and impact.

Related issue:
https://github.com/PreTeXtBook/pretext/issues/2794

