### PR TITLE
Assembly: fixes and a skipped pass for dynamic exercises

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1718,8 +1718,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="fillin[@ansobj]" mode="dynamic-substitution">
     <xsl:choose>
         <xsl:when test="($exercise-style = 'static') and not($b-extracting)">
+            <!-- The substitutions file is keyed by the late "visible-id",  -->
+            <!-- which prefers @label, then @xml:id.  This early pass runs  -->
+            <!-- before the promotion of @xml:id to @label, so consult both -->
+            <xsl:variable name="owner" select="ancestor::statement/.."/>
             <xsl:variable name="parent-id">
-                <xsl:apply-templates select="ancestor::statement/../@label" />
+                <xsl:apply-templates select="$owner/@label | $owner[not(@label)]/@xml:id" />
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
             <xsl:variable name="object" select="@ansobj"/>
@@ -1745,8 +1749,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <!-- static, for multiple conversions, but primarily LaTeX -->
         <xsl:when test="($exercise-style = 'static') and not($b-extracting)">
+            <!-- The substitutions file is keyed by the late "visible-id",  -->
+            <!-- which prefers @label, then @xml:id.  This early pass runs  -->
+            <!-- before the promotion of @xml:id to @label, so consult both -->
+            <xsl:variable name="owner" select="(ancestor::statement|ancestor::solution|ancestor::evaluation)/.."/>
             <xsl:variable name="parent-id">
-               <xsl:apply-templates select="(ancestor::statement|ancestor::solution|ancestor::evaluation)/../@label" />
+               <xsl:apply-templates select="$owner/@label | $owner[not(@label)]/@xml:id" />
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
             <xsl:variable name="object" select="@obj"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1031,11 +1031,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="assembly" select="exsl:node-set($assembly-rtf)"/>
 
-<!-- Make static substitutions for dynamic exercises.  -->
+<!-- Make static substitutions for dynamic exercises.                -->
+<!-- The pass only acts on the elements enumerated in this presence  -->
+<!-- test (see the "dynamic-substitution" templates); without any of -->
+<!-- them it is the identity, so we skip the full-tree copy.  NB: a  -->
+<!-- new template in the mode must be reflected in this test.        -->
+<xsl:variable name="b-has-dynamic-markup" select="boolean($assembly//setup | $assembly//numcmp | $assembly//strcmp | $assembly//jscmp | $assembly//mathcmp | $assembly//logic | $assembly//fillin[@ansobj] | $assembly//eval[@obj])"/>
 <xsl:variable name="dynamic-rtf">
-    <xsl:apply-templates select="$assembly" mode="dynamic-substitution"/>
+    <xsl:if test="$b-has-dynamic-markup">
+        <xsl:apply-templates select="$assembly" mode="dynamic-substitution"/>
+    </xsl:if>
 </xsl:variable>
-<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)"/>
+<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)[$b-has-dynamic-markup] | $assembly[not($b-has-dynamic-markup)]"/>
 
 <!-- Exercises are "tagged" as to their nature (division, inline, -->
 <!-- worksheet, reading, project-like) and interactive exercises  -->
@@ -1698,6 +1705,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ##################################################### -->
 <!-- Dynamic Substitutions                                 -->
 <!-- Cut out dynamic setup and evaluation for static mode. -->
+<!-- NB: a new match in this mode must be reflected in the -->
+<!-- $b-has-dynamic-markup presence test gating the pass.  -->
 <!-- ##################################################### -->
 <xsl:template match="setup[de-object|setupScript]" mode="dynamic-substitution">
     <xsl:if test="$exercise-style = 'dynamic'">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -4415,11 +4415,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>.html</xsl:text>
 </xsl:template>
 
-<xsl:template match="exercise[//task/@exercise-interactive='fillin' and //task/setup]
-                   | project[//task/@exercise-interactive='fillin' and //task/setup]
-                   | activity[//task/@exercise-interactive='fillin' and //task/setup]
-                   | exploration[//task/@exercise-interactive='fillin' and //task/setup]
-                   | investigation[//task/@exercise-interactive='fillin' and //task/setup]"
+<xsl:template match="exercise[.//task/@exercise-interactive='fillin' and .//task/setup]
+                   | project[.//task/@exercise-interactive='fillin' and .//task/setup]
+                   | activity[.//task/@exercise-interactive='fillin' and .//task/setup]
+                   | exploration[.//task/@exercise-interactive='fillin' and .//task/setup]
+                   | investigation[.//task/@exercise-interactive='fillin' and .//task/setup]"
                    mode="standalone-filename">
     <xsl:apply-templates select="." mode="assembly-id" />
     <xsl:text>.html</xsl:text>


### PR DESCRIPTION
Three changes in `pretext-assembly.xsl` concerning dynamically-generated (fill-in-the-blank) exercises.

**Bug fixes** (affect documents that use dynamic exercises)
- **Over-broad `standalone-filename` match** — the template choosing the standalone-page filename for a fill-in exercise tested `//task` (an absolute path matching any `task` in the whole document) where `.//task` was intended, so it matched any such exercise whenever a fill-in `task` existed anywhere in the source.
- **Substitution lookup missed `@xml:id`-only exercises** — the static substitutions for a dynamic exercise are keyed by the same identifier used downstream (`@label`, falling back to `@xml:id`), but this early lookup consulted only an authored `@label`. Since the promotion of `@xml:id` to `@label` happens in a later pass, an exercise identified solely by `@xml:id` never matched. The lookup now consults `@label` or `@xml:id`.

**Fewer passes**
- **Skip the dynamic-substitution pass** when the document contains no dynamic markup. The pass is otherwise the identity, so a document with no dynamic exercises no longer copies the entire source tree to no effect. The presence test is paired with a source note so that a new template added to the pass is reflected in the gate.

Verified output-neutral on the sample article, whose fill-in exercises carry labels: the post-pre-processor `assembly-dynamic` source is byte-identical to master. The fixes change behavior only for the edge cases they address.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
