### PR TITLE
XSL-FO: center display mathematics and place equation numbers

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2457,6 +2457,46 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </md>.  There should not be anything to see in <latex/>/<init>PDF</init> output. (2021-10-21)</p>
 
             </subsection>
+
+            <subsection>
+                <title>Wide and Narrow Displays</title>
+
+                <p>This subsection stresses how a displayed equation is placed when it does, or does not, fit the width of the text, and how a number or a custom tag interacts with that placement.  In print (<init>PDF</init>) output a display that fits is centered, with any number at the right margin; a display too wide to fit is set flush with the left margin, so it overruns only the right margin and never the left.</p>
+
+                <p>A narrow display, numbered, centers with its number at the right margin:<md number="yes">a^2 + b^2 = c^2</md></p>
+
+                <p>The same narrow display, unnumbered, simply centers:<md>a^2 + b^2 = c^2</md></p>
+
+                <p>A display wider than the text, numbered, is set flush left and overruns the right margin (and triggers an authoring warning):<md number="yes">x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 + x_8 + x_9 + x_{10} + x_{11} + x_{12} + x_{13} + x_{14} + x_{15} = \sum_{i=1}^{15} x_i</md></p>
+
+                <p>The same wide display, unnumbered, behaves the same way:<md>x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 + x_8 + x_9 + x_{10} + x_{11} + x_{12} + x_{13} + x_{14} + x_{15} = \sum_{i=1}^{15} x_i</md></p>
+
+                <p>A wide display with a custom tag flushes left as well, the tag taking the place of a number:<md><mrow tag="star">x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 + x_8 + x_9 + x_{10} + x_{11} + x_{12} + x_{13} + x_{14} + x_{15} = \sum_{i=1}^{15} x_i</mrow></md></p>
+
+                <p>A multi-line display, numbered, with one narrow line and one too wide, exercises per-line numbering:<md number="yes">
+                    <mrow>a + b = c</mrow>
+                    <mrow>x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 + x_8 + x_9 + x_{10} + x_{11} + x_{12} + x_{13} + x_{14} + x_{15} = \sum_{i=1}^{15} x_i</mrow>
+                </md></p>
+
+                <p>Inside a narrow container the available width is smaller, so a display centers within the container rather than the full text.  Pushing a number all the way out to such a container's own right margin awaits a future refinement, so for now a number stays beside its centered equation.  Here are two panels side by side, each with a numbered display.</p>
+
+                <sidebyside widths="45% 45%">
+                    <p>A panel display:<md number="yes">a^2 + b^2 = c^2</md></p>
+                    <p>Another panel display:<md number="yes">u + v = w</md></p>
+                </sidebyside>
+
+                <p>A numbered display inside a block quotation, which is indented on both sides:</p>
+
+                <blockquote>
+                    <p>An indented, numbered display:<md number="yes">e^{i\pi} + 1 = 0</md></p>
+                </blockquote>
+
+                <p>A numbered display inside a doubly-nested list, where the item is indented twice:<ol>
+                    <li><p>Outer item.<ol>
+                        <li><p>Inner item, with a numbered display:<md number="yes">\int_0^1 x^2 \, dx = \frac{1}{3}</md></p></li>
+                    </ol></p></li>
+                </ol></p>
+            </subsection>
         </section>
 
         <section xml:id="block-samples">

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3747,6 +3747,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- justified paragraph passes its own down to this lone   -->
         <!-- line, which would otherwise justify (left-pin) the SVG -->
         <xsl:when test="$svg">
+            <!-- a display wider than the measure cannot be placed well;  -->
+            <!-- warn the author, by number when there is one, and report -->
+            <!-- its location                                             -->
+            <xsl:if test="$width-points &gt; $text-width-points">
+                <xsl:message>
+                    <xsl:text>PTX:WARNING: a display </xsl:text>
+                    <xsl:if test="not(normalize-space($eqn-number) = '')">
+                        <xsl:text>(</xsl:text>
+                        <xsl:value-of select="normalize-space($eqn-number)"/>
+                        <xsl:text>) </xsl:text>
+                    </xsl:if>
+                    <xsl:text>is wider than the text and overruns the right margin in the XSL-FO output</xsl:text>
+                </xsl:message>
+                <xsl:apply-templates select="." mode="location-report"/>
+            </xsl:if>
             <fo:block text-align="{$display-align}" text-align-last="{$display-align}" space-before="0.5em" space-after="0.5em">
                 <!-- an over-wide numbered display is a centered body in a -->
                 <!-- "min-width" SVG, so its body sits one number-width in -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3650,16 +3650,37 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:variable name="svg" select="$math-repr/pi:math[@id = $id]/div[@class = 'svg']/svg:svg"/>
     <xsl:variable name="speech" select="normalize-space($speech-repr/pi:math[@id = $id]/div[@class = 'speech'])"/>
+    <!-- A display fills the full text measure only when no     -->
+    <!-- ancestor narrows the line: a "sidebyside" panel, an    -->
+    <!-- "ol"/"ul"/"dl" list item, a "blockquote", a "tabular"  -->
+    <!-- cell, a "task", or a multicolumn "exercisegroup" each  -->
+    <!-- reduce the width (and a cell's width is not known here -->
+    <!-- in points).                                            -->
+    <xsl:variable name="b-full-measure" select="not(ancestor::sidebyside or ancestor::ol or ancestor::ul or ancestor::dl or ancestor::blockquote or ancestor::tabular or ancestor::task or ancestor::exercisegroup[@cols])"/>
     <xsl:variable name="width-points">
         <xsl:choose>
             <xsl:when test="contains($svg/@width, 'ex')">
                 <xsl:value-of select="number(substring-before($svg/@width, 'ex')) * $math-points-per-ex"/>
             </xsl:when>
-            <!-- a wide, aligned display gets width="100%" from   -->
-            <!-- MathJax, with the true width as a "min-width" in -->
-            <!-- the @style                                       -->
+            <!-- a wide, aligned display arrives as width="100%" with    -->
+            <!-- no viewBox and its true width as a "min-width" in the   -->
+            <!-- @style; MathJax's own layout then centers the body and  -->
+            <!-- drives any tag to the right edge of whatever width we   -->
+            <!-- assign.  At the full text measure that reproduces the   -->
+            <!-- LaTeX result (tag at the margin); in a narrower         -->
+            <!-- container we cannot know the available width in points, -->
+            <!-- so we fall back to the content (min-width) and let      -->
+            <!-- "text-align-last" center it.                            -->
             <xsl:when test="contains($svg/@style, 'min-width:')">
-                <xsl:value-of select="number(substring-before(substring-after($svg/@style, 'min-width:'), 'ex')) * $math-points-per-ex"/>
+                <xsl:variable name="content-width-points" select="number(substring-before(substring-after($svg/@style, 'min-width:'), 'ex')) * $math-points-per-ex"/>
+                <xsl:choose>
+                    <xsl:when test="$b-full-measure and ($content-width-points &lt; $text-width-points)">
+                        <xsl:value-of select="$text-width-points"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$content-width-points"/>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:when>
             <!-- last resort: the third entry of the @viewBox, in -->
             <!-- thousandths of an em                             -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3671,6 +3671,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:variable name="height-points"
                   select="number(substring-before($svg/@height, 'ex')) * $math-points-per-ex"/>
+    <!-- a display is centered, but when it is wider than the -->
+    <!-- text measure, flushing it left lets it overrun only  -->
+    <!-- the right margin rather than both                    -->
+    <xsl:variable name="display-align">
+        <xsl:choose>
+            <xsl:when test="$width-points &gt; $text-width-points">left</xsl:when>
+            <xsl:otherwise>center</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:choose>
         <xsl:when test="$svg and self::m">
             <!-- for math sitting on the baseline (e.g. a lone digit),  -->
@@ -3697,10 +3706,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:apply-templates>
             </fo:instream-foreign-object>
         </xsl:when>
-        <!-- display mathematics, in a centered block; absorbed -->
-        <!-- clause-ending punctuation is already in the SVG    -->
+        <!-- display mathematics in its own block; absorbed         -->
+        <!-- clause-ending punctuation is already in the SVG.       -->
+        <!-- "text-align-last" repeats the choice because a         -->
+        <!-- justified paragraph passes its own down to this lone   -->
+        <!-- line, which would otherwise justify (left-pin) the SVG -->
         <xsl:when test="$svg">
-            <fo:block text-align="center" space-before="0.5em" space-after="0.5em">
+            <fo:block text-align="{$display-align}" text-align-last="{$display-align}" space-before="0.5em" space-after="0.5em">
                 <xsl:apply-templates select="." mode="link-id-attribute"/>
                 <!-- an "xref" targets a constituent "mrow", so each -->
                 <!-- contributes an invisible anchor                 -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3701,6 +3701,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:otherwise>center</xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
+    <!-- the number or symbol of the display's first numbered or -->
+    <!-- tagged "mrow" (@pi:numbered="yes" or @tag); empty for   -->
+    <!-- inline math (no "mrow") and fully unnumbered displays.  -->
+    <xsl:variable name="numbered-row" select="mrow[@pi:numbered = 'yes' or @tag][1]"/>
+    <xsl:variable name="eqn-number">
+        <xsl:choose>
+            <xsl:when test="$numbered-row/@tag">
+                <xsl:apply-templates select="$numbered-row/@tag" mode="tag-symbol"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="$numbered-row" mode="number"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:choose>
         <xsl:when test="$svg and self::m">
             <!-- for math sitting on the baseline (e.g. a lone digit),  -->
@@ -3734,6 +3748,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- line, which would otherwise justify (left-pin) the SVG -->
         <xsl:when test="$svg">
             <fo:block text-align="{$display-align}" text-align-last="{$display-align}" space-before="0.5em" space-after="0.5em">
+                <!-- an over-wide numbered display is a centered body in a -->
+                <!-- "min-width" SVG, so its body sits one number-width in -->
+                <!-- from the left.  At the full measure (inherited        -->
+                <!-- start-indent zero) pull left by a conservative under- -->
+                <!-- estimate of that width, flushing the body toward the  -->
+                <!-- margin without crossing it                            -->
+                <xsl:if test="$b-full-measure and ($width-points &gt; $text-width-points) and contains($svg/@style, 'min-width:') and not(normalize-space($eqn-number) = '')">
+                    <xsl:attribute name="start-indent">
+                        <xsl:text>-</xsl:text>
+                        <xsl:value-of select="format-number((string-length(normalize-space($eqn-number)) + 2) * 0.5 * number(substring-before($font-size, 'pt')), '0.##')"/>
+                        <xsl:text>pt</xsl:text>
+                    </xsl:attribute>
+                </xsl:if>
                 <xsl:apply-templates select="." mode="link-id-attribute"/>
                 <!-- an "xref" targets a constituent "mrow", so each -->
                 <!-- contributes an invisible anchor                 -->


### PR DESCRIPTION
## What

In the experimental `pdf-fo` conversion (XSL-FO via Apache FOP), displayed mathematics was mis-placed: numbered and multi-line displays rendered shifted to the left, with the equation number floating mid-line. This matches the rendering to the LaTeX output and adds sane handling for displays too wide for the text.

## Root cause

A display sits in its own `<fo:block text-align="center">`, but that block is a child of its paragraph, which carries `text-align-last="justify"`. That property is inherited, so the display's single line (the MathJax SVG) was justified — and a lone object with no stretchable space is pushed to the left. Separately, MathJax emits a numbered display as a responsive `width="100%"` SVG (true width in a `min-width`), which the conversion sized to that tight width, so the number never reached the right margin.

## The changes (all `pretext-fo.xsl`, except the sample article)

1. **Center reliably** — `text-align-last="center"` on the display block, defeating the inherited `justify`.
2. **Number at the right margin** — at the full text measure a responsive display is widened to the measure; MathJax then centers the body and drives the number to the right margin (LaTeX parity). Content-sized (`viewBox`) displays are untouched.
3. **Over-wide displays flush left** — a display wider than the measure is set flush-left so it overruns only the right margin, not both. A numbered one is nudged left by a conservative estimate of its number width (`mode="number"`, or the `@tag` symbol) so its body sits ~flush at the left.
4. **Author warning** — a display wider than the measure emits a warning (citing the number when present) plus a location report.
5. **Sample article** — a new *Wide and Narrow Displays* subsection in the Mathematics section stress-tests all of this: wide vs. narrow, numbered/tagged/unnumbered, multi-line, and inside a `sidebyside`, a `blockquote`, and a doubly-nested list.

The MathJax SVG itself is unchanged, so HTML and EPUB are unaffected.

## Testing

Built the sample article to `pdf-fo`: numbered displays center with their number at the right margin; the over-measure displays flush left and overrun only the right; the warning fires for each wide display, by number where present; veraPDF reports PDF/UA-1 compliant.

## Known limitation (planned follow-on)

Inside a narrow container (`sidebyside` panel, `blockquote`, list item) a numbered display centers correctly, but its number stays beside the equation rather than traveling to the container's own right margin (that needs the container width computed). The new subsection notes this, and it is reserved for a follow-up.

---
*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
