### PR TITLE
XSL-FO: publisher-selectable fonts for the pdf-fo route (Latin Modern default)

### DIFF
--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -294,4 +294,15 @@
 
         <p>If you suspect some packages are not playing well with each other, this record might be helpful for debugging this (rare) situation.  It can also be useful if you wish to have a perfect archive of how some publication was produced.  See the package documentation for more on the format and use.</p>
     </section>
+
+    <section xml:id="pdf-xsl-fo">
+        <title>Direct <init>PDF</init> via <init>XSL-FO</init></title>
+        <idx><h>PDF</h><h>XSL-FO</h></idx>
+        <idx><h>XSL-FO</h></idx>
+        <idx>FOP</idx>
+
+        <p>The conversions described so far in this chapter reach a <init>PDF</init> by way of <latex/>, as an intermediate format (<xref ref="latex-file"/>).  An experimental alternative produces a <init>PDF</init> directly from an <init>XSL-FO</init> rendering of your source, formatted by Apache <init>FOP</init>, with no <latex/> stage at all.  This route is under active development and does not yet match the maturity or typographic polish of the <latex/> route, so it is not yet a substitute for it.</p>
+
+        <p>One motivation for this route is accessibility: it produces a tagged, <init>PDF/UA</init> <init>PDF</init>, and every font it uses is fully embedded.  Because there is no <latex/> in the pipeline, the available fonts are a small, curated set rather than the whole <tex/> ecosystem.  You may choose the font set with a publication option; by default it matches the Latin Modern fonts of the <latex/> route.  See <xref ref="pdf-fo-font-options"/> for the option and its values.</p>
+    </section>
 </chapter>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -488,6 +488,26 @@
         </subsection>
     </section>
 
+    <section xml:id="publication-file-pdf-fo">
+        <title>PDF (<init>XSL-FO</init>) Options</title>
+        <idx><h>publisher options</h><h>PDF, XSL-FO</h></idx>
+        <idx><h>XSL-FO</h><h>publisher options</h></idx>
+
+        <introduction>
+            <p>These options affect the experimental conversion that produces <init>PDF</init> directly from <init>XSL-FO</init> with Apache <init>FOP</init>, without an intermediate <latex/> stage.  This conversion is under active development.  See <xref ref="pdf-xsl-fo"/> for an overview.</p>
+        </introduction>
+
+        <subsection xml:id="pdf-fo-font-options">
+            <title>Font Selection</title>
+            <idx><h>font selection</h><h>PDF, XSL-FO</h></idx>
+            <idx><h>XSL-FO</h><h>font selection</h></idx>
+
+            <p>The text and monospace fonts of the <init>PDF</init> are chosen with the<cd>
+                <cline>/publication/pdf/@font</cline>
+            </cd>attribute, whose value is a key naming a tested font set.  The value <c>latin-modern</c> (the default) selects Latin Modern, matching the <latex/> conversion, while <c>dejavu</c> selects the DejaVu families.  In either case a small number of symbols absent from the chosen font are supplied from a fallback font.  Every font is fully embedded, as required for the accessible (<init>PDF/UA</init>) output this conversion produces.</p>
+        </subsection>
+    </section>
+
     <section xml:id="publication-file-online">
         <title>Online (HTML) Options</title>
         <idx>HTML publisher options</idx>

--- a/pretext/fop.xconf
+++ b/pretext/fop.xconf
@@ -130,6 +130,43 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <font-triplet name="Helvetica" style="italic" weight="bold"/>
                     <font-triplet name="Arial" style="italic" weight="bold"/>
                 </font>
+                <!-- Latin Modern: the default body and monospace faces, matching -->
+                <!-- the LaTeX route (lmodern).  Selected by the publication       -->
+                <!-- option  pdf/@font="latin-modern".  Declaring these alongside  -->
+                <!-- the DejaVu faces costs nothing in an output that uses only one -->
+                <!-- set, since FOP embeds only the faces a document actually uses. -->
+                <!-- Paths are Debian's texmf tree (the OTF/CFF Latin Modern); a    -->
+                <!-- later refinement will resolve them per host.  No generic       -->
+                <!-- aliases here: the XSL names these families explicitly, and the -->
+                <!-- DejaVu blocks above keep the generic/legacy fallbacks.         -->
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmroman10-regular.otf">
+                    <font-triplet name="Latin Modern Roman" style="normal" weight="normal"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmroman10-bold.otf">
+                    <font-triplet name="Latin Modern Roman" style="normal" weight="bold"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmroman10-italic.otf">
+                    <font-triplet name="Latin Modern Roman" style="italic" weight="normal"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmroman10-bolditalic.otf">
+                    <font-triplet name="Latin Modern Roman" style="italic" weight="bold"/>
+                </font>
+                <!-- Latin Modern Mono ships regular and italic only at this design -->
+                <!-- weight (lmmono10); the bold cells borrow the Mono Light family -->
+                <!-- (lmmonolt10), the closest embeddable bold.  Bold monospace is  -->
+                <!-- rare, so the slight weight mismatch is an accepted stopgap.    -->
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmmono10-regular.otf">
+                    <font-triplet name="Latin Modern Mono" style="normal" weight="normal"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmmonolt10-bold.otf">
+                    <font-triplet name="Latin Modern Mono" style="normal" weight="bold"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmmono10-italic.otf">
+                    <font-triplet name="Latin Modern Mono" style="italic" weight="normal"/>
+                </font>
+                <font embedding-mode="full" embed-url="/usr/share/texmf/fonts/opentype/public/lm/lmmonolt10-boldoblique.otf">
+                    <font-triplet name="Latin Modern Mono" style="italic" weight="bold"/>
+                </font>
             </fonts>
         </renderer>
     </renderers>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -9,6 +9,7 @@
                     Source? &
                     Numbering? &
                     Latex? &
+                    Pdf? &
                     Html? &
                     Revealjs? &
                     Epub? &
@@ -206,6 +207,11 @@
             Asymptote =
                 element asymptote {
                     attribute links { "yes" | "no" }?
+                }
+            
+            Pdf =
+                element pdf {
+                    attribute font { "latin-modern" | "dejavu" }?
                 }
             
             Html =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -19,6 +19,9 @@
           <ref name="Latex"/>
         </optional>
         <optional>
+          <ref name="Pdf"/>
+        </optional>
+        <optional>
           <ref name="Html"/>
         </optional>
         <optional>
@@ -659,6 +662,18 @@
           <choice>
             <value>yes</value>
             <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="Pdf">
+    <element name="pdf">
+      <optional>
+        <attribute name="font">
+          <choice>
+            <value>latin-modern</value>
+            <value>dejavu</value>
           </choice>
         </attribute>
       </optional>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -100,6 +100,7 @@
                     Source? &amp;
                     Numbering? &amp;
                     Latex? &amp;
+                    Pdf? &amp;
                     Html? &amp;
                     Revealjs? &amp;
                     Epub? &amp;
@@ -358,6 +359,24 @@
             Asymptote =
                 element asymptote {
                     attribute links { "yes" | "no" }?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>PDF (XSL-FO) Options</title>
+
+        <p>
+            These options control the experimental <c>pdf</c> output produced directly from <init>XSL-FO</init> by Apache <init>FOP</init>, without an intermediate <latex /> stage.
+        </p>
+
+        <fragment xml:id="pdf">
+            <title>PDF (XSL-FO) Options</title>
+            <code>
+            Pdf =
+                element pdf {
+                    attribute font { "latin-modern" | "dejavu" }?
                 }
             </code>
         </fragment>
@@ -641,6 +660,7 @@
             <fragref ref="source" />
             <fragref ref="numbering" />
             <fragref ref="latex" />
+            <fragref ref="pdf" />
             <fragref ref="html" />
             <fragref ref="revealjs" />
             <fragref ref="epub" />

--- a/schema/publication-schema.xsd
+++ b/schema/publication-schema.xsd
@@ -7,6 +7,7 @@
         <xs:element ref="source"/>
         <xs:element ref="numbering"/>
         <xs:element ref="latex"/>
+        <xs:element ref="pdf"/>
         <xs:element ref="html"/>
         <xs:element ref="revealjs"/>
         <xs:element ref="epub"/>
@@ -586,6 +587,18 @@
           <xs:restriction base="xs:token">
             <xs:enumeration value="yes"/>
             <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pdf">
+    <xs:complexType>
+      <xs:attribute name="font">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="latin-modern"/>
+            <xs:enumeration value="dejavu"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -105,10 +105,32 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- PDF/UA (ISO 14289) requires every font to be embedded, so    -->
 <!-- each font family must name a real, available font: a generic -->
 <!-- family (serif, monospace) would fall back to a base-14 PDF   -->
-<!-- font, which is never embedded.  The choices are centralized  -->
-<!-- here, on the way to becoming publisher-configurable.         -->
-<xsl:variable name="font-family-main" select="'DejaVu Serif'"/>
-<xsl:variable name="font-family-monospace" select="'DejaVu Sans Mono'"/>
+<!-- font, which is never embedded.  Each named family must have a -->
+<!-- matching declaration in  pretext/fop.xconf.  The body and     -->
+<!-- monospace faces follow the  pdf/@font  publication key; the    -->
+<!-- symbol fallback stays on DejaVu Sans, which carries glyphs     -->
+<!-- (the tombstone, the U+2BA0 "enter" key) that Latin Modern      -->
+<!-- lacks.                                                         -->
+<xsl:variable name="font-family-main">
+    <xsl:choose>
+        <xsl:when test="$pdf-font = 'dejavu'">
+            <xsl:text>DejaVu Serif</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>Latin Modern Roman</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="font-family-monospace">
+    <xsl:choose>
+        <xsl:when test="$pdf-font = 'dejavu'">
+            <xsl:text>DejaVu Sans Mono</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>Latin Modern Mono</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
 <!-- for symbols absent from the main font (e.g. the tombstone) -->
 <xsl:variable name="font-family-symbol" select="'DejaVu Sans'"/>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1147,15 +1147,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </fo:block>
 </xsl:template>
 
-<!-- The implication arrows of a "case" direction, and the spacing -->
-<!-- inside a "cycle" decoration, expected by pretext-common.xsl.  -->
+<!-- The implication arrows of a "case" direction, and the spacing  -->
+<!-- inside a "cycle" decoration, expected by pretext-common.xsl.    -->
+<!-- The double arrows are taken from the symbol font: the main body -->
+<!-- font (e.g. Latin Modern Roman) need not carry them.             -->
 <xsl:template name="double-right-arrow-symbol">
-    <!-- RIGHTWARDS DOUBLE ARROW -->
-    <xsl:text>&#x21d2;</xsl:text>
+    <fo:inline font-family="{$font-family-symbol}">
+        <!-- RIGHTWARDS DOUBLE ARROW -->
+        <xsl:text>&#x21d2;</xsl:text>
+    </fo:inline>
 </xsl:template>
 <xsl:template name="double-left-arrow-symbol">
-    <!-- LEFTWARDS DOUBLE ARROW -->
-    <xsl:text>&#x21d0;</xsl:text>
+    <fo:inline font-family="{$font-family-symbol}">
+        <!-- LEFTWARDS DOUBLE ARROW -->
+        <xsl:text>&#x21d0;</xsl:text>
+    </fo:inline>
 </xsl:template>
 <xsl:template name="case-cycle-delimiter-space">
     <!-- THIN SPACE -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3214,6 +3214,31 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
+<!-- Font selection for the XSL-FO PDF route ("pdf-fo").  A key names a -->
+<!-- tested font set; the FO conversion maps the key to concrete font  -->
+<!-- family names, which  pretext/fop.xconf  embeds.  Guaranteed to be  -->
+<!-- 'latin-modern' (default, matching the LaTeX route) or 'dejavu'.    -->
+<xsl:variable name="pdf-font">
+    <xsl:variable name="default-pdf-font" select="'latin-modern'"/>
+    <xsl:choose>
+        <xsl:when test="$publication/pdf/@font = 'latin-modern'">
+            <xsl:text>latin-modern</xsl:text>
+        </xsl:when>
+        <xsl:when test="$publication/pdf/@font = 'dejavu'">
+            <xsl:text>dejavu</xsl:text>
+        </xsl:when>
+        <!-- attempted to set, but not a recognized key -->
+        <xsl:when test="$publication/pdf/@font">
+            <xsl:message>PTX:WARNING: PDF (XSL-FO) font setting in publisher file should be "latin-modern" or "dejavu", not "<xsl:value-of select="$publication/pdf/@font"/>". Proceeding with default value: "<xsl:value-of select="$default-pdf-font"/>"</xsl:message>
+            <xsl:value-of select="$default-pdf-font"/>
+        </xsl:when>
+        <!-- no attempt at all, so default -->
+        <xsl:otherwise>
+            <xsl:value-of select="$default-pdf-font"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- Simple - just feeds into a LaTeX \geometry{} -->
 <xsl:variable name="latex-page-geometry">
     <xsl:choose>


### PR DESCRIPTION
## Summary

The experimental `pdf-fo` route (PDF produced directly from XSL-FO by Apache FOP, no LaTeX stage) previously hardcoded the DejaVu font families. This adds a publisher-selectable font set, chosen by a new publication-file option:

```xml
<publication>
  <pdf font="latin-modern"/>   <!-- or "dejavu" -->
</publication>
```

- **`latin-modern`** (the new default) matches the LaTeX route's body font, so the two PDF paths look alike.
- **`dejavu`** preserves the previous behavior exactly.

In both cases a small number of symbols absent from the chosen body font (the proof-cycle/tombstone glyphs, the `enter`-key symbol, etc.) are supplied from a DejaVu symbol fallback, and every font is fully embedded as the accessible PDF/UA output requires.

This is a first, deliberately modest step: two curated keys, with font file paths currently hardcoded to a Debian/TeX layout. Resolving fonts per host (e.g. via `fc-list`) and broadening to additional families are left for later.

## What changed

- **`pretext/fop.xconf`** — declares the Latin Modern faces (Roman ×4; Mono regular/italic, with bold borrowed from the Mono Light face, which is the closest embeddable bold) alongside the existing DejaVu faces. FOP embeds only the faces a document actually uses, so carrying both sets costs nothing per build.
- **`xsl/publisher-variables.xsl`** — reads `pdf/@font`, validates it, warns on an unrecognized value, and defaults to `latin-modern`.
- **`xsl/pretext-fo.xsl`** — selects the main and monospace family names from that key; the symbol fallback stays on DejaVu Sans.
- **Schema** — adds the `pdf` element with `@font` to the publication-file schema (literate source plus regenerated `.rnc`/`.rng`/`.xsd`).
- **Guide** — a reference entry for the option and a short conversational overview of the XSL-FO route, cross-linked.

Also included (a small independent fix exposed by the switch): the `case` direction arrows (`⇒`/`⇐`) in proofs are now drawn from the symbol font rather than the body font, so they render whether or not the body font carries them.

## Testing

Built `pdf-fo` for both the **sample article** (`examples/sample-article`) and the **XSL-FO development article** (`examples/pdf-fo-development`):

- With the default `latin-modern`: body and monospace render in Latin Modern, symbols fall back to DejaVu, no missing-glyph or non-embedded-font warnings.
- With `font="dejavu"`: output reverts to the all-DejaVu faces.
- Both default-font PDFs validate as **PDF/UA-1 compliant** (veraPDF, 0 failed rules) — confirming the full OpenType/CFF embedding of Latin Modern survives the accessibility profile.
- Schema accepts the two valid keys and rejects others (`jing`); the Guide validates against the development schema.

---

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
