### PR TITLE
HTML: route dialog close buttons through insert-symbol template

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12515,7 +12515,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <div class="ptx-embed-popup-controls">
             <p>Copy the code below to embed this page in your own website or LMS page.</p>
             <button class="ptx-embed-close-button button" id="ptx-embed-close-button" title="Close embed popup">
-                <span class="material-symbols-outlined">close</span>
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'close'"/>
+                </xsl:call-template>
             </button>
         </div>
         <div class="ptx-embed-code-container">
@@ -14074,7 +14076,11 @@ TODO:
         <dialog id="ptx-search-dialog" class="ptx-dialog ptx-search-dialog" closedby="closerequest">
             <div class="ptx-search-dialog-controls">
                 <input aria-label="Search term" id="ptx-search-terms" class="ptx-search-terms" type="text" name="terms" placeholder="Search terms"/>
-                <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close" commandfor="ptx-search-dialog"  command="close"><span class="material-symbols-outlined">close</span></button>
+                <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close" commandfor="ptx-search-dialog"  command="close">
+                    <xsl:call-template name="insert-symbol">
+                        <xsl:with-param name="name" select="'close'"/>
+                    </xsl:call-template>
+                </button>
             </div>
             <!-- Will contain notice about how many results there are for screen readers to announce-->
             <div id="ptx-search-status" class="ptx-search-status" aria-live="polite" aria-atomic="true">


### PR DESCRIPTION
Just noticed the close buttons for embed and search were never set up to use the `insert-symbol` template.