### PR TITLE
FITB: key the dynamic-substitution round trip on "@assembly-id"

### DIFF
--- a/xsl/extract-dynamic.xsl
+++ b/xsl/extract-dynamic.xsl
@@ -96,7 +96,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>,&#xa;</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:text>  "exercise_id": "</xsl:text>
-    <xsl:apply-templates select="." mode="visible-id" />
+    <!-- Key the round trip on @assembly-id, the early identifier the   -->
+    <!-- substitution pass reads back.  @label only exists for labeled  -->
+    <!-- exercises, so it would miss unlabeled exercises and tasks.      -->
+    <xsl:apply-templates select="." mode="assembly-id" />
     <xsl:text>",&#xa;</xsl:text>
     <xsl:text>  "exercise_setup": </xsl:text>
     <xsl:call-template name="dynamic-setup" />

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2853,6 +2853,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                    mode="assembly-id">
     <xsl:value-of select="@assembly-id"/>
 </xsl:template>
+<!-- A fill-in "task" is the "owner" that the dynamic-substitution lookup -->
+<!-- keys on, so it too must report its "@assembly-id" (matching the      -->
+<!-- "exercise//task" extraction in extract-dynamic.xsl).                 -->
+<xsl:template match="exercise//task[@exercise-interactive='fillin' and setup]
+                   | project//task[@exercise-interactive='fillin' and setup]
+                   | activity//task[@exercise-interactive='fillin' and setup]
+                   | exploration//task[@exercise-interactive='fillin' and setup]
+                   | investigation//task[@exercise-interactive='fillin' and setup]"
+                   mode="assembly-id">
+    <xsl:value-of select="@assembly-id"/>
+</xsl:template>
 
 <xsl:template match="datafile" mode="assembly-id">
     <xsl:value-of select="@assembly-id"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1031,19 +1031,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="assembly" select="exsl:node-set($assembly-rtf)"/>
 
-<!-- Make static substitutions for dynamic exercises.                -->
-<!-- The pass only acts on the elements enumerated in this presence  -->
-<!-- test (see the "dynamic-substitution" templates); without any of -->
-<!-- them it is the identity, so we skip the full-tree copy.  NB: a  -->
-<!-- new template in the mode must be reflected in this test.        -->
-<xsl:variable name="b-has-dynamic-markup" select="boolean($assembly//setup | $assembly//numcmp | $assembly//strcmp | $assembly//jscmp | $assembly//mathcmp | $assembly//logic | $assembly//fillin[@ansobj] | $assembly//eval[@obj])"/>
-<xsl:variable name="dynamic-rtf">
-    <xsl:if test="$b-has-dynamic-markup">
-        <xsl:apply-templates select="$assembly" mode="dynamic-substitution"/>
-    </xsl:if>
-</xsl:variable>
-<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)[$b-has-dynamic-markup] | $assembly[not($b-has-dynamic-markup)]"/>
-
 <!-- Exercises are "tagged" as to their nature (division, inline, -->
 <!-- worksheet, reading, project-like) and interactive exercises  -->
 <!-- get more precise categorization.  The latter is used to      -->
@@ -1051,7 +1038,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:variable name="exercise-rtf">
     <!-- initialize with default, 'inline' -->
-    <xsl:apply-templates select="$dynamic" mode="exercise">
+    <xsl:apply-templates select="$assembly" mode="exercise">
         <xsl:with-param name="division" select="'inline'"/>
     </xsl:apply-templates>
 </xsl:variable>
@@ -1065,12 +1052,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="assembly-label" select="exsl:node-set($assembly-label-rtf)"/>
 
+<!-- Make static substitutions for dynamic exercises.  This runs AFTER  -->
+<!-- the @assembly-id stamp because the substitution round trip keys on  -->
+<!-- @assembly-id: extract-dynamic.xsl writes it as the exercise_id, and -->
+<!-- the lookup below reads it.  @assembly-id is the early identifier    -->
+<!-- both ends can compute consistently (the authored @label would only  -->
+<!-- match for labeled exercises, missing unlabeled ones and tasks).     -->
+<!-- The pass only acts on the elements enumerated in this presence      -->
+<!-- test (see the "dynamic-substitution" templates); without any of     -->
+<!-- them it is the identity, so we skip the full-tree copy.  NB: a      -->
+<!-- new template in the mode must be reflected in this test.            -->
+<xsl:variable name="b-has-dynamic-markup" select="boolean($assembly-label//setup | $assembly-label//numcmp | $assembly-label//strcmp | $assembly-label//jscmp | $assembly-label//mathcmp | $assembly-label//logic | $assembly-label//fillin[@ansobj] | $assembly-label//eval[@obj])"/>
+<xsl:variable name="dynamic-rtf">
+    <xsl:if test="$b-has-dynamic-markup">
+        <xsl:apply-templates select="$assembly-label" mode="dynamic-substitution"/>
+    </xsl:if>
+</xsl:variable>
+<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)[$b-has-dynamic-markup] | $assembly-label[not($b-has-dynamic-markup)]"/>
+
 <xsl:variable name="representations-rtf">
     <xsl:choose>
         <!-- short-circuit to stop after adding @assembly-id -->
         <xsl:when test="$b-assembly-id-only"/>
         <xsl:otherwise>
-            <xsl:apply-templates select="$assembly-label" mode="representations"/>
+            <xsl:apply-templates select="$dynamic" mode="representations"/>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -1727,12 +1732,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="fillin[@ansobj]" mode="dynamic-substitution">
     <xsl:choose>
         <xsl:when test="($exercise-style = 'static') and not($b-extracting)">
-            <!-- The substitutions file is keyed by the late "visible-id",  -->
-            <!-- which prefers @label, then @xml:id.  This early pass runs  -->
-            <!-- before the promotion of @xml:id to @label, so consult both -->
+            <!-- The substitutions file is keyed by @assembly-id, which     -->
+            <!-- extract-dynamic.xsl writes as the exercise_id.  This pass   -->
+            <!-- runs after the @assembly-id stamp, so the owner carries it. -->
             <xsl:variable name="owner" select="ancestor::statement/.."/>
             <xsl:variable name="parent-id">
-                <xsl:apply-templates select="$owner/@label | $owner[not(@label)]/@xml:id" />
+                <xsl:apply-templates select="$owner" mode="assembly-id"/>
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
             <xsl:variable name="object" select="@ansobj"/>
@@ -1758,12 +1763,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <!-- static, for multiple conversions, but primarily LaTeX -->
         <xsl:when test="($exercise-style = 'static') and not($b-extracting)">
-            <!-- The substitutions file is keyed by the late "visible-id",  -->
-            <!-- which prefers @label, then @xml:id.  This early pass runs  -->
-            <!-- before the promotion of @xml:id to @label, so consult both -->
+            <!-- The substitutions file is keyed by @assembly-id, which     -->
+            <!-- extract-dynamic.xsl writes as the exercise_id.  This pass   -->
+            <!-- runs after the @assembly-id stamp, so the owner carries it. -->
             <xsl:variable name="owner" select="(ancestor::statement|ancestor::solution|ancestor::evaluation)/.."/>
             <xsl:variable name="parent-id">
-               <xsl:apply-templates select="$owner/@label | $owner[not(@label)]/@xml:id" />
+               <xsl:apply-templates select="$owner" mode="assembly-id"/>
             </xsl:variable>
             <xsl:variable name="eval-subs" select="document($dynamic-substitutions-file,$original)"/>
             <xsl:variable name="object" select="@obj"/>


### PR DESCRIPTION
Computed fill-in-the-blank exercises (those with `fillin[@ansobj]` / `eval[@obj]` driven by a `setup`) use a two-pass round trip: an extraction pass writes each exercise's identity and the values to compute, and a later assembly pass reads them back to splice the answers into static (PDF/LaTeX) output. The two ends keyed on **different** identifiers — extraction wrote the late `visible-id` (`@unique-id`), while the substitution lookup keyed on the authored `@label`. They aligned only for labeled exercises; an exercise with no `@label`, or a fill-in inside a `task` (the owner is the unlabeled task), silently lost its computed answer.

This keys both ends on `@assembly-id`, the early identifier minted precisely so assembly passes can coordinate before `@unique-id` exists.

- **`extract-dynamic.xsl`** writes `@assembly-id` as the `exercise_id`.
- The substitution lookup reads `$owner`'s `@assembly-id` (via the `assembly-id` getter mode) instead of `@label`.
- The dynamic-substitution pass now runs **after** the `@assembly-id` stamp (it must still precede the representations pass that consumes the spliced answer). A side benefit: stamping before the static-mode removal of `setup`/`eval` makes `@assembly-id` independent of build mode, which is what lets the extraction (dynamic) and substitution (static) passes agree.
- A bare fill-in `task` now reports its `@assembly-id` from the getter (it is the lookup owner).

Compatibility: for any labeled exercise `@assembly-id == @label == visible-id`, so existing generated substitution files keep working unchanged; previously-broken unlabeled exercises and task fill-ins now resolve. Rendered HTML and LaTeX are unchanged.

**Testing.** Because every computed fill-in in the sample documents is labeled, the bug is invisible to them — so verification used two deliberately bug-inducing duplicates of an existing computed exercise: one with its `@label`/`@xml:id` removed, and one with the fill-in moved inside a `task`. Both render a blank answer on `master` and the correct answer with this change. To guard the identification contract (the substitution pass now runs between the `@assembly-id` and `@unique-id` stamps), the `assembly.debug` coherence check was run on the sample article before and after — the set of `@assembly-id`/`@unique-id` mismatches is byte-identical, so the change adds none. Regenerating the dynamic substitutions for the sample article yields a file byte-identical to the committed one, and the sample book's rendered HTML is unchanged.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
