### PR TITLE
XSL-FO: localize quotation marks by document language

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3345,6 +3345,35 @@ Book (with parts), "section" at level 3
 <xsl:key name="quote-character-key" match="quote-character"
     use="concat(@style, '|', @side)"/>
 
+<!-- Given a quotation "style" and a "side", return the Unicode -->
+<!-- character from the table above.  Output formats that quote  -->
+<!-- with literal characters (HTML, XSL-FO) route their          -->
+<!-- "*-character" templates through here.                       -->
+<xsl:template match="*" mode="quote-character-unicode">
+    <xsl:param name="style"/>
+    <xsl:param name="side"/>
+    <xsl:variable name="unicode-character">
+        <xsl:for-each select="$quote-character-table">
+            <xsl:value-of select="key('quote-character-key',
+                concat($style, '|', $side))/@unicode-character"/>
+        </xsl:for-each>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="$unicode-character != ''">
+            <xsl:value-of select="$unicode-character"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>
+                <xsl:text>PTX:BUG:  the quotation style "</xsl:text>
+                <xsl:value-of select="$style"/>
+                <xsl:text>" (</xsl:text>
+                <xsl:value-of select="$side"/>
+                <xsl:text>) was not recognized</xsl:text>
+            </xsl:message>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 
 <!-- ##### -->
 <!-- Icons -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3148,36 +3148,72 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- secondary for single) to its Unicode character, exactly as -->
 <!-- the HTML conversion does, through the shared lookup.       -->
 <xsl:template match="*" mode="lsq-character">
-    <xsl:apply-templates select="." mode="quote-character-unicode">
+    <xsl:call-template name="fo-localized-quote-character">
         <xsl:with-param name="style">
             <xsl:apply-templates select="." mode="get-quote-secondary"/>
         </xsl:with-param>
         <xsl:with-param name="side" select="'left'"/>
-    </xsl:apply-templates>
+    </xsl:call-template>
 </xsl:template>
 <xsl:template match="*" mode="rsq-character">
-    <xsl:apply-templates select="." mode="quote-character-unicode">
+    <xsl:call-template name="fo-localized-quote-character">
         <xsl:with-param name="style">
             <xsl:apply-templates select="." mode="get-quote-secondary"/>
         </xsl:with-param>
         <xsl:with-param name="side" select="'right'"/>
-    </xsl:apply-templates>
+    </xsl:call-template>
 </xsl:template>
 <xsl:template match="*" mode="lq-character">
-    <xsl:apply-templates select="." mode="quote-character-unicode">
+    <xsl:call-template name="fo-localized-quote-character">
         <xsl:with-param name="style">
             <xsl:apply-templates select="." mode="get-quote-primary"/>
         </xsl:with-param>
         <xsl:with-param name="side" select="'left'"/>
-    </xsl:apply-templates>
+    </xsl:call-template>
 </xsl:template>
 <xsl:template match="*" mode="rq-character">
-    <xsl:apply-templates select="." mode="quote-character-unicode">
+    <xsl:call-template name="fo-localized-quote-character">
         <xsl:with-param name="style">
             <xsl:apply-templates select="." mode="get-quote-primary"/>
         </xsl:with-param>
         <xsl:with-param name="side" select="'right'"/>
-    </xsl:apply-templates>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- Look a quotation mark up in the shared table, then emit it -->
+<!-- with any narrow no-break space drawn from the symbol font: -->
+<!-- Latin Modern lacks that glyph, so a literal U+202F would   -->
+<!-- print as a missing-glyph box next to the guillemets.       -->
+<xsl:template name="fo-localized-quote-character">
+    <xsl:param name="style"/>
+    <xsl:param name="side"/>
+    <xsl:variable name="mark">
+        <xsl:apply-templates select="." mode="quote-character-unicode">
+            <xsl:with-param name="style" select="$style"/>
+            <xsl:with-param name="side" select="$side"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+    <xsl:call-template name="isolate-narrow-no-break-space">
+        <xsl:with-param name="text" select="$mark"/>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- Emit a string, drawing each narrow no-break space (U+202F) -->
+<!-- from the symbol font, passing the rest unchanged.          -->
+<xsl:template name="isolate-narrow-no-break-space">
+    <xsl:param name="text"/>
+    <xsl:choose>
+        <xsl:when test="contains($text, '&#x202f;')">
+            <xsl:value-of select="substring-before($text, '&#x202f;')"/>
+            <xsl:call-template name="narrow-no-break-space-character"/>
+            <xsl:call-template name="isolate-narrow-no-break-space">
+                <xsl:with-param name="text" select="substring-after($text, '&#x202f;')"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$text"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- The adornments of manually-tagged equations.  The star and -->
@@ -3215,6 +3251,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 <xsl:template name="thin-space-character">
     <xsl:text>&#x2009;</xsl:text>
+</xsl:template>
+<!-- the narrow no-break space is missing from the main (serif) -->
+<!-- face, so it borrows the symbol font, as the tombstone does -->
+<xsl:template name="narrow-no-break-space-character">
+    <fo:inline font-family="{$font-family-symbol}">
+        <xsl:text>&#x202f;</xsl:text>
+    </fo:inline>
 </xsl:template>
 <!-- the white square brackets are missing from the main (serif)  -->
 <!-- face, so they borrow the symbol font, as the tombstone does  -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3143,20 +3143,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>LaTeX</xsl:text>
 </xsl:template>
 
-<!-- Quotation marks: fixed Unicode for now.  The HTML conversion -->
-<!-- localizes quotation style by language; port that here when   -->
-<!-- localization becomes a focus.                                -->
+<!-- Quotation marks follow the document's language: each side  -->
+<!-- resolves the ambient quotation style (primary for double,  -->
+<!-- secondary for single) to its Unicode character, exactly as -->
+<!-- the HTML conversion does, through the shared lookup.       -->
 <xsl:template match="*" mode="lsq-character">
-    <xsl:text>&#x2018;</xsl:text>
+    <xsl:apply-templates select="." mode="quote-character-unicode">
+        <xsl:with-param name="style">
+            <xsl:apply-templates select="." mode="get-quote-secondary"/>
+        </xsl:with-param>
+        <xsl:with-param name="side" select="'left'"/>
+    </xsl:apply-templates>
 </xsl:template>
 <xsl:template match="*" mode="rsq-character">
-    <xsl:text>&#x2019;</xsl:text>
+    <xsl:apply-templates select="." mode="quote-character-unicode">
+        <xsl:with-param name="style">
+            <xsl:apply-templates select="." mode="get-quote-secondary"/>
+        </xsl:with-param>
+        <xsl:with-param name="side" select="'right'"/>
+    </xsl:apply-templates>
 </xsl:template>
 <xsl:template match="*" mode="lq-character">
-    <xsl:text>&#x201c;</xsl:text>
+    <xsl:apply-templates select="." mode="quote-character-unicode">
+        <xsl:with-param name="style">
+            <xsl:apply-templates select="." mode="get-quote-primary"/>
+        </xsl:with-param>
+        <xsl:with-param name="side" select="'left'"/>
+    </xsl:apply-templates>
 </xsl:template>
 <xsl:template match="*" mode="rq-character">
-    <xsl:text>&#x201d;</xsl:text>
+    <xsl:apply-templates select="." mode="quote-character-unicode">
+        <xsl:with-param name="style">
+            <xsl:apply-templates select="." mode="get-quote-primary"/>
+        </xsl:with-param>
+        <xsl:with-param name="side" select="'right'"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- The adornments of manually-tagged equations.  The star and -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9145,32 +9145,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Special Characters -->
 <!-- ################## -->
 
-<!-- Quotation marks come in left and right variants. -->
-<!-- The lookup table is in pretext-common.xsl.       -->
-<xsl:template match="*" mode="quote-character-unicode">
-    <xsl:param name="style"/>
-    <xsl:param name="side"/>
-    <xsl:variable name="unicode-character">
-        <xsl:for-each select="$quote-character-table">
-            <xsl:value-of select="key('quote-character-key',
-                concat($style, '|', $side))/@unicode-character"/>
-        </xsl:for-each>
-    </xsl:variable>
-    <xsl:choose>
-        <xsl:when test="$unicode-character != ''">
-            <xsl:value-of select="$unicode-character"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:message>
-                <xsl:text>PTX:BUG:  a quotation style ("</xsl:text>
-                <xsl:value-of select="$style"/>
-                <xsl:text>") for a left quote character in HTML was not recognized</xsl:text>
-            </xsl:message>
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-
 <!-- Left Single Quote -->
 <xsl:template match="*" mode="lsq-character">
     <xsl:apply-templates select="." mode="quote-character-unicode">


### PR DESCRIPTION
The XSL-FO (LaTeX-free PDF) conversion hard-coded English curly quotes
for every `<q>`/`<sq>`/`<lq>`/`<rq>`/`<lsq>`/`<rsq>`, regardless of the
document's language. This makes it localize by language, the way the
HTML conversion already does, reusing the shared machinery rather than
duplicating it.

## Changes

- **Share the quotation-style lookup.** The style-and-side → Unicode
  reader (`quote-character-unicode`) lived privately in
  `pretext-html.xsl`. It is promoted into `pretext-common.xsl`, beside
  the lookup table, key, and `get-quote-primary`/`get-quote-secondary`
  language resolvers it already depends on. HTML inherits it unchanged.

- **Localize the FO quotes.** The four FO quote-character templates now
  resolve the ambient quotation style (primary for double, secondary
  for single) and look up the character through that shared template —
  identical in spirit to HTML. English output is unchanged; other
  languages now get their national marks (German `„…"`, French
  `«…»`, etc.).

- **Draw the narrow no-break space from the symbol font.** The French
  styles set a narrow no-break space (U+202F) beside each guillemet,
  and Latin Modern (the conversion's text font) has no such glyph, so a
  literal U+202F printed as a missing-glyph box. A new isolated
  `narrow-no-break-space-character` template draws it from the symbol
  font, exactly as the conversion already does for the tombstone, the
  white brackets, and the equation-tag marks.

## Testing

The sample article's multilingual quotation demo (en-US, fr-FR, fr-CA,
de-DE, each with primary and secondary marks) exercises every path. A
before/after `pdf-fo` build of the sample article confirms:

- English: byte-for-byte unchanged (no regression);
- German: correct low quotes `„…"` / `‚…'`;
- French (FR and CA): correct guillemets with their narrow spacing, and
  no missing-glyph boxes (FOP reports no U+202F glyph warning).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
