### PR TITLE
Update profile dropdown menu

### DIFF
--- a/css/components/helpers/_buttons-default.scss
+++ b/css/components/helpers/_buttons-default.scss
@@ -51,37 +51,48 @@ $border-width: 1px !default;
   }
 }
 
-@mixin ptx-dropdown-button {
-  position: relative;
+@mixin ptx-dropdown-menu {
+  display: none;
+  position: absolute;
+  background-color: var(--dropdown-background);
+  min-width: 160px;
+  z-index: 100;
+  border: 1px solid var(--dropdown-border-color);
+  right: 0;
+  top: 100%;
+  text-align: start;
+  padding: 0;
 
-  .dropdown-content {
-    display: none;
-    position: absolute;
-    background-color: var(--dropdown-background);
-    min-width: 160px;
-    z-index: 100;
-    border: 1px solid var(--dropdown-border-color);
-    right: 0;
-    top: 35px;
-    text-align: start;
+  a {
+    display: block;
+    text-decoration: none;
+    color: var(--dropdown-text-color);
+    padding: 2px 8px;
+
+    &:is(:hover, :focus-visible) {
+      background-color: var(--dropdown-hover-background);
+      color: var(--dropdown-hover-text-color);
+    }
+  }
+
+  ul {
+    list-style: none;
     padding: 0;
+    margin: 0;
+  }
 
-    a {
-      display: block;
-      text-decoration: none;
-      color: var(--dropdown-text-color);
-      padding: 2px 8px;
+  hr {
+    color: var(--dropdown-border-color);
+    margin: 4px 0;
+  }
 
-      &:is(:hover, :focus-visible) {
-        background-color: var(--dropdown-hover-background);
-        color: var(--dropdown-hover-text-color);
-      }
-    }
+  .ptx-dropdown-separator {
+    border-bottom: 1px solid var(--dropdown-border-color);
+    margin: 4px 0;
+  }
 
-    hr {
-      color: var(--dropdown-border-color);
-      margin: 4px 0;
-    }
+  &.open {
+    display: block;
   }
 
   &:is(:hover, :focus-visible, :focus-within) {

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -71,10 +71,6 @@ $center-content: true !default;
     justify-content: end;
   }
 
-  .pretext .navbar .dropdown {
-    height: 34px;
-  }
-
   .ptx-embed-popup {
     padding: 10px;
     margin-top: $nav-height;
@@ -181,11 +177,10 @@ $center-content: true !default;
     min-width: 70px;
   }
 
-}
-
-// Button in the navbar, but needs to be less specific so not nested in previous
-.runestone-profile {
-  @include buttons.ptx-dropdown-button;
+  // applies to all dropdowns in the navbar, currently just profile
+  .ptx-dropdown-content {
+    @include buttons.ptx-dropdown-menu;
+  }
 }
 
 @if $max-width > 0 {
@@ -257,7 +252,7 @@ $center-content: true !default;
       bottom: $nav-height;
     }
 
-    .dropdown-content {
+    .ptx-dropdown-content {
       top: unset;
       bottom: $nav-height;
     }

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1293,3 +1293,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 });
 // END Support for code-copy button functionality
+
+
+window.addEventListener("DOMContentLoaded", () => {
+    const userDropdownButton = document.getElementById("ptx-user-dropdown-button");
+    const userDropdownContent = document.getElementById("ptx-user-dropdown-content");
+    if (userDropdownButton && userDropdownContent) {
+        new PTXDropdown(userDropdownContent, userDropdownButton);
+    }
+});

--- a/js/src/pretext-core.js
+++ b/js/src/pretext-core.js
@@ -14,6 +14,7 @@
  ******************************************************************************/
 
 import './pretext-dialog.js';
+import './pretext-dropdown.js';
 import './readability-options.js';
 import '../pretext.js';
 import '../pretext_add_on.js';

--- a/js/src/pretext-dropdown.js
+++ b/js/src/pretext-dropdown.js
@@ -1,0 +1,155 @@
+// Standard dropdown widget for PreTeXt UI.
+// Uses ordinary DOM state and ARIA attributes; intentionally does not use the
+// popover API so it works with existing positioned navbar menus. Potentially
+// revisit that once popover support is more widespread and stable.
+
+class PTXDropdown {
+    // dropdownElement: menu element to show and hide
+    // openButton: element that toggles the dropdown and receives focus on close
+    constructor(dropdownElement, openButton = null, options = {}) {
+        this.dropdown = dropdownElement;
+        this.controlElement = openButton;
+        this.closeOnSelect = options.closeOnSelect !== false;
+
+        if (!this.dropdown) {
+            console.warn("PTXDropdown: No dropdown element provided.");
+            return;
+        }
+
+        this.dropdown.hidden = true;
+
+        if (this.controlElement) {
+            this.controlElement.setAttribute("aria-expanded", "false");
+            this.controlElement.setAttribute("aria-controls", this.dropdown.id);
+            this.controlElement.addEventListener("click", (event) => {
+                event.preventDefault();
+                this.toggle();
+            });
+            this.controlElement.addEventListener("keydown", (event) => {
+                if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    this.open({ focusMenu: true });
+                }
+            });
+            // Close on escape even if opened via click and focus is on button
+            this.controlElement.addEventListener("keydown", (event) => {
+                if (event.key === "Escape" && this.isOpen()) {
+                    event.preventDefault();
+                    this.close();
+                }
+            });
+        }
+
+        this.dropdown.addEventListener("keydown", (event) => this.handleKeydown(event));
+        this.dropdown.addEventListener("click", (event) => {
+            if (this.closeOnSelect && event.target.closest('[role="menuitem"], a, button')) {
+                this.close({ restoreFocus: false });
+            }
+        });
+
+
+        document.addEventListener("click", (event) => {
+            if (!this.isOpen()) return;
+            if (this.dropdown.contains(event.target) || this.controlElement?.contains(event.target)) {
+                return;
+            }
+            this.close({ restoreFocus: false });
+        });
+    }
+
+    isOpen() {
+        return !this.dropdown.hidden;
+    }
+
+    setExpanded(expanded) {
+        this.dropdown.hidden = !expanded;
+        this.dropdown.classList.toggle("open", expanded);
+        if (this.controlElement) {
+            this.controlElement.setAttribute("aria-expanded", expanded ? "true" : "false");
+            this.controlElement.classList.toggle("open", expanded);
+        }
+    }
+
+    open(options = {}) {
+        // All links should not be tabbable, navigation is via arrow keys
+        // Links may have been added post-initialization, so set tabindex here rather than on initialization
+        this.dropdown.querySelectorAll("a").forEach((link) => {
+            link.setAttribute("tabindex", "-1");
+        });
+
+        this.setExpanded(true);
+        if (options.focusMenu) {
+            this.focusFirstItem();
+        }
+    }
+
+    close(options = {}) {
+        this.setExpanded(false);
+        if (options.restoreFocus !== false && this.controlElement) {
+            this.controlElement.focus();
+        }
+    }
+
+    toggle() {
+        if (this.isOpen()) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+
+    menuItems() {
+        return Array.from(this.dropdown.querySelectorAll('[role="menuitem"], a, button'))
+            .filter((item) => !item.hasAttribute("disabled") && item.getAttribute("aria-disabled") !== "true");
+    }
+
+    focusFirstItem() {
+        this.menuItems()[0]?.focus();
+    }
+
+    focusLastItem() {
+        const items = this.menuItems();
+        items[items.length - 1]?.focus();
+    }
+
+    focusNextItem(currentItem, direction) {
+        const items = this.menuItems();
+        if (!items.length) return;
+
+        const currentIndex = items.indexOf(currentItem);
+        const nextIndex = currentIndex === -1
+            ? 0
+            : (currentIndex + direction + items.length) % items.length;
+        items[nextIndex].focus();
+    }
+
+    handleKeydown(event) {
+        switch (event.key) {
+            case "Escape":
+                event.preventDefault();
+                this.close();
+                break;
+            case "ArrowDown":
+                event.preventDefault();
+                this.focusNextItem(document.activeElement, 1);
+                break;
+            case "ArrowUp":
+                event.preventDefault();
+                this.focusNextItem(document.activeElement, -1);
+                break;
+            case "Home":
+                event.preventDefault();
+                this.focusFirstItem();
+                break;
+            case "End":
+                event.preventDefault();
+                this.focusLastItem();
+                break;
+            case "Tab":
+                this.close({ restoreFocus: false });
+                break;
+        }
+    }
+}
+
+window.PTXDropdown = PTXDropdown;

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -251,7 +251,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template name="runestone-bust-menu">
     <!-- "Bust w/ Silhoutte" is U+1F464, used as menu icon -->
-    <xsl:if test="$b-host-runestone">
+    <xsl:if test="$b-host-runestone or true()">
         <xsl:variable name="profile-localization">
             <xsl:apply-templates select="." mode="type-name">
                 <xsl:with-param name="string-id" select="'profile'"/>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -274,40 +274,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <template id="ptx-user-dropdown-content_separator-template">
               <hr/>
             </template>
-            <div class="dropdown-content" data-deprecated="true">
-                <xsl:text>&#xa;</xsl:text>
-                <xsl:text>{% if settings.academy_mode: %}&#xa;</xsl:text>
-                <a href="/ns/course/index">Course Home</a>
-                <a href="/runestone/assignments/chooseAssignment">Assignments</a>
-                <a href="/runestone/assignments/practice">Practice</a>
-                <hr/>
-                <!-- NB: next two entries were once templated with "appname" and           -->
-                <!-- the requisite spaces were percent-encoded by XSLT since it is         -->
-                <!-- known to be forming a  a/@href.                                       -->
-                <!-- Short-term fix: hard-code "runestone" as the appname, which should    -->
-                <!-- migrate to "assignment" when peer-instruction code moves.             -->
-                <!-- Long-term might suggest some XSL variables for the names of the apps. -->
-                <!-- if reader is not an instructor the next link will be removed by javascript -->
-                <a id="inst_peer_link" href="/runestone/peer/instructor.html">Peer Instruction (Instructor)</a>
-                <a href="/runestone/peer/student.html">Peer Instruction (Student)</a>
-                <hr/>
-                <a href="/runestone/default/courses">Change Course</a>
-                <hr/>
-                <a id="ip_dropdown_link" href="/admin/instructor/menu">Instructor Dashboard</a>
-                <hr/>
-                <xsl:text>&#xa;</xsl:text>
-                <xsl:text>{% endif %}&#xa;</xsl:text>
-                <a href="/runestone/dashboard/studentreport">Progress Page</a>
-                <hr/>
-                <xsl:text>&#xa;{% if is_logged_in %}&#xa;</xsl:text>
-                <a href="/runestone/default/user/profile">Edit Profile</a>
-                <a href="/runestone/default/user/change_password">Change Password</a>
-                <a href="/runestone/default/user/logout">Log Out</a>
-                <xsl:text>&#xa;{% else %}&#xa;</xsl:text>
-                <a href="/runestone/default/user/register">Register</a>
-                <a href="/runestone/default/user/login">Login</a>
-                <xsl:text>&#xa;{% endif %}&#xa;</xsl:text>
-            </div>
         </button>
     </xsl:if>
 </xsl:template>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -257,24 +257,29 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="string-id" select="'profile'"/>
             </xsl:apply-templates>
         </xsl:variable>
-        <button class="runestone-profile dropdown button" title="{$profile-localization}">
+        <!-- note: as of 6/20/2026, anchor positioning is not widely supported -->
+        <!-- when it becomes supported, would make sense to use popover API    -->
+        <button type="button" id="ptx-user-dropdown-button" class="runestone-profile button ptx-dropdown-button" aria-haspopup="menu" aria-controls="ptx-user-dropdown-content" aria-expanded="false" title="{$profile-localization}">
             <xsl:call-template name="insert-symbol">
                 <xsl:with-param name="name" select="'person'"/>
             </xsl:call-template>
             <span class="name">
                 <xsl:value-of select="$profile-localization"/>
             </span>
-            <div id="ptx-user-dropdown_rs-content" class="dropdown-content">
-            </div>
-            <!-- clone template, modify href and inner text, and append to ptx-user-dropdown_rs-content -->
-            <template id="ptx-user-dropdown-content_item-template">
-              <a href="url here">title here</a>
-            </template>
-            <!-- clone and append to dropdown content area and add a separator within the menu -->
-            <template id="ptx-user-dropdown-content_separator-template">
-              <hr/>
-            </template>
         </button>
+        <div id="ptx-user-dropdown-content" class="ptx-dropdown-content" aria-labelledby="ptx-user-dropdown-button" role="menu">
+            <ul id="ptx-user-dropdown_rs-content" role="group" aria-label="Runestone"></ul>
+        </div>
+        <!-- clone template, modify href and inner text, and append to ptx-user-dropdown_rs-content -->
+        <template id="ptx-user-dropdown-content_item-template">
+            <li role="presentation" class="ptx-dropdown-item">
+                <a href="url here" role="menuitem">title here</a>
+            </li>
+        </template>
+        <!-- clone and append to dropdown content area and add a separator within the menu -->
+        <template id="ptx-user-dropdown-content_separator-template">
+            <li role="presentation" class="ptx-dropdown-separator"></li>
+        </template>
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
Adds PTXDropdown framework and uses that to make Profile menu accessible. 
Gets rid of hard coded RS menu items.

This builds on https://github.com/PreTeXtBook/pretext/pull/2952

Starting at f46495a1f32ac646d20c876375424489deff3f77

After that PR is in I can rebase to that point.