### PR TITLE
HTML: revert to MathJax version 4.1.1

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13629,7 +13629,7 @@ TODO:
     <!-- MathJax 4 CDN -->
     <script defer="true">
         <xsl:attribute name="src">
-            <xsl:text>https://cdn.jsdelivr.net/npm/mathjax@4/</xsl:text>
+            <xsl:text>https://cdn.jsdelivr.net/npm/mathjax@4.1.1/</xsl:text>
             <xsl:choose>
                 <xsl:when test="$debug.mathjax.svg = 'yes'">
                     <xsl:text>tex-svg.js</xsl:text>


### PR DESCRIPTION
For consideration. See my forum post about how MathJax 4.1.2 has a rather serious bug.

I'm not sure where else MathJax versions are specified (for braille extraction, etc). So maybe ignore this if there is a larger reversion to make.

Or maybe you don't want to make this reversion. But I thought it wouldn't hurt to get the ball rolling in case you agree it should be done.