### PR TITLE
Fix typo in "Custom Versions" > "Versions"

### DIFF
--- a/doc/guide/publisher/custom-versions.xml
+++ b/doc/guide/publisher/custom-versions.xml
@@ -79,7 +79,7 @@
         <subsection>
             <title>Forming a Version</title>
 
-            <p>Now, a publisher can elect to include or exclude all of the content of each component.  This is accomplished with the <attr>include</attr> attribute of the <c>source/include</c> element inside a publication file.  The value of this attribute is a space-separated listing of some of the component names in use.  An example minimal publication file could look like the following example.  See <xref ref="publication-file-source-version"/> for the specifics.</p>
+            <p>Now, a publisher can elect to include or exclude all of the content of each component.  This is accomplished with the <attr>include</attr> attribute of the <c>source/version</c> element inside a publication file.  The value of this attribute is a space-separated listing of some of the component names in use.  An example minimal publication file could look like the following example.  See <xref ref="publication-file-source-version"/> for the specifics.</p>
 
             <pre><![CDATA[
                 <publication>


### PR DESCRIPTION
In the section "27.2.2 Forming a Version" in the PreTeXt guide, there is a small typo:

> This is accomplished with the `@include` attribute of the `source/include` element inside a publication file.

This should be attribute of the `source/version` element. This PR fixes this typo.