### PR TITLE
Toc accessibility improvements

### DIFF
--- a/js/pretext.js
+++ b/js/pretext.js
@@ -60,16 +60,29 @@ function scrollTocToActive() {
 }
 
 function toggletoc() {
-   thesidebar = document.getElementById("ptx-sidebar");
-   if (thesidebar.classList.contains("hidden") || thesidebar.classList.contains("visible")) {
-       thesidebar.classList.toggle("hidden");
-       thesidebar.classList.toggle("visible");
-   } else if (thesidebar.offsetParent === null) {  /* not currently visible */
-       thesidebar.classList.toggle("visible");
-   } else {
-       thesidebar.classList.toggle("hidden");
-   }
-   scrollTocToActive();
+    let ptxSidebar = document.getElementById("ptx-sidebar");
+    let sideBarIsHidden = ptxSidebar.classList.contains("hidden") || (!ptxSidebar.classList.contains("visible") && ptxSidebar.offsetParent === null);
+
+    if (sideBarIsHidden) {
+        ptxSidebar.classList.add("visible");
+        ptxSidebar.classList.remove("hidden");
+    } else {
+        ptxSidebar.classList.remove("visible");
+        ptxSidebar.classList.add("hidden");
+    }
+    sideBarIsHidden = !sideBarIsHidden; //toggled value for aria-expanded
+
+    let ptxTocButton = document.getElementById("ptx-toc-toggle");
+    ptxTocButton.setAttribute("aria-expanded", !sideBarIsHidden);
+
+    if (!sideBarIsHidden) {
+        scrollTocToActive();
+        // Focus the TOC for accessibility
+        document.querySelector("#ptx-toc").focus();
+    } else {
+        // Focus the TOC toggle button for accessibility
+        ptxTocButton.focus();
+    }
 }
 
 function samePageLink(a) {
@@ -93,11 +106,17 @@ function samePageLink(a) {
 
 
 window.addEventListener("DOMContentLoaded",function(event) {
-    thetocbutton = document.getElementsByClassName("toc-toggle")[0];
-    thetocbutton.addEventListener("click", (e) => {
+    let tocButton = document.getElementById("ptx-toc-toggle");
+
+    tocButton.addEventListener("click", (e) => {
         toggletoc();
         e.stopPropagation(); // keep global click handler from immediately toggling it back
     });
+
+    // determine if toc starts off hidden or not, use that to set aria-expanded
+    let ptxSidebar = document.getElementById("ptx-sidebar");
+    let sideBarIsHidden = ptxSidebar.classList.contains("hidden") || (!ptxSidebar.classList.contains("visible") && ptxSidebar.offsetParent === null);
+    tocButton.setAttribute("aria-expanded", !sideBarIsHidden);
 
     // For themes that want it, install click handlers to auto close the toc
     // when the reader clicks anywhere outside it or selects a subsection.
@@ -128,6 +147,14 @@ window.addEventListener("DOMContentLoaded",function(event) {
             if (e.persisted) {
                 sidebar.classList.remove('visible');
                 sidebar.classList.add('hidden');
+                tocButton.setAttribute("aria-expanded", "false");
+            }
+        });
+
+        // Handle Escape key to close the sidebar
+        window.addEventListener("keydown", function(event) {
+            if (event.key === "Escape" && sidebar.classList.contains("visible")) {
+                toggletoc();
             }
         });
     }
@@ -139,17 +166,22 @@ window.addEventListener("DOMContentLoaded",function(event) {
 //-----------------------------------------------------------------------------
 
 //item is assumed to be expander in toc-item
-function toggleTOCItem(expander) {
+function toggleTOCItem(expander, event = null) {
     let listItem = expander.closest(".toc-item");
     listItem.classList.toggle("expanded");
     let expanded = listItem.classList.contains("expanded");
+    let targetElement = document.getElementById(expander.controlledGroup);
 
-    let itemType = getTOCItemType(listItem);
     if(expanded) {
-        expander.title = "Close" + (itemType !== "" ? " " + itemType : "");
+        let groupName = listItem.querySelector(".toc-title-box").innerText;
+        expander.title = "Close " + groupName;
+        expander.setAttribute("aria-expanded", "true");
     } else {
-        expander.title = "Expand" + (itemType !== "" ? " " + itemType : "");
+        let groupName = listItem.querySelector(".toc-title-box").innerText;
+        expander.title = "Expand " + groupName;
+        expander.setAttribute("aria-expanded", "false");
     }
+    expander.setAttribute("aria-label", expander.title);
 
     //should be one of each... for/of for safety and built in null avoidance
     for (const childUL of listItem.querySelectorAll(":scope > ul.toc-item-list")) {
@@ -163,16 +195,17 @@ function toggleTOCItem(expander) {
             }
         }
     }
-}
 
-//finds item type from classes or empty string on failure
-function getTOCItemType(item) {
-    //Type should be class that looks like toc-X where X is not item. Find it and return X
-    for(let className of item.classList) {
-        if(className !== "toc-item" && className.length > 3 && className.slice(0,4) === "toc-")
-            return className.slice(4);
+    // if opened by keyboard, focus on the first child item, if any
+    if (expanded && expander === document.activeElement && event && event instanceof KeyboardEvent) {
+        const firstChildItem = listItem.querySelector(":scope > ul.toc-item-list > li.toc-item");
+        if (firstChildItem) {
+            const firstChildLink = firstChildItem.querySelector("a");
+            if (firstChildLink) {
+                firstChildLink.focus();
+            }
+        }
     }
-    return "";
 }
 
 //finds depth of toc-item as defined by number .toc-item-lists it is in
@@ -208,23 +241,29 @@ window.addEventListener("DOMContentLoaded", function(event) {
 
         if(hasChildren && depth < maxDepth) {
             let expander = document.createElement("button");
+            expander.type = "button";
             expander.classList.add('toc-expander');
             expander.classList.add('toc-chevron-surround');
             expander.title = 'toc-expander';
             // content of span is set by CSS :before rule.
             expander.innerHTML = '<span class="icon material-symbols-outlined" aria-hidden="true"></span>';
+            const subList = tocItem.querySelector('.toc-item-list');
+            expander.controlledGroup = subList.id;
+            expander.setAttribute('aria-controls', subList.id);
+            expander.setAttribute("aria-expanded", "false");
             tocItem.querySelector(".toc-title-box").append(expander);
-            expander.addEventListener('click', () => {
-                toggleTOCItem(expander);
+            expander.addEventListener('click', (e) => {
+                toggleTOCItem(expander, e);
             });
 
             let isActive = tocItem.classList.contains("contains-active") || tocItem.classList.contains("active");
             let preExpanded = isActive || depth < preexpandedLevels;
-            let itemType = getTOCItemType(tocItem);
             if(preExpanded) {
                 toggleTOCItem(expander);
             } else {
-                expander.title = "Expand" + (itemType !== "" ? " " + itemType : "");
+                let groupName = tocItem.querySelector(".toc-title-box").innerText;
+                expander.title = "Expand " + groupName;
+                expander.setAttribute("aria-label", expander.title);
             }
         }
     }

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10106,7 +10106,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <!-- Audited against the HTML output, 2026-06-04.                     -->
     <xsl:variable name="reserved-html-ids">
         <xsl:text>ptx-masthead ptx-content ptx-content-footer ptx-page-footer </xsl:text>
-        <xsl:text>ptx-navbar ptx-sidebar ptx-toc mainmatter logo-link latex-macros </xsl:text>
+        <xsl:text>ptx-navbar ptx-sidebar ptx-toc-toggle ptx-toc mainmatter logo-link latex-macros </xsl:text>
         <xsl:text>ptx-search-button ptx-search-results ptx-search-dialog ptx-search-terms ptx-search-status ptx-search-empty ptx-search-close </xsl:text>
         <xsl:text>light-dark-button papersize-select highlight-workspace-checkbox </xsl:text>
         <xsl:text>hide-hint-checkbox hide-answer-checkbox hide-solution-checkbox </xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12774,7 +12774,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="*" mode="primary-navigation-toc">
-    <button>
+    <button id="ptx-toc-toggle" type="button" aria-controls="ptx-sidebar">
         <xsl:attribute name="class">
             <xsl:text>toc-toggle button</xsl:text>
             <xsl:if test="$toc-level = 0">
@@ -12799,14 +12799,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- ToC sidebar                                                -->
 <xsl:template match="*" mode="sidebars">
-    <div id="ptx-sidebar">
+    <div id="ptx-sidebar" role="complementary">
         <xsl:attribute name="class">
             <xsl:text>ptx-sidebar</xsl:text>
             <xsl:if test="$toc-level = 0">
                 <xsl:text> hidden</xsl:text>
             </xsl:if>
         </xsl:attribute>
-        <nav id="ptx-toc">
+        <nav id="ptx-toc" tabindex="-1">
+            <xsl:attribute name="aria-label">
+                <xsl:apply-templates select="." mode="type-name">
+                    <xsl:with-param name="string-id" select="'toc'"/>
+                </xsl:apply-templates>
+            </xsl:attribute>
             <xsl:attribute name="class">
                 <xsl:text>ptx-toc</xsl:text>
                 <!-- A class indicates how much of the ToC we want   -->
@@ -12905,9 +12910,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:variable name="child-list" select="frontmatter|abstract|frontmatter/colophon|biography|dedication|acknowledgement|preface|contributors|part|chapter|section|subsection|subsubsection|exercises|solutions|reading-questions|references|glossary|worksheet|handout|backmatter|appendix|index|backmatter/colophon"/>
         <xsl:if test="$child-list">
             <ul>
+                <!-- visible id for element - needed for accessibility wiring -->
+                <xsl:attribute name="id">
+                    <xsl:text>ptx-toc-group-</xsl:text>
+                    <xsl:apply-templates select="." mode="unique-id"/>
+                </xsl:attribute>
                 <!-- copy id of this ui for use in customization pass, will remove there -->
                 <xsl:attribute name="uid">
-                    <xsl:value-of select="@unique-id"/>
+                    <xsl:apply-templates select="." mode="unique-id"/>
                 </xsl:attribute>
                 <xsl:attribute name="class">
                     <xsl:text>structural toc-item-list</xsl:text>


### PR DESCRIPTION
Work related to https://github.com/PreTeXtBook/pretext/issues/2794

This will add lots of `ptx-toc-group-*` ids to the HTML output for which there is no way to check against authored ids using the existing reserved id mechanism.