### PR TITLE
XSL-FO: keep a tabular or sidebyside whole on a page when it fits

### DIFF
--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2740,7 +2740,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="has-gaps" select="number(substring-before($layout/space-width, '%')) &gt; 0"/>
     <!-- a row without cells is fatal to FOP, so no panels, no table -->
     <xsl:if test="$panels">
-    <fo:table table-layout="fixed" width="100%" space-before="0.5em" space-after="0.5em">
+    <!-- Keep a "sidebyside" whole on a page when it fits, matching  -->
+    <!-- LaTeX, where its panels are an unbreakable "tcbraster".  As -->
+    <!-- for a "tabular", the finite strength lets FOP break one too -->
+    <!-- tall for a page instead of clipping it; tune it if needed.  -->
+    <fo:table table-layout="fixed" width="100%" space-before="0.5em" space-after="0.5em" keep-together.within-page="5">
         <xsl:if test="$has-left-margin">
             <fo:table-column column-width="proportional-column-width({substring-before($layout/left-margin, '%')})"/>
         </xsl:if>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2047,7 +2047,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- margin, and derives the width from the indents, so both are  -->
     <!-- set to keep the table centered rather than stretched right). -->
     <xsl:variable name="side-indent" select="round((100 - $table-percent) div 2)"/>
-    <fo:table table-layout="fixed" width="{$table-percent}%" start-indent="{$side-indent}%" end-indent="{$side-indent}%" space-before="0.75em" space-after="0.75em">
+    <!-- Keep a "tabular" whole on a page when it fits there, so one  -->
+    <!-- that would otherwise split at a page boundary moves forward  -->
+    <!-- intact.  This matches LaTeX, where a tabular sits inside an  -->
+    <!-- unbreakable tcolorbox.  A finite keep strength (not the      -->
+    <!-- forcing "always") lets FOP override it and break a tabular   -->
+    <!-- too tall for one page, rather than overflow and clip it as   -->
+    <!-- "always" would.  Tune the strength if the keeping proves     -->
+    <!-- too eager or too weak.                                       -->
+    <fo:table table-layout="fixed" width="{$table-percent}%" start-indent="{$side-indent}%" end-indent="{$side-indent}%" space-before="0.75em" space-after="0.75em" keep-together.within-page="5">
         <xsl:call-template name="rule-attribute">
             <xsl:with-param name="side" select="'top'"/>
             <xsl:with-param name="thickness" select="@top"/>


### PR DESCRIPTION
Two related fixes to the (experimental) XSL-FO conversion, one commit each.

A `<tabular>` or a `<sidebyside>` could break across a page boundary even
when the whole thing would fit on a single page — an early or late break
that strands a row or two while saving little vertical space. Each now
carries `keep-together.within-page`, so one that would otherwise split near
a page boundary moves forward intact instead.

This restores parity with the LaTeX conversion, where both are already
unbreakable: a `<sidebyside>` is a `tcbraster` of `tcolorbox` panels
(unbreakable by default), and a standalone `<tabular>` sits in an
unbreakable `tabularbox` tcolorbox.

**Why a finite keep strength rather than `"always"`:** FOP treats
`keep-together.within-page="always"` as an absolute keep and, for content
too tall for one page, overflows the page region and clips the excess —
losing rows and the caption. A finite strength is one FOP will override, so
a table or side-by-side taller than a page still breaks normally (header
repeated) rather than being clipped. The value is arbitrary and is flagged
in the code as a tunable knob, should it prove too eager or too weak.

Commits:
- keep a `"tabular"` on one page when it fits
- keep a `"sidebyside"` on one page when it fits

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
