### PR TITLE
Assembly: distinguish identical "intertext" when exploding "md"

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3204,7 +3204,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- true and there is no filtering.  Otherwise we compare an      -->
                 <!-- "mrow"'s following "intertext" to see if it is $break or not. -->
                 <xsl:variable name="md-block" select="$lead-node |
-                    $lead-node/following-sibling::mrow[not($break) or (following-sibling::intertext[1] = $break)]"/>
+                    $lead-node/following-sibling::mrow[not($break) or (count(following-sibling::intertext[1] | $break) = count(following-sibling::intertext[1]))]"/>
                 <!-- put the maximal run into a fresh "md"     -->
                 <!-- Location helps with reconstruction in     -->
                 <!-- the LaTeX conversion, where we un-explode -->


### PR DESCRIPTION
### Problem

A display-math `<md>` containing two or more `<intertext>` elements with **identical text** silently loses one of them. For example:

```xml
<md>
    <mrow>N_1 &amp; = \binom{52}{13} = 635013559600</mrow>
    <intertext>Some text</intertext>
    <mrow>N_2 &amp; = \binom{39}{13} = 8122425444</mrow>
    <intertext>Some text</intertext>
    <mrow>N_3 &amp; = \binom{26}{13} = 10400600</mrow>
    <mrow>N_4 &amp; = 1</mrow>
</md>
```

Only one `Some text` line appears in the output, and the first `<mrow>` pair runs together as if no `<intertext>` separated them. With *distinct* intertext text both survive, which is what makes this easy to miss.

### Root cause

The `intertext-exploder` mode in `xsl/pretext-assembly.xsl` splits the `<md>` into runs of `<mrow>` delimited by each `<intertext>`, identifying the delimiter with

```xslt
following-sibling::intertext[1] = $break
```

In XSLT 1.0 `=` compares **string-values**, not node identity, so two `<intertext>` with the same text are indistinguishable — a later `<mrow>` whose following `<intertext>` merely reads the same as `$break` is pulled into the wrong run, swallowing one of the breaks.

### Fix

Compare by node identity with the union-count idiom (membership form, since the `<mrow>`'s following `<intertext>` may be empty for a trailing row):

```xslt
count(following-sibling::intertext[1] | $break) = count(following-sibling::intertext[1])
```

One line changed.

### Effect and testing

The explosion runs in the shared assembly `repair` pass, so the assembled tree itself was wrong and **both HTML and LaTeX output were affected**. Verified against the sample above:

| output | before | after |
|---|---|---|
| rendered HTML (`para intertext` divs) | 1 | 2 |
| LaTeX (`\intertext`) | 1 | 2 |
| assembled tree (`md` blocks) | 2 | 3 |

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
