### PR TITLE
XSL-FO "li" titles, and a WeBWorK no-problem-sets crash

### DIFF
--- a/pretext/lib/webwork.py
+++ b/pretext/lib/webwork.py
@@ -926,8 +926,13 @@ def webwork_sets(xml_source, pub_file, stringparams, dest_dir, tgz, need_macros)
     tmp_dir = common.get_temporary_directory()
     common.xsltproc(extraction_xslt, xml_source, None, output_dir=tmp_dir, stringparams=stringparams)
     # We don't explicitly know the name of the folder that has all of the sets
-    # But it is the only thing in the tmp_dir
-    folder_name = os.listdir(tmp_dir)[0]
+    # But it is the only thing in the tmp_dir.  A document with no WeBWorK
+    # problems produces no folder, so there are no sets to collect.
+    set_folders = os.listdir(tmp_dir)
+    if not set_folders:
+        log.info("no WeBWorK problem sets to construct")
+        return
+    folder_name = set_folders[0]
     folder = os.path.join(tmp_dir, folder_name)
     macros_folder = os.path.join(folder, 'macros')
     os.mkdir(macros_folder)

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1840,13 +1840,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- per the schema; otherwise the item is mixed content, set -->
 <!-- as a single paragraph.                                   -->
 <xsl:template match="li" mode="list-item-content">
+    <!-- An optional title leads as an italic heading line, kept with the content that follows -->
+    <xsl:if test="title">
+        <fo:block font-style="italic" keep-with-next.within-page="always">
+            <xsl:apply-templates select="." mode="title-full"/>
+        </fo:block>
+    </xsl:if>
     <xsl:choose>
         <xsl:when test="p|blockquote|pre|image|video|program|console|tabular|&FIGURE-LIKE;|&ASIDE-LIKE;|sidebyside|sbsgroup|sage">
-            <xsl:apply-templates select="*"/>
+            <xsl:apply-templates select="*[not(self::title)]"/>
         </xsl:when>
         <xsl:otherwise>
             <fo:block text-align="{$text-alignment}" space-after="0.5em">
-                <xsl:apply-templates/>
+                <xsl:apply-templates select="node()[not(self::title)]"/>
             </fo:block>
         </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
Two small, independent fixes, one commit each.

**XSL-FO: render `li` titles in `ol`/`ul` lists.** The FO conversion dropped
the `<title>` of an ordered/unordered list item — only the item content
rendered. (`dl/li` titles already worked.) They now render as an italic
run-in heading, matching the LaTeX `\lititle` output. Untitled items are
unchanged.

**WeBWorK: avoid a crash when there are no problem sets.** `webwork_sets`
took the first entry of its scratch directory unconditionally, so a document
with no WeBWorK problems raised `IndexError`. It now returns early, with an
informational message, when no sets are produced. The sample chapter still
builds its full set of `.def`/`.pg` files.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
