### PR TITLE
Accessibility updates for calculator

### DIFF
--- a/css/components/helpers/_dialogs.scss
+++ b/css/components/helpers/_dialogs.scss
@@ -11,10 +11,15 @@ $border-radius: 0 !default;
   box-shadow: 0 0 5px var(--dialog-shadow-color);
   color: var(--dialog-text-color);
 
-  & .ptx-dialog-close-button {
+  .ptx-dialog-close-button {
     @include buttons.ptx-button(
       $border-width: 0
     );
+  }
+
+  .ptx-dialog-topbar {
+    min-height: 15px;
+    user-select: none;
   }
 }
 

--- a/css/components/interactives/_calculators.scss
+++ b/css/components/interactives/_calculators.scss
@@ -1,19 +1,30 @@
 // GeoGebra calculator
+@use 'components/helpers/dialogs' as dialogs;
 
 $navbar-breakpoint: 856px !default;
 
 .ptx-calculator-container {
   position: fixed;
   z-index: 100;
-  bottom: 5px;
-  right: 5px;
-  width: 253px;
-  height: 460px;
+  top: max(10px, calc(100vh - 650px));
+  left: max(10px, calc(100vw - 350px));
+  padding: 0;
+  width: 330px;
+  height: 600px;
+  resize: both;
+  overflow: hidden;
+  flex-direction: column;
+  @include dialogs.ptx-dialog-modal;
 }
 
-@media screen and (max-width: $navbar-breakpoint) {
-  .ptx-calculator-container {
-    //assumes navbar moves to bottom of screen
-    bottom: 50px !important;
+.ptx-calculator-container[open] {
+  display: flex;
+}
+
+.ptx-geogebra-calculator {
+  flex: 1;
+
+  .button {
+    all: unset;  //get rid of ptx ".button" styles that interfere with geogebra's buttons
   }
 }

--- a/css/components/interactives/_calculators.scss
+++ b/css/components/interactives/_calculators.scss
@@ -2,7 +2,7 @@
 
 $navbar-breakpoint: 856px !default;
 
-.calculator-container {
+.ptx-calculator-container {
   position: fixed;
   z-index: 100;
   bottom: 5px;
@@ -12,7 +12,7 @@ $navbar-breakpoint: 856px !default;
 }
 
 @media screen and (max-width: $navbar-breakpoint) {
-  .calculator-container {
+  .ptx-calculator-container {
     //assumes navbar moves to bottom of screen
     bottom: 50px !important;
   }

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -109,7 +109,7 @@ $center-content: true !default;
     display: none;
   }
 
-  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .calculator-toggle, .light-dark-button, .ptx-embed-button) .name {
+  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .ptx-calculator-toggle, .light-dark-button, .ptx-embed-button) .name {
     @include accessibility.sr-only;
   }
 
@@ -191,7 +191,7 @@ $center-content: true !default;
       bottom: $nav-height;
     }
 
-    :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button, .ptx-embed-button) .name {
+    :is(.toc-toggle, .previous-button, .up-button, .next-button, .ptx-calculator-toggle, .index-button, .ptx-embed-button) .name {
       display: none;
     }
   }

--- a/css/legacy/colors/colors_blue_red_dark.css
+++ b/css/legacy/colors/colors_blue_red_dark.css
@@ -96,10 +96,10 @@
     background-color: #fafafa;
     color: #000;
   }
-  .ptx-navbar .calculator-toggle {
+  .ptx-navbar .ptx-calculator-toggle {
     background-color: #336;
   }
-  .ptx-navbar .calculator-toggle:hover {
+  .ptx-navbar .ptx-calculator-toggle:hover {
     background-color: #fce;
   }
 

--- a/css/legacy/colors/setcolors.css
+++ b/css/legacy/colors/setcolors.css
@@ -371,10 +371,10 @@ body.pretext {
   background-color: var(--linkbackgroundhighlight);
   color: var(--bodyfontcolorhighlight);
 }
-.pretext[data-atmosphere*="dark"] .ptx-navbar .calculator-toggle {
+.pretext[data-atmosphere*="dark"] .ptx-navbar .ptx-calculator-toggle {
   background-color: var(--buttonbackground);
 }
-.pretext[data-atmosphere*="dark"] .ptx-navbar .calculator-toggle:hover {
+.pretext[data-atmosphere*="dark"] .ptx-navbar .ptx-calculator-toggle:hover {
   background-color: var(--linkbackgroundhighlight);
   color: var(--bodyfontcolorhighlight);
 }

--- a/css/legacy/pretext_add_on.css
+++ b/css/legacy/pretext_add_on.css
@@ -2749,7 +2749,7 @@ body.standalone.worksheet .ptx-content section.worksheet > .heading + .para {
 
 /* GeoGebra calculator */
 
-.calculator-container {
+.ptx-calculator-container {
     position: fixed;
     z-index: 100;
     bottom: 5px;
@@ -2764,7 +2764,7 @@ body.standalone.worksheet .ptx-content section.worksheet > .heading + .para {
     height: 460px;
 }
 @media screen and (max-width: 800px) {
-    .calculator-container {
+    .ptx-calculator-container {
          bottom: 50px !important;
     }
 }

--- a/css/targets/html/legacy/crc/navbar_crc.css
+++ b/css/targets/html/legacy/crc/navbar_crc.css
@@ -7,11 +7,11 @@
 }
 
 .ptx-navbar .previous-button, .ptx-navbar .up-button, .ptx-navbar .next-button,
-.ptx-navbar .index-button, .ptx-navbar .calculator-toggle, .ptx-navbar .toc-toggle {
+.ptx-navbar .index-button, .ptx-navbar .ptx-calculator-toggle, .ptx-navbar .toc-toggle {
   width: unset;
 }
 
-.ptx-navbar .calculator-toggle {
+.ptx-navbar .ptx-calculator-toggle {
   margin-left: unset;
   margin-right: unset;
 }
@@ -136,7 +136,7 @@ nav.ptx-navbar::after {
     grid-area: MH-extras-area1;
     justify-self: right;
 }
-.calculator-toggle {
+.ptx-calculator-toggle {
     grid-area: MH-extras-area2;
     justify-self: left;
 }
@@ -236,11 +236,11 @@ nav.ptx-navbar::after {
         justify-content: center;
     }
     
-    .ptx-navbar :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button) .name {
+    .ptx-navbar :is(.toc-toggle, .previous-button, .up-button, .next-button, .ptx-calculator-toggle, .index-button) .name {
         display: none;
     }
 
-    .pretext .ptx-navbar :is(.calculator-toggle, .index-button) .icon {
+    .pretext .ptx-navbar :is(.ptx-calculator-toggle, .index-button) .icon {
         display: inline-block;
     }
 
@@ -289,10 +289,10 @@ nav.ptx-navbar::after {
     display: none;
 }
 
-.ptx-navbar .calculator-toggle .name {
+.ptx-navbar .ptx-calculator-toggle .name {
     /*  Nada */
 }
-.ptx-navbar .calculator-toggle .icon {
+.ptx-navbar .ptx-calculator-toggle .icon {
     display: none;
 }
 
@@ -357,7 +357,7 @@ nav.ptx-navbar::after {
         margin: 0;
     }
 
-    .ptx-navbar .calculator-toggle .icon {
+    .ptx-navbar .ptx-calculator-toggle .icon {
         padding-top: 5px;
     }
 }

--- a/css/targets/html/legacy/default/navbar_default.css
+++ b/css/targets/html/legacy/default/navbar_default.css
@@ -114,7 +114,7 @@ nav.ptx-navbar {
   margin: 0 -7px;  /* chevrons have lots of horizontal padding */
 }
 
-.ptx-navbar :is(.index-button, .calculator-toggle)  .icon {
+.ptx-navbar :is(.index-button, .ptx-calculator-toggle)  .icon {
   display: none;
 }
 .ptx-navbar :is(.runestone-profile, .activecode-toggle, .ptx-search-button) .name {
@@ -125,7 +125,7 @@ nav.ptx-navbar {
   width: 70px;
 }
 
-.ptx-navbar .calculator-toggle {
+.ptx-navbar .ptx-calculator-toggle {
   width: 60px;
   min-height: 32px;
   text-align: center;
@@ -137,7 +137,7 @@ nav.ptx-navbar {
   background-color: #eef;
 }
 
-.ptx-navbar .calculator-toggle.open {
+.ptx-navbar .ptx-calculator-toggle.open {
   background: #fee;
   border: 2px solid #f66;
 }
@@ -174,11 +174,11 @@ nav.ptx-navbar {
     border-left: 0;
   }
 
-  .ptx-navbar :is(.toc-toggle, .previous-button, .up-button, .next-button, .calculator-toggle, .index-button) .name {
+  .ptx-navbar :is(.toc-toggle, .previous-button, .up-button, .next-button, .ptx-calculator-toggle, .index-button) .name {
     display: none;
   }
 
-  .pretext .ptx-navbar :is(.calculator-toggle, .index-button) .icon {
+  .pretext .ptx-navbar :is(.ptx-calculator-toggle, .index-button) .icon {
     display: inline-block;
   }
 
@@ -186,7 +186,7 @@ nav.ptx-navbar {
     border-left: 0
   }
 
-  .ptx-navbar .calculator-toggle {
+  .ptx-navbar .ptx-calculator-toggle {
     width: auto;
     height: 35px;
     border-radius: 0;

--- a/css/targets/html/legacy/min/shell_min.css
+++ b/css/targets/html/legacy/min/shell_min.css
@@ -248,7 +248,7 @@
   .pretext .ptx-toc {
     height: calc(100vh - 50px);
   }
-  .pretext .ptx-navbar .calculator-toggle,
+  .pretext .ptx-navbar .ptx-calculator-toggle,
   .pretext .ptx-navbar .index-button {
     display: none;
   }

--- a/css/targets/html/legacy/wide/navbar_wide.scss
+++ b/css/targets/html/legacy/wide/navbar_wide.scss
@@ -25,7 +25,7 @@
   border-left: 0;
 }
 
-.ptx-navbar .calculator-toggle {
+.ptx-navbar .ptx-calculator-toggle {
   width: auto;
   height: 35px;
   text-align: center;

--- a/js/dist/pretext-core.js
+++ b/js/dist/pretext-core.js
@@ -501,21 +501,6 @@
       return key;
     }
   };
-  function getScrollbarWidth() {
-    var outer = document.createElement("div");
-    outer.style.visibility = "hidden";
-    outer.style.width = "100px";
-    outer.style.msOverflowStyle = "scrollbar";
-    document.body.appendChild(outer);
-    var widthNoScroll = outer.offsetWidth;
-    outer.style.overflow = "scroll";
-    var inner = document.createElement("div");
-    inner.style.width = "100%";
-    outer.appendChild(inner);
-    var widthWithScroll = inner.offsetWidth;
-    outer.parentNode.removeChild(outer);
-    return widthNoScroll - widthWithScroll;
-  }
   async function copyPermalink(linkNode) {
     if (!navigator.clipboard) {
       console.log("Error: Clipboard API not available");
@@ -705,53 +690,62 @@
     console.log("processing workspace");
     MathJax.typesetPromise();
   }
-  function pretext_geogebra_calculator_onload() {
-    $("#calculator-toggle").focus();
-    var inputfield = $("input.gwt-SuggestBox.TextField")[0];
-    console.log("inputfield", inputfield);
-    inputfield.focus();
-  }
   window.addEventListener("load", function(event2) {
-    var scrollWidth = getScrollbarWidth();
-    if (navigator.userAgent.match(/Mozilla/i) != null) {
+    const calcDialogElement = document.getElementById("ptx-calculator-container");
+    const calcButtonElement = document.getElementById("ptx-calculator-toggle");
+    if (!calcDialogElement || !calcButtonElement) {
+      return;
     }
-    console.log("scrollWidth", scrollWidth);
-    calcoffsetR = 5;
-    calcoffsetB = 5;
-    $("body").on("mouseover", "#geogebra-calculator canvas", function() {
-      $("body").css("overflow", "hidden");
-      $("html").css("margin-right", "15px");
-      $("#calculator-container").css("right", (calcoffsetR + scrollWidth).toString() + "px");
-      $("#calculator-container").css("bottom", (calcoffsetB + scrollWidth).toString() + "px");
-    });
-    $("body").on("mouseout", "#geogebra-calculator canvas", function() {
-      $("body").css("overflow", "scroll");
-      $("html").css("margin-right", "0");
-      $("#calculator-container").css("right", calcoffsetR.toString() + "px");
-      $("#calculator-container").css("bottom", calcoffsetB.toString() + "px");
-    });
-    $("body").on("click", "#calculator-toggle", function() {
-      if ($("#calculator-container").css("display") == "none") {
-        $("#calculator-container").css("display", "block");
-        $("#calculator-toggle").addClass("open");
-        $("#calculator-toggle").attr("title", "Hide calculator");
-        $("#calculator-toggle").attr("aria-expanded", "true");
-        create_calc_script = document.getElementById("create_ggb_calc");
-        if (!create_calc_script) {
-          var ggbscript = document.createElement("script");
-          ggbscript.id = "create_ggb_calc";
-          ggbscript.innerHTML = "ggbApp.inject('geogebra-calculator')";
-          document.body.appendChild(ggbscript);
+    const calcDialog = new PTXDialog(calcDialogElement, calcButtonElement, { "kind": "non-modal" });
+    const focusCalcInput = function() {
+      const inputField = document.querySelector("#ptx-geogebra-calculator input.gwt-SuggestBox.TextField");
+      if (inputField) {
+        inputField.focus();
+      }
+    };
+    function initGeogebra() {
+      const geoGebraDiv = document.getElementById("ptx-geogebra-calculator");
+      const fixedParams = {
+        showToolBar: true,
+        showAlgebraInput: true,
+        perspective: "G/A",
+        algebraInputPosition: "bottom",
+        appletOnLoad: focusCalcInput,
+        scaleContainerClass: "ptx-calculator-container",
+        allowUpscale: false,
+        autoHeight: false
+      };
+      const generatedParams = typeof ggbParams === "object" && ggbParams ? ggbParams : {};
+      const params = { ...generatedParams, ...fixedParams };
+      let applet2 = new GGBApplet(params, true);
+      applet2.inject("ptx-geogebra-calculator");
+      return applet2;
+    }
+    let applet;
+    calcButtonElement.addEventListener("click", function() {
+      if (calcDialog.dialog.open) {
+        let initialized = calcDialogElement.dataset.initialized || false;
+        if (!initialized) {
+          applet = initGeogebra();
+          calcDialogElement.dataset.initialized = true;
         } else {
-          pretext_geogebra_calculator_onload();
+          focusCalcInput();
         }
-      } else {
-        $("#calculator-container").css("display", "none");
-        $("#calculator-toggle").removeClass("open");
-        $("#calculator-toggle").attr("title", "Show calculator");
-        $("#calculator-toggle").attr("aria-expanded", "false");
       }
     });
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        if (entry.target === calcDialogElement && applet && applet.getAppletObject()) {
+          const width = entry.contentRect.width;
+          const height = entry.contentRect.height;
+          const geoGebraDiv = document.getElementById("ptx-geogebra-calculator");
+          const topBarHeight = calcDialogElement.querySelector(".ptx-dialog-topbar").clientHeight || 0;
+          applet.getAppletObject().setSize(width, height - topBarHeight);
+          applet.getAppletObject().recalculateEnvironments();
+        }
+      }
+    });
+    resizeObserver.observe(calcDialogElement);
   });
   window.addEventListener(
     "load",
@@ -1468,9 +1462,29 @@
       this.controlElement = openButton;
       this.kind = options.kind || "modal";
       this.isModal = this.kind === "modal" || this.kind === "light-close";
-      this.openButton = openButton;
-      if (this.openButton && !_PTXDialog.hasNativeCommandInvokers()) {
-        this.openButton.addEventListener("click", () => this.open());
+      if (!this.dialog) {
+        console.log("PTXDialog: No dialog element provided.");
+        return;
+      }
+      this.dialog.setAttribute("aria-modal", this.isModal ? "true" : "false");
+      if (_PTXDialog.hasNativeCommandInvokers()) {
+        if (this.isModal) {
+          this.dialog.closedBy = this.kind !== "light-close" ? "closerequest" : "any";
+        } else {
+          this.dialog.closedBy = "none";
+        }
+      }
+      if (this.controlElement) {
+        this.controlElement.setAttribute("aria-expanded", "false");
+        this.controlElement.setAttribute("aria-controls", this.dialog.id);
+        if (_PTXDialog.hasNativeCommandInvokers()) {
+          this.controlElement.commandFor = this.dialog.id;
+        }
+        if (this.isModal) {
+          this.controlElement.addEventListener("click", () => this.open());
+        } else {
+          this.controlElement.addEventListener("click", () => this.toggle());
+        }
       }
       this.closeButton = options.closeButton;
       if (!this.closeButton && this.isModal) {
@@ -1478,7 +1492,7 @@
         topBar.classList.add("ptx-dialog-topbar");
         this.dialog.prepend(topBar);
         this.closeButton = document.createElement("button");
-        this.closeButton.classList.add("ptx-dialog-close-button");
+        this.closeButton.classList.add("button", "ptx-dialog-close-button");
         this.closeButton.setAttribute("aria-label", "Close dialog");
         this.closeButton.innerHTML = `<span class="material-symbols-outlined">close</span>`;
         topBar.appendChild(this.closeButton);
@@ -1486,11 +1500,20 @@
       if (this.closeButton) {
         this.closeButton.addEventListener("click", () => this.close());
       }
+      if (!this.isModal) {
+        const topBar = document.createElement("div");
+        topBar.classList.add("ptx-dialog-topbar");
+        this.topBar = topBar;
+        this.dialog.prepend(topBar);
+      }
       if (_PTXDialog.hasNativeCommandInvokers()) {
         this.open = () => {
           if (this.isModal) {
             this.dialog.showModal();
           } else {
+            if (this.controlElement) {
+              this.setExpanded(true);
+            }
             this.dialog.show();
           }
         };
@@ -1498,6 +1521,7 @@
           this.dialog.close();
           if (this.controlElement) {
             this.controlElement.focus();
+            this.setExpanded(false);
           }
         };
         this.toggle = () => {
@@ -1512,7 +1536,7 @@
         this.close = () => this.closeDialogFallback();
         this.toggle = () => this.toggleDialogFallback();
       }
-      if (this.kind === "light-close") {
+      if (!_PTXDialog.hasNativeCommandInvokers() && this.kind === "light-close") {
         this.dialog.addEventListener("click", (event2) => {
           if (event2.target === this.dialog) {
             const rect = this.dialog.getBoundingClientRect();
@@ -1523,6 +1547,59 @@
           }
         });
       }
+      if (this.isModal) {
+        this.dialog.addEventListener("keydown", (event2) => {
+          if (event2.key === "Escape") {
+            this.close();
+          }
+        });
+      }
+      if (!this.isModal) {
+        const topBar = this.dialog.querySelector(".ptx-dialog-topbar");
+        let isDragging = false;
+        let offsetX = 0;
+        let offsetY = 0;
+        topBar.addEventListener("pointerover", (e2) => {
+          topBar.style.cursor = "move";
+        });
+        topBar.addEventListener("pointerdown", (e2) => {
+          isDragging = true;
+          const dialogRect = this.dialog.getBoundingClientRect();
+          offsetX = e2.clientX - dialogRect.left;
+          offsetY = e2.clientY - dialogRect.top;
+          topBar.setPointerCapture(e2.pointerId);
+        });
+        topBar.addEventListener("pointermove", (e2) => {
+          if (!isDragging) return;
+          const newX = e2.clientX - offsetX;
+          const newY = e2.clientY - offsetY;
+          this.dialog.style.left = `${newX}px`;
+          this.dialog.style.top = `${newY}px`;
+          this.dialog.style.bottom = "auto";
+          this.dialog.style.right = "auto";
+        });
+        topBar.addEventListener("pointerup", (e2) => {
+          isDragging = false;
+          topBar.releasePointerCapture(e2.pointerId);
+        });
+        window.addEventListener("resize", (event2) => {
+          this.dialog.style.left = "";
+          this.dialog.style.right = "";
+          if (this.dialog.getBoundingClientRect().top > window.innerHeight) {
+            this.dialog.style.top = "20px";
+          }
+        });
+      }
+    }
+    setExpanded(expanded) {
+      if (this.controlElement) {
+        this.controlElement.setAttribute("aria-expanded", expanded ? "true" : "false");
+        if (expanded) {
+          this.controlElement.classList.add("open");
+        } else {
+          this.controlElement.classList.remove("open");
+        }
+      }
     }
     openDialogFallback() {
       if (this.dialog && typeof this.dialog.showModal === "function" && !this.dialog.open) {
@@ -1531,11 +1608,13 @@
         } else {
           this.dialog.show();
         }
+        this.setExpanded(true);
       }
     }
     closeDialogFallback() {
       if (this.dialog && typeof this.dialog.close === "function" && this.dialog.open) {
         this.dialog.close();
+        this.setExpanded(false);
       }
       if (this.controlElement) {
         this.controlElement.focus();

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1319,19 +1319,26 @@ class PTXDialog {
         }
 
         this.closeButton = options.closeButton;
-        // add a close button unless the dialog already has one as identified in options
+        // add a close button to modals unless the dialog already has one as identified in options
         if (!this.closeButton && this.isModal) {
             const topBar = document.createElement("div");
             topBar.classList.add("ptx-dialog-topbar");
             this.dialog.prepend(topBar);
             this.closeButton = document.createElement("button");
-            this.closeButton.classList.add("ptx-dialog-close-button");
+            this.closeButton.classList.add("button", "ptx-dialog-close-button");
             this.closeButton.setAttribute("aria-label", "Close dialog");
             this.closeButton.innerHTML = `<span class="material-symbols-outlined">close</span>`;
             topBar.appendChild(this.closeButton);
         }
         if (this.closeButton) {
             this.closeButton.addEventListener("click", () => this.close());
+        }
+        if (!this.isModal) {
+            // For non-modal dialogs, make a top bar as a grab area for dragging
+            const topBar = document.createElement("div");
+            topBar.classList.add("ptx-dialog-topbar");
+            this.topBar = topBar;
+            this.dialog.prepend(topBar);
         }
 
         if (PTXDialog.hasNativeCommandInvokers()) {
@@ -1371,7 +1378,7 @@ class PTXDialog {
             this.toggle = () => this.toggleDialogFallback();
         }
 
-        if (this.kind === "light-close") {
+        if (!PTXDialog.hasNativeCommandInvokers() && this.kind === "light-close") {
             // Add event listener to close the dialog if the user clicks outside of it
             this.dialog.addEventListener("click", (event) => {
                 if (event.target === this.dialog) {
@@ -1387,6 +1394,63 @@ class PTXDialog {
                     if (!isInDialog) {
                         this.close();
                     }
+                }
+            });
+        }
+
+        // make non-modal dialogs draggable by their top bar
+        if (!this.isModal) {
+            const topBar = this.dialog.querySelector(".ptx-dialog-topbar");
+            let isDragging = false;
+            let offsetX = 0;
+            let offsetY = 0;
+            
+            topBar.addEventListener("pointerover", (e) => {
+                topBar.style.cursor = "move";
+            });
+
+            // Trigger when the user presses down on the element
+            topBar.addEventListener("pointerdown", (e) => {
+                isDragging = true;
+
+                const dialogRect = this.dialog.getBoundingClientRect();
+
+                // Track the pointer offset within the dialog so movement stays smooth.
+                offsetX = e.clientX - dialogRect.left;
+                offsetY = e.clientY - dialogRect.top;
+                
+                // Lock pointer to capture movement even outside the element boundaries
+                topBar.setPointerCapture(e.pointerId);
+            });
+
+            // Trigger as the user moves the pointer
+            topBar.addEventListener("pointermove", (e) => {
+                if (!isDragging) return;
+
+                // Calculate new coordinates from the current pointer position.
+                const newX = e.clientX - offsetX;
+                const newY = e.clientY - offsetY;
+
+                // Apply styles to move the element.
+                this.dialog.style.left = `${newX}px`;
+                this.dialog.style.top = `${newY}px`;
+                this.dialog.style.bottom = "auto"; // Reset bottom to auto to allow top positioning
+                this.dialog.style.right = "auto"; // Reset right to auto to allow left positioning
+            });
+
+            // Trigger when the user releases the pointer
+            topBar.addEventListener("pointerup", (e) => {
+                isDragging = false;
+                topBar.releasePointerCapture(e.pointerId);
+            });
+            
+            // Make sure we stay in view during resizes
+            window.addEventListener('resize', (event) => {
+                this.dialog.style.left = '';
+                this.dialog.style.right = '';
+                // make sure top is in viewport
+                if (this.dialog.getBoundingClientRect().top > window.innerHeight) {
+                    this.dialog.style.top = '20px';
                 }
             });
         }

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -23,32 +23,6 @@ window.i18next = window.i18next || {
     }
 };
 
-/* scrollbar width from https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript */
-function getScrollbarWidth() {
-    var outer = document.createElement("div");
-    outer.style.visibility = "hidden";
-    outer.style.width = "100px";
-    outer.style.msOverflowStyle = "scrollbar"; // needed for WinJS apps
-
-    document.body.appendChild(outer);
-
-    var widthNoScroll = outer.offsetWidth;
-    // force scrollbars
-    outer.style.overflow = "scroll";
-
-    // add innerdiv
-    var inner = document.createElement("div");
-    inner.style.width = "100%";
-    outer.appendChild(inner);
-
-    var widthWithScroll = inner.offsetWidth;
-
-    // remove divs
-    outer.parentNode.removeChild(outer);
-
-    return widthNoScroll - widthWithScroll;
-}
-
 /*
   copy permalink address to clipboard
   requires browser support, otherwise does nothing
@@ -312,61 +286,69 @@ function process_workspace() {
     console.log("processing workspace");
     MathJax.typesetPromise();
 }
-/* for the GeoGebra calculator */
 
-function pretext_geogebra_calculator_onload() {
-    $("#calculator-toggle").focus();
-    var inputfield = $("input.gwt-SuggestBox.TextField")[0];
-    console.log("inputfield", inputfield);
-    inputfield.focus();
-}
 window.addEventListener("load",function(event) {
+    const calcDialogElement = document.getElementById('ptx-calculator-container');
+    const calcButtonElement = document.getElementById('ptx-calculator-toggle');
+    if (!calcDialogElement || !calcButtonElement) {
+        return;
+    }
+    const calcDialog = new PTXDialog(calcDialogElement, calcButtonElement, {"kind": "non-modal"});
 
-   /* scrolling on GG plot should scale, not move browser body */
-//     var scrollWidth = 15;  //currently correct for FF, Ch, and Saf, but would be better to calculate
-     var scrollWidth = getScrollbarWidth();
-     if ( (navigator.userAgent.match(/Mozilla/i) != null) ) {
-        // scrollWidth += 0.5
-     }
-     console.log("scrollWidth", scrollWidth);
-     calcoffsetR = 5;
-     calcoffsetB = 5;
-     $('body').on('mouseover','#geogebra-calculator canvas', function(){
-         $('body').css('overflow', 'hidden');
-         $('html').css('margin-right', '15px');
-         $('#calculator-container').css('right', (calcoffsetR+scrollWidth).toString() + 'px');
-         $('#calculator-container').css('bottom', (calcoffsetB+scrollWidth).toString() + 'px');
-     });
+    const focusCalcInput = function() {
+        const inputField = document.querySelector("#ptx-geogebra-calculator input.gwt-SuggestBox.TextField");
+        if (inputField) {
+            inputField.focus();
+        }
+    }
+    function initGeogebra() {
+        const geoGebraDiv = document.getElementById('ptx-geogebra-calculator');
+        // Some paramaters are fixed here, others are set by publisher options in the HTML source
+        // and stored in ggbParams. Merge those here.
+        const fixedParams = {
+            showToolBar: true,
+            showAlgebraInput: true,
+            perspective: "G/A",
+            algebraInputPosition: "bottom",
+            appletOnLoad: focusCalcInput,
+            scaleContainerClass: "ptx-calculator-container",
+            allowUpscale: false,
+            autoHeight: false,
+        }
+        const generatedParams = (typeof ggbParams === "object" && ggbParams) ? ggbParams : {};
+        const params = {...generatedParams, ...fixedParams};
+        let applet = new GGBApplet(params, true);
+        applet.inject('ptx-geogebra-calculator');
+        return applet;
+    }
 
-     $('body').on('mouseout','#geogebra-calculator canvas', function(){
-         $('body').css('overflow', 'scroll')
-         $('html').css('margin-right', '0');
-         $('#calculator-container').css('right', calcoffsetR.toString() + 'px');
-         $('#calculator-container').css('bottom', calcoffsetB.toString() + 'px');
-     });
+    let applet;
+    calcButtonElement.addEventListener('click', function() {
+        if (calcDialog.dialog.open) {
+            let initialized = calcDialogElement.dataset.initialized || false;
+            if (!initialized) {
+                applet = initGeogebra();
+                calcDialogElement.dataset.initialized = true;
+            } else {
+                focusCalcInput();
+            }
+        }
+    });
 
-     $('body').on('click', '#calculator-toggle', function() {
-         if ($('#calculator-container').css('display') == 'none') {
-             $('#calculator-container').css('display', 'block');
-             $('#calculator-toggle').addClass('open');
-             $('#calculator-toggle').attr('title', 'Hide calculator');
-             $('#calculator-toggle').attr('aria-expanded', 'true');
-             create_calc_script = document.getElementById("create_ggb_calc");
-             if (!create_calc_script) {
-                 var ggbscript = document.createElement("script");
-                 ggbscript.id = "create_ggb_calc";
-                 ggbscript.innerHTML = "ggbApp.inject('geogebra-calculator')";
-                 document.body.appendChild(ggbscript);
-             } else {
-                 pretext_geogebra_calculator_onload();
-             }
-         } else {
-             $('#calculator-container').css('display', 'none');
-             $('#calculator-toggle').removeClass('open');
-             $('#calculator-toggle').attr('title', 'Show calculator');
-             $('#calculator-toggle').attr('aria-expanded', 'false');
-         }
-     });
+    //add resize observer for dialog
+    const resizeObserver = new ResizeObserver(entries => {
+        for (let entry of entries) {
+            if (entry.target === calcDialogElement && applet && applet.getAppletObject()) {
+                const width = entry.contentRect.width;
+                const height = entry.contentRect.height;
+                const geoGebraDiv = document.getElementById('ptx-geogebra-calculator');
+                const topBarHeight = calcDialogElement.querySelector('.ptx-dialog-topbar').clientHeight || 0;
+                applet.getAppletObject().setSize(width, height - topBarHeight);
+                applet.getAppletObject().recalculateEnvironments();
+            }
+        }
+    });
+    resizeObserver.observe(calcDialogElement);
 });
 
 
@@ -1301,7 +1283,13 @@ class PTXDialog {
         }
         this.dialog.setAttribute("aria-modal", this.isModal ? "true" : "false");
         if (PTXDialog.hasNativeCommandInvokers()) {
-            this.dialog.closedBy = (this.kind !== "light-close") ? "closerequest" : "any";
+            if (this.isModal) {
+                this.dialog.closedBy = (this.kind !== "light-close") ? "closerequest" : "any";
+            } else {
+                // non-modal dialogs don't have a native closedBy behavior
+                // but make explicit
+                this.dialog.closedBy = "none";
+            }
         }
 
         // set up the control element if provided
@@ -1348,9 +1336,7 @@ class PTXDialog {
                 this.dialog.showModal();
               } else {
                 if (this.controlElement) {
-                    const isExpanded = this.controlElement.getAttribute('aria-expanded') === 'true';
-                    this.controlElement.setAttribute('aria-expanded', !isExpanded);
-                    this.controlElement.classList.add('open');
+                    this.setExpanded(true);
                 }
                 this.dialog.show();
               }
@@ -1359,9 +1345,7 @@ class PTXDialog {
                 this.dialog.close();
                 if (this.controlElement) {
                     this.controlElement.focus();
-                    const isExpanded = this.controlElement.getAttribute('aria-expanded') === 'true';
-                    this.controlElement.setAttribute('aria-expanded', !isExpanded);
-                    this.controlElement.classList.remove('open');
+                    this.setExpanded(false);
                 }
             };
             this.toggle = () => {
@@ -1404,7 +1388,7 @@ class PTXDialog {
             let isDragging = false;
             let offsetX = 0;
             let offsetY = 0;
-            
+
             topBar.addEventListener("pointerover", (e) => {
                 topBar.style.cursor = "move";
             });
@@ -1418,7 +1402,7 @@ class PTXDialog {
                 // Track the pointer offset within the dialog so movement stays smooth.
                 offsetX = e.clientX - dialogRect.left;
                 offsetY = e.clientY - dialogRect.top;
-                
+
                 // Lock pointer to capture movement even outside the element boundaries
                 topBar.setPointerCapture(e.pointerId);
             });
@@ -1443,7 +1427,7 @@ class PTXDialog {
                 isDragging = false;
                 topBar.releasePointerCapture(e.pointerId);
             });
-            
+
             // Make sure we stay in view during resizes
             window.addEventListener('resize', (event) => {
                 this.dialog.style.left = '';
@@ -1456,6 +1440,17 @@ class PTXDialog {
         }
     }
 
+    setExpanded(expanded) {
+        if (this.controlElement) {
+            this.controlElement.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            if (expanded) {
+                this.controlElement.classList.add('open');
+            } else {
+                this.controlElement.classList.remove('open');
+            }
+        }
+    }
+
     openDialogFallback() {
         if (this.dialog && typeof this.dialog.showModal === "function" && !this.dialog.open) {
             if(this.isModal) {
@@ -1463,12 +1458,14 @@ class PTXDialog {
             } else {
               this.dialog.show();
             }
+            this.setExpanded(true);
         }
     }
 
     closeDialogFallback() {
         if (this.dialog && typeof this.dialog.close === "function" && this.dialog.open) {
             this.dialog.close();
+            this.setExpanded(false);
         }
         if (this.controlElement) {
             this.controlElement.focus();

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1294,9 +1294,28 @@ class PTXDialog {
         this.kind = options.kind || "modal";
         this.isModal = this.kind === "modal" || this.kind === "light-close";
 
-        this.openButton = openButton;
-        if (this.openButton && !PTXDialog.hasNativeCommandInvokers()) {
-            this.openButton.addEventListener("click", () => this.open());
+        // verify we have a dialog and set some basic attributes on the dialog
+        if (!this.dialog) {
+            console.log("PTXDialog: No dialog element provided.");
+            return;
+        }
+        this.dialog.setAttribute("aria-modal", this.isModal ? "true" : "false");
+        if (PTXDialog.hasNativeCommandInvokers()) {
+            this.dialog.closedBy = (this.kind !== "light-close") ? "closerequest" : "any";
+        }
+
+        // set up the control element if provided
+        if (this.controlElement ) {
+            this.controlElement.setAttribute('aria-expanded', "false");
+            this.controlElement.setAttribute('aria-controls', this.dialog.id);
+            if(PTXDialog.hasNativeCommandInvokers()) {
+                this.controlElement.commandFor = this.dialog.id;
+            }
+            if (this.isModal) {
+                this.controlElement.addEventListener("click", () => this.open());
+            } else {
+                this.controlElement.addEventListener("click", () => this.toggle());
+            }
         }
 
         this.closeButton = options.closeButton;
@@ -1318,9 +1337,14 @@ class PTXDialog {
         if (PTXDialog.hasNativeCommandInvokers()) {
             // If the browser supports command invokers, we can just use the native dialog element and its showModal and close methods.
             this.open = () => {
-              if(this.isModal) {
+              if (this.isModal) {
                 this.dialog.showModal();
               } else {
+                if (this.controlElement) {
+                    const isExpanded = this.controlElement.getAttribute('aria-expanded') === 'true';
+                    this.controlElement.setAttribute('aria-expanded', !isExpanded);
+                    this.controlElement.classList.add('open');
+                }
                 this.dialog.show();
               }
             };
@@ -1328,6 +1352,9 @@ class PTXDialog {
                 this.dialog.close();
                 if (this.controlElement) {
                     this.controlElement.focus();
+                    const isExpanded = this.controlElement.getAttribute('aria-expanded') === 'true';
+                    this.controlElement.setAttribute('aria-expanded', !isExpanded);
+                    this.controlElement.classList.remove('open');
                 }
             };
             this.toggle = () => {

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1382,6 +1382,15 @@ class PTXDialog {
             });
         }
 
+        // Should be handled natively, but Sagecells currently break native esc handling
+        if (this.isModal) {
+            this.dialog.addEventListener("keydown", (event) => {
+                if (event.key === "Escape") {
+                    this.close();
+                }
+            });
+        }
+
         // make non-modal dialogs draggable by their top bar
         if (!this.isModal) {
             const topBar = this.dialog.querySelector(".ptx-dialog-topbar");

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10163,7 +10163,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:text>hide-hint-checkbox hide-answer-checkbox hide-solution-checkbox </xsl:text>
         <xsl:text>print-first-page-header-checkbox print-running-header-checkbox </xsl:text>
         <xsl:text>print-first-page-footer-checkbox print-running-footer-checkbox </xsl:text>
-        <xsl:text>calculator-toggle calculator-container geogebra-calculator </xsl:text>
+        <xsl:text>ptx-calculator-toggle ptx-calculator-container ptx-geogebra-calculator </xsl:text>
         <xsl:text>ptx-user-dropdown_rs-content ptx-user-dropdown-content_item-template ptx-user-dropdown-content_separator-template </xsl:text>
         <xsl:text>ptx-embed-button ptx-embed-popup ptx-embed-close-button ptx-embed-code-textbox ptx-embed-copy-button </xsl:text>
         <!-- Runestone Services ids, banned always: these components can appear -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12478,14 +12478,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template name="embed-button">
-    <button id="ptx-embed-button" class="ptx-embed-button button" title="Embed this page" commandfor="ptx-embed-popup" command="show-modal">
+    <button id="ptx-embed-button" class="ptx-embed-button button" title="Embed this page">
         <xsl:call-template name="insert-symbol">
             <xsl:with-param name="name" select="'code'"/>
         </xsl:call-template>
         <span class="name">Embed</span>
-
     </button>
-    <dialog class="ptx-dialog ptx-embed-popup" id="ptx-embed-popup" closedby="closerequest">
+    <dialog class="ptx-dialog ptx-embed-popup" id="ptx-embed-popup">
         <div class="ptx-embed-popup-controls">
             <p>Copy the code below to embed this page in your own website or LMS page.</p>
             <button class="ptx-embed-close-button button" id="ptx-embed-close-button" title="Close embed popup">
@@ -14030,7 +14029,7 @@ TODO:
     <xsl:if test="$has-native-search">
         <div class="ptx-search-box">
             <div class="ptx-search-widget">
-                <button id="ptx-search-button" type="button" class="ptx-search-button button" title="Search book" commandfor="ptx-search-dialog" command="show-modal" >
+                <button id="ptx-search-button" type="button" class="ptx-search-button button" title="Search book">
                     <xsl:call-template name="insert-symbol">
                         <xsl:with-param name="name" select="'search'"/>
                     </xsl:call-template>
@@ -14045,10 +14044,10 @@ TODO:
 <!-- Div for native search results -->
 <xsl:template name="native-search-results">
     <xsl:if test="$has-native-search">
-        <dialog id="ptx-search-dialog" class="ptx-dialog ptx-search-dialog" closedby="closerequest">
+        <dialog id="ptx-search-dialog" class="ptx-dialog ptx-search-dialog">
             <div class="ptx-search-dialog-controls">
                 <input aria-label="Search term" id="ptx-search-terms" class="ptx-search-terms" type="text" name="terms" placeholder="Search terms"/>
-                <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close" commandfor="ptx-search-dialog"  command="close"><span class="material-symbols-outlined">close</span></button>
+                <button aria-label="Close search" id="ptx-search-close" class="ptx-search-close"><span class="material-symbols-outlined">close</span></button>
             </div>
             <!-- Will contain notice about how many results there are for screen readers to announce-->
             <div id="ptx-search-status" class="ptx-search-status" aria-live="polite" aria-atomic="true">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12460,7 +12460,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template name="calculator-toggle">
-    <button id="calculator-toggle" class="calculator-toggle button" title="Show calculator" aria-expanded="false" aria-controls="calculator-container">
+    <button type="button" id="ptx-calculator-toggle" class="ptx-calculator-toggle button" title="Show calculator">
         <xsl:call-template name="insert-symbol">
             <xsl:with-param name="name" select="'calculate'"/>
         </xsl:call-template>
@@ -12812,9 +12812,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template name="calculator">
     <xsl:if test="contains($html-calculator,'geogebra')">
-        <div id="calculator-container" class="calculator-container" style="display: none; z-index:100;">
-            <div id="geogebra-calculator"></div>
-        </div>
         <script>
             <xsl:text>&#xa;</xsl:text>
             <!-- Here is where we could initialize some things to customize the display.                    -->
@@ -12851,6 +12848,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!--   ggbApp.inject('geogebra-calculator');           -->
             <!--   which is inserted by code in pretext_add_on.js  -->
         </script>
+        <dialog id="ptx-calculator-container" class="ptx-dialog ptx-calculator-container">
+            <div id="ptx-geogebra-calculator" class="ptx-geogebra-calculator"></div>
+        </dialog>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12812,44 +12812,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template name="calculator">
     <xsl:if test="contains($html-calculator,'geogebra')">
-        <script>
-            <xsl:text>&#xa;</xsl:text>
-            <!-- Here is where we could initialize some things to customize the display.                    -->
-            <!-- But the customization should be different depending on classic, graphing, geometry, or 3d. -->
-            <!-- For instance geometry probably does not benefit from showing the grid.                     -->
-            <!-- If this is not in use, no need to set "appletOnLoad" further below.                        -->
-            <!-- var onLoad = function(applet) {
-                applet.setAxisLabels(1,'x','y','z');
-                applet.setGridVisible(1,true);
-                applet.showFullscreenButton(true);
-            }; -->
-            <xsl:text>var ggbApp = new GGBApplet({"appName": "</xsl:text>
-            <xsl:value-of select="substring-after($html-calculator,'-')"/>
-            <xsl:text>",&#xa;</xsl:text>
-            <!-- width and height are required parameters                   -->
-            <!-- All the rest is customizing some things away from defaults -->
-            <!-- (or maybe in some cases explicitly using the defaults)     -->
-            <!-- The last parameters have to do with scaling. This combination allows the 330x600 applet -->
-            <!-- to scale up or down to the width of the contining div with class calculator-container.  -->
-            <!-- The applet's height will scale proportionately.                                         -->
-            <xsl:text>    "width": 330,&#xa;</xsl:text>
-            <xsl:text>    "height": 600,&#xa;</xsl:text>
-            <xsl:text>    "showToolBar": true,&#xa;</xsl:text>
-            <xsl:text>    "showAlgebraInput": true,&#xa;</xsl:text>
-            <xsl:text>    "perspective": "G/A",&#xa;</xsl:text>
-            <xsl:text>    "algebraInputPosition": "bottom",&#xa;</xsl:text>
-            <!--          "appletOnLoad": onLoad, -->
-            <xsl:text>    "scaleContainerClass": "calculator-container",&#xa;</xsl:text>
-            <xsl:text>    "allowUpscale": true,&#xa;</xsl:text>
-            <xsl:text>    "autoHeight": true,&#xa;</xsl:text>
-            <xsl:text>    "disableAutoScale": false},&#xa;</xsl:text>
-            <xsl:text>true);&#xa;</xsl:text>
-            <!--   The calculator is created by                    -->
-            <!--   ggbApp.inject('geogebra-calculator');           -->
-            <!--   which is inserted by code in pretext_add_on.js  -->
-        </script>
         <dialog id="ptx-calculator-container" class="ptx-dialog ptx-calculator-container">
             <div id="ptx-geogebra-calculator" class="ptx-geogebra-calculator"></div>
+            <script id="ptx-geogebra-calculator-params">
+                <!-- params for Geogebra that can be set from PTX -->
+                <xsl:text>&#xa;</xsl:text>
+                <xsl:text>let ggbParams = {&#xa;</xsl:text>
+                <xsl:text>    "appName": "</xsl:text>
+                <xsl:value-of select="substring-after($html-calculator,'-')"/>
+                <xsl:text>"&#xa;</xsl:text>
+                <xsl:text>};&#xa;</xsl:text>
+            </script>
         </dialog>
     </xsl:if>
 </xsl:template>


### PR DESCRIPTION
Updates PTXDialog to do more of the lifting for accessibility attributes on affected elements.

Fixes accessibility issues for the calculator and moves it to the PTXDialog framework. Non-modal dialogs are really tricky vis-a-vis accessibility. And we don't control anything going on inside the calculator. But this definitely is an improvement over the old behavior. 

Also allows the calculator to be resized and repositioned. The code for repositioning is part of PTXDialog and can be reused for other non-modals.

Added a build of the JS incase anyone else wants to test the PR. @rbeezer - you may want to discard that last commit and rebuild yourself.