### PR TITLE
XSL-FO: shrink the superscript shift on raised "fn" and unit marks

### DIFF
--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2632,7 +2632,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="key('base-key', concat('bases', $the-base))/@short"/>
     </xsl:for-each>
     <xsl:if test="@exp">
-        <fo:inline baseline-shift="super" font-size="70%">
+        <!-- a raised exponent, shifted a fixed fraction of the line-height -->
+        <fo:inline baseline-shift="35%" font-size="70%">
             <xsl:value-of select="@exp"/>
         </fo:inline>
     </xsl:if>
@@ -3428,7 +3429,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="serial-number"/>
     </xsl:variable>
     <fo:footnote>
-        <fo:inline baseline-shift="super" font-size="70%">
+        <!-- A fixed fraction of the line-height raises the mark; FOP's -->
+        <!-- "super" keyword shifts so far it inflates the line box and -->
+        <!-- drops a list item's first line below its label.            -->
+        <fo:inline baseline-shift="35%" font-size="70%">
             <xsl:value-of select="$the-mark"/>
         </fo:inline>
         <fo:footnote-body>
@@ -3437,7 +3441,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- stretches a one-line note across the whole measure       -->
             <fo:block font-size="80%" text-align="{$text-alignment}" text-align-last="start" space-before="0.25em">
                 <xsl:apply-templates select="." mode="link-id-attribute"/>
-                <fo:inline baseline-shift="super" font-size="70%">
+                <fo:inline baseline-shift="35%" font-size="70%">
                     <xsl:value-of select="$the-mark"/>
                 </fo:inline>
                 <xsl:text> </xsl:text>


### PR DESCRIPTION
## Problem

In `pdf-fo` output, a footnote attached to a list item was misplaced: the superscript mark floated up near the list label while the item's own text dropped onto the line *below* it. It is visible in the sample article's *List Calisthenics* section — "Second¹" in an ordered list and "Red²" in an unordered list both broke this way.

## Cause

Footnote marks — and `unit` exponents — were raised with `baseline-shift="super"`. With the Latin Modern fonts, Apache FOP resolves `super` to a large rise that inflates the first line box of the `fo:list-item-body`. Because FOP stacks lines by `max-height` (and does not honor `line-stacking-strategy`), that inflated line drops the body's text baseline below the adjacent label's baseline. In an ordinary paragraph the extra rise is absorbed as leading, so the over-shift only became obvious in a list, right next to the label.

## Fix

Replace `baseline-shift="super"` with a fixed `baseline-shift="35%"` — a fraction of the line-height, so it scales with the surrounding font size — at the three sites that share this idiom:

- the footnote (`fn`) mark in the running text,
- the repeated `fn` mark in the footnote body, and
- the `unit` element's `@exp` exponent.

Keeping `super` while trying to constrain the line box (`line-stacking-strategy`, an explicit `line-height`, a zero `line-height` on the mark) had no effect in FOP; reducing the shift magnitude is the only effective lever. The smaller shift also produces cleaner, more conventional superscripts in ordinary paragraphs.

## Testing

Built the sample article to `pdf-fo`. The *List Calisthenics* list items now set their footnote marks inline at superscript height, aligned with the list labels, and the in-paragraph footnote and bottom-of-page markers are unchanged in behavior. PDF/UA-1 validation of the output still passes.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*