### PR TITLE
XSL-FO: live cross-reference links inside display mathematics

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -145,7 +145,7 @@ except ImportError:
 #############################
 
 
-def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
+def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format, math_cross_references):
     """Convert PreTeXt source to a structured file of representations of mathematics"""
     # formats:  'svg', 'mml', 'nemeth', 'speech', 'kindle'
     # Internal calls will specify out_file with complete path
@@ -182,6 +182,10 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format):
         punctuation = "none"
     params = {}
     params["math.punctuation"] = punctuation
+    # a single-file target (XSL-FO/PDF) can ask that cross-references
+    # inside mathematics become active internal links (an SVG "a")
+    if math_cross_references:
+        params["math.cross-references"] = "yes"
     if pub_file:
         params["publisher"] = pub_file
     common.xsltproc(extraction_xslt, xml_source, mjinput, None, params)
@@ -2380,7 +2384,7 @@ def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format)
     # ripping out LaTeX as math representations
     msg = "converting raw LaTeX from {} into clean {} format placed into {}"
     log.debug(msg.format(xml_source, math_format, math_representations))
-    mathjax_latex(xml_source, pub_file, math_representations, None, math_format)
+    mathjax_latex(xml_source, pub_file, math_representations, None, math_format, False)
 
     # use XSL to make a simplified BRF-like XML version, "preprint"
     msg = "converting source ({}) and clean representations ({}) into preprint XML file ({})"
@@ -2803,11 +2807,11 @@ def epub(xml_source, pub_file, out_file, dest_dir, file_format, math_format, str
     # ripping out LaTeX as math representations
     msg = "converting raw LaTeX from {} into clean {} format placed into {}"
     log.debug(msg.format(xml_source, math_format, math_representations))
-    mathjax_latex(xml_source, pub_file, math_representations, None, math_format)
+    mathjax_latex(xml_source, pub_file, math_representations, None, math_format, False)
     # optionally, build a file of speech versions of the math
     if math_format == "svg":
         log.debug(msg.format(xml_source, "speech", speech_representations))
-        mathjax_latex(xml_source, pub_file, speech_representations, None, "speech")
+        mathjax_latex(xml_source, pub_file, speech_representations, None, "speech", False)
 
     # Build necessary content and infrastructure EPUB files,
     # using SVG images of math.  Most output goes into the
@@ -4250,6 +4254,39 @@ def _downgrade_svg2_for_batik(directory):
             tree.write(svg_file)
 
 
+def _math_links_for_batik(math_file):
+    """Make a cross-reference inside mathematics a live link in the PDF.
+
+    When asked for cross-reference links, MathJax wraps the reference in
+    an SVG "a" element carrying a plain SVG 2 "href".  Apache Batik (the
+    SVG engine inside FOP) honors only the SVG 1.1 "xlink:href", so the
+    link is present but dead until the value is moved over -- exactly the
+    fix  _downgrade_svg2_for_batik  applies to a "use".  Operates on the
+    math representations file, where these "a" elements live.
+    """
+    import lxml.etree as ET
+
+    svg_namespace = "http://www.w3.org/2000/svg"
+    xlink_namespace = "http://www.w3.org/1999/xlink"
+    anchor_tag = "{{{}}}a".format(svg_namespace)
+    xlink_href = "{{{}}}href".format(xlink_namespace)
+
+    try:
+        tree = ET.parse(math_file)
+    except (ET.XMLSyntaxError, OSError):
+        return
+    root = tree.getroot()
+    changed = False
+    for anchor in root.iter(anchor_tag):
+        target = anchor.get("href")
+        if target is not None and anchor.get(xlink_href) is None:
+            anchor.set(xlink_href, target)
+            del anchor.attrib["href"]
+            changed = True
+    if changed:
+        tree.write(math_file)
+
+
 def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
     """
     Generate a PDF from an XML source using XSL-FO as an intermediate
@@ -4285,13 +4322,21 @@ def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
     # the FO stylesheet as the  $mathfile  string parameter, which
     # melds each image into the page (the model is  epub()  above)
     math_representations = os.path.join(tmp_dir, "math-representations-svg.xml")
-    mathjax_latex(xml, pub_file, math_representations, None, "svg")
+    # The final argument requests live cross-reference links inside the
+    # mathematics.  This (single-file) PDF is the only conversion that
+    # asks for them: a link is a bare "#id" fragment, which resolves
+    # only within one file, and FOP renders it from the SVG that MathJax
+    # emits.  Chunked conversions (HTML, EPUB) would need real filenames,
+    # and not every reader honors an SVG link, so they pass False.
+    mathjax_latex(xml, pub_file, math_representations, None, "svg", True)
+    # let Batik honor the cross-reference links MathJax placed in the math
+    _math_links_for_batik(math_representations)
     stringparams["mathfile"] = math_representations.replace(os.sep, "/")
 
     # Speech versions of the mathematics become the alternate text
     # of the SVG images, as PDF/UA requires; again the model is epub()
     speech_representations = os.path.join(tmp_dir, "math-representations-speech.xml")
-    mathjax_latex(xml, pub_file, speech_representations, None, "speech")
+    mathjax_latex(xml, pub_file, speech_representations, None, "speech", False)
     stringparams["speechfile"] = speech_representations.replace(os.sep, "/")
 
     # make the XSL-FO file in scratch directory

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4165,6 +4165,111 @@ def _pdf_fo_accessibility_repairs(pdfname):
         if doc.xref_get_key(xref, "S")[1] == "/Note" and doc.xref_get_key(xref, "ID")[0] == "null":
             doc.xref_set_key(xref, "ID", "(Note-{})".format(xref))
             additions += 1
+
+    # repair three: tag the link annotations FOP leaves untagged.  Apache
+    # Batik turns the SVG "a" that MathJax emits for a cross-reference
+    # inside display mathematics into a Link annotation, but -- unlike
+    # FOP's own "fo:basic-link" -- does not nest it in a Link structure
+    # element, which PDF/UA-1 (Clause 7.18.5) requires.  Wrap each such
+    # annotation (a Link with no /StructParent) in a new Link structure
+    # element under the document's structure element, with an /OBJR back
+    # to the annotation, and register its /StructParent in the number
+    # tree.  Nesting under the math's own figure would read better, but
+    # needs per-figure geometry that FOP and PyMuPDF do not expose; this
+    # keeps the PDF conformant.
+    struct_root = doc.xref_get_key(doc.pdf_catalog(), "StructTreeRoot")
+    if struct_root[0] == "xref":
+        root_xref = int(struct_root[1].split()[0])
+        root_kids = doc.xref_get_key(root_xref, "K")
+        if root_kids[0] == "xref":
+            document_element = int(root_kids[1].split()[0])
+        elif root_kids[0] == "array":
+            document_refs = re.findall(r"(\d+)\s+0\s+R", root_kids[1])
+            document_element = int(document_refs[0]) if document_refs else None
+        else:
+            document_element = None
+
+        # The /ParentTree is a number tree, given inline on the structure
+        # root or as an indirect object.  Read a node's /Nums and /Kids
+        # whichever way it is stored.
+        def tree_node(node_type, node_value):
+            if node_type == "xref":
+                node = int(node_value.split()[0])
+                nums = doc.xref_get_key(node, "Nums")
+                kids = doc.xref_get_key(node, "Kids")
+                return (nums[1] if nums[0] == "array" else None,
+                        kids[1] if kids[0] == "array" else None)
+            nums = re.search(r"/Nums\s*(\[.*\])", node_value)
+            kids = re.search(r"/Kids\s*(\[[^\]]*\])", node_value)
+            return (nums.group(1) if nums else None,
+                    kids.group(1) if kids else None)
+
+        # an indirect leaf to extend (follow /Kids to its last child), the
+        # highest key already in the tree (a page's /StructParents or an
+        # annotation's /StructParent), so new keys sit above it
+        def resolve_leaf(node_type, node_value):
+            nums, kids = tree_node(node_type, node_value)
+            if kids:
+                refs = re.findall(r"(\d+)\s+0\s+R", kids)
+                if refs:
+                    return resolve_leaf("xref", refs[-1] + " 0 R")
+            return int(node_value.split()[0]) if node_type == "xref" else None
+
+        def tree_max_key(node_type, node_value):
+            nums, kids = tree_node(node_type, node_value)
+            keys = [-1]
+            if nums:
+                keys += [int(k) for k in re.findall(r"(\d+)\s+(?:\d+\s+0\s+R|<<|\[)", nums)]
+            if kids:
+                keys += [tree_max_key("xref", r + " 0 R") for r in re.findall(r"(\d+)\s+0\s+R", kids)]
+            return max(keys)
+
+        parent_tree = doc.xref_get_key(root_xref, "ParentTree")
+        leaf = resolve_leaf(*parent_tree) if document_element is not None else None
+        if leaf is not None:
+            next_key = doc.xref_get_key(root_xref, "ParentTreeNextKey")
+            key = int(next_key[1]) if next_key[0] == "int" else tree_max_key(*parent_tree) + 1
+
+            new_links = []
+            for page in doc:
+                page_xref = page.xref
+                for link in page.links():
+                    annot = link["xref"]
+                    if doc.xref_get_key(annot, "Subtype")[1] != "/Link":
+                        continue
+                    if doc.xref_get_key(annot, "StructParent")[0] == "int":
+                        continue
+                    link_element = doc.get_new_xref()
+                    objr = "<</Type/OBJR/Pg {} 0 R/Obj {} 0 R>>".format(page_xref, annot)
+                    doc.update_object(link_element, "<</Type/StructElem/S/Link/P {} 0 R/Pg {} 0 R/K {}>>".format(document_element, page_xref, objr))
+                    doc.xref_set_key(annot, "StructParent", str(key))
+                    new_links.append((key, link_element))
+                    key += 1
+                    additions += 1
+
+            if new_links:
+                # the new Link elements become children of the document
+                new_refs = " ".join("{} 0 R".format(x) for _, x in new_links)
+                k_entry = doc.xref_get_key(document_element, "K")
+                if k_entry[0] == "array":
+                    document_kids = k_entry[1].rstrip()[:-1] + " " + new_refs + "]"
+                elif k_entry[0] == "xref":
+                    document_kids = "[{} {}]".format(k_entry[1], new_refs)
+                else:
+                    document_kids = "[{}]".format(new_refs)
+                doc.xref_set_key(document_element, "K", document_kids)
+                # map each annotation's /StructParent to its Link element,
+                # extending the leaf's /Nums (kept sorted, as the new keys
+                # are all above the existing ones) and its /Limits
+                nums = " ".join("{} {} 0 R".format(k, x) for k, x in new_links)
+                leaf_nums = doc.xref_get_key(leaf, "Nums")
+                existing = leaf_nums[1].strip()[1:-1].strip() if leaf_nums[0] == "array" else ""
+                doc.xref_set_key(leaf, "Nums", "[{}]".format((existing + " " + nums).strip()))
+                leaf_limits = doc.xref_get_key(leaf, "Limits")
+                low = re.findall(r"-?\d+", leaf_limits[1])[0] if (leaf_limits[0] == "array" and existing) else str(new_links[0][0])
+                doc.xref_set_key(leaf, "Limits", "[{} {}]".format(low, new_links[-1][0]))
+                doc.xref_set_key(root_xref, "ParentTreeNextKey", str(key))
+
     if additions > 0:
         doc.saveIncr()
     doc.close()

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -332,6 +332,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </rdf:Description>
                 </rdf:RDF>
             </x:xmpmeta>
+            <xsl:call-template name="math-cross-reference-destinations"/>
         </fo:declarations>
         <fo:bookmark-tree>
             <xsl:apply-templates select="$document-root/*" mode="bookmark"/>
@@ -3853,6 +3854,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$text"/>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- The cross-references that sit inside display mathematics (an  -->
+<!-- "xref" is schema-allowed in an "md", through an "mrow" or a    -->
+<!-- single-line "md", but never in an inline "m"), keyed by the    -->
+<!-- "@ref" they carry, so a destination is named just once even    -->
+<!-- when several references share a target.                        -->
+<xsl:key name="math-cross-reference"
+         match="xref[ancestor::md]"
+         use="@ref"/>
+
+<!-- FOP resolves its own internal links directly and creates no  -->
+<!-- named destinations; but a cross-reference inside mathematics -->
+<!-- becomes an SVG "a" (see "math.cross-references" in           -->
+<!-- extract-math.xsl) that FOP compiles into a GoTo a *named*    -->
+<!-- destination.  So, in "fo:declarations", name a destination   -->
+<!-- for the target of each such reference, once per target;      -->
+<!-- "fox:destination" aims at the element carrying that id,      -->
+<!-- wherever it sits.                                            -->
+<xsl:template name="math-cross-reference-destinations">
+    <xsl:for-each select="$document-root//xref[ancestor::md and id(@ref)]">
+        <xsl:if test="count(. | key('math-cross-reference', @ref)[1]) = 1">
+            <xsl:variable name="dest-id">
+                <xsl:apply-templates select="id(@ref)" mode="unique-id"/>
+            </xsl:variable>
+            <fox:destination internal-destination="{$dest-id}"/>
+        </xsl:if>
+    </xsl:for-each>
 </xsl:template>
 
 <!-- Hard-coded numbers, as in the HTML conversion: the number of -->

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -81,6 +81,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="math.punctuation" select="'none'"/>
 <xsl:variable name="math.punctuation.include" select="$math.punctuation"/>
 
+<!-- A consumer that renders the math SVG into a single-file target  -->
+<!-- (such as the XSL-FO conversion to PDF) can make a               -->
+<!-- cross-reference inside math an active link by setting this to   -->
+<!-- 'yes': the "xref" then emits a \href{#id} that MathJax turns    -->
+<!-- into an SVG "a" element. The "#id" is the shared "unique-id" of -->
+<!-- the target, so it matches the anchor that conversion places on  -->
+<!-- the target. Off ('no') by default, since a chunked target       -->
+<!-- (HTML, EPUB) needs a filename, not a bare fragment, and not     -->
+<!-- every reader honors the SVG link.                               -->
+<xsl:param name="math.cross-references" select="'no'"/>
+
 <!-- We import the HTML stylesheet since we want HTML versions of -->
 <!-- the math bits, but we don't need all the chunking machinery  -->
 <!-- for extracting math, since we are building a single file,    -->
@@ -197,15 +208,40 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!--       And the lxml parser complains when a global XSL variable is redefined      -->
 <!--       in an override/import.                                                     -->
 <!--                                                                                  -->
-<!-- We are going to punt right now and just drop in text, so (1) is  important,      -->
-<!-- but (2) and (3) are no longer issues. This override just plops in text, which    -->
-<!-- automatically comes wrapped in a LaTeX \text{}                                   -->
+<!-- We drop in text (1, the computed number, already wrapped in a LaTeX \text{}),    -->
+<!-- which is all a chunked target (3) can use, and is the default ('no') because not -->
+<!-- every reader honors an SVG link (2). But when "math.cross-references" is 'yes' a -->
+<!-- single-file target (such as the XSL-FO conversion to PDF) wants the live link of -->
+<!-- (2): wrap that same text in a \href to the target's "#id", which MathJax renders -->
+<!-- as an "a" element in the SVG.                                                    -->
 <xsl:template match="*" mode="xref-link-display-math">
     <xsl:param name="target"/>
     <xsl:param name="content"/>
-    <!-- <xsl:text>\text{</xsl:text> -->
-    <xsl:value-of select="$content"/>
-    <!-- <xsl:text>}</xsl:text> -->
+    <xsl:choose>
+        <xsl:when test="$math.cross-references = 'yes'">
+            <xsl:text>\href{#</xsl:text>
+            <xsl:apply-templates select="$target" mode="unique-id"/>
+            <xsl:text>}{</xsl:text>
+            <xsl:choose>
+                <!-- an electronic PDF colors the reference like every    -->
+                <!-- other link (the dark blue of "link-attributes" in    -->
+                <!-- pretext-fo.xsl), via MathJax's \color; print leaves   -->
+                <!-- it black, exactly as the other links do               -->
+                <xsl:when test="$b-latex-print">
+                    <xsl:value-of select="$content"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>\color{#000080}{</xsl:text>
+                    <xsl:value-of select="$content"/>
+                    <xsl:text>}</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>}</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$content"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Knowls -->


### PR DESCRIPTION
A cross-reference (`<xref>`) inside display math (`<md>`) now renders as a live, clickable link in the XSL-FO → PDF output (Apache FOP), colored navy like every other cross-reference. Previously it was static text. Scoped to the FO/PDF route — no change to any other conversion.

### How it works (each link in the chain verified)

1. **Offline MathJax** emits the reference as `\href{#id}{…}` (navy via `\color`, left black for print), which the offline MathJax SVG pass turns into an SVG `<a>`. `#id` is the target's shared `unique-id`.
2. **Script** — FOP's SVG engine (Batik) honors only `xlink:href`, so the build rewrites MathJax's plain `href` to it (the same downgrade FOP applies to `<use>`); and `pdf_fo` asks for the links (see the signature note).
3. **XSL-FO** — FOP creates no *named* destinations for its own links, so `fo:declarations` now emits one `fox:destination` per in-math target, naming the destination the GoTo needs.
4. **Script** — Batik's annotation isn't tagged into the structure tree, so a PDF/UA repair wraps each in a `Link` structure element (ISO 14289, clause 7.18.5).

### Opt-in

A new `math.cross-references` stylesheet parameter (default `no`) gates the link; only `pdf_fo` turns it on. The links are bare `#id` fragments that resolve only within a single file (the PDF), and not every reader honors an SVG link — so chunked targets (HTML, EPUB) keep the static text.

### Python signature change (may affect pretext-CLI)

`mathjax_latex` gains a **required** `math_cross_references` argument (no default), passed positionally at every call site — only the FO SVG call passes `True`, so it is explicit which conversion gets links. This deliberately breaks the signature. **pretext-CLI might call this function**, so I'll open a pretext-CLI issue once this PR exists, in case its call sites need updating.

### Known tradeoff

The `Link` structure elements attach under the document element rather than nesting in their math figure: UA-valid, but reading order is slightly out of context. Precise per-figure nesting needs content-stream geometry FOP/PyMuPDF don't expose — deferred as a follow-up.

### Commits (topic matches the code touched)

- `Offline MathJax: emit an "xref" inside display math as a link` — `extract-math.xsl`
- `Script: enable in-math cross-reference links on the XSL-FO route` — `pretext.py`
- `XSL-FO: name PDF destinations for in-math "xref" targets` — `pretext-fo.xsl`
- `Script: tag in-math link annotations for PDF/UA conformance` — `pretext.py`

### Testing

Sample article builds (306 pages), validates as **PDF/UA-1 (veraPDF, 106/0)**; 5 named destinations and 9 resolved GoTo links including the in-math ones. The sample's "Xref Inside MathJAX" figure shows "Theorem 2.1" / "Section 2" inside the display as navy clickable links.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
