### PR TITLE
CSS: Fix accessibility contrast issue with ice-fire quad color scheme

### DIFF
--- a/css/colors/_palette-quad-chunks.scss
+++ b/css/colors/_palette-quad-chunks.scss
@@ -25,7 +25,7 @@ $schemes: (
   ),
   "ice-fire": (
     "color-main": hsl(210, 45%, 27%),
-    "color-do": hsl(208, 7%, 49%),
+    "color-do": hsl(208, 7%, 45%),
     "color-fact": #0f80b0,
     "color-meta": #a13838,
   ),


### PR DESCRIPTION
One of the colors used in the "ice-fire" color scheme doesn't have quite enough contrast vs white. This gets it above a 4.5 ratio for WCAG AA.