### PR TITLE
Runestone: prepare for RS user menu responsibility handoff

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10048,6 +10048,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:text>print-first-page-footer-checkbox print-running-footer-checkbox </xsl:text>
         <xsl:text>calculator-toggle calculator-container geogebra-calculator </xsl:text>
         <xsl:text>embed-button embed-popup embed-code-textbox copy-embed-button </xsl:text>
+        <xsl:text>ptx-user-dropdown ptx-user-dropdown-content_item-template ptx-user-dropdown-content_separator-template </xsl:text>
         <!-- Runestone Services ids, banned always: these components can appear -->
         <!-- even on a non-hosted build.  (When actually hosted on Runestone the -->
         <!-- HTML ids are mangled, so the collision risk there is small.)        -->

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -255,7 +255,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="name" select="'person'"/>
             </xsl:call-template>
             <span class="name"><xsl:text>Profile</xsl:text></span>
-            <div class="dropdown-content">
+            <div id="ptx-user-dropdown_rs-content" class="dropdown-content">
+            </div>
+            <!-- clone template, modify href and innertext, and append to ptx-rs-dropdown-content -->
+            <template id="ptx-user-dropdown-content_item-template">
+              <a href="url here" >title here</a>
+            </template>
+            <!-- clone and append to dropdown contenet area add a separator within the menu -->
+            <template id="ptx-user-dropdown-content_separator-template">
+              <hr/>
+            </template>
+            <div class="dropdown-content" data-deprecated="true">
                 <xsl:text>&#xa;</xsl:text>
                 <xsl:text>{% if settings.academy_mode: %}&#xa;</xsl:text>
                 <a href="/ns/course/index">Course Home</a>


### PR DESCRIPTION
This preps the way for Runestone to take control over its entries in the "bust" menu.

This marks the old menu items so RS can discard them and provides templates for RS to use to insert items. Should be 100% safe to deploy before RS code. Once RS code is in place, we can fully remove the old HTML.

PreTeXt will control the HTML in the templates and the location where RS places items. RS will instantiate template copies for whatever menu items it wants and customize the <a> href and text.

@bnmnetp - I don't know what menu options you want to give and in what order. So not doing a RS PR. but here is some sample JS for removing the old items and inserting ones you want:

```js

window.addEventListener("DOMContentLoaded", function(event) {

  const oldDropDown = this.document.querySelector(".dropdown-content[data-deprecated]");
  if( oldDropDown )
    oldDropDown.remove();

  const itemTemplate = this.document.getElementById("ptx-user-dropdown-content_item-template");
  const sepTemplate = this.document.getElementById("ptx-user-dropdown-content_separator-template");
  const menuContentArea = this.document.getElementById("ptx-user-dropdown_rs-content");

  if( !itemTemplate || !sepTemplate || !menuContentArea ) {
    console.error("Missing required template or content area for user dropdown");
    return;
  }

  function makeLink(url, title, ariaLabel = null) {
    // All we should assume about the item template is that it has an anchor element
    const link =  itemTemplate.content.cloneNode(true);
    const linkAnchor = link.querySelector("a");
    linkAnchor.href = url;
    linkAnchor.innerText = title;
    if(ariaLabel) {
      linkAnchor.ariaLabel = ariaLabel;
    }
    // return entire item template, not just link
    return link;
  }

  menuContentArea.appendChild(makeLink("http://google.com", "Go to google"));
  menuContentArea.appendChild(makeLink("http://github.com", "Go to github"));
  menuContentArea.appendChild(sepTemplate.content.cloneNode(true));
  menuContentArea.appendChild(makeLink("http://apple.com", "Go to apple"));
});
```