### PR TITLE
Validate PreFigure diagrams against PreFigure's own schema

### DIFF
--- a/schema/build.sh
+++ b/schema/build.sh
@@ -68,14 +68,22 @@ declare XSL=${PTX}/xsl
 # ******************
 
 # PreTeXt extraction of RELAX-NG compact schema
+# Also emits the PreFigure adapter, "pf-adapter.rnc"
 xsltproc ${XSL}/pretext-litprog.xsl pretext.xml
 
 # System trang conversion to RELAX-NG XML schema
 trang -I rnc -O rng pretext.rnc pretext.rng
 trang -I rnc -O rng pretext-dev.rnc pretext-dev.rng
 
+# PreFigure adapter, which "externalRef" reaches from "pretext.rnc";
+# it in turn "include"s the upstream "pf_schema.rnc"/"pf_schema.rng"
+trang -I rnc -O rng pf-adapter.rnc pf-adapter.rng
+
 # System trang conversion to W3C XSD schema
 # "abstract groups" make schema browser too obtuse
+# NOTE: trang cannot follow the PreFigure "externalRef" when emitting XSD
+# ("sorry, externalRef is not yet supported"), so the XSD path does not yet
+# carry structural PreFigure validation.
 trang -o disable-abstract-elements -I rnc -O xsd pretext.rnc pretext.xsd
 
 # And the same steps for the publication-schema

--- a/schema/pf-adapter.rnc
+++ b/schema/pf-adapter.rnc
@@ -1,0 +1,6 @@
+
+                default namespace = "https://prefigure.org"
+                grammar {
+                    include "pf_schema.rnc"
+                }
+            

--- a/schema/pf-adapter.rng
+++ b/schema/pf-adapter.rng
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="https://prefigure.org" xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="pf_schema.rng"/>
+</grammar>

--- a/schema/pf_schema.rnc
+++ b/schema/pf_schema.rnc
@@ -297,6 +297,7 @@ StrokeAttributes =
     attribute linejoin {text}?,
     attribute linecap {text}?,
     attribute dash {text}?,
+    attribute tactile-dash {text}?,
     attribute cliptobbox {"yes"|"no"}?,
     attribute outline {"yes"|"no"}?
 
@@ -433,12 +434,10 @@ Grid = element grid {
     attribute basis {text}?,
     attribute h-pi-format {"yes"|"no"}?,
     attribute v-pi-format {"yes"|"no"}?,
-    attribute stroke {text}?,
-    attribute thickness {text}?,
     attribute coordinates {text}?,
     attribute spacing-degrees {"yes"|"no"}?,
     attribute scales {"linear"|"semilogx"|"semilogy"|"loglog"}?,
-    Stroke-Attributes,
+    StrokeAttributes,
     CommonAttributes
 }
 
@@ -473,9 +472,7 @@ Tick-Mark = element tick-mark {
     attribute at {text}?,
     attribute location {text},
     attribute axis {text}?,
-    attribute stroke {text}?,
     attribute size {text}?,
-    attribute thickness {text}?,
     StrokeAttributes,
     LabelAttributes,
     LabelText?
@@ -543,8 +540,6 @@ Histogram = element histogram {
     attribute max {text}?,
     attribute bins {text}?,
     attribute bin-text {text}?,
-    attribute annotate {"yes"|"no"}?,
-    attribute text {text}?,
     FillAttributes,
     CommonAttributes
 }
@@ -597,7 +592,7 @@ Network = element network {
     attribute directed {"yes"|"no"}?,
     attribute arrows {"end"|"middle"}?,
     attribute bipartite-set {text}?,
-    attribute alignment {'vertical', 'horizontal'}?,
+    attribute alignment {'vertical' | 'horizontal'}?,
     attribute loop-scale {text}?,
     attribute layout {text}?,
     attribute seed {text}?,
@@ -730,10 +725,8 @@ Riemann-Sum = element riemann-sum {
     attribute N {text},
     attribute domain {text}?,
     attribute rule {text}?,
-    attribute annotate {"yes"|"no"}?,
     FillAttributes,
-    CommonAttributes,
-    AnnotatedElementAttributes
+    CommonAttributes
 }
 
 Scatter = element scatter {
@@ -744,8 +737,6 @@ Scatter = element scatter {
     attribute y {text}?,
     attribute filter {text}?,
     attribute point-text {text}?,
-    attribute annotate {"yes"|"no"}?,
-    attribute text {text}?,
     FillAttributes,
     CommonAttributes
 }
@@ -813,7 +804,6 @@ Vector = element vector {
     attribute at {text}?,
     attribute v {text},
     attribute tail {text}?,
-    attribute scale {text}?,
     attribute head-location {text}?,
     attribute arrow-width {text}?,
     attribute arrow-angles {text}?,

--- a/schema/pf_schema.rnc
+++ b/schema/pf_schema.rnc
@@ -1,0 +1,840 @@
+grammar {
+start = Diagram
+
+Diagram = element diagram {
+    attribute dimensions {text},
+    attribute margins {text}?,
+    (
+        Annotations? &
+        DefinitionElements* &
+        GraphicalElements* &
+        GroupElements* &
+        Caption?
+    )
+}
+
+Caption = element caption {text}
+
+# Annotations are constructed with a single #annotations element,
+# which contains a single #annotation
+Annotations = element annotations {
+    Annotation
+}
+
+AnnotationAttributes = 
+    attribute ref {text},
+    AnnotatedElementAttributes
+
+AnnotatedElementAttributes = 
+    attribute text {text}?,
+    attribute speech {text}?,
+    attribute circular {"yes"|"no"}?,
+    attribute sonify {"yes"|"no"}?
+
+# An #annotation can contain any number of #annotation elements
+Annotation = element annotation {
+    AnnotationAttributes,
+    Annotation*
+}
+
+# Most elements can be annotated
+CommonAttributes =
+    attribute annotate {"yes"|"no"}?,
+    AnnotatedElementAttributes?
+
+# next come some definition elements that can be added anywhere
+DefinitionElements = 
+    Definition?,
+    Derivative?,
+    DE-Solution?,
+    Define-Shapes?,
+    Read?
+
+Definition = element definition {
+    text,
+    attribute substitution {"yes"|"no"}?,
+    attribute id-suffix {text}?
+}
+
+Derivative = element derivative {
+    attribute function {text},
+    attribute name {text}
+}
+
+DE-Solution = element de-solve {
+    attribute name {text},
+    attribute function {text},
+    attribute t0 {text},
+    attribute y0 {text},
+    attribute t1 {text}?,
+    attribute method {text}?,
+    attribute N {text}?,
+    attribute max-step {text}?
+}
+
+Define-Shapes = element define-shapes {
+    ShapeElements+
+}
+
+Read = element read {
+    attribute filename {text},
+    attribute name {text},
+    attribute delimiter {text}?,
+    attribute quotechar {text}?,
+    attribute string-columns {text}?,
+    attribute type {text}
+}
+
+# the next elements group other elements together
+GroupElements =
+(
+    Coordinates? &
+    Group? &
+    Repeat? &
+    Clip? &
+    Transform?
+)
+
+# coordinates are special in that they can contain everything a diagram can
+Coordinates = element coordinates {
+    attribute bbox {text},
+    attribute destination {text}?,
+    attribute aspect-ratio {text}?,
+    attribute preserve-y-range {"yes"|"no"}?,
+    (
+        DefinitionElements* &
+        GraphicalElements* &
+        GroupElements* &
+        TransformElements*
+    )
+}
+
+Group = element group {
+    attribute at {text}?,
+    attribute outline {text}?,
+    attribute transform {text}?,
+    CommonAttributes,
+    (
+        DefinitionElements* &
+        GraphicalElements* &
+        GroupElements* &
+        TransformElements*
+    )
+}
+
+Repeat = element repeat {
+    attribute parameter {text},
+    attribute at {text}?,
+    CommonAttributes,
+    (
+        DefinitionElements* &
+        GraphicalElements* &
+        GroupElements* &
+        TransformElements*
+    )
+}
+
+Clip = element clip {
+    attribute at {text}?,
+    attribute shape {text},
+    CommonAttributes,
+    (
+        DefinitionElements* &
+        GraphicalElements* &
+        GroupElements* &
+        TransformElements
+    )
+}
+
+Transform = element transform {
+    DefinitionElements* &
+    GraphicalElements* &
+    GroupElements* &
+    TransformElements*
+}
+
+TransformElements = (
+    element translate {
+        attribute by {text}
+    }* &
+    element rotate {
+        attribute by {text},
+        attribute about {text}?,
+        attribute degrees {"yes"|"no"}?
+    }* &
+    element scale {
+        attribute by {text}
+    }*
+)
+
+# attributes and text for labels
+LabelAttributes = 
+    attribute alignment {text}?,
+    attribute offset {text}?,
+    attribute justify {"right" | "left" | "center"}?,
+    attribute interline {text}?,
+    attribute scale {text}?,
+    attribute rotate {text}?,
+    attribute clear-background {"yes"|"no"}?,
+    attribute background-margin {text}?,
+    attribute color {text}?,
+    attribute font {text}?,
+    attribute font-size {text}?
+
+Math = element m {attribute color {text}? & text}
+Bold = element b {attribute color {text}? & text & Italic*}
+Italic = element it {attribute color {text}? & text & Bold*}
+Plain = element plain {attribute color{text}? & text}
+Newline = element newline {empty}
+LabelElements = (
+    Math* &
+    Bold* &
+    Italic* &
+    Plain* &
+    Newline*
+)
+LabelText = (text | LabelElements*)
+
+Label = element label {
+    attribute at {text}?,
+    attribute anchor {text},
+    LabelAttributes,
+    LabelText+
+}
+
+XLabel = element xlabel {
+    attribute at {text}?,
+    LabelAttributes,
+    LabelText+
+}
+
+YLabel = element ylabel {
+    attribute at {text}?,
+    LabelAttributes,
+    LabelText+
+}
+
+# elements that can go inside a path
+PathElements = (
+    element moveto {
+        attribute point {text}?,
+        attribute distance {text}?,
+        attribute heading {text}?,
+        attribute degrees {"yes"|"no"}?
+    }* &
+    element rmoveto {
+        attribute point {text}?,
+        attribute distance {text}?,
+        attribute heading {text}?,
+        attribute degrees {"yes"|"no"}?        
+    }* &
+    element lineto {
+        attribute point {text},
+        attribute decoration {text}?,
+        attribute distance {text}?,
+        attribute heading {text}?,
+        attribute degrees {"yes"|"no"}?        
+    }* &
+    element rlineto {
+        attribute point {text},
+        attribute decoration {text}?,
+        attribute distance {text}?,
+        attribute heading {text}?,
+        attribute degrees {"yes"|"no"}?        
+    }* &
+    element horizontal {
+        attribute distance {text},
+        attribute decoration {text}?
+    }* &
+    element vertical {
+        attribute distance {text},
+        attribute decoration {text}?
+    }* &
+    element cubic-bezier {
+        attribute controls {text}
+    }* &
+    element quadratic-bezier {
+        attribute controls {text}
+    }* &
+    element arc {
+        attribute center {text},
+        attribute radius {text},
+        attribute range {text},
+        attribute degrees {text}?
+    }* &
+    Graph* &
+    Parametric-Curve* &
+    Polygon* &
+    Spline* &
+    element repeat {
+        attribute parameter {text},
+        PathElements
+    }*
+)
+
+ShapeElements = (
+    Arc* &
+    Area-Between-Curves* &
+    Area-Under-Curve* &
+    Circle* &
+    Ellipse* &
+    Graph* &
+    Parametric-Curve* &
+    Path* &
+    Polygon* &
+    Rectangle* &
+    Shape* &
+    Spline*
+)
+
+# graphical elements can be stroked and possibly filled
+StrokeAttributes = 
+    attribute stroke {text}?,
+    attribute stroke-opacity {text}?,
+    attribute opacity {text}?,
+    attribute thickness {text}?,
+    attribute miterlimit {text}?,
+    attribute linejoin {text}?,
+    attribute linecap {text}?,
+    attribute dash {text}?,
+    attribute cliptobbox {"yes"|"no"}?,
+    attribute outline {"yes"|"no"}?
+
+FillAttributes =
+    StrokeAttributes,
+    attribute fill {text}?,
+    attribute fill-opacity {text}?,
+    attribute fill-rule {text}?
+
+# start defining the graphical elements
+GraphicalElements = 
+    (
+        Angle-Marker* &
+        Arc* &
+        Area-Between-Curves* &
+        Area-Under-Curve* &
+        Axes* &
+        Circle* &
+        Contour* &
+        Ellipse* &
+        Graph* &
+        Grid* &
+        Grid-Axes* &
+        Histogram* &
+        Image*&
+        Implicit-Curve* &
+        Label* &
+        Legend* &
+        Line* &
+        Network* &
+        Parametric-Curve* &
+        Path* &
+        Plot-DE-Solution* &
+        Point* &
+        Polygon* &
+        Rectangle* &
+        Riemann-Sum* &
+        Scatter* &
+        Shape* &
+        Slope-Field* &
+        Spline* &
+        Tick-Mark* &
+        Tangent-line* &
+        Triangle* &
+        Vector* & 
+        Vector-Field*
+    )
+
+Angle-Marker = element angle-marker {
+    attribute at {text}?,
+    attribute points {text},
+    attribute radius {text}?,
+    attribute arrow {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    LabelAttributes,
+    StrokeAttributes,
+    CommonAttributes,
+    LabelText?
+}
+
+Arc = element arc {
+    attribute at {text}?,
+    attribute points {text}?,
+    attribute center {text}?,
+    attribute range {text}?,
+    attribute radius {text},
+    attribute sector {"yes"|"no"}?,
+    attribute N {text}?,
+    attribute degrees {"yes"|"no"}?,
+    attribute arrows {text}?,
+    attribute reverse {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Area-Between-Curves = element area-between-curves {
+    attribute at {text}?,
+    attribute function1 {text}?,
+    attribute function2 {text}?,
+    attribute functions {text}?,
+    attribute domain {text}?,
+    attribute N {text}?,
+    attribute coordinates {"polar"|"cartesian"}?,
+    attribute domain-degrees {"yes"|"no"}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Area-Under-Curve = element area-under-curve {
+    attribute at {text}?,
+    attribute function {text},
+    attribute domain {text}?,
+    attribute N {text}?,
+    attribute coordinates {"polar"|"cartesian"}?,
+    attribute domain-degrees {"yes"|"no"}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+# grids and axes
+Axes = element axes {
+    attribute at {text}?,
+    attribute hlabels {text}?,
+    attribute vlabels {text}?,
+    attribute xlabel {text}?,
+    attribute ylabel {text}?,
+    attribute arrows {text}?,
+    attribute decorations {"yes"|"no"}?,
+    attribute h-pi-format {"yes"|"no"}?,
+    attribute v-pi-format {"yes"|"no"}?,
+    attribute h-frame {"bottom"|"top"}?,
+    attribute v-frame {"left"|"right"}?,
+    attribute stroke {text}?,
+    attribute thickness {text}?,
+    attribute tick-size {text}?,
+    attribute axes {"horizontal"|"vertical"}?,
+    attribute bounding-box {"yes"|"no"}?,
+    attribute h-zero-label {"yes"|"no"}?,
+    attribute v-zero-label {"yes"|"no"}?,
+    attribute label-commas {"yes"|"no"}?,
+    CommonAttributes,
+    XLabel?,
+    YLabel?
+}
+
+Grid = element grid {
+    attribute at {text}?,
+    attribute spacings {text}?,
+    attribute hspacing {text}?,
+    attribute vspacing {text}?,
+    attribute basis {text}?,
+    attribute h-pi-format {"yes"|"no"}?,
+    attribute v-pi-format {"yes"|"no"}?,
+    attribute stroke {text}?,
+    attribute thickness {text}?,
+    attribute coordinates {text}?,
+    attribute spacing-degrees {"yes"|"no"}?,
+    attribute scales {"linear"|"semilogx"|"semilogy"|"loglog"}?,
+    Stroke-Attributes,
+    CommonAttributes
+}
+
+Grid-Axes = element grid-axes {
+    attribute at {text}?,
+    attribute spacings {text}?,
+    attribute hspacing {text}?,
+    attribute vspacing {text}?,
+    attribute h-pi-format {"yes"|"no"}?,
+    attribute v-pi-format {"yes"|"no"}?,
+    attribute h-frame {"bottom"|"top"}?,
+    attribute v-frame {"left"|"right"}?,
+    attribute hlabels {text}?,
+    attribute vlabels {text}?,
+    attribute xlabel {text}?,
+    attribute ylabel {text}?,
+    attribute arrows {text}?,
+    attribute decorations {"yes"|"no"}?,
+    attribute tick-size {text}?,
+    attribute axes {"horizontal"|"vertical"}?,
+    attribute bounding-box {"yes"|"no"}?,
+    attribute h-zero-label {"yes"|"no"}?,
+    attribute v-zero-label {"yes"|"no"}?,
+    attribute label-commas {"yes"|"no"}?,
+    StrokeAttributes,
+    CommonAttributes,
+    XLabel?,
+    YLabel?    
+}
+
+Tick-Mark = element tick-mark {
+    attribute at {text}?,
+    attribute location {text},
+    attribute axis {text}?,
+    attribute stroke {text}?,
+    attribute size {text}?,
+    attribute thickness {text}?,
+    StrokeAttributes,
+    LabelAttributes,
+    LabelText?
+}
+
+Contour = element contour {
+    attribute at {text}?,
+    attribute function {text},
+    attribute k {text}?,
+    attribute value {text}?,
+    attribute depth {text}?,
+    attribute initial-depth {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Circle = element circle {
+    attribute at {text}?,
+    attribute center {text},
+    attribute radius {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Ellipse = element ellipse {
+    attribute at {text}?,
+    attribute center {text},
+    attribute axes {text}?,
+    attribute rotate {text}?,
+    attribute degrees {text}?,
+    attribute N {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Graph = element graph {
+    attribute at {text}?,
+    attribute function {text},
+    attribute N {text}?,
+    attribute domain {text}?,
+    attribute coordinates {"polar"|"coordinates"}?,
+    attribute domain-degress {"yes"|"no"}?,
+    attribute closed {"yes"|"no"}?,
+    attribute fill {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Image = element image {
+    attribute at {text}?,
+    attribute source{text},
+    attribute lower-left {text}?,
+    attribute center {text}?,
+    attribute dimensions {text}?,
+    attribute opacity {text}?,
+    attribute filetype {"svg"|"png"|"gif"|"jpeg"|"jpg"}?,
+    attribute rotate {text}?,
+    attribute scale {text}?
+}
+
+Histogram = element histogram {
+    attribute at {text}?,
+    attribute data {text},
+    attribute min {text}?,
+    attribute max {text}?,
+    attribute bins {text}?,
+    attribute bin-text {text}?,
+    attribute annotate {"yes"|"no"}?,
+    attribute text {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Implicit-Curve = element implicit-curve {
+    attribute at {text}?,
+    attribute function {text},
+    attribute k {text}?,
+    attribute value {text}?,
+    attribute depth {text}?,
+    attribute initial-depth {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Legend = element legend {
+    attribute at {text}?,
+    attribute anchor {text},
+    attribute alignment {text}?,
+    attribute vertical-skip {text}?,
+    attribute scale {text}?,
+    attribute stroke {text}?,
+    attribute opacity {text}?,
+    element item {
+        attribute ref {text},
+        LabelText+
+    }+}
+
+Line = element line {
+    attribute at {text}?,
+    attribute endpoints {text}?,
+    attribute p1 {text}?,
+    attribute p2 {text}?,
+    attribute endpoint-offsets {text}?,
+    attribute infinite {"yes"|"no"}?,
+    attribute arrows {text}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    attribute reverse {"yes"|"no"}?,
+    attribute additional-arrows {"yes"|"no"}?,
+    StrokeAttributes,
+    CommonAttributes,
+    LabelAttributes,
+    LabelText?
+}
+
+Network = element network {
+    attribute at {text}?,
+    attribute graph {text}?,
+    attribute directed {"yes"|"no"}?,
+    attribute arrows {"end"|"middle"}?,
+    attribute bipartite-set {text}?,
+    attribute alignment {'vertical', 'horizontal'}?,
+    attribute loop-scale {text}?,
+    attribute layout {text}?,
+    attribute seed {text}?,
+    attribute start {text}?,
+    attribute scale {text}?,
+    attribute rotate {text}?,
+    attribute edge-stroke {text}?,
+    attribute edge-thickness {text}?,
+    attribute edge-dash {text}?,
+    attribute node-fill {text}?,
+    attribute node-stroke {text}?,
+    attribute node-thickness {text}?,
+    attribute node-style {text}?,
+    attribute node-size {text}?,
+    attribute labels {"yes"|"no"}?,
+    attribute label-dictionary {text}?,
+    (
+        element node {
+            attribute at {text}?,
+            attribute p {text}?,
+            attribute edges {text}?,
+            attribute loop-orientation {text}?,
+            attribute style {text}?,
+            FillAttributes,
+            LabelAttributes,
+            LabelText?
+
+        }* &
+        element edge {
+            attribute at {text}?,
+            attribute vertices {text},
+            attribute weight {text}?,
+            attribute loop-scale {text}?,
+            attribute label-location {text}?,
+            StrokeAttributes,
+            LabelAttributes,
+            LabelText?
+        }*
+    ),
+    CommonAttributes
+}
+
+Parametric-Curve = element parametric-curve {
+    attribute at {text}?,
+    attribute function {text},
+    attribute domain {text},
+    attribute N {text}?,
+    attribute closed {"yes"|"no"}?,
+    attribute arrows {text}?,
+    attribute arrow-location {text}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    attribute reverse {"yes"|"no"}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Path = element path {
+    attribute at {text}?,
+    attribute start {text},
+    attribute closed {text}?,
+    attribute arrows {text}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    attribute reverse {"yes"|"no"}?,
+    attribute mid-arrow {"yes"|"no"}?,
+    FillAttributes,
+    CommonAttributes,
+    PathElements
+}
+
+Plot-DE-Solution = element plot-de-solution {
+    attribute at {text}?,
+    attribute solution {text}?,
+    attribute axes {text}?,
+    attribute arrow {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-location {text}?,
+    attribute function {text}?,
+    attribute t0 {text}?,
+    attribute y0 {text}?,
+    attribute t1 {text}?,
+    attribute method {text}?,
+    attribute N {text}?,
+    attribute max-step {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Point = element point {
+    attribute p {text},
+    attribute at {text}?,
+    attribute style {text}?,
+    attribute size {text}?,
+    attribute coordinates {"cartesian"|"polar"}?,
+    attribute degrees {"yes"|"no"}?,
+    LabelAttributes,
+    FillAttributes,
+    CommonAttributes,
+    LabelText?
+}
+
+Polygon = element polygon {
+    attribute at {text}?,
+    attribute points {text},
+    attribute parameter {text}?,
+    attribute corner-radius {text}?,
+    attribute arrows {text}?,
+    attribute closed {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Rectangle = element rectangle {
+    attribute at {text}?,
+    attribute lower-left {text}?,
+    attribute center {text}?,
+    attribute dimensions {text}?,
+    attribute rotate {text}?,
+    attribute corner-radius {text}?,
+    FillAttributes,
+    CommonAttributes    
+}
+
+Riemann-Sum = element riemann-sum {
+    attribute at {text}?,
+    attribute function {text},
+    attribute N {text},
+    attribute domain {text}?,
+    attribute rule {text}?,
+    attribute annotate {"yes"|"no"}?,
+    FillAttributes,
+    CommonAttributes,
+    AnnotatedElementAttributes
+}
+
+Scatter = element scatter {
+    attribute at {text}?,
+    attribute points {text}?,
+    attribute data {text}?,
+    attribute x {text}?,
+    attribute y {text}?,
+    attribute filter {text}?,
+    attribute point-text {text}?,
+    attribute annotate {"yes"|"no"}?,
+    attribute text {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Shape = element shape {
+    attribute at {text}?,
+    attribute shape {text}?,
+    attribute shapes {text}?,
+    attribute operation {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Slope-Field = element slope-field {
+    attribute at {text}?,
+    attribute function {text},
+    attribute arrows {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    attribute system {"yes"|"no"}?,
+    attribute spacings {text}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Spline = element spline {
+    attribute at {text}?,
+    attribute bc {text}?,
+    attribute points {text},
+    attribute parameter {text}?,
+    attribute N {text}?,
+    attribute arrows {text}?,
+    attribute domain {text}?,
+    attribute arrow-location {text}?,
+    attribute closed {"yes"|"no"}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    attribute name {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Tangent-line = element tangent-line {
+    attribute at {text}?,
+    attribute function {text},
+    attribute point {text},
+    attribute domain {text}?,
+    attribute infinite {"yes"|"no"}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+Triangle = element triangle {
+    attribute at {text}?,
+    attribute vertices {text},
+    attribute angle-markers {"yes"|"no"}?,
+    attribute labels {text}?,
+    attribute show-vertices {"yes"|"no"}?,
+    attribute point-fill {text}?,
+    FillAttributes,
+    CommonAttributes
+}
+
+Vector = element vector {
+    attribute at {text}?,
+    attribute v {text},
+    attribute tail {text}?,
+    attribute scale {text}?,
+    attribute head-location {text}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text}?,
+    StrokeAttributes,
+    CommonAttributes,
+    LabelAttributes,
+    LabelText?
+}
+
+Vector-Field = element vector-field {
+    attribute at {text}?,
+    attribute function {text}?,
+    attribute spacings {text}?,
+    attribute scale {text}?,
+    attribute curve {text}?,
+    attribute domain {text}?,
+    attribute N {text}?,
+    attribute arrow-width {text}?,
+    attribute arrow-angles {text?}?,
+    StrokeAttributes,
+    CommonAttributes
+}
+
+}

--- a/schema/pf_schema.rng
+++ b/schema/pf_schema.rng
@@ -721,6 +721,9 @@
       <attribute name="dash"/>
     </optional>
     <optional>
+      <attribute name="tactile-dash"/>
+    </optional>
+    <optional>
       <attribute name="cliptobbox">
         <choice>
           <value>yes</value>
@@ -1167,12 +1170,6 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="stroke"/>
-      </optional>
-      <optional>
-        <attribute name="thickness"/>
-      </optional>
-      <optional>
         <attribute name="coordinates"/>
       </optional>
       <optional>
@@ -1193,7 +1190,7 @@
           </choice>
         </attribute>
       </optional>
-      <ref name="Stroke-Attributes"/>
+      <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>
     </element>
   </define>
@@ -1329,13 +1326,7 @@
         <attribute name="axis"/>
       </optional>
       <optional>
-        <attribute name="stroke"/>
-      </optional>
-      <optional>
         <attribute name="size"/>
-      </optional>
-      <optional>
-        <attribute name="thickness"/>
       </optional>
       <ref name="StrokeAttributes"/>
       <ref name="LabelAttributes"/>
@@ -1499,17 +1490,6 @@
       <optional>
         <attribute name="bin-text"/>
       </optional>
-      <optional>
-        <attribute name="annotate">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
-      <optional>
-        <attribute name="text"/>
-      </optional>
       <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
     </element>
@@ -1654,10 +1634,10 @@
       </optional>
       <optional>
         <attribute name="alignment">
-          <group>
+          <choice>
             <value>vertical</value>
             <value>horizontal</value>
-          </group>
+          </choice>
         </attribute>
       </optional>
       <optional>
@@ -2001,17 +1981,8 @@
       <optional>
         <attribute name="rule"/>
       </optional>
-      <optional>
-        <attribute name="annotate">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
       <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
-      <ref name="AnnotatedElementAttributes"/>
     </element>
   </define>
   <define name="Scatter">
@@ -2036,17 +2007,6 @@
       </optional>
       <optional>
         <attribute name="point-text"/>
-      </optional>
-      <optional>
-        <attribute name="annotate">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
-      </optional>
-      <optional>
-        <attribute name="text"/>
       </optional>
       <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
@@ -2212,9 +2172,6 @@
       <attribute name="v"/>
       <optional>
         <attribute name="tail"/>
-      </optional>
-      <optional>
-        <attribute name="scale"/>
       </optional>
       <optional>
         <attribute name="head-location"/>

--- a/schema/pf_schema.rng
+++ b/schema/pf_schema.rng
@@ -1,0 +1,2273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <ref name="Diagram"/>
+  </start>
+  <define name="Diagram">
+    <element name="diagram">
+      <attribute name="dimensions"/>
+      <optional>
+        <attribute name="margins"/>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="Annotations"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="Caption"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="Caption">
+    <element name="caption">
+      <text/>
+    </element>
+  </define>
+  <!--
+    Annotations are constructed with a single #annotations element,
+    which contains a single #annotation
+  -->
+  <define name="Annotations">
+    <element name="annotations">
+      <ref name="Annotation"/>
+    </element>
+  </define>
+  <define name="AnnotationAttributes">
+    <attribute name="ref"/>
+    <ref name="AnnotatedElementAttributes"/>
+  </define>
+  <define name="AnnotatedElementAttributes">
+    <optional>
+      <attribute name="text"/>
+    </optional>
+    <optional>
+      <attribute name="speech"/>
+    </optional>
+    <optional>
+      <attribute name="circular">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="sonify">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- An #annotation can contain any number of #annotation elements -->
+  <define name="Annotation">
+    <element name="annotation">
+      <ref name="AnnotationAttributes"/>
+      <zeroOrMore>
+        <ref name="Annotation"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- Most elements can be annotated -->
+  <define name="CommonAttributes">
+    <optional>
+      <attribute name="annotate">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <ref name="AnnotatedElementAttributes"/>
+    </optional>
+  </define>
+  <!-- next come some definition elements that can be added anywhere -->
+  <define name="DefinitionElements">
+    <optional>
+      <ref name="Definition"/>
+    </optional>
+    <optional>
+      <ref name="Derivative"/>
+    </optional>
+    <optional>
+      <ref name="DE-Solution"/>
+    </optional>
+    <optional>
+      <ref name="Define-Shapes"/>
+    </optional>
+    <optional>
+      <ref name="Read"/>
+    </optional>
+  </define>
+  <define name="Definition">
+    <element name="definition">
+      <text/>
+      <optional>
+        <attribute name="substitution">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id-suffix"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Derivative">
+    <element name="derivative">
+      <attribute name="function"/>
+      <attribute name="name"/>
+    </element>
+  </define>
+  <define name="DE-Solution">
+    <element name="de-solve">
+      <attribute name="name"/>
+      <attribute name="function"/>
+      <attribute name="t0"/>
+      <attribute name="y0"/>
+      <optional>
+        <attribute name="t1"/>
+      </optional>
+      <optional>
+        <attribute name="method"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="max-step"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Define-Shapes">
+    <element name="define-shapes">
+      <oneOrMore>
+        <ref name="ShapeElements"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Read">
+    <element name="read">
+      <attribute name="filename"/>
+      <attribute name="name"/>
+      <optional>
+        <attribute name="delimiter"/>
+      </optional>
+      <optional>
+        <attribute name="quotechar"/>
+      </optional>
+      <optional>
+        <attribute name="string-columns"/>
+      </optional>
+      <attribute name="type"/>
+    </element>
+  </define>
+  <!-- the next elements group other elements together -->
+  <define name="GroupElements">
+    <interleave>
+      <optional>
+        <ref name="Coordinates"/>
+      </optional>
+      <optional>
+        <ref name="Group"/>
+      </optional>
+      <optional>
+        <ref name="Repeat"/>
+      </optional>
+      <optional>
+        <ref name="Clip"/>
+      </optional>
+      <optional>
+        <ref name="Transform"/>
+      </optional>
+    </interleave>
+  </define>
+  <!-- coordinates are special in that they can contain everything a diagram can -->
+  <define name="Coordinates">
+    <element name="coordinates">
+      <attribute name="bbox"/>
+      <optional>
+        <attribute name="destination"/>
+      </optional>
+      <optional>
+        <attribute name="aspect-ratio"/>
+      </optional>
+      <optional>
+        <attribute name="preserve-y-range">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <interleave>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="TransformElements"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="Group">
+    <element name="group">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="outline"/>
+      </optional>
+      <optional>
+        <attribute name="transform"/>
+      </optional>
+      <ref name="CommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="TransformElements"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="Repeat">
+    <element name="repeat">
+      <attribute name="parameter"/>
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <ref name="CommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="TransformElements"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="Clip">
+    <element name="clip">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="shape"/>
+      <ref name="CommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <ref name="TransformElements"/>
+      </interleave>
+    </element>
+  </define>
+  <define name="Transform">
+    <element name="transform">
+      <interleave>
+        <zeroOrMore>
+          <ref name="DefinitionElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="TransformElements"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="TransformElements">
+    <interleave>
+      <zeroOrMore>
+        <element name="translate">
+          <attribute name="by"/>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="rotate">
+          <attribute name="by"/>
+          <optional>
+            <attribute name="about"/>
+          </optional>
+          <optional>
+            <attribute name="degrees">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="scale">
+          <attribute name="by"/>
+        </element>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <!-- attributes and text for labels -->
+  <define name="LabelAttributes">
+    <optional>
+      <attribute name="alignment"/>
+    </optional>
+    <optional>
+      <attribute name="offset"/>
+    </optional>
+    <optional>
+      <attribute name="justify">
+        <choice>
+          <value>right</value>
+          <value>left</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="interline"/>
+    </optional>
+    <optional>
+      <attribute name="scale"/>
+    </optional>
+    <optional>
+      <attribute name="rotate"/>
+    </optional>
+    <optional>
+      <attribute name="clear-background">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="background-margin"/>
+    </optional>
+    <optional>
+      <attribute name="color"/>
+    </optional>
+    <optional>
+      <attribute name="font"/>
+    </optional>
+    <optional>
+      <attribute name="font-size"/>
+    </optional>
+  </define>
+  <define name="Math">
+    <element name="m">
+      <interleave>
+        <optional>
+          <attribute name="color"/>
+        </optional>
+        <text/>
+      </interleave>
+    </element>
+  </define>
+  <define name="Bold">
+    <element name="b">
+      <interleave>
+        <optional>
+          <attribute name="color"/>
+        </optional>
+        <text/>
+        <zeroOrMore>
+          <ref name="Italic"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="Italic">
+    <element name="it">
+      <interleave>
+        <optional>
+          <attribute name="color"/>
+        </optional>
+        <text/>
+        <zeroOrMore>
+          <ref name="Bold"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="Plain">
+    <element name="plain">
+      <interleave>
+        <optional>
+          <attribute name="color"/>
+        </optional>
+        <text/>
+      </interleave>
+    </element>
+  </define>
+  <define name="Newline">
+    <element name="newline">
+      <empty/>
+    </element>
+  </define>
+  <define name="LabelElements">
+    <interleave>
+      <zeroOrMore>
+        <ref name="Math"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Bold"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Italic"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Plain"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Newline"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <define name="LabelText">
+    <choice>
+      <text/>
+      <zeroOrMore>
+        <ref name="LabelElements"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <define name="Label">
+    <element name="label">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="anchor"/>
+      <ref name="LabelAttributes"/>
+      <oneOrMore>
+        <ref name="LabelText"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="XLabel">
+    <element name="xlabel">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <ref name="LabelAttributes"/>
+      <oneOrMore>
+        <ref name="LabelText"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="YLabel">
+    <element name="ylabel">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <ref name="LabelAttributes"/>
+      <oneOrMore>
+        <ref name="LabelText"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <!-- elements that can go inside a path -->
+  <define name="PathElements">
+    <interleave>
+      <zeroOrMore>
+        <element name="moveto">
+          <optional>
+            <attribute name="point"/>
+          </optional>
+          <optional>
+            <attribute name="distance"/>
+          </optional>
+          <optional>
+            <attribute name="heading"/>
+          </optional>
+          <optional>
+            <attribute name="degrees">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="rmoveto">
+          <optional>
+            <attribute name="point"/>
+          </optional>
+          <optional>
+            <attribute name="distance"/>
+          </optional>
+          <optional>
+            <attribute name="heading"/>
+          </optional>
+          <optional>
+            <attribute name="degrees">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="lineto">
+          <attribute name="point"/>
+          <optional>
+            <attribute name="decoration"/>
+          </optional>
+          <optional>
+            <attribute name="distance"/>
+          </optional>
+          <optional>
+            <attribute name="heading"/>
+          </optional>
+          <optional>
+            <attribute name="degrees">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="rlineto">
+          <attribute name="point"/>
+          <optional>
+            <attribute name="decoration"/>
+          </optional>
+          <optional>
+            <attribute name="distance"/>
+          </optional>
+          <optional>
+            <attribute name="heading"/>
+          </optional>
+          <optional>
+            <attribute name="degrees">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="horizontal">
+          <attribute name="distance"/>
+          <optional>
+            <attribute name="decoration"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="vertical">
+          <attribute name="distance"/>
+          <optional>
+            <attribute name="decoration"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="cubic-bezier">
+          <attribute name="controls"/>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="quadratic-bezier">
+          <attribute name="controls"/>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="arc">
+          <attribute name="center"/>
+          <attribute name="radius"/>
+          <attribute name="range"/>
+          <optional>
+            <attribute name="degrees"/>
+          </optional>
+        </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Graph"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Parametric-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Polygon"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Spline"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="repeat">
+          <attribute name="parameter"/>
+          <ref name="PathElements"/>
+        </element>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <define name="ShapeElements">
+    <interleave>
+      <zeroOrMore>
+        <ref name="Arc"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Area-Between-Curves"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Area-Under-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Circle"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Ellipse"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Graph"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Parametric-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Path"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Polygon"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Rectangle"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Shape"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Spline"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <!-- graphical elements can be stroked and possibly filled -->
+  <define name="StrokeAttributes">
+    <optional>
+      <attribute name="stroke"/>
+    </optional>
+    <optional>
+      <attribute name="stroke-opacity"/>
+    </optional>
+    <optional>
+      <attribute name="opacity"/>
+    </optional>
+    <optional>
+      <attribute name="thickness"/>
+    </optional>
+    <optional>
+      <attribute name="miterlimit"/>
+    </optional>
+    <optional>
+      <attribute name="linejoin"/>
+    </optional>
+    <optional>
+      <attribute name="linecap"/>
+    </optional>
+    <optional>
+      <attribute name="dash"/>
+    </optional>
+    <optional>
+      <attribute name="cliptobbox">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="outline">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="FillAttributes">
+    <ref name="StrokeAttributes"/>
+    <optional>
+      <attribute name="fill"/>
+    </optional>
+    <optional>
+      <attribute name="fill-opacity"/>
+    </optional>
+    <optional>
+      <attribute name="fill-rule"/>
+    </optional>
+  </define>
+  <!-- start defining the graphical elements -->
+  <define name="GraphicalElements">
+    <interleave>
+      <zeroOrMore>
+        <ref name="Angle-Marker"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Arc"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Area-Between-Curves"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Area-Under-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Axes"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Circle"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Contour"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Ellipse"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Graph"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Grid"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Grid-Axes"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Histogram"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Image"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Implicit-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Label"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Legend"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Line"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Network"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Parametric-Curve"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Path"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Plot-DE-Solution"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Point"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Polygon"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Rectangle"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Riemann-Sum"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Scatter"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Shape"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Slope-Field"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Spline"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Tick-Mark"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Tangent-line"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Triangle"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Vector"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Vector-Field"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <define name="Angle-Marker">
+    <element name="angle-marker">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="points"/>
+      <optional>
+        <attribute name="radius"/>
+      </optional>
+      <optional>
+        <attribute name="arrow">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <ref name="LabelAttributes"/>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+      <optional>
+        <ref name="LabelText"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Arc">
+    <element name="arc">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="points"/>
+      </optional>
+      <optional>
+        <attribute name="center"/>
+      </optional>
+      <optional>
+        <attribute name="range"/>
+      </optional>
+      <attribute name="radius"/>
+      <optional>
+        <attribute name="sector">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="degrees">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="reverse">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Area-Between-Curves">
+    <element name="area-between-curves">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="function1"/>
+      </optional>
+      <optional>
+        <attribute name="function2"/>
+      </optional>
+      <optional>
+        <attribute name="functions"/>
+      </optional>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="coordinates">
+          <choice>
+            <value>polar</value>
+            <value>cartesian</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="domain-degrees">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Area-Under-Curve">
+    <element name="area-under-curve">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="coordinates">
+          <choice>
+            <value>polar</value>
+            <value>cartesian</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="domain-degrees">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <!-- grids and axes -->
+  <define name="Axes">
+    <element name="axes">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="hlabels"/>
+      </optional>
+      <optional>
+        <attribute name="vlabels"/>
+      </optional>
+      <optional>
+        <attribute name="xlabel"/>
+      </optional>
+      <optional>
+        <attribute name="ylabel"/>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="decorations">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="h-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="h-frame">
+          <choice>
+            <value>bottom</value>
+            <value>top</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-frame">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="stroke"/>
+      </optional>
+      <optional>
+        <attribute name="thickness"/>
+      </optional>
+      <optional>
+        <attribute name="tick-size"/>
+      </optional>
+      <optional>
+        <attribute name="axes">
+          <choice>
+            <value>horizontal</value>
+            <value>vertical</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="bounding-box">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="h-zero-label">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-zero-label">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="label-commas">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="CommonAttributes"/>
+      <optional>
+        <ref name="XLabel"/>
+      </optional>
+      <optional>
+        <ref name="YLabel"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Grid">
+    <element name="grid">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="spacings"/>
+      </optional>
+      <optional>
+        <attribute name="hspacing"/>
+      </optional>
+      <optional>
+        <attribute name="vspacing"/>
+      </optional>
+      <optional>
+        <attribute name="basis"/>
+      </optional>
+      <optional>
+        <attribute name="h-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="stroke"/>
+      </optional>
+      <optional>
+        <attribute name="thickness"/>
+      </optional>
+      <optional>
+        <attribute name="coordinates"/>
+      </optional>
+      <optional>
+        <attribute name="spacing-degrees">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="scales">
+          <choice>
+            <value>linear</value>
+            <value>semilogx</value>
+            <value>semilogy</value>
+            <value>loglog</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="Stroke-Attributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Grid-Axes">
+    <element name="grid-axes">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="spacings"/>
+      </optional>
+      <optional>
+        <attribute name="hspacing"/>
+      </optional>
+      <optional>
+        <attribute name="vspacing"/>
+      </optional>
+      <optional>
+        <attribute name="h-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-pi-format">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="h-frame">
+          <choice>
+            <value>bottom</value>
+            <value>top</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-frame">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="hlabels"/>
+      </optional>
+      <optional>
+        <attribute name="vlabels"/>
+      </optional>
+      <optional>
+        <attribute name="xlabel"/>
+      </optional>
+      <optional>
+        <attribute name="ylabel"/>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="decorations">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="tick-size"/>
+      </optional>
+      <optional>
+        <attribute name="axes">
+          <choice>
+            <value>horizontal</value>
+            <value>vertical</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="bounding-box">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="h-zero-label">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="v-zero-label">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="label-commas">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+      <optional>
+        <ref name="XLabel"/>
+      </optional>
+      <optional>
+        <ref name="YLabel"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Tick-Mark">
+    <element name="tick-mark">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="location"/>
+      <optional>
+        <attribute name="axis"/>
+      </optional>
+      <optional>
+        <attribute name="stroke"/>
+      </optional>
+      <optional>
+        <attribute name="size"/>
+      </optional>
+      <optional>
+        <attribute name="thickness"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="LabelAttributes"/>
+      <optional>
+        <ref name="LabelText"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Contour">
+    <element name="contour">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <optional>
+        <attribute name="k"/>
+      </optional>
+      <optional>
+        <attribute name="value"/>
+      </optional>
+      <optional>
+        <attribute name="depth"/>
+      </optional>
+      <optional>
+        <attribute name="initial-depth"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Circle">
+    <element name="circle">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="center"/>
+      <optional>
+        <attribute name="radius"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Ellipse">
+    <element name="ellipse">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="center"/>
+      <optional>
+        <attribute name="axes"/>
+      </optional>
+      <optional>
+        <attribute name="rotate"/>
+      </optional>
+      <optional>
+        <attribute name="degrees"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Graph">
+    <element name="graph">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="coordinates">
+          <choice>
+            <value>polar</value>
+            <value>coordinates</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="domain-degress">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="closed">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="fill"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Image">
+    <element name="image">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="source"/>
+      <optional>
+        <attribute name="lower-left"/>
+      </optional>
+      <optional>
+        <attribute name="center"/>
+      </optional>
+      <optional>
+        <attribute name="dimensions"/>
+      </optional>
+      <optional>
+        <attribute name="opacity"/>
+      </optional>
+      <optional>
+        <attribute name="filetype">
+          <choice>
+            <value>svg</value>
+            <value>png</value>
+            <value>gif</value>
+            <value>jpeg</value>
+            <value>jpg</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rotate"/>
+      </optional>
+      <optional>
+        <attribute name="scale"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Histogram">
+    <element name="histogram">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="data"/>
+      <optional>
+        <attribute name="min"/>
+      </optional>
+      <optional>
+        <attribute name="max"/>
+      </optional>
+      <optional>
+        <attribute name="bins"/>
+      </optional>
+      <optional>
+        <attribute name="bin-text"/>
+      </optional>
+      <optional>
+        <attribute name="annotate">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="text"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Implicit-Curve">
+    <element name="implicit-curve">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <optional>
+        <attribute name="k"/>
+      </optional>
+      <optional>
+        <attribute name="value"/>
+      </optional>
+      <optional>
+        <attribute name="depth"/>
+      </optional>
+      <optional>
+        <attribute name="initial-depth"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Legend">
+    <element name="legend">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="anchor"/>
+      <optional>
+        <attribute name="alignment"/>
+      </optional>
+      <optional>
+        <attribute name="vertical-skip"/>
+      </optional>
+      <optional>
+        <attribute name="scale"/>
+      </optional>
+      <optional>
+        <attribute name="stroke"/>
+      </optional>
+      <optional>
+        <attribute name="opacity"/>
+      </optional>
+      <oneOrMore>
+        <element name="item">
+          <attribute name="ref"/>
+          <oneOrMore>
+            <ref name="LabelText"/>
+          </oneOrMore>
+        </element>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Line">
+    <element name="line">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="endpoints"/>
+      </optional>
+      <optional>
+        <attribute name="p1"/>
+      </optional>
+      <optional>
+        <attribute name="p2"/>
+      </optional>
+      <optional>
+        <attribute name="endpoint-offsets"/>
+      </optional>
+      <optional>
+        <attribute name="infinite">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="reverse">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="additional-arrows">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+      <ref name="LabelAttributes"/>
+      <optional>
+        <ref name="LabelText"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Network">
+    <element name="network">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="graph"/>
+      </optional>
+      <optional>
+        <attribute name="directed">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrows">
+          <choice>
+            <value>end</value>
+            <value>middle</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="bipartite-set"/>
+      </optional>
+      <optional>
+        <attribute name="alignment">
+          <group>
+            <value>vertical</value>
+            <value>horizontal</value>
+          </group>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="loop-scale"/>
+      </optional>
+      <optional>
+        <attribute name="layout"/>
+      </optional>
+      <optional>
+        <attribute name="seed"/>
+      </optional>
+      <optional>
+        <attribute name="start"/>
+      </optional>
+      <optional>
+        <attribute name="scale"/>
+      </optional>
+      <optional>
+        <attribute name="rotate"/>
+      </optional>
+      <optional>
+        <attribute name="edge-stroke"/>
+      </optional>
+      <optional>
+        <attribute name="edge-thickness"/>
+      </optional>
+      <optional>
+        <attribute name="edge-dash"/>
+      </optional>
+      <optional>
+        <attribute name="node-fill"/>
+      </optional>
+      <optional>
+        <attribute name="node-stroke"/>
+      </optional>
+      <optional>
+        <attribute name="node-thickness"/>
+      </optional>
+      <optional>
+        <attribute name="node-style"/>
+      </optional>
+      <optional>
+        <attribute name="node-size"/>
+      </optional>
+      <optional>
+        <attribute name="labels">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="label-dictionary"/>
+      </optional>
+      <interleave>
+        <zeroOrMore>
+          <element name="node">
+            <optional>
+              <attribute name="at"/>
+            </optional>
+            <optional>
+              <attribute name="p"/>
+            </optional>
+            <optional>
+              <attribute name="edges"/>
+            </optional>
+            <optional>
+              <attribute name="loop-orientation"/>
+            </optional>
+            <optional>
+              <attribute name="style"/>
+            </optional>
+            <ref name="FillAttributes"/>
+            <ref name="LabelAttributes"/>
+            <optional>
+              <ref name="LabelText"/>
+            </optional>
+          </element>
+        </zeroOrMore>
+        <zeroOrMore>
+          <element name="edge">
+            <optional>
+              <attribute name="at"/>
+            </optional>
+            <attribute name="vertices"/>
+            <optional>
+              <attribute name="weight"/>
+            </optional>
+            <optional>
+              <attribute name="loop-scale"/>
+            </optional>
+            <optional>
+              <attribute name="label-location"/>
+            </optional>
+            <ref name="StrokeAttributes"/>
+            <ref name="LabelAttributes"/>
+            <optional>
+              <ref name="LabelText"/>
+            </optional>
+          </element>
+        </zeroOrMore>
+      </interleave>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Parametric-Curve">
+    <element name="parametric-curve">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <attribute name="domain"/>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="closed">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-location"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="reverse">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Path">
+    <element name="path">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="start"/>
+      <optional>
+        <attribute name="closed"/>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="reverse">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mid-arrow">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+      <ref name="PathElements"/>
+    </element>
+  </define>
+  <define name="Plot-DE-Solution">
+    <element name="plot-de-solution">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="solution"/>
+      </optional>
+      <optional>
+        <attribute name="axes"/>
+      </optional>
+      <optional>
+        <attribute name="arrow">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-location"/>
+      </optional>
+      <optional>
+        <attribute name="function"/>
+      </optional>
+      <optional>
+        <attribute name="t0"/>
+      </optional>
+      <optional>
+        <attribute name="y0"/>
+      </optional>
+      <optional>
+        <attribute name="t1"/>
+      </optional>
+      <optional>
+        <attribute name="method"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="max-step"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Point">
+    <element name="point">
+      <attribute name="p"/>
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="style"/>
+      </optional>
+      <optional>
+        <attribute name="size"/>
+      </optional>
+      <optional>
+        <attribute name="coordinates">
+          <choice>
+            <value>cartesian</value>
+            <value>polar</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="degrees">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="LabelAttributes"/>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+      <optional>
+        <ref name="LabelText"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Polygon">
+    <element name="polygon">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="points"/>
+      <optional>
+        <attribute name="parameter"/>
+      </optional>
+      <optional>
+        <attribute name="corner-radius"/>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="closed">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Rectangle">
+    <element name="rectangle">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="lower-left"/>
+      </optional>
+      <optional>
+        <attribute name="center"/>
+      </optional>
+      <optional>
+        <attribute name="dimensions"/>
+      </optional>
+      <optional>
+        <attribute name="rotate"/>
+      </optional>
+      <optional>
+        <attribute name="corner-radius"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Riemann-Sum">
+    <element name="riemann-sum">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <attribute name="N"/>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="rule"/>
+      </optional>
+      <optional>
+        <attribute name="annotate">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+      <ref name="AnnotatedElementAttributes"/>
+    </element>
+  </define>
+  <define name="Scatter">
+    <element name="scatter">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="points"/>
+      </optional>
+      <optional>
+        <attribute name="data"/>
+      </optional>
+      <optional>
+        <attribute name="x"/>
+      </optional>
+      <optional>
+        <attribute name="y"/>
+      </optional>
+      <optional>
+        <attribute name="filter"/>
+      </optional>
+      <optional>
+        <attribute name="point-text"/>
+      </optional>
+      <optional>
+        <attribute name="annotate">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="text"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Shape">
+    <element name="shape">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="shape"/>
+      </optional>
+      <optional>
+        <attribute name="shapes"/>
+      </optional>
+      <optional>
+        <attribute name="operation"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Slope-Field">
+    <element name="slope-field">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <optional>
+        <attribute name="arrows">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="system">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="spacings"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Spline">
+    <element name="spline">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="bc"/>
+      </optional>
+      <attribute name="points"/>
+      <optional>
+        <attribute name="parameter"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-location"/>
+      </optional>
+      <optional>
+        <attribute name="closed">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="name"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Tangent-line">
+    <element name="tangent-line">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="function"/>
+      <attribute name="point"/>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="infinite">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Triangle">
+    <element name="triangle">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="vertices"/>
+      <optional>
+        <attribute name="angle-markers">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="labels"/>
+      </optional>
+      <optional>
+        <attribute name="show-vertices">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="point-fill"/>
+      </optional>
+      <ref name="FillAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+  <define name="Vector">
+    <element name="vector">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <attribute name="v"/>
+      <optional>
+        <attribute name="tail"/>
+      </optional>
+      <optional>
+        <attribute name="scale"/>
+      </optional>
+      <optional>
+        <attribute name="head-location"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles"/>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+      <ref name="LabelAttributes"/>
+      <optional>
+        <ref name="LabelText"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Vector-Field">
+    <element name="vector-field">
+      <optional>
+        <attribute name="at"/>
+      </optional>
+      <optional>
+        <attribute name="function"/>
+      </optional>
+      <optional>
+        <attribute name="spacings"/>
+      </optional>
+      <optional>
+        <attribute name="scale"/>
+      </optional>
+      <optional>
+        <attribute name="curve"/>
+      </optional>
+      <optional>
+        <attribute name="domain"/>
+      </optional>
+      <optional>
+        <attribute name="N"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-width"/>
+      </optional>
+      <optional>
+        <attribute name="arrow-angles">
+          <optional>
+            <text/>
+          </optional>
+        </attribute>
+      </optional>
+      <ref name="StrokeAttributes"/>
+      <ref name="CommonAttributes"/>
+    </element>
+  </define>
+</grammar>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1004,7 +1004,6 @@
                     Component?,
                     text
                 }
-            AnyPFContent = text | element * { attribute * { text }*, AnyPFContent* }
             ImageCode =
                 element image {
                     UniqueID?,
@@ -1040,7 +1039,7 @@
                             } |
                             element pf:prefigure {
                                 attribute label {text}?,
-                                AnyPFContent*
+                                external "pf-adapter.rnc"
                             }
                           )
                         )

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2647,22 +2647,6 @@
       <text/>
     </element>
   </define>
-  <define name="AnyPFContent">
-    <choice>
-      <text/>
-      <element>
-        <anyName/>
-        <zeroOrMore>
-          <attribute>
-            <anyName/>
-          </attribute>
-        </zeroOrMore>
-        <zeroOrMore>
-          <ref name="AnyPFContent"/>
-        </zeroOrMore>
-      </element>
-    </choice>
-  </define>
   <define name="ImageCode">
     <element name="image">
       <optional>
@@ -2741,9 +2725,7 @@
                 <optional>
                   <attribute name="label"/>
                 </optional>
-                <zeroOrMore>
-                  <ref name="AnyPFContent"/>
-                </zeroOrMore>
+                <externalRef href="pf-adapter.rng"/>
               </element>
             </choice>
           </interleave>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1918,6 +1918,8 @@
 
         <p>Note: the <c>ImageCode</c> pattern allows an <attr>xml:id</attr> attribute since it is used to construct a filename.</p>
 
+        <p>A <c>pf:prefigure</c> image holds a <pretext/>-namespaced <c>label</c> attribute followed by a single <init>PreFigure</init> diagram.  Rather than validate the diagram with a permissive wildcard, we defer to <init>PreFigure</init>'s own schema by way of an <c>externalRef</c> to the adapter described below.  This isolates the two grammars, so the many pattern names they share (such as <c>Label</c>, <c>Image</c>, and <c>Caption</c>) do not collide.</p>
+
         <fragment xml:id="image">
             <title>Images</title>
             <code>
@@ -1953,7 +1955,6 @@
                     Component?,
                     text
                 }
-            AnyPFContent = text | element * { attribute * { text }*, AnyPFContent* }
             ImageCode =
                 element image {
                     UniqueID?,
@@ -1989,7 +1990,7 @@
                             } |
                             element pf:prefigure {
                                 attribute label {text}?,
-                                AnyPFContent*
+                                external "pf-adapter.rnc"
                             }
                           )
                         )
@@ -3587,6 +3588,25 @@
             <title>Experimental Document Info</title>
             <fragref ref="blurb"/>
             <fragref ref="document-id"/>
+        </fragment>
+    </section>
+
+    <section>
+        <title>PreFigure Schema
+                Adapter</title>
+
+        <p>The <init>PreFigure</init> project publishes its own <init>RELAX-NG</init> compact schema (<c>pf_schema.rnc</c>), which we copy into this directory nearly verbatim (carrying only a handful of minimal upstream bug fixes needed for the grammar to load).  That schema defines every <init>PreFigure</init> element in no namespace, with a start pattern of the <c>diagram</c> element.  <pretext/>, however, expects <init>PreFigure</init> content in the <c>https://prefigure.org</c> namespace, signalled by the <attr>xmlns</attr> on a <c>prefigure</c> element.</p>
+
+        <p>This adapter reconciles the two.  Declaring a default namespace and then including the upstream schema remaps every one of its elements into the <init>PreFigure</init> namespace, all without restructuring the upstream file.  The included grammar's start pattern (the <c>diagram</c> element) becomes this adapter's start pattern, which is exactly what the <c>externalRef</c> in <c>ImageCode</c> reaches.  Keeping our edits to the upstream schema minimal means a future <init>PreFigure</init> release can be re-synced by copying a single file.</p>
+
+        <fragment filename="pf-adapter.rnc">
+            <title>PreFigure Schema Adapter</title>
+            <code>
+                default namespace = "https://prefigure.org"
+                grammar {
+                    include "pf_schema.rnc"
+                }
+            </code>
         </fragment>
     </section>
 


### PR DESCRIPTION
## Motivation

PreFigure content inside an `<image>` (a `pf:prefigure` element in the `https://prefigure.org` namespace) was accepted by a permissive wildcard (`AnyPFContent = text | element * { … }`) — any element, any attribute, any nesting. Authoring mistakes in a diagram passed validation silently. PreFigure now publishes its own RELAX-NG schema, so we can validate diagram structure for real.

## Approach

Integration is built into the literate program (`schema/pretext.xml`):

- A new **adapter** (`pf-adapter.rnc`, emitted by the literate program) declares `default namespace = "https://prefigure.org"` and `include`s the upstream `pf_schema.rnc`. The default namespace remaps PreFigure's no-namespace elements into the PreFigure namespace without restructuring the upstream file.
- `pf:prefigure`'s content model changes from the wildcard to `external "pf-adapter.rnc"`. Using `externalRef` keeps the two grammars isolated, so the many pattern names they share (`Label`, `Image`, `Caption`, …) don't collide — a plain `include` is impossible here.
- Re-syncing a future PreFigure release is a one-file copy.

## Upstream schema bugs (fixed in our copy)

PreFigure's shipped schema (commit `c529af4`) does not load under `jing` — it appears never to have been checked with a strict RELAX-NG validator. The second commit fixes the minimum needed to load, in both `.rnc` and `.rng`:

- Undefined reference `Stroke-Attributes` (should be `StrokeAttributes`)
- Duplicate attributes from elements that declare an attribute explicitly *and* pull in a pattern that already provides it: `grid`, `tick-mark`, `histogram`, `scatter`, `riemann-sum`, `vector`
- Overlapping pattern references in `riemann-sum` (`CommonAttributes` already contains `AnnotatedElementAttributes`)
- `network/@alignment` written as a sequence `{'vertical', 'horizontal'}` instead of a choice `{'vertical' | 'horizontal'}`
- Missing `tactile-dash` attribute (used in PreFigure's own `de-system.xml` example and in our sample article) — added to `StrokeAttributes`

These should be reported upstream to `davidaustinm/prefigure`.

## Testing

Validated the sample article with `jing` against `pretext-dev.rng`. The 201 pre-existing, unrelated errors are unchanged; **0** PreFigure errors. Positive control confirms real validation through the `pretext.rng → pf-adapter.rng → pf_schema.rng` chain: a valid diagram passes, while a bogus element and a bogus attribute are both rejected.

## Known limitation: XSD

`trang -O xsd` cannot follow `externalRef` ("sorry, externalRef is not yet supported"), so the XSD schema (`pretext.xsd`/`pf.xsd`/`xml.xsd`) is left on the old wildcard model and does not yet carry structural PreFigure validation. `jing`/RNG is PreTeXt's validation path, so this is acceptable for now; a comment in `build.sh` records it.

## Commits

1. `Schema: add upstream PreFigure RELAX-NG schema files` — upstream, verbatim
2. `Schema: fix bugs in the PreFigure schema so it loads` — the fixes above; the diff isolates exactly what was wrong upstream
3. `Schema: validate "pf:prefigure" content with a PreFigure adapter` — the adapter, literate-program and regenerated-schema changes, `build.sh`

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
