### PR TITLE
XSL-FO: render captions as run-in paragraphs, not centered

### DIFF
--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3287,15 +3287,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- The FIGURE-LIKE blocks (a captioned "figure"; and "table",   -->
 <!-- "listing", "list", each titled) wrap their contents and      -->
-<!-- finish with a centered caption line; all share one counter.  -->
-<!-- The "caption" element is consumed here, so it is killed in   -->
-<!-- the default mode, with the other metadata.                   -->
+<!-- finish with a caption: a body-aligned paragraph led by a     -->
+<!-- bold run-in heading (the type name and number), so a long    -->
+<!-- caption sets as ordinary prose, not centered ragged lines.   -->
+<!-- All share one counter.  The "caption" element is consumed    -->
+<!-- here, so it is killed in the default mode, with the rest     -->
+<!-- of the metadata.                                             -->
 <xsl:template match="&FIGURE-LIKE;">
     <xsl:apply-templates select="." mode="forced-pagebreak"/>
     <fo:block space-before="1em" space-after="1em">
         <xsl:apply-templates select="." mode="link-id-attribute"/>
         <xsl:apply-templates select="*"/>
-        <fo:block text-align="center" space-before="0.5em" keep-with-previous.within-page="always">
+        <fo:block text-align="{$text-alignment}" space-before="0.5em" keep-with-previous.within-page="always">
             <fo:inline font-weight="bold">
                 <xsl:apply-templates select="." mode="type-name"/>
                 <xsl:variable name="the-number">


### PR DESCRIPTION
In the XSL-FO → PDF route, a figure-like block's caption — a `figure`'s `caption`, and the title of a `table`, `listing`, or `list` — was set in a `text-align="center"` block. A short caption survives this, but a long one renders as awkward centered, ragged, multi-line text. A caption is really a paragraph and should follow the same rules: a bold **run-in heading** (the type name and number) leading body-aligned prose.

This switches that block to the document's body alignment (`$text-alignment` — `justify`, or `start` when ragged-right), so the bold "Figure 5.3." / "Table 5.1." becomes a true run-in heading and the caption sets as ordinary prose. The paragraph following the figure already indents correctly via the `p` template's `preceding-sibling::p` rule, and a `caption` holds inline content, so there are no paragraphs *within* it to indent.

### Testing

Sample article: the `figure-long-caption` test (Figure 10.31) now reads as a justified paragraph led by a bold "Figure 10.31." run-in heading, rather than a centered ragged block; short captions and the table/listing/list titles get the same flush run-in treatment. veraPDF `--flavour ua1`: **106 passed / 0 failed**.

### Commits

- `XSL-FO: render captions as run-in paragraphs, not centered`

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
