### PR TITLE
XSL-FO: mark paragraphs by first-line indentation, shared with LaTeX

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -447,6 +447,14 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <!-- takes the "enumerate" default, roughly 2.5em.)             -->
 <xsl:variable name="task-indentation" select="2"/>
 
+<!-- A new paragraph is marked by indenting its first line by   -->
+<!-- this many "em", not by vertical space, the book-typography -->
+<!-- default (and what the LaTeX conversion does, through the   -->
+<!-- class "\parindent"). The "p" template of the XSL-FO        -->
+<!-- conversion applies it, and makes Bringhurst's case for the -->
+<!-- indent and for which paragraphs take it.                   -->
+<xsl:variable name="paragraph-indentation" select="1.5"/>
+
 
 <!-- ###### -->
 <!-- Levels -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -939,7 +939,36 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="trailing-tombstone"/>
     <xsl:param name="alignment" select="$text-alignment"/>
     <xsl:apply-templates select="." mode="forced-pagebreak"/>
-    <fo:block text-align="{$alignment}" space-after="0.5em">
+    <fo:block text-align="{$alignment}">
+        <!-- A new paragraph is set off by indenting its first line      -->
+        <!-- rather than by vertical space, so consecutive paragraphs    -->
+        <!-- share the body leading (no "space-after").  Indent a "p"     -->
+        <!-- exactly when another "p" precedes it among its siblings.     -->
+        <!-- The opening paragraph of a division or block (after a        -->
+        <!-- heading, or a figure's "caption") then stays flush, having   -->
+        <!-- no earlier paragraph to break from, while a paragraph that   -->
+        <!-- follows an interruption between paragraphs (a figure, a      -->
+        <!-- list) is the next paragraph in the prose and indents.  Using -->
+        <!-- "preceding-sibling::p" (not the immediate predecessor) keeps -->
+        <!-- an invisible "idx" or "notation" marker between paragraphs   -->
+        <!-- from masking the earlier one.  Text resuming after an        -->
+        <!-- in-paragraph display stays flush: FOP indents only a         -->
+        <!-- block's first line, not a line that follows a nested block.  -->
+        <!-- Bringhurst (The Elements of Typographic Style, 4th ed.)     -->
+        <!-- makes the case for both. Sec. 2.3.2: "In continuous text    -->
+        <!-- mark all paragraphs after the first with an indent of at    -->
+        <!-- least one en" (the 1.5em here, the LaTeX article default,   -->
+        <!-- exceeds that minimum). Sec. 2.3.1, on the flush opener:     -->
+        <!-- "The function of a paragraph indent is to mark a pause,     -->
+        <!-- setting the paragraph apart from what precedes it. If a     -->
+        <!-- paragraph is preceded by a title or subhead, the indent is  -->
+        <!-- superfluous and can therefore be omitted, as it is here."   -->
+        <xsl:if test="preceding-sibling::p">
+            <xsl:attribute name="text-indent">
+                <xsl:value-of select="$paragraph-indentation"/>
+                <xsl:text>em</xsl:text>
+            </xsl:attribute>
+        </xsl:if>
         <!-- a tombstone arriving from an enclosing PROOF-LIKE rides -->
         <!-- the final line, whose elastic leader needs the line     -->
         <!-- justified to push the tombstone to the right margin     -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -569,9 +569,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- paragraph and page setup -->
 <xsl:template name="page-setup">
     <!-- This should save-off the indentation used for the first line of  -->
-    <!-- a paragraph, in effect for the chosen document class.  Then the  -->
-    <!-- "parbox" used by "tcolorbox" can restore indentation rather than -->
-    <!-- run with none.  Part of                                          -->
+    <!-- a paragraph, which we prescribe just below to match the XSL-FO   -->
+    <!-- conversion. Then the "parbox" used by "tcolorbox" can restore    -->
+    <!-- indentation rather than run with none. Part of                   -->
     <!-- https://tex.stackexchange.com/questions/250165/                  -->
     <!-- normal-body-text-within-tcolorbox                                -->
     <!-- In a similar fashion we save/restore the parskip, only should    -->
@@ -579,6 +579,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%% Save default paragraph indentation and parskip for use later, when adjusting parboxes&#xa;</xsl:text>
     <xsl:text>\newlength{\normalparindent}&#xa;</xsl:text>
     <xsl:text>\newlength{\normalparskip}&#xa;</xsl:text>
+    <xsl:text>%% Prescribe the paragraph indent to the value shared with the&#xa;</xsl:text>
+    <xsl:text>%% XSL-FO conversion, so the two agree, rather than accepting the&#xa;</xsl:text>
+    <xsl:text>%% document class default; "\normalparindent" then captures it&#xa;</xsl:text>
+    <xsl:text>\AtBeginDocument{\setlength{\parindent}{</xsl:text>
+    <xsl:value-of select="$paragraph-indentation"/>
+    <xsl:text>em}}&#xa;</xsl:text>
     <xsl:text>\AtBeginDocument{\setlength{\normalparindent}{\parindent}}&#xa;</xsl:text>
     <xsl:text>\AtBeginDocument{\setlength{\normalparskip}{\parskip}}&#xa;</xsl:text>
     <xsl:text>\newcommand{\setparstyle}{\setlength{\parindent}{\normalparindent}\setlength{\parskip}{\normalparskip}}</xsl:text>


### PR DESCRIPTION
In the XSL-FO → PDF route, a new paragraph is now marked by a **first-line indent** rather than by vertical space (each `<p>` previously carried `space-after="0.5em"`). This is the book-typography default and matches the **LaTeX** route. The indent distance lives in the shared "Dimensions and Colors" section of `pretext-common.xsl`, and **both** conversions are driven by it — so they can't drift.

Bringhurst, *The Elements of Typographic Style* (4th ed.): §2.3.2, *"In continuous text mark all paragraphs after the first with an indent of at least one en"*; and §2.3.1 on the flush opening paragraph, *"…the indent is superfluous and can therefore be omitted, as it is here."*

### The rule (FO)

A `<p>` is indented exactly when `preceding-sibling::p` exists. Consequences, all standard practice:

- The opening paragraph of a division or block (after a heading, or a figure's `caption`) is **flush**.
- Subsequent paragraphs **indent**.
- Text resuming after an *in-paragraph* display stays **flush** (FOP indents only a block's first line, not a line that follows a nested block).
- A paragraph after a between-paragraph interruption (figure, list) **indents** — it's the next paragraph of the prose. Using `preceding-sibling::p` rather than the immediate predecessor keeps an invisible `idx`/`notation` marker from masking the earlier paragraph.

### Shared value / consistency

`$paragraph-indentation` is a bare `1.5` in `pretext-common.xsl`; the FO route applies it as `text-indent="1.5em"`, and the LaTeX route now prescribes `\setlength{\parindent}{1.5em}` at begin-document (before `\normalparindent` captures it) rather than accepting the document-class default. At the default 10pt this equals the old class default (15pt), so existing LaTeX output is unchanged — the change locks the two routes together at any size or class.

### Testing

Sample article: FO builds 306 pages, validates **PDF/UA-1 (veraPDF, 106/0)**, with flush openers, indented continuations, flush post-display/figure-inner paragraphs, and indented post-figure paragraphs; the LaTeX route emits `\setlength{\parindent}{1.5em}`.

### Commits

- `Common: share the paragraph indentation distance` — `pretext-common.xsl`, `pretext-latex-common.xsl`
- `XSL-FO: mark new paragraphs by first-line indentation, not vertical space` — `pretext-fo.xsl`

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
