### PR TITLE
XSL-FO: fix a block heading and end-mark around a leading marker or a closing display

### DIFF
--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1050,7 +1050,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- consumed by the heading, and so not content.                 -->
 <xsl:template name="heading-then-content">
     <xsl:param name="heading"/>
-    <xsl:variable name="content" select="*[not(self::title)]"/>
+    <!-- "idx" and "notation" are invisible markers, not content;     -->
+    <!-- render them for their side effects, but do not let them take  -->
+    <!-- the heading or block its run-in into a leading paragraph.     -->
+    <xsl:apply-templates select="idx | notation"/>
+    <xsl:variable name="content" select="*[not(self::title) and not(self::idx) and not(self::notation)]"/>
     <xsl:choose>
         <xsl:when test="$content[1][self::p] or $content[1][self::statement and *[1][self::p]]">
             <xsl:apply-templates select="$content[1]">
@@ -1203,7 +1207,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$mark"/>
         </fo:inline>
     </xsl:variable>
-    <xsl:variable name="content" select="*[not(self::title)]"/>
+    <!-- "idx" and "notation" are invisible markers (an index entry,  -->
+    <!-- the notation list), not content: render them for those side  -->
+    <!-- effects, but keep them from taking the heading or the mark,   -->
+    <!-- or blocking the heading's run-in (a "definition" often leads  -->
+    <!-- with them).                                                   -->
+    <xsl:apply-templates select="idx | notation"/>
+    <xsl:variable name="content" select="*[not(self::title) and not(self::idx) and not(self::notation)]"/>
     <xsl:variable name="last" select="$content[last()]"/>
     <xsl:variable name="b-mark-rides" select="boolean($last[self::p] or ($last[self::statement] and $last/*[last()][self::p]))"/>
     <!-- the heading runs in to a leading paragraph, plain or in a "statement" -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1215,7 +1215,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="idx | notation"/>
     <xsl:variable name="content" select="*[not(self::title) and not(self::idx) and not(self::notation)]"/>
     <xsl:variable name="last" select="$content[last()]"/>
-    <xsl:variable name="b-mark-rides" select="boolean($last[self::p] or ($last[self::statement] and $last/*[last()][self::p]))"/>
+    <!-- The mark rides a closing paragraph only when that paragraph   -->
+    <!-- holds running text alone.  A paragraph that carries a display  -->
+    <!-- ("...written as <md/>") would otherwise have its line          -->
+    <!-- justified (to push the mark to the margin), spreading the text -->
+    <!-- around the display; such a block takes the mark on its own     -->
+    <!-- line instead.                                                  -->
+    <xsl:variable name="b-mark-rides" select="boolean(($last[self::p] and not($last/md)) or ($last[self::statement] and $last/*[last()][self::p] and not($last/*[last()]/md)))"/>
     <!-- the heading runs in to a leading paragraph, plain or in a "statement" -->
     <xsl:choose>
         <xsl:when test="$content[1][self::p] or ($content[1][self::statement] and $content[1]/*[1][self::p])">


### PR DESCRIPTION
Two pre-existing rendering bugs in the XSL-FO → PDF route, both visible on the sample article's Definition 2.2 (a `definition` that leads with `idx`/`notation` and whose statement ends in a display). Confined to `xsl/pretext-fo.xsl`; no effect on other conversions.

### 1. A leading `idx`/`notation` dropped the heading to its own line

`heading-then-content` and `block-with-end-mark` run a block's heading *into* its first paragraph only when the first child is a `<p>` (or a `<statement>` leading with one), skipping only `<title>`. A `<definition>` (and any block) that leads with an `<idx>` or `<notation>` therefore had its first "content" child be that invisible marker, the run-in test failed, and the heading fell back to a standalone block — an unwanted line break and gap before the content. These markers are now rendered for their side effects (index entry, notation list) but excluded when locating the leading content, so the heading runs in.

### 2. A closing display spread the text and mis-placed the end-mark

A `definition`/`example` closes with an end-mark (◆) that, when the block ends in a paragraph, rides that paragraph's last line via an elastic leader, with `text-align-last="justify"` to push it to the margin. When the closing paragraph carries a display (`…written as <md/>`), that justification spread the *text around the display* into very wide word-spacing. The end-mark now takes its own (right-aligned) line whenever the closing paragraph contains a display, so the text sets normally and the mark still lands at the right margin.

Both fixes are general (any block leading with `idx`, any definition/example whose statement ends in a display), not specific to this one definition.

### Testing

Sample article builds (306 pages) and validates as **PDF/UA-1 (veraPDF, 106/0)**; the run-in heading, normal text, and right-margin end-mark all confirmed on Definition 2.2, and the `idx` entries still reach the Index ("indefinite integral, 2" → page 2).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
