### PR TITLE
Exercise group intro/conclusion spacing

### DIFF
--- a/css/components/_spacing.scss
+++ b/css/components/_spacing.scss
@@ -25,13 +25,16 @@ $line-height: 1.35 !default;
 // Most spacing should be done with margin-top.
 
 @layer spacing {
+  // selectors for items that are expected to contain sequences of items
+  $containers: "section, article, .knowl__content, .introduction, .conclusion";
+
   // inter-item spacing high level containers
-  :is(section, article, .knowl__content) > *:not(:first-child) {
+  :is(#{$containers}) > *:not(:first-child) {
     margin-top: 1.5em;
   }
 
   // but tighten up spacing slightly for adjacent paragraphs in a section
-  :is(section, article, .knowl__content) > .para + .para {
+  :is(#{$containers}) > .para + .para {
     margin-top: 1em;
   }
 

--- a/css/components/chunks/_exercises.scss
+++ b/css/components/chunks/_exercises.scss
@@ -8,6 +8,10 @@
   font-size: inherit;
 }
 
+.exercise-like > *:is(.solutions) {
+    margin-top: 0.5em;  // tighten up spacing between answer, hint, solution, etc...
+}
+
 .exercisegroup {
 
   .exercise-like {
@@ -38,7 +42,7 @@
   }
 
   .conclusion {
-    margin-left: 40px;  // match the padding of the exercisegroup-exercises
+    margin-top: 1em;
   
     .heading {
       // exercise heading/numbers regular size

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1133,7 +1133,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <title>A very structured exercise</title>
 
                         <introduction>
-                            <p>This is an over-arching introduction to the whole exercise.  We follow with some tasks.  In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
+                            <p>This is an over-arching introduction to the whole exercise.  We follow with some tasks.</p>
+                            <p>In interdum suscipit ullamcorper. Morbi sit amet malesuada augue, id vestibulum magna. Nulla blandit dui metus, malesuada mollis sapien ullamcorper sit amet. Nulla at neque nisi. Integer vel porta felis.</p>
                         </introduction>
 
                         <task>
@@ -17141,6 +17142,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <exercisegroup>
                     <introduction>
                         <p>This is an exercise group, and this is its introduction.</p>
+                        <p>And a second line for the introduction.</p>
                     </introduction>
                     <exercise>
                         <title>One</title>
@@ -17157,6 +17159,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <p><m>1+1</m></p>
                         </statement>
                     </exercise>
+                    <conclusion>
+                        <p>Here we conclude the group.</p>
+                        <p>And a second line for the conclusion.</p>
+                    </conclusion>
                 </exercisegroup>
 
                 <exercise>
@@ -17379,6 +17385,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             </md></p>
                         </statement>
                     </exercise>
+                    <conclusion>
+                        <p>Here we conclude the group of exercises.</p>
+                        <p>And a second line for the conclusion.</p>
+                    </conclusion>
                 </exercisegroup>
             </exercises>
 


### PR DESCRIPTION
Addresses spacing issues identified by @jjrsylvestre in exercise group intro/conclusions.

I'm not sure the horizontal indent on conclusion makes sense, feels like it should match the intro, not the exercises, but that is what was there historically.