### PR TITLE
Number open problems (openproblem, openquestion, openconjecture)

### DIFF
--- a/doc/guide/publisher/conversions.xml
+++ b/doc/guide/publisher/conversions.xml
@@ -72,7 +72,7 @@
 
         <p>If it is so important to not have separate sequences of serial numbers, then why do equations and footnotes get their own sequences?  These items are substantially different visually, and even their numbers are formatted quite differently, so scanning for blocks or equations or footnotes should be very distinct visually.  Notice that it is their <em>distinctive appearance</em> that is the criteria for an independent sequence of serial numbers.</p>
 
-        <p>We provide exactly this flexibility for three groups of blocks: the figure-like objects (<tag>figure</tag>, <tag>table</tag>, <tag>listing</tag>, <tag>list</tag>), <tag>project</tag>-like objects, and inline <tag>exercise</tag>.  By default each shares the single <q>blocks</q> sequence, but a publisher may split any of them out onto its own sequence of serial numbers.  See <xref ref="publication-file-numbering"/> for the switches that control this.</p>
+        <p>We provide exactly this flexibility for four groups of blocks: the figure-like objects (<tag>figure</tag>, <tag>table</tag>, <tag>listing</tag>, <tag>list</tag>), <tag>project</tag>-like objects, inline <tag>exercise</tag>, and the open problems (<tag>openproblem</tag>, <tag>openquestion</tag>, <tag>openconjecture</tag>).  By default each shares the single <q>blocks</q> sequence, but a publisher may split any of them out onto its own sequence of serial numbers.  See <xref ref="publication-file-numbering"/> for the switches that control this.</p>
 
         <note xml:id="best-practice-distinct-counters">
             <title>Use Separate Counters Sparingly</title>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -261,14 +261,16 @@
             <cline>/publication/numbering/equations/@level</cline>
             <cline>/publication/numbering/footnotes/@level</cline>
         </cd> whose values should be integers (zero is a possibility) that do not exceed the maximum level specified for divisions.</p>
-        <p>By default that <q>blocks</q> sequence also numbers three further groups<mdash/><tag>project</tag>-like objects, the figure-like objects (<tag>figure</tag>, <tag>table</tag>, <tag>listing</tag>, <tag>list</tag>), and inline <tag>exercise</tag>.  Any one of these may instead run on its own independent sequence of serial numbers, by setting the matching <attr>distinct</attr> switch<cd>
+        <p>By default that <q>blocks</q> sequence also numbers four further groups<mdash/><tag>project</tag>-like objects, the figure-like objects (<tag>figure</tag>, <tag>table</tag>, <tag>listing</tag>, <tag>list</tag>), inline <tag>exercise</tag>, and the open problems (<tag>openproblem</tag>, <tag>openquestion</tag>, <tag>openconjecture</tag>).  Any one of these may instead run on its own independent sequence of serial numbers, by setting the matching <attr>distinct</attr> switch<cd>
             <cline>/publication/numbering/projects/@distinct</cline>
             <cline>/publication/numbering/figures/@distinct</cline>
             <cline>/publication/numbering/exercises/@distinct</cline>
+            <cline>/publication/numbering/openproblems/@distinct</cline>
         </cd> to <c>yes</c> (the default is <c>no</c>).  When a group runs distinct, the hierarchy of its independent numbers is set by its own <attr>level</attr><cd>
             <cline>/publication/numbering/projects/@level</cline>
             <cline>/publication/numbering/figures/@level</cline>
             <cline>/publication/numbering/exercises/@level</cline>
+            <cline>/publication/numbering/openproblems/@level</cline>
         </cd> which is ignored while the group shares the blocks count.  For why blocks otherwise share a single sequence, and which groups make sense to separate, see <xref ref="publisher-numbering"/>.</p>
         <p>Chapters of a <tag>book</tag> may start numbering from something other than one.  This feature is not available in a book with structural parts (rather than decorative parts).  Read about this at the end of <xref ref="publisher-numbering"/> and <xref ref="best-practice-chapter-zero"/>.  If you still want to proceed, then set the publication file entry<cd>
             <cline>/publication/numbering/divisions/@chapter-start</cline>

--- a/examples/numbering/main.ptx
+++ b/examples/numbering/main.ptx
@@ -171,6 +171,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <statement><p>An investigation (project-like) in chapter A.</p></statement>
                 </investigation>
 
+                <!-- open problems: run on a distinct counter (publisher      -->
+                <!-- openproblems/@distinct="yes").  All three element names,  -->
+                <!-- and both content models: statement-plus-discussion        -->
+                <!-- appendage, and task-structured.                           -->
+                <openproblem xml:id="op-1-chA">
+                    <statement><p>First open problem in chapter A.</p></statement>
+                    <discussion><p>A discussion appendage on the first open problem.</p></discussion>
+                </openproblem>
+                <openquestion xml:id="oq-1-chA">
+                    <statement><p>An open question (open-problem-like) in chapter A.</p></statement>
+                </openquestion>
+                <openconjecture xml:id="oc-1-chA">
+                    <introduction><p>A task-structured open conjecture.</p></introduction>
+                    <task xml:id="oc-1-chA-a"><statement><p>First part.</p></statement></task>
+                    <task xml:id="oc-1-chA-b"><statement><p>Second part.</p></statement></task>
+                    <conclusion><p>End of the open conjecture.</p></conclusion>
+                </openconjecture>
+
                 <!-- equations: a plain pair, plus a multi-line md with mixed -->
                 <!-- numbered and unnumbered rows (edge case).                -->
                 <p><md><mrow xml:id="eq-1-chA" number="yes">u_1 = v_1</mrow></md></p>
@@ -451,6 +469,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <theorem xml:id="t-intro-2-chC"><statement><p>Second theorem in the chapter C introduction.</p></statement></theorem>
                     <project xml:id="pj-intro-1-chC"><statement><p>First project in the chapter C introduction.</p></statement></project>
                     <project xml:id="pj-intro-2-chC"><statement><p>Second project in the chapter C introduction.</p></statement></project>
+                    <openproblem xml:id="op-intro-1-chC"><statement><p>First open problem in the chapter C introduction.</p></statement></openproblem>
+                    <openproblem xml:id="op-intro-2-chC"><statement><p>Second open problem in the chapter C introduction.</p></statement></openproblem>
                     <figure xml:id="fg-intro-1-chC">
                         <caption>First figure in the chapter C introduction.</caption>
                         <sidebyside><p>A placeholder.</p></sidebyside>
@@ -842,6 +862,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <theorem xml:id="t-concl-1-chC"><statement><p>First theorem in the chapter C conclusion.</p></statement></theorem>
                     <theorem xml:id="t-concl-2-chC"><statement><p>Second theorem in the chapter C conclusion.</p></statement></theorem>
                     <project xml:id="pj-concl-1-chC"><statement><p>Project in the chapter C conclusion.</p></statement></project>
+                    <openproblem xml:id="op-concl-1-chC"><statement><p>Open problem in the chapter C conclusion.</p></statement></openproblem>
                     <figure xml:id="fg-concl-1-chC">
                         <caption>Figure in the chapter C conclusion.</caption>
                         <sidebyside><p>A placeholder.</p></sidebyside>

--- a/examples/numbering/publication.xml
+++ b/examples/numbering/publication.xml
@@ -31,8 +31,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- divisions/@level is the maximum depth at which divisions themselves -->
 <!-- carry numbers.  The other entries are each bounded above by it.     -->
 <!--                                                                     -->
-<!-- The "distinct" switch on projects/figures/exercises below picks     -->
-<!-- an own counter ("yes") versus the shared blocks counter ("no").     -->
+<!-- The "distinct" switch on projects/figures/exercises/openproblems    -->
+<!-- below picks an own counter ("yes") versus the shared blocks         -->
+<!-- counter ("no").                                                     -->
 
 <publication>
 
@@ -60,10 +61,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- footnotes) are the knobs you edit between builds to test   -->
         <!-- different scenarios.                                       -->
         <divisions level="5" part-structure="structural"/>
-        <blocks    level="2"/>
-        <projects  level="2" distinct="yes"/>
-        <figures   level="2" distinct="no"/>
-        <exercises level="2" distinct="no"/>
+        <blocks       level="2"/>
+        <projects     level="2" distinct="yes"/>
+        <figures      level="2" distinct="no"/>
+        <exercises    level="2" distinct="no"/>
+        <openproblems level="2" distinct="yes"/>
         <equations level="2"/>
         <footnotes level="2"/>
     </numbering>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -13527,13 +13527,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <section xml:id="open-problems" label="section-open-problems">
             <title>Open Problems</title>
 
-            <p>Like for mathematical research.  Experimental as of 2023-07-06.</p>
+            <p>Like for mathematical research.  An <c>openproblem</c>, <c>openquestion</c>, or <c>openconjecture</c> is numbered as a block, sharing the overall block counter by default, though a publisher can give them a counter of their own.</p>
 
             <openproblem>
                 <statement>
                     <p>Solve the Riemann Hypothesis<fn>Footnotes were once incomplete on open problems.</fn> <em>and</em> provide a short proof of Fermat's Last Theorem.</p>
                 </statement>
             </openproblem>
+
+            <openquestion>
+                <statement>
+                    <p>Is every even integer greater than two the sum of two primes?</p>
+                </statement>
+            </openquestion>
 
         </section>
 

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -500,7 +500,7 @@
             BlockDivision =
                 BlockStatement |
                 Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | Exercise | Project |
+                Axiom | Example | Exercise | Project | OpenProblem |
                 Poem | Assemblage | ListGenerator | Fragment
             
             Prelude =
@@ -806,6 +806,36 @@
                         (IntroductionStatement?, Task+, ConclusionStatement?)
                     )
                 }
+            
+            OpenProblemLike =
+                MetaDataTitleOptional,
+                Prelude?,
+                (
+                    (Statement, Discussion*) |
+                    (IntroductionStatement?, OpenProblemTask+, ConclusionStatement?)
+                ),
+                Postlude?
+            OpenProblem =
+                element openproblem {OpenProblemLike} |
+                element openquestion {OpenProblemLike} |
+                element openconjecture {OpenProblemLike}
+            OpenProblemTask =
+                element task {
+                    MetaDataTitleOptional,
+                    (
+                        (Statement, Discussion*) |
+                        (IntroductionStatement?, OpenProblemTask+, ConclusionStatement?)
+                    )
+                }
+            Discussion =
+                element context {DiscussionLike} |
+                element discussion {DiscussionLike} |
+                element opinion {DiscussionLike} |
+                element status {DiscussionLike} |
+                element suggestion {DiscussionLike}
+            DiscussionLike =
+                MetaDataTitleOptional,
+                BlockStatement+
             
             RemarkLike =
                 MetaDataTitleOptional,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1413,6 +1413,7 @@
       <ref name="Example"/>
       <ref name="Exercise"/>
       <ref name="Project"/>
+      <ref name="OpenProblem"/>
       <ref name="Poem"/>
       <ref name="Assemblage"/>
       <ref name="ListGenerator"/>
@@ -2231,6 +2232,96 @@
         </group>
       </choice>
     </element>
+  </define>
+  <define name="OpenProblemLike">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <ref name="Prelude"/>
+    </optional>
+    <choice>
+      <group>
+        <ref name="Statement"/>
+        <zeroOrMore>
+          <ref name="Discussion"/>
+        </zeroOrMore>
+      </group>
+      <group>
+        <optional>
+          <ref name="IntroductionStatement"/>
+        </optional>
+        <oneOrMore>
+          <ref name="OpenProblemTask"/>
+        </oneOrMore>
+        <optional>
+          <ref name="ConclusionStatement"/>
+        </optional>
+      </group>
+    </choice>
+    <optional>
+      <ref name="Postlude"/>
+    </optional>
+  </define>
+  <define name="OpenProblem">
+    <choice>
+      <element name="openproblem">
+        <ref name="OpenProblemLike"/>
+      </element>
+      <element name="openquestion">
+        <ref name="OpenProblemLike"/>
+      </element>
+      <element name="openconjecture">
+        <ref name="OpenProblemLike"/>
+      </element>
+    </choice>
+  </define>
+  <define name="OpenProblemTask">
+    <element name="task">
+      <ref name="MetaDataTitleOptional"/>
+      <choice>
+        <group>
+          <ref name="Statement"/>
+          <zeroOrMore>
+            <ref name="Discussion"/>
+          </zeroOrMore>
+        </group>
+        <group>
+          <optional>
+            <ref name="IntroductionStatement"/>
+          </optional>
+          <oneOrMore>
+            <ref name="OpenProblemTask"/>
+          </oneOrMore>
+          <optional>
+            <ref name="ConclusionStatement"/>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="Discussion">
+    <choice>
+      <element name="context">
+        <ref name="DiscussionLike"/>
+      </element>
+      <element name="discussion">
+        <ref name="DiscussionLike"/>
+      </element>
+      <element name="opinion">
+        <ref name="DiscussionLike"/>
+      </element>
+      <element name="status">
+        <ref name="DiscussionLike"/>
+      </element>
+      <element name="suggestion">
+        <ref name="DiscussionLike"/>
+      </element>
+    </choice>
+  </define>
+  <define name="DiscussionLike">
+    <ref name="MetaDataTitleOptional"/>
+    <oneOrMore>
+      <ref name="BlockStatement"/>
+    </oneOrMore>
   </define>
   <define name="RemarkLike">
     <ref name="MetaDataTitleOptional"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1038,7 +1038,7 @@
             BlockDivision =
                 BlockStatement |
                 Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | Exercise | Project |
+                Axiom | Example | Exercise | Project | OpenProblem |
                 Poem | Assemblage | ListGenerator | Fragment
             </code>
         </fragment>
@@ -1569,6 +1569,47 @@
                         (IntroductionStatement?, Task+, ConclusionStatement?)
                     )
                 }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Open Problems</title>
+
+        <p>Open problems collect unsolved questions, perhaps the subject of current research.  They are numbered like a <c>project</c><mdash/>sharing the overall blocks counter, or running on their own counter when a publisher requests a <attr>distinct</attr> number.  Possibly structured with <c>task</c>.  The appendages are discussion-like (<tag>discussion</tag>, <tag>context</tag>, and similar), rather than the hints, answers, and solutions of an exercise or a project.</p>
+
+        <fragment xml:id="open-problem-like">
+            <title>Open problems, and similar</title>
+            <code>
+            OpenProblemLike =
+                MetaDataTitleOptional,
+                Prelude?,
+                (
+                    (Statement, Discussion*) |
+                    (IntroductionStatement?, OpenProblemTask+, ConclusionStatement?)
+                ),
+                Postlude?
+            OpenProblem =
+                element openproblem {OpenProblemLike} |
+                element openquestion {OpenProblemLike} |
+                element openconjecture {OpenProblemLike}
+            OpenProblemTask =
+                element task {
+                    MetaDataTitleOptional,
+                    (
+                        (Statement, Discussion*) |
+                        (IntroductionStatement?, OpenProblemTask+, ConclusionStatement?)
+                    )
+                }
+            Discussion =
+                element context {DiscussionLike} |
+                element discussion {DiscussionLike} |
+                element opinion {DiscussionLike} |
+                element status {DiscussionLike} |
+                element suggestion {DiscussionLike}
+            DiscussionLike =
+                MetaDataTitleOptional,
+                BlockStatement+
             </code>
         </fragment>
     </section>
@@ -3584,6 +3625,7 @@
             <fragref ref="axiom-like" />
             <fragref ref="example-like" />
             <fragref ref="project-like" />
+            <fragref ref="open-problem-like" />
             <fragref ref="remark-like" />
             <fragref ref="computation-like" />
             <fragref ref="aside" />

--- a/schema/pretext.xsd
+++ b/schema/pretext.xsd
@@ -1156,6 +1156,7 @@
       <xs:group ref="Example"/>
       <xs:group ref="Exercise"/>
       <xs:group ref="Project"/>
+      <xs:group ref="OpenProblem"/>
       <xs:element ref="poem"/>
       <xs:element ref="assemblage"/>
       <xs:element ref="list-of"/>
@@ -1862,6 +1863,79 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
+  <xs:complexType name="OpenProblemLike">
+    <xs:sequence>
+      <xs:group ref="MetaDataTitleOptional"/>
+      <xs:element minOccurs="0" ref="prelude"/>
+      <xs:choice>
+        <xs:sequence>
+          <xs:group ref="Statement"/>
+          <xs:group minOccurs="0" maxOccurs="unbounded" ref="Discussion"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:group minOccurs="0" ref="IntroductionStatement"/>
+          <xs:group maxOccurs="unbounded" ref="OpenProblemTask"/>
+          <xs:group minOccurs="0" ref="ConclusionStatement"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:element minOccurs="0" ref="postlude"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="MetaDataTitleOptional"/>
+  </xs:complexType>
+  <xs:group name="OpenProblem">
+    <xs:choice>
+      <xs:element ref="openproblem"/>
+      <xs:element ref="openquestion"/>
+      <xs:element ref="openconjecture"/>
+    </xs:choice>
+  </xs:group>
+  <xs:element name="openproblem" type="OpenProblemLike"/>
+  <xs:element name="openquestion" type="OpenProblemLike"/>
+  <xs:element name="openconjecture" type="OpenProblemLike"/>
+  <xs:group name="OpenProblemTask">
+    <xs:sequence>
+      <xs:element name="task">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="MetaDataTitleOptional"/>
+            <xs:choice>
+              <xs:sequence>
+                <xs:group ref="Statement"/>
+                <xs:group minOccurs="0" maxOccurs="unbounded" ref="Discussion"/>
+              </xs:sequence>
+              <xs:sequence>
+                <xs:group minOccurs="0" ref="IntroductionStatement"/>
+                <xs:group maxOccurs="unbounded" ref="OpenProblemTask"/>
+                <xs:group minOccurs="0" ref="ConclusionStatement"/>
+              </xs:sequence>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attributeGroup ref="MetaDataTitleOptional"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="Discussion">
+    <xs:choice>
+      <xs:element ref="context"/>
+      <xs:element ref="discussion"/>
+      <xs:element ref="opinion"/>
+      <xs:element ref="status"/>
+      <xs:element ref="suggestion"/>
+    </xs:choice>
+  </xs:group>
+  <xs:element name="context" type="DiscussionLike"/>
+  <xs:element name="discussion" type="DiscussionLike"/>
+  <xs:element name="opinion" type="DiscussionLike"/>
+  <xs:element name="status" type="DiscussionLike"/>
+  <xs:element name="suggestion" type="DiscussionLike"/>
+  <xs:complexType name="DiscussionLike">
+    <xs:sequence>
+      <xs:group ref="MetaDataTitleOptional"/>
+      <xs:group maxOccurs="unbounded" ref="BlockStatement"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="MetaDataTitleOptional"/>
+  </xs:complexType>
   <xs:complexType name="RemarkLike">
     <xs:sequence>
       <xs:group ref="MetaDataTitleOptional"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -556,6 +556,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:apply-templates select="@*|node()" mode="serial-stamp">
             <xsl:with-param name="eq-nodes" select="$eq-nodes"/>
@@ -564,6 +565,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -613,6 +615,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:variable name="b-terminal" select="not(part|chapter|appendix|section|subsection|subsubsection|preface)"/>
     <xsl:variable name="b-open-eq"          select="not($eq-nodes)          and ($b-terminal or (@level &gt;= $numbering-equations))"/>
     <xsl:variable name="b-open-fn"          select="not($fn-nodes)          and ($b-terminal or (@level &gt;= $numbering-footnotes))"/>
@@ -620,6 +623,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="b-open-figure"      select="$b-number-figure-distinct      and not($figure-nodes)      and ($b-terminal or (@level &gt;= $numbering-figures))"/>
     <xsl:variable name="b-open-project"     select="$b-number-project-distinct     and not($project-nodes)     and ($b-terminal or (@level &gt;= $numbering-projects))"/>
     <xsl:variable name="b-open-exercise"    select="$b-number-exercise-distinct    and not($exercise-nodes)    and ($b-terminal or (@level &gt;= $numbering-exercises))"/>
+    <xsl:variable name="b-open-openproblem" select="$b-number-openproblem-distinct and not($openproblem-nodes) and ($b-terminal or (@level &gt;= $numbering-openproblems))"/>
     <xsl:variable name="next-eq" select="$eq-nodes | self::*[$b-open-eq]//mrow[@pi:numbered = 'yes']"/>
     <xsl:variable name="next-fn" select="$fn-nodes | self::*[$b-open-fn]//fn"/>
     <!-- The shared "blocks" pool also gathers figure-likes, projects,  -->
@@ -628,10 +632,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         | self::*[$b-open-blocks]//*[&FUNDAMENTAL-BLOCK-FILTER;]
         | self::*[$b-open-blocks and not($b-number-figure-distinct)]//*[&TOP-FIGURE-FILTER;]
         | self::*[$b-open-blocks and not($b-number-project-distinct)]//*[&PROJECT-FILTER;]
-        | self::*[$b-open-blocks and not($b-number-exercise-distinct)]//exercise[&INLINE-EXERCISE-FILTER;]"/>
+        | self::*[$b-open-blocks and not($b-number-exercise-distinct)]//exercise[&INLINE-EXERCISE-FILTER;]
+        | self::*[$b-open-blocks and not($b-number-openproblem-distinct)]//*[&OPENPROBLEM-FILTER;]"/>
     <xsl:variable name="next-figure"      select="$figure-nodes      | self::*[$b-open-figure]//*[&TOP-FIGURE-FILTER;]"/>
     <xsl:variable name="next-project"     select="$project-nodes     | self::*[$b-open-project]//*[&PROJECT-FILTER;]"/>
     <xsl:variable name="next-exercise"    select="$exercise-nodes    | self::*[$b-open-exercise]//exercise[&INLINE-EXERCISE-FILTER;]"/>
+    <xsl:variable name="next-openproblem" select="$openproblem-nodes | self::*[$b-open-openproblem]//*[&OPENPROBLEM-FILTER;]"/>
     <xsl:copy>
         <xsl:apply-templates select="@*|node()" mode="serial-stamp">
             <xsl:with-param name="eq-nodes" select="$next-eq"/>
@@ -640,6 +646,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$next-figure"/>
             <xsl:with-param name="project-nodes" select="$next-project"/>
             <xsl:with-param name="exercise-nodes" select="$next-exercise"/>
+            <xsl:with-param name="openproblem-nodes" select="$next-openproblem"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -658,16 +665,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:variable name="next-eq" select="$eq-nodes | (../introduction | ../conclusion)[not($eq-nodes)]//mrow[@pi:numbered = 'yes']"/>
     <xsl:variable name="next-fn" select="$fn-nodes | (../introduction | ../conclusion)[not($fn-nodes)]//fn"/>
     <xsl:variable name="next-blocks" select="$blocks-nodes
         | (../introduction | ../conclusion)[not($blocks-nodes)]//*[&FUNDAMENTAL-BLOCK-FILTER;]
         | (../introduction | ../conclusion)[not($blocks-nodes) and not($b-number-figure-distinct)]//*[&TOP-FIGURE-FILTER;]
         | (../introduction | ../conclusion)[not($blocks-nodes) and not($b-number-project-distinct)]//*[&PROJECT-FILTER;]
-        | (../introduction | ../conclusion)[not($blocks-nodes) and not($b-number-exercise-distinct)]//exercise[&INLINE-EXERCISE-FILTER;]"/>
+        | (../introduction | ../conclusion)[not($blocks-nodes) and not($b-number-exercise-distinct)]//exercise[&INLINE-EXERCISE-FILTER;]
+        | (../introduction | ../conclusion)[not($blocks-nodes) and not($b-number-openproblem-distinct)]//*[&OPENPROBLEM-FILTER;]"/>
     <xsl:variable name="next-figure"      select="$figure-nodes      | (../introduction | ../conclusion)[not($figure-nodes)      and $b-number-figure-distinct]//*[&TOP-FIGURE-FILTER;]"/>
     <xsl:variable name="next-project"     select="$project-nodes     | (../introduction | ../conclusion)[not($project-nodes)     and $b-number-project-distinct]//*[&PROJECT-FILTER;]"/>
     <xsl:variable name="next-exercise"    select="$exercise-nodes    | (../introduction | ../conclusion)[not($exercise-nodes)    and $b-number-exercise-distinct]//exercise[&INLINE-EXERCISE-FILTER;]"/>
+    <xsl:variable name="next-openproblem" select="$openproblem-nodes | (../introduction | ../conclusion)[not($openproblem-nodes) and $b-number-openproblem-distinct]//*[&OPENPROBLEM-FILTER;]"/>
     <xsl:copy>
         <xsl:apply-templates select="@*|node()" mode="serial-stamp">
             <xsl:with-param name="eq-nodes" select="$next-eq"/>
@@ -676,6 +686,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$next-figure"/>
             <xsl:with-param name="project-nodes" select="$next-project"/>
             <xsl:with-param name="exercise-nodes" select="$next-exercise"/>
+            <xsl:with-param name="openproblem-nodes" select="$next-openproblem"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -689,6 +700,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -702,6 +714,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -715,6 +728,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -728,6 +742,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -744,6 +759,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -757,6 +773,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -769,6 +786,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -782,6 +800,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -794,6 +813,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -807,6 +827,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -819,6 +840,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="figure-nodes"/>
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
     <xsl:copy>
         <xsl:attribute name="serial">
             <xsl:apply-templates select="." mode="position-in-node-set">
@@ -832,6 +854,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
             <xsl:with-param name="project-nodes" select="$project-nodes"/>
             <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
+        </xsl:apply-templates>
+    </xsl:copy>
+</xsl:template>
+
+<!-- Open problems: distinct counter when split out, else "blocks". -->
+<xsl:template match="&OPENPROBLEM-LIKE;" mode="serial-stamp">
+    <xsl:param name="eq-nodes"/>
+    <xsl:param name="fn-nodes"/>
+    <xsl:param name="blocks-nodes"/>
+    <xsl:param name="figure-nodes"/>
+    <xsl:param name="project-nodes"/>
+    <xsl:param name="exercise-nodes"/>
+    <xsl:param name="openproblem-nodes"/>
+    <xsl:copy>
+        <xsl:attribute name="serial">
+            <xsl:apply-templates select="." mode="position-in-node-set">
+                <xsl:with-param name="nodes" select="$openproblem-nodes[$b-number-openproblem-distinct] | $blocks-nodes[not($b-number-openproblem-distinct)]"/>
+            </xsl:apply-templates>
+        </xsl:attribute>
+        <xsl:apply-templates select="@*|node()" mode="serial-stamp">
+            <xsl:with-param name="eq-nodes" select="$eq-nodes"/>
+            <xsl:with-param name="fn-nodes" select="$fn-nodes"/>
+            <xsl:with-param name="blocks-nodes" select="$blocks-nodes"/>
+            <xsl:with-param name="figure-nodes" select="$figure-nodes"/>
+            <xsl:with-param name="project-nodes" select="$project-nodes"/>
+            <xsl:with-param name="exercise-nodes" select="$exercise-nodes"/>
+            <xsl:with-param name="openproblem-nodes" select="$openproblem-nodes"/>
         </xsl:apply-templates>
     </xsl:copy>
 </xsl:template>
@@ -1078,6 +1128,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="figure-nodes" select="/.."/>
         <xsl:with-param name="project-nodes" select="/.."/>
         <xsl:with-param name="exercise-nodes" select="/.."/>
+        <xsl:with-param name="openproblem-nodes" select="/.."/>
     </xsl:apply-templates>
 </xsl:variable>
 <xsl:variable name="serial-stamp" select="exsl:node-set($serial-stamp-rtf)"/>

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -810,6 +810,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <xsl:text>]{figure-distinct}{}&#xa;</xsl:text>
     </xsl:if>
+    <xsl:if test="$b-number-openproblem-distinct">
+        <xsl:text>%%&#xa;</xsl:text>
+        <xsl:text>%% This document is set to number OPENPROBLEM-LIKE on a separate numbering scheme&#xa;</xsl:text>
+        <xsl:text>%% So, a faux tcolorbox whose only purpose is to provide this numbering&#xa;</xsl:text>
+        <xsl:text>%% Controlled by  numbering.openproblems.level  processing parameter&#xa;</xsl:text>
+        <xsl:text>\newtcolorbox[auto counter</xsl:text>
+        <!-- control the levels of the numbering -->
+        <!-- global (no periods) is the default  -->
+        <xsl:if test="not($numbering-openproblems = 0)">
+            <xsl:text>, number within=</xsl:text>
+            <xsl:call-template name="level-to-name">
+                <xsl:with-param name="level" select="$numbering-openproblems" />
+            </xsl:call-template>
+        </xsl:if>
+        <xsl:text>]{openproblem-distinct}{}&#xa;</xsl:text>
+    </xsl:if>
     <!-- TODO: condition of figure/*/figure-like, or $subfigure-reps -->
     <xsl:text>%% A faux tcolorbox whose only purpose is to provide common numbering&#xa;</xsl:text>
     <xsl:text>%% facilities for 2D displays which are subnumbered as part of a "sidebyside"&#xa;</xsl:text>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -2110,6 +2110,22 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <xsl:text>]{figure-distinct}{}&#xa;</xsl:text>
     </xsl:if>
+    <xsl:if test="$b-number-openproblem-distinct">
+        <xsl:text>%%&#xa;</xsl:text>
+        <xsl:text>%% This document is set to number OPENPROBLEM-LIKE on a separate numbering scheme&#xa;</xsl:text>
+        <xsl:text>%% So, a faux tcolorbox whose only purpose is to provide this numbering&#xa;</xsl:text>
+        <xsl:text>%% Controlled by  numbering.openproblems.level  processing parameter&#xa;</xsl:text>
+        <xsl:text>\newtcolorbox[auto counter</xsl:text>
+        <!-- control the levels of the numbering -->
+        <!-- global (no periods) is the default  -->
+        <xsl:if test="not($numbering-openproblems = 0)">
+            <xsl:text>, number within=</xsl:text>
+            <xsl:call-template name="level-to-name">
+                <xsl:with-param name="level" select="$numbering-openproblems" />
+            </xsl:call-template>
+        </xsl:if>
+        <xsl:text>]{openproblem-distinct}{}&#xa;</xsl:text>
+    </xsl:if>
     <!-- TODO: condition of figure/*/figure-like, or $subfigure-reps -->
     <xsl:text>%% A faux tcolorbox whose only purpose is to provide common numbering&#xa;</xsl:text>
     <xsl:text>%% facilities for 2D displays which are subnumbered as part of a "sidebyside"&#xa;</xsl:text>
@@ -3250,7 +3266,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- projects and inline exercises sometimes run on their own counters -->
+    <!-- projects, inline exercises, and open problems sometimes run on their own counters -->
     <xsl:variable name="counter">
         <xsl:choose>
             <xsl:when test="(&PROJECT-FILTER;) and $b-number-project-distinct">
@@ -3258,6 +3274,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;) and $b-number-exercise-distinct">
                 <xsl:text>exercise-distinct</xsl:text>
+            </xsl:when>
+            <xsl:when test="(&OPENPROBLEM-FILTER;) and $b-number-openproblem-distinct">
+                <xsl:text>openproblem-distinct</xsl:text>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>block</xsl:text>

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -221,7 +221,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- "serial-stamp" pass stamped.  That pass decides, from the    -->
 <!-- publication "@distinct" switches, whether a group shares the -->
 <!-- overall blocks counter or runs on its own distinct counter.  -->
-<xsl:template match="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|&FIGURE-LIKE;|exercise" mode="serial-number">
+<xsl:template match="&DEFINITION-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|&FIGURE-LIKE;|&OPENPROBLEM-LIKE;|exercise" mode="serial-number">
     <xsl:value-of select="@serial"/>
 </xsl:template>
 
@@ -507,13 +507,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:number count="stage" from="static" />
 </xsl:template>
 
-<!-- TEMPORARY -->
-<!-- 2023-02-16: placeholder numbers for OPENPROBLEM-LIKE, DISCUSSION-LIKE -->
-<xsl:template match="&OPENPROBLEM-LIKE;" mode="serial-number">
-    <xsl:text>N</xsl:text>
-</xsl:template>
+<!-- OPENPROBLEM-LIKE are blocks: their serial number is read from @serial,  -->
+<!-- alongside the other block families above.  Their structure number      -->
+<!-- follows the figure/project pattern: the open-problem level when they    -->
+<!-- run on a distinct counter, otherwise the shared "blocks" level.         -->
 <xsl:template match="&OPENPROBLEM-LIKE;" mode="structure-number">
-    <xsl:text>M</xsl:text>
+    <xsl:variable name="openproblem-levels">
+        <xsl:choose>
+            <xsl:when test="$b-number-openproblem-distinct">
+                <xsl:value-of select="$numbering-openproblems" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$numbering-blocks" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:call-template name="block-structure-number">
+        <xsl:with-param name="levels" select="$openproblem-levels"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- DISCUSSION-LIKE are appendages; their number is inherited from the parent. -->


### PR DESCRIPTION
Open problems — `<openproblem>`, `<openquestion>`, `<openconjecture>` — have until now rendered with placeholder numbers (`N`/`M`) and were absent from the content schema. This admits them to the schema and numbers them as blocks, reusing the assembly-time `@serial` mechanism built for the other block families.

- **Schema** — adds the three elements (with their `statement`/`task` and discussion-appendage structure) to the document content model.
- **Numbering** — they are stamped with an `@serial` during assembly and read it at render time. By default they share the overall "blocks" counter; a publisher can give them their own sequence with `numbering/openproblems/@distinct`, parallel to projects, figures, and inline exercises.
- **LaTeX** — a distinct-counter environment so the PDF output matches when a separate counter is requested.
- **Examples** — open problems in the numbering test document (covering the shared and distinct cases, and introduction/conclusion pooling) and a numbered pair in the sample article.
- **Guide** — documents the `openproblems/@distinct` switch alongside the other distinct-numbering switches.

The absence of real numbers was the one thing keeping open problems experimental. With the numbering refactor concluded and those placeholders replaced by proper numbers, open problems are no longer experimental.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
