### PR TITLE
XSL-FO: blue Sage input background and boxes flush with the margins

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -429,11 +429,12 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <!-- Dimensions and Colors, Shared -->
 <!-- ############################# -->
 
-<!-- Distances (and, in time, colors) that should agree         -->
-<!-- between the LaTeX/print and XSL-FO conversions live        -->
-<!-- here, defined once, so the two stay consistent.  A         -->
-<!-- value is a bare number; each conversion attaches its       -->
-<!-- own units as it uses it.                                   -->
+<!-- Distances and colors that should agree between the LaTeX   -->
+<!-- and XSL-FO conversions live here, defined once, so the     -->
+<!-- two stay consistent.  A distance is a bare number, and     -->
+<!-- each conversion attaches its own units; a color is a       -->
+<!-- six-hex-digit RRGGBB string, which each conversion         -->
+<!-- wraps in its own syntax.                                   -->
 
 <!-- An "exercisegroup" indents its exercises, to show the      -->
 <!-- scope of the group, by this fraction of the prevailing     -->
@@ -454,6 +455,10 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <!-- conversion applies it, and makes Bringhurst's case for the -->
 <!-- indent and for which paragraphs take it.                   -->
 <xsl:variable name="paragraph-indentation" select="1.5"/>
+
+<!-- The background tint of a Sage cell's input box: a very     -->
+<!-- pale blue, a heavily lightened version of Sage's own.      -->
+<xsl:variable name="sage-input-background" select="'F2F2FF'"/>
 
 
 <!-- ###### -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3071,6 +3071,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:attribute name="padding">
                 <xsl:text>3pt</xsl:text>
             </xsl:attribute>
+            <!-- the shared Sage-input tint, defined in pretext-common.xsl -->
+            <xsl:attribute name="background-color">
+                <xsl:text>#</xsl:text>
+                <xsl:value-of select="$sage-input-background"/>
+            </xsl:attribute>
+            <!-- FO draws a block's border and padding outward from   -->
+            <!-- the content edge; indenting the content by border +  -->
+            <!-- padding (3.5pt) keeps the box flush with the margins.-->
+            <xsl:attribute name="start-indent">
+                <xsl:text>3.5pt</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="end-indent">
+                <xsl:text>3.5pt</xsl:text>
+            </xsl:attribute>
         </xsl:if>
         <xsl:copy-of select="$content"/>
     </fo:block>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1168,10 +1168,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- A prominent enclosing box, matching the LaTeX conversion's   -->
     <!-- tcolorbox: a thin black frame (0.5mm, the tcolorbox default)  -->
     <!-- on the white page, with padding between frame and content.    -->
+    <!-- Start- and end-indents hold the frame within the text         -->
+    <!-- margins, since FO draws border and padding outward.           -->
     <!-- XSL-FO/FOP has no rounded corners, so the box is square; a    -->
     <!-- finite keep prefers the box whole on a page but yields if it  -->
     <!-- is too tall, rather than clip it.                             -->
-    <fo:block space-before="1em" space-after="1em" border="0.5mm solid black" padding="0.5em" keep-together.within-page="5">
+    <fo:block space-before="1em" space-after="1em" border="0.5mm solid black" padding="2mm" start-indent="2.5mm" end-indent="2.5mm" keep-together.within-page="5">
         <xsl:apply-templates select="." mode="link-id-attribute"/>
         <xsl:if test="title">
             <fo:block font-weight="bold" text-align="center" space-after="0.5em" keep-with-next.within-page="always">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1801,7 +1801,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <!-- See: https://tex.stackexchange.com/questions/240246/           -->
             <!-- problem-with-tcblisting-at-page-break                          -->
             <!-- TODO: integrate into the LaTeX styling schemes -->
-            <xsl:text>\definecolor{sageblue}{rgb}{0.95,0.95,1}&#xa;</xsl:text>
+            <xsl:text>\definecolor{sageblue}{HTML}{</xsl:text><xsl:value-of select="$sage-input-background"/><xsl:text>}&#xa;</xsl:text>
             <xsl:text>\tcbset{ sagestyle/.style={left=0pt, right=0pt, top=0ex, bottom=0ex, middle=0pt, toptitle=0pt, bottomtitle=0pt,&#xa;</xsl:text>
             <xsl:text>boxsep=4pt, listing only, fontupper=\small\ttfamily,&#xa;</xsl:text>
             <xsl:text>breakable, &#xa;</xsl:text>


### PR DESCRIPTION
Two improvements to the XSL-FO route's boxed material, plus a small shared-color precedent.

### A shared color (precedent)

The Sage input's background tint was defined only in the LaTeX preamble (`\definecolor{sageblue}{rgb}{0.95,0.95,1}`). It now lives once in the "Dimensions and Colors, Shared" area of `pretext-common.xsl` as `$sage-input-background = 'F2F2FF'`, and each route wraps it in its own syntax — LaTeX `\definecolor{sageblue}{HTML}{F2F2FF}`, XSL-FO `background-color="#F2F2FF"`. That section already anticipated this ("*and, in time, colors*"); the convention is now stated there: **a shared color is a six-hex-digit RRGGBB string**. (F2F2FF equals the old `rgb(0.95,0.95,1)` at 8 bits, so the LaTeX output is unchanged.)

### Sage cell input — blue background, flush box

The XSL-FO Sage input now carries that pale-blue background, matching the LaTeX route. Its box is also pulled flush with the text margins: XSL-FO draws a block's border and padding *outward* from the content edge, so the box bled ~10px past each side; `start-indent`/`end-indent` of `3.5pt` (border 0.5pt + padding 3pt) bring the border to the margins and inset the code.

### Assemblage box — flush

The assemblage box had the same overflow. Because its frame is `0.5mm` and its padding was `0.5em` — mixed units that can't be summed into one length — the padding is now `2mm`, so border + padding gives a single `2.5mm` inset (also closer to tcolorbox's absolute spacing).

### Testing

Sample and dev articles build via `pdf-fo`; veraPDF `--flavour ua1` stays **106 / 0**. Measured: the Sage box border is flush within 1px and the assemblage within 2px, where both previously bled ~4–12px past the margins. The LaTeX route emits the shared color and is otherwise unchanged.

### Commits

- `Common: share the Sage cell input background color`
- `XSL-FO: tint a Sage cell input box and keep it within the margins`
- `XSL-FO: hold the assemblage box flush with the text margins`

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
