### PR TITLE
XSL-FO: multicolumn "ol"/"ul" via "@cols"

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -5720,6 +5720,11 @@
                 <p>Periods, commas, and semi-colons that follow directly after mathematics are handled differently by <pretext/> for visual formats versus non-visual ones (e.g. braille, audio).   But this only happens if you author the punctuation in the <em>logically</em> correct location and let <pretext/> do the rest for you.  See <xref ref="authoring-math-punctuation"/> and <xref ref="punctuation-display-math"/> for details.</p>
             </li>
 
+            <li>
+                <title>Multiple Columns</title>
+                <p>The <attr>cols</attr> attribute on a list (<tag>ol</tag>, <tag>ul</tag>) or on an <tag>exercisegroup</tag> is purely presentational<mdash/>it packs items into several columns to save space.  Prefer to leave it off.  Multiple columns are of no help to a screen reader, and in some conversions they carry a cost: the conversion to <init>PDF</init> via <init>XSL-FO</init> cannot flow a single block into balanced columns, so a multi-column list must be built as a table.  Each item keeps its marker, but a screen reader then navigates the result cell by cell<mdash/>each cell announced as its own one-item list<mdash/>rather than reading a single list; an <tag>exercisegroup</tag> is likewise announced as a table.  Column layout is better left as a publisher or styling choice than fixed in your source.</p>
+            </li>
+
         </dl></p>
     </subsection>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1862,12 +1862,50 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- wide markers (e.g. "xviii.") may eventually warrant a width  -->
 <!-- computed from the actual labels.                             -->
 <xsl:template match="ol|ul">
-    <fo:list-block provisional-distance-between-starts="2em"
-                   provisional-label-separation="0.25em"
-                   space-before="0.5em"
-                   space-after="0.5em">
-        <xsl:apply-templates select="li"/>
-    </fo:list-block>
+    <xsl:choose>
+        <!-- A "cols" request (2 to 6) lays the items out in that many    -->
+        <!-- equal columns.  XSL-FO has no block-level multicolumn (only  -->
+        <!-- a page region carries "column-count"), so the columns are an -->
+        <!-- fo:table, filled across each row, padding a short final row  -->
+        <!-- for the equal-width rows a tagged table needs (ISO 14289-1). -->
+        <!-- Each cell is a one-item fo:list-block, so the marker shows   -->
+        <!-- and the item keeps "L"/"LI" structure for a screen reader    -->
+        <!-- despite the table layout.                                    -->
+        <xsl:when test="@cols">
+            <xsl:variable name="cols" select="@cols"/>
+            <fo:table table-layout="fixed" width="100%" space-before="0.5em" space-after="0.5em">
+                <xsl:call-template name="equal-table-columns">
+                    <xsl:with-param name="remaining" select="$cols"/>
+                </xsl:call-template>
+                <fo:table-body>
+                    <xsl:for-each select="li[(position() mod $cols) = 1]">
+                        <fo:table-row>
+                            <xsl:variable name="row-items" select=".|following-sibling::li[position() &lt; $cols]"/>
+                            <xsl:for-each select="$row-items">
+                                <fo:table-cell padding-right="6pt">
+                                    <fo:list-block provisional-distance-between-starts="2em"
+                                                   provisional-label-separation="0.25em">
+                                        <xsl:apply-templates select="."/>
+                                    </fo:list-block>
+                                </fo:table-cell>
+                            </xsl:for-each>
+                            <xsl:call-template name="empty-table-cells">
+                                <xsl:with-param name="remaining" select="$cols - count($row-items)"/>
+                            </xsl:call-template>
+                        </fo:table-row>
+                    </xsl:for-each>
+                </fo:table-body>
+            </fo:table>
+        </xsl:when>
+        <xsl:otherwise>
+            <fo:list-block provisional-distance-between-starts="2em"
+                           provisional-label-separation="0.25em"
+                           space-before="0.5em"
+                           space-after="0.5em">
+                <xsl:apply-templates select="li"/>
+            </fo:list-block>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="ol/li|ul/li">


### PR DESCRIPTION
`@cols` on `ol`/`ul` (2–6) was ignored in the `pdf-fo` conversion — lists always rendered single-column. This lays them out in the requested number of columns.

**Approach.** The columns are an `fo:table` (equal columns, filled row-major, short final row padded for the equal-width rows a tagged table needs), mirroring the existing `exercisegroup @cols`. Each cell holds a **one-item `fo:list-block`**, so the marker still shows and each item keeps `L`/`LI` list structure inside its cell. Row-major vs column-major is treated as presentational (HTML is row-major, LaTeX column-major); this follows HTML.

**Two accessibility avenues were investigated and rejected:**
- *Native page columns.* XSL-FO's only multicolumn is `column-count` on `fo:region-body` — exactly how the index renders two columns. Using it for a list means placing the list in its own `fo:page-sequence`, which forces a page break before and after; unacceptable for a list inside running prose. So an inline list cannot use native columns, leaving `fo:table` as the only option.
- *A silent screen-reader description.* I tried to attach an AT-only description to the table (so it could announce, e.g., "a list in two columns"). FOP 2.8 ignores `fox:alt-text` on both `fo:table` and `fo:block` (verified — no `/Alt` or `/ActualText` is emitted) and exposes no table-`Summary` property. The only alternative was a visible caption, which we chose not to add. So the layout is announced as a table; the per-cell list markup is the AT signal that these are list items. (A publisher switch to *flatten* multi-column layouts for exactly this reason is proposed in #2943.)

**Related Guide content.** This PR also adds an author-facing note in the Accessibility section of the Guide, discouraging `@cols`/multicolumn: columns are presentational, and in PDF they force the list into a table for assistive technology.

**Testing** (sample article, `pdf-fo`): the 5-column numbered list and the 2-column text and derivative/antiderivative lists render with columns and markers intact; single-column lists are unchanged. veraPDF PDF/UA-1: compliant, 106 rules / 0 failures. The Guide validates against the dev schema.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
