### PR TITLE
XSL-FO: fix SVG image rendering in the Apache FOP PDF route

### DIFF
--- a/pretext/fop.xconf
+++ b/pretext/fop.xconf
@@ -73,12 +73,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf">
                     <font-triplet name="DejaVu Serif" style="normal" weight="bold"/>
+                    <font-triplet name="serif" style="normal" weight="bold"/>
+                    <font-triplet name="Times" style="normal" weight="bold"/>
+                    <font-triplet name="Times New Roman" style="normal" weight="bold"/>
+                    <font-triplet name="any" style="normal" weight="bold"/>
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSerif-Italic.ttf">
                     <font-triplet name="DejaVu Serif" style="italic" weight="normal"/>
+                    <font-triplet name="serif" style="italic" weight="normal"/>
+                    <font-triplet name="Times" style="italic" weight="normal"/>
+                    <font-triplet name="Times New Roman" style="italic" weight="normal"/>
+                    <font-triplet name="any" style="italic" weight="normal"/>
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSerif-BoldItalic.ttf">
                     <font-triplet name="DejaVu Serif" style="italic" weight="bold"/>
+                    <font-triplet name="serif" style="italic" weight="bold"/>
+                    <font-triplet name="Times" style="italic" weight="bold"/>
+                    <font-triplet name="Times New Roman" style="italic" weight="bold"/>
+                    <font-triplet name="any" style="italic" weight="bold"/>
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf">
                     <font-triplet name="DejaVu Sans Mono" style="normal" weight="normal"/>
@@ -102,12 +114,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf">
                     <font-triplet name="DejaVu Sans" style="normal" weight="bold"/>
+                    <font-triplet name="sans-serif" style="normal" weight="bold"/>
+                    <font-triplet name="Helvetica" style="normal" weight="bold"/>
+                    <font-triplet name="Arial" style="normal" weight="bold"/>
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSans-Oblique.ttf">
                     <font-triplet name="DejaVu Sans" style="italic" weight="normal"/>
+                    <font-triplet name="sans-serif" style="italic" weight="normal"/>
+                    <font-triplet name="Helvetica" style="italic" weight="normal"/>
+                    <font-triplet name="Arial" style="italic" weight="normal"/>
                 </font>
                 <font embedding-mode="full" embed-url="/usr/share/fonts/truetype/dejavu/DejaVuSans-BoldOblique.ttf">
                     <font-triplet name="DejaVu Sans" style="italic" weight="bold"/>
+                    <font-triplet name="sans-serif" style="italic" weight="bold"/>
+                    <font-triplet name="Helvetica" style="italic" weight="bold"/>
+                    <font-triplet name="Arial" style="italic" weight="bold"/>
                 </font>
             </fonts>
         </renderer>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4167,6 +4167,89 @@ def _pdf_fo_accessibility_repairs(pdfname):
     log.debug("made {} accessibility repairs in {}".format(additions, pdfname))
 
 
+def _downgrade_svg2_for_batik(directory):
+    """Rewrite the SVG 2 constructs that Apache Batik cannot render.
+
+    Apache FOP rasterizes SVG with Batik, an SVG 1.1 implementation, so
+    SVG 2 syntax inside an image aborts the whole graphic.  Two such
+    constructs occur in PreFigure output; this rewrites the SVG copies
+    staged for FOP, leaving the managed source assets untouched.
+
+      * "orient" of "auto-start-reverse" on a "marker".  Its value
+        differs from "auto" only at a "marker-start" placement, so the
+        marker becomes plain "auto"; a marker actually placed at a start
+        also gets a companion rotated 180 degrees, with that start
+        reference repointed to the companion.
+
+      * a "use" element carrying a plain "href" rather than "xlink:href".
+    """
+    import glob
+    import copy
+    import lxml.etree as ET
+
+    svg_namespace = "http://www.w3.org/2000/svg"
+    xlink_namespace = "http://www.w3.org/1999/xlink"
+    ET.register_namespace("xlink", xlink_namespace)
+    use_tag = "{{{}}}use".format(svg_namespace)
+    marker_tag = "{{{}}}marker".format(svg_namespace)
+    group_tag = "{{{}}}g".format(svg_namespace)
+    xlink_href = "{{{}}}href".format(xlink_namespace)
+
+    for svg_file in glob.glob(os.path.join(directory, "**", "*.svg"), recursive=True):
+        try:
+            tree = ET.parse(svg_file)
+        except ET.XMLSyntaxError:
+            continue
+        root = tree.getroot()
+        changed = False
+
+        # SVG 2 plain "href" on a "use" becomes SVG 1.1 "xlink:href"
+        for use in root.iter(use_tag):
+            target = use.get("href")
+            if target is not None and use.get(xlink_href) is None:
+                use.set(xlink_href, target)
+                del use.attrib["href"]
+                changed = True
+
+        # a marker placed at a "marker-start" needs a 180-degree twin,
+        # since SVG 1.1 "auto" cannot express the reversal "auto-start-reverse"
+        start_references = set(
+            element.get("marker-start")
+            for element in root.iter()
+            if element.get("marker-start")
+        )
+        reversed_twin = {}
+        for marker in list(root.iter(marker_tag)):
+            if marker.get("orient") != "auto-start-reverse":
+                continue
+            marker.set("orient", "auto")
+            changed = True
+            marker_id = marker.get("id")
+            reference = "url(#{})".format(marker_id) if marker_id else None
+            if reference and reference in start_references:
+                twin = copy.deepcopy(marker)
+                twin.set("id", "{}-start".format(marker_id))
+                rotation = ET.Element(group_tag)
+                rotation.set(
+                    "transform",
+                    "rotate(180 {} {})".format(twin.get("refX", "0"), twin.get("refY", "0")),
+                )
+                for child in list(twin):
+                    twin.remove(child)
+                    rotation.append(child)
+                twin.append(rotation)
+                marker.getparent().append(twin)
+                reversed_twin[reference] = "url(#{}-start)".format(marker_id)
+
+        for element in root.iter():
+            replacement = reversed_twin.get(element.get("marker-start"))
+            if replacement is not None:
+                element.set("marker-start", replacement)
+
+        if changed:
+            tree.write(svg_file)
+
+
 def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
     """
     Generate a PDF from an XML source using XSL-FO as an intermediate
@@ -4224,6 +4307,10 @@ def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
 
     # Make image files available, relative to the FO file
     common.copy_managed_directories(tmp_dir, external_abs=external_abs, generated_abs=generated_abs, data_abs=data_dir)
+
+    # FOP renders SVG through Batik (SVG 1.1); downgrade the SVG 2
+    # constructs in the staged images so the diagrams render
+    _downgrade_svg2_for_batik(tmp_dir)
 
     # render the FO file as a PDF with Apache FOP, configured
     # by the  fop.xconf  file maintained in this distribution


### PR DESCRIPTION
Two fixes that let the experimental XSL-FO → PDF route (Apache FOP) render PreFigure diagrams — and SVG image text generally — that previously failed. Found while building *Understanding Linear Algebra* (~380 PreFigure diagrams) with `-f pdf-fo`.

**1. Embed bold/italic fonts named generically in SVG images** (`pretext/fop.xconf`)

`fop.xconf` declares PDF/UA-1, which forbids non-embedded fonts. The generic/legacy font-name aliases (`sans-serif`/`Helvetica`/`Arial`; `serif`/`Times`/`Times New Roman`/`any`) were mapped to embedded DejaVu faces only at *normal* weight, while the bold and italic faces carried only their canonical `DejaVu …` names. So SVG text in a bold or italic generic font — PreFigure renders labels as bold `sans-serif` — fell back to the base-14 `Helvetica-Bold`, and FOP aborted at document finalization with no PDF produced. This adds the missing bold/italic/bold-italic alias triplets. The change is purely additive (new triplets), so existing output is unaffected.

**2. Downgrade SVG 2 `marker`/`use` syntax for Batik** (`pretext/lib/pretext.py`)

FOP rasterizes SVG with Batik, an SVG 1.1 implementation, so SVG 2 syntax inside an image aborts the whole graphic ("SVG graphic could not be built" → blank box). Two constructs occur in PreFigure output:
- `orient="auto-start-reverse"` on arrowhead `<marker>`s (every diagram with an arrow or vector);
- `<use>` with a plain `href` instead of `xlink:href`.

`pdf_fo()` now rewrites the SVG copies *staged for FOP* (the managed source assets are left untouched), just before FOP runs: `auto-start-reverse` → `auto`, adding a 180°-rotated companion marker for any `marker-start` placement (SVG 1.1 `auto` cannot express that reversal); and plain `href` → `xlink:href`. These constructs are reported upstream as davidaustinm/prefigure#50 and #51; the shim is a downstream compatibility fallback until PreFigure emits SVG 1.1-safe output.

**Verification.** A full `pdf-fo` build of *Understanding Linear Algebra*: a complete 685-page tagged PDF, no PDF/UA abort, and the 206 previously-blank diagrams now render (including a reversed `marker-start` self-loop, checked visually).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
