### PR TITLE
Bibliography schema and expanded examples

### DIFF
--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -741,6 +741,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </name>
                 </author>
                 <title>Three Regularity Results in Harmonic Analysis</title>
+                <genre>Ph.D. thesis</genre>
                 <issued>
                     <date year="1996"/>
                 </issued>

--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -600,11 +600,178 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </worksheet>
 
         <references xml:id="references-development" label="references-development">
-            <biblio type="raw" xml:id="biblio-fcla" label="biblio-fcla">
-                <author>R. A. Beezer</author>, <title>A First Course in Linear Algebra</title>, 3rd Edition, Congruent Press, 2012.
+            <title>References</title>
+
+            <biblio xml:id="csl-judson" type="book">
+                <author>
+                    <name>
+                        <given>Thomas W.</given>
+                        <family>Judson</family>
+                    </name>
+                </author>
+                <title>Abstract Algebra: Theory and Applications</title>
+                <issued>
+                    <date year="2022"/>
+                </issued>
+                <publisher>Orthogonal Publishing</publisher>
+                <publisher-place>Ann Arbor, MI</publisher-place>
             </biblio>
-            <biblio type="raw" xml:id="biblio-judson" label="biblio-judson">
-                <author>T. W. Judson</author>, <title>Abstract Algebra: Theory and Applications</title>, Orthogonal Publishing, 2024.
+
+            <biblio xml:id="csl-lay" type="article-journal">
+                <author>
+                    <name>
+                        <given>David C.</given>
+                        <family>Lay</family>
+                    </name>
+                </author>
+                <title>Subspaces and Echelon Forms</title>
+                <container-title>The College Mathematics Journal</container-title>
+                <volume>24</volume>
+                <number>1</number>
+                <issued>
+                    <date year="1993" month="1"/>
+                </issued>
+                <page>57-62</page>
+            </biblio>
+
+            <biblio xml:id="csl-conrey" type="article-journal">
+                <author>
+                    <name>
+                        <given>J. B.</given>
+                        <family>Conrey</family>
+                    </name>
+                    <name>
+                        <given>D. W.</given>
+                        <family>Farmer</family>
+                    </name>
+                </author>
+                <title>Mean values of <m>L</m>-functions and symmetry</title>
+                <container-title>International Mathematics Research Notices</container-title>
+                <volume>17</volume>
+                <issued>
+                    <date year="2000"/>
+                </issued>
+                <page>883-908</page>
+            </biblio>
+
+            <biblio xml:id="csl-dummit" type="book">
+                <author>
+                    <name>
+                        <given>David S.</given>
+                        <family>Dummit</family>
+                    </name>
+                    <name>
+                        <given>Richard M.</given>
+                        <family>Foote</family>
+                    </name>
+                </author>
+                <title>Abstract Algebra</title>
+                <edition>3rd</edition>
+                <issued>
+                    <date year="2004"/>
+                </issued>
+                <publisher>John Wiley &amp; Sons</publisher>
+                <publisher-place>Hoboken, NJ</publisher-place>
+            </biblio>
+
+            <biblio xml:id="csl-pretext" type="webpage">
+                <author>
+                    <name>
+                        <literal>The PreTeXt Project</literal>
+                    </name>
+                </author>
+                <title>The PreTeXt Guide</title>
+                <accessed>
+                    <date year="2026" month="6" day="1"/>
+                </accessed>
+                <URL>https://pretextbook.org/doc/guide/html/</URL>
+            </biblio>
+
+            <biblio xml:id="csl-chapter" type="chapter">
+                <author>
+                    <name>
+                        <given>Jane Q.</given>
+                        <family>Author</family>
+                    </name>
+                </author>
+                <editor>
+                    <name>
+                        <given>John</given>
+                        <family>Smith</family>
+                    </name>
+                </editor>
+                <title>Finite Fields and Their Applications</title>
+                <container-title>Topics in Modern Algebra</container-title>
+                <issued>
+                    <date year="2010"/>
+                </issued>
+                <page>45-98</page>
+                <publisher>Academic Press</publisher>
+                <publisher-place>San Diego, CA</publisher-place>
+            </biblio>
+
+            <biblio xml:id="csl-icm" type="paper-conference">
+                <author>
+                    <name>
+                        <given>A.</given>
+                        <family>Lovelace</family>
+                    </name>
+                    <name>
+                        <given>C.</given>
+                        <family>Babbage</family>
+                    </name>
+                    <name>
+                        <given>G.</given>
+                        <family>Boole</family>
+                    </name>
+                </author>
+                <title>A Fast Algorithm for Matrix Factorization</title>
+                <container-title>Proceedings of the International Congress of Mathematicians</container-title>
+                <issued>
+                    <date year="2018"/>
+                </issued>
+                <page>1123-1140</page>
+            </biblio>
+
+            <biblio xml:id="csl-tao" type="thesis">
+                <author>
+                    <name>
+                        <given>Terence</given>
+                        <family>Tao</family>
+                    </name>
+                </author>
+                <title>Three Regularity Results in Harmonic Analysis</title>
+                <issued>
+                    <date year="1996"/>
+                </issued>
+                <publisher>Princeton University</publisher>
+            </biblio>
+
+            <biblio xml:id="csl-sage" type="software">
+                <author>
+                    <name>
+                        <literal>The Sage Developers</literal>
+                    </name>
+                </author>
+                <title>SageMath, the Sage Mathematics Software System (Version 10.3)</title>
+                <issued>
+                    <date year="2024"/>
+                </issued>
+                <URL>https://www.sagemath.org</URL>
+            </biblio>
+
+            <biblio xml:id="csl-nist" type="report">
+                <author>
+                    <name>
+                        <literal>National Institute of Standards and Technology</literal>
+                    </name>
+                </author>
+                <title>Digital Signature Standard (DSS)</title>
+                <number>FIPS PUB 186-4</number>
+                <issued>
+                    <date year="2013"/>
+                </issued>
+                <publisher>U.S. Department of Commerce</publisher>
             </biblio>
         </references>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17477,6 +17477,315 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </references>
         </section>
 
+        <section xml:id="bibliography-styles" label="bibliography-styles">
+            <title>Bibliography Markup Styles</title>
+
+            <subsection xml:id="bibliography-styles-intro" label="bibliography-styles-intro">
+                <title>The Three Styles</title>
+
+                <p>PreTeXt supports three styles of markup for the <tag>biblio</tag> entries of a <tag>references</tag> division.  To compare them, the same ten references appear three times in the divisions that follow, once in each style.  The references are deliberately varied: books and journal articles, a chapter and a conference paper, a thesis, a report, a software system, and a web page; with one, two, and three authors, as well as organizational authors.</p>
+
+                <p>A <term>raw</term> entry (<c>type="raw"</c>) is free-form mixed content: the author supplies the order, the punctuation, and almost all of the formatting, while PreTeXt styles only a few recognized elements, such as an italicized <tag>title</tag>, a bold <tag>volume</tag>, a parenthesized <tag>year</tag>, and a <tag>number</tag> prefixed by <q>no.</q></p>
+
+                <p>A <term>BibTeX-style</term> entry (<c>type="bibtex"</c>) uses structured fields, rendered in the order written, with punctuation supplied automatically.  The result is more uniform than raw markup, but the field set is small, so details with no dedicated field<mdash/>an edition, a URL, a thesis designation, a report number<mdash/>are tucked into a free-form <tag>pubnote</tag>.</p>
+
+                <p>A <term>CSL-style</term> entry records structured data only<mdash/>names, dates, titles, and the like<mdash/>using markup modeled on the <init>CSL</init>-<init>JSON</init> data format, in a fixed canonical order.  The order of presentation and the punctuation are then supplied by PreTeXt, or, when a <init>CSL</init> style is configured in the publication file, by the <c>citeproc</c> processor.  This is the recommended style as of 2025-08-13.</p>
+            </subsection>
+
+            <references xml:id="references-raw" label="references-raw">
+                <title>Raw Entries</title>
+                <introduction>
+                    <p>The ten references as <c>type="raw"</c> entries.</p>
+                </introduction>
+
+                <biblio xml:id="raw-judson" type="raw">Thomas W. Judson, <title>Abstract Algebra: Theory and Applications</title>, Orthogonal Publishing, Ann Arbor, MI, 2022.</biblio>
+
+                <biblio xml:id="raw-lay" type="raw">David C. Lay, <title>Subspaces and Echelon Forms</title>, <journal>The College Mathematics Journal</journal> <volume>24</volume>, <number>1</number> <year>1993</year>, 57<ndash/>62.</biblio>
+
+                <biblio xml:id="raw-conrey" type="raw">J. B. Conrey and D. W. Farmer, <title>Mean values of <m>L</m>-functions and symmetry</title>, <journal>International Mathematics Research Notices</journal> <volume>17</volume> <year>2000</year>, 883<ndash/>908.</biblio>
+
+                <biblio xml:id="raw-dummit" type="raw">David S. Dummit and Richard M. Foote, <title>Abstract Algebra</title>, 3rd edition, John Wiley &amp; Sons, Hoboken, NJ, 2004.</biblio>
+
+                <biblio xml:id="raw-pretext" type="raw">The PreTeXt Project, <title>The PreTeXt Guide</title>, <c>https://pretextbook.org/doc/guide/html/</c>, accessed June 1, 2026.</biblio>
+
+                <biblio xml:id="raw-chapter" type="raw">Jane Q. Author, <q>Finite Fields and Their Applications</q>, in <title>Topics in Modern Algebra</title>, edited by John Smith, Academic Press, San Diego, CA, 2010, 45<ndash/>98.</biblio>
+
+                <biblio xml:id="raw-icm" type="raw">A. Lovelace, C. Babbage, and G. Boole, <q>A Fast Algorithm for Matrix Factorization</q>, in <title>Proceedings of the International Congress of Mathematicians</title>, 2018, 1123<ndash/>1140.</biblio>
+
+                <biblio xml:id="raw-tao" type="raw">Terence Tao, <title>Three Regularity Results in Harmonic Analysis</title>, Ph.D. thesis, Princeton University, 1996.</biblio>
+
+                <biblio xml:id="raw-sage" type="raw">The Sage Developers, <title>SageMath, the Sage Mathematics Software System (Version 10.3)</title>, 2024, <c>https://www.sagemath.org</c>.</biblio>
+
+                <biblio xml:id="raw-nist" type="raw">National Institute of Standards and Technology, <title>Digital Signature Standard (DSS)</title>, FIPS PUB 186-4, U.S. Department of Commerce, 2013.</biblio>
+            </references>
+
+            <references xml:id="references-bibtex" label="references-bibtex">
+                <title>BibTeX-Style Entries</title>
+                <introduction>
+                    <p>The ten references as <c>type="bibtex"</c> entries.</p>
+                </introduction>
+
+                <biblio xml:id="bibtex-judson" type="bibtex">
+                    <author>Thomas W. Judson</author>
+                    <title>Abstract Algebra: Theory and Applications</title>
+                    <publisher>Orthogonal Publishing, Ann Arbor, MI</publisher>
+                    <year>2022</year>
+                </biblio>
+
+                <biblio xml:id="bibtex-lay" type="bibtex">
+                    <author>David C. Lay</author>
+                    <title>Subspaces and Echelon Forms</title>
+                    <journal>The College Mathematics Journal</journal>
+                    <volume>24</volume>
+                    <number>1</number>
+                    <year>1993</year>
+                    <pages start="57" end="62"/>
+                </biblio>
+
+                <biblio xml:id="bibtex-conrey" type="bibtex">
+                    <author>J. B. Conrey and D. W. Farmer</author>
+                    <title>Mean values of <m>L</m>-functions and symmetry</title>
+                    <journal>International Mathematics Research Notices</journal>
+                    <volume>17</volume>
+                    <year>2000</year>
+                    <pages start="883" end="908"/>
+                </biblio>
+
+                <biblio xml:id="bibtex-dummit" type="bibtex">
+                    <author>David S. Dummit and Richard M. Foote</author>
+                    <title>Abstract Algebra</title>
+                    <publisher>John Wiley &amp; Sons, Hoboken, NJ</publisher>
+                    <year>2004</year>
+                    <pubnote>3rd edition</pubnote>
+                </biblio>
+
+                <biblio xml:id="bibtex-pretext" type="bibtex">
+                    <author>The PreTeXt Project</author>
+                    <title>The PreTeXt Guide</title>
+                    <pubnote>https://pretextbook.org/doc/guide/html/, accessed June 1, 2026</pubnote>
+                </biblio>
+
+                <biblio xml:id="bibtex-chapter" type="bibtex">
+                    <author>Jane Q. Author</author>
+                    <editor>John Smith</editor>
+                    <title>Finite Fields and Their Applications</title>
+                    <series>Topics in Modern Algebra</series>
+                    <publisher>Academic Press, San Diego, CA</publisher>
+                    <year>2010</year>
+                    <pages start="45" end="98"/>
+                </biblio>
+
+                <biblio xml:id="bibtex-icm" type="bibtex">
+                    <author>A. Lovelace, C. Babbage, and G. Boole</author>
+                    <title>A Fast Algorithm for Matrix Factorization</title>
+                    <series>Proceedings of the International Congress of Mathematicians</series>
+                    <year>2018</year>
+                    <pages start="1123" end="1140"/>
+                </biblio>
+
+                <biblio xml:id="bibtex-tao" type="bibtex">
+                    <author>Terence Tao</author>
+                    <title>Three Regularity Results in Harmonic Analysis</title>
+                    <pubnote>Ph.D. thesis, Princeton University</pubnote>
+                    <year>1996</year>
+                </biblio>
+
+                <biblio xml:id="bibtex-sage" type="bibtex">
+                    <author>The Sage Developers</author>
+                    <title>SageMath, the Sage Mathematics Software System (Version 10.3)</title>
+                    <year>2024</year>
+                    <pubnote>https://www.sagemath.org</pubnote>
+                </biblio>
+
+                <biblio xml:id="bibtex-nist" type="bibtex">
+                    <author>National Institute of Standards and Technology</author>
+                    <title>Digital Signature Standard (DSS)</title>
+                    <publisher>U.S. Department of Commerce</publisher>
+                    <year>2013</year>
+                    <pubnote>FIPS PUB 186-4</pubnote>
+                </biblio>
+            </references>
+
+            <references xml:id="references-csl" label="references-csl">
+                <title>CSL-Style Entries</title>
+                <introduction>
+                    <p>The ten references as CSL-style entries.</p>
+                </introduction>
+
+                <biblio xml:id="csl-judson" type="book">
+                    <author>
+                        <name>
+                            <given>Thomas W.</given>
+                            <family>Judson</family>
+                        </name>
+                    </author>
+                    <title>Abstract Algebra: Theory and Applications</title>
+                    <issued>
+                        <date year="2022"/>
+                    </issued>
+                    <publisher>Orthogonal Publishing</publisher>
+                    <publisher-place>Ann Arbor, MI</publisher-place>
+                </biblio>
+
+                <biblio xml:id="csl-lay" type="article-journal">
+                    <author>
+                        <name>
+                            <given>David C.</given>
+                            <family>Lay</family>
+                        </name>
+                    </author>
+                    <title>Subspaces and Echelon Forms</title>
+                    <container-title>The College Mathematics Journal</container-title>
+                    <volume>24</volume>
+                    <number>1</number>
+                    <issued>
+                        <date year="1993" month="1"/>
+                    </issued>
+                    <page>57-62</page>
+                </biblio>
+
+                <biblio xml:id="csl-conrey" type="article-journal">
+                    <author>
+                        <name>
+                            <given>J. B.</given>
+                            <family>Conrey</family>
+                        </name>
+                        <name>
+                            <given>D. W.</given>
+                            <family>Farmer</family>
+                        </name>
+                    </author>
+                    <title>Mean values of <m>L</m>-functions and symmetry</title>
+                    <container-title>International Mathematics Research Notices</container-title>
+                    <volume>17</volume>
+                    <issued>
+                        <date year="2000"/>
+                    </issued>
+                    <page>883-908</page>
+                </biblio>
+
+                <biblio xml:id="csl-dummit" type="book">
+                    <author>
+                        <name>
+                            <given>David S.</given>
+                            <family>Dummit</family>
+                        </name>
+                        <name>
+                            <given>Richard M.</given>
+                            <family>Foote</family>
+                        </name>
+                    </author>
+                    <title>Abstract Algebra</title>
+                    <edition>3rd</edition>
+                    <issued>
+                        <date year="2004"/>
+                    </issued>
+                    <publisher>John Wiley &amp; Sons</publisher>
+                    <publisher-place>Hoboken, NJ</publisher-place>
+                </biblio>
+
+                <biblio xml:id="csl-pretext" type="webpage">
+                    <author>
+                        <name>
+                            <literal>The PreTeXt Project</literal>
+                        </name>
+                    </author>
+                    <title>The PreTeXt Guide</title>
+                    <accessed>
+                        <date year="2026" month="6" day="1"/>
+                    </accessed>
+                    <URL>https://pretextbook.org/doc/guide/html/</URL>
+                </biblio>
+
+                <biblio xml:id="csl-chapter" type="chapter">
+                    <author>
+                        <name>
+                            <given>Jane Q.</given>
+                            <family>Author</family>
+                        </name>
+                    </author>
+                    <editor>
+                        <name>
+                            <given>John</given>
+                            <family>Smith</family>
+                        </name>
+                    </editor>
+                    <title>Finite Fields and Their Applications</title>
+                    <container-title>Topics in Modern Algebra</container-title>
+                    <issued>
+                        <date year="2010"/>
+                    </issued>
+                    <page>45-98</page>
+                    <publisher>Academic Press</publisher>
+                    <publisher-place>San Diego, CA</publisher-place>
+                </biblio>
+
+                <biblio xml:id="csl-icm" type="paper-conference">
+                    <author>
+                        <name>
+                            <given>A.</given>
+                            <family>Lovelace</family>
+                        </name>
+                        <name>
+                            <given>C.</given>
+                            <family>Babbage</family>
+                        </name>
+                        <name>
+                            <given>G.</given>
+                            <family>Boole</family>
+                        </name>
+                    </author>
+                    <title>A Fast Algorithm for Matrix Factorization</title>
+                    <container-title>Proceedings of the International Congress of Mathematicians</container-title>
+                    <issued>
+                        <date year="2018"/>
+                    </issued>
+                    <page>1123-1140</page>
+                </biblio>
+
+                <biblio xml:id="csl-tao" type="thesis">
+                    <author>
+                        <name>
+                            <given>Terence</given>
+                            <family>Tao</family>
+                        </name>
+                    </author>
+                    <title>Three Regularity Results in Harmonic Analysis</title>
+                    <issued>
+                        <date year="1996"/>
+                    </issued>
+                    <publisher>Princeton University</publisher>
+                </biblio>
+
+                <biblio xml:id="csl-sage" type="software">
+                    <author>
+                        <name>
+                            <literal>The Sage Developers</literal>
+                        </name>
+                    </author>
+                    <title>SageMath, the Sage Mathematics Software System (Version 10.3)</title>
+                    <issued>
+                        <date year="2024"/>
+                    </issued>
+                    <URL>https://www.sagemath.org</URL>
+                </biblio>
+
+                <biblio xml:id="csl-nist" type="report">
+                    <author>
+                        <name>
+                            <literal>National Institute of Standards and Technology</literal>
+                        </name>
+                    </author>
+                    <title>Digital Signature Standard (DSS)</title>
+                    <number>FIPS PUB 186-4</number>
+                    <issued>
+                        <date year="2013"/>
+                    </issued>
+                    <publisher>U.S. Department of Commerce</publisher>
+                </biblio>
+            </references>
+        </section>
+
         <exercises xml:id="exercises" label="exercises-top-level">
             <title>Exercises, Top-Level</title>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17835,11 +17835,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </author>
                     <title>Subspaces and Echelon Forms</title>
                     <collection-title>The College Mathematics Journal</collection-title>
+                    <volume>24</volume>
+                    <number>1</number>
                     <issued>
                         <date year="1993" month="1"/>
                     </issued>
-                    <volume>24</volume>
-                    <number>1</number>
                     <page>57-62</page>
                 </biblio>
 
@@ -17851,10 +17851,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <given>John</given>
                         </name>
                     </author>
+                    <title>Still Anonymous, But now Ibid</title>
                     <issued>
                         <date year="1970" month="6" day="1"/>
                     </issued>
-                    <title>Still Anonymous, But now Ibid</title>
                 </biblio>
 
                 <!-- from test suite in citeproc.py JSON example program -->
@@ -17865,10 +17865,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <given>John</given>
                         </name>
                     </author>
+                    <title>His Anonymous Life</title>
                     <issued>
                         <date year="1965" month="6" day="1"/>
                     </issued>
-                    <title>His Anonymous Life</title>
                 </biblio>
 
                 <biblio xml:id="conrey-farmer" type="article-journal">
@@ -17884,10 +17884,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     </author>
                     <title>Mean values of <m>L</m>-functions and symmetry</title>
                     <collection-title>Internat. Math. Res. Notices</collection-title>
+                    <volume>17</volume>
                     <issued>
                         <date year="2000"/>
                     </issued>
-                    <volume>17</volume>
                     <page>883-908</page>
                 </biblio>
 
@@ -17901,11 +17901,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </name>
                     </author>
                     <title>Boundaries of Dissent: Protest and State Power in the Media Age</title>
-                    <publisher>Routledge</publisher>
-                    <publisher-place>New York</publisher-place>
                     <issued>
                         <date year="2006"/>
                     </issued>
+                    <publisher>Routledge</publisher>
+                    <publisher-place>New York</publisher-place>
                     <URL>http://www.test01.com</URL>
                 </biblio>
             </references>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17751,6 +17751,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </name>
                     </author>
                     <title>Three Regularity Results in Harmonic Analysis</title>
+                    <genre>Ph.D. thesis</genre>
                     <issued>
                         <date year="1996"/>
                     </issued>
@@ -18143,7 +18144,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </name>
                     </author>
                     <title>Subspaces and Echelon Forms</title>
-                    <collection-title>The College Mathematics Journal</collection-title>
+                    <container-title>The College Mathematics Journal</container-title>
                     <volume>24</volume>
                     <number>1</number>
                     <issued>
@@ -18192,7 +18193,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         </name>
                     </author>
                     <title>Mean values of <m>L</m>-functions and symmetry</title>
-                    <collection-title>Internat. Math. Res. Notices</collection-title>
+                    <container-title>Internat. Math. Res. Notices</container-title>
                     <volume>17</volume>
                     <issued>
                         <date year="2000"/>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1268,8 +1268,60 @@
                         BibPages |
                         BibPubnote |
                         BibNote)*
-                    ))
+                    ) |
+                    (
+                        # A CSL-style entry, modeled on the CSL-JSON data
+                        # format.  Structured fields, all optional, in a fixed
+                        # canonical order.  With no CSL style active the fields
+                        # are rendered in this (document) order; with a style,
+                        # citeproc-py supplies the order from the CSL-JSON.
+                        attribute type {CSLType},
+                        CSLAuthor?,
+                        CSLEditor?,
+                        CSLTranslator?,
+                        BibTitle?,
+                        BibContainerTitle?,
+                        BibCollectionTitle?,
+                        BibGenre?,
+                        Edition?,
+                        BibVolume?,
+                        BibNumber?,
+                        BibIssue?,
+                        BibIssued?,
+                        BibAccessed?,
+                        BibPage?,
+                        BibPageFirst?,
+                        BibNumberOfPages?,
+                        BibPublisher?,
+                        BibPublisherPlace?,
+                        BibDOI?,
+                        BibISBN?,
+                        BibISSN?,
+                        BibURL?))
                 }
+            # CSL-JSON item types, a curated scholarly subset
+            CSLType =
+                "article" |
+                "article-journal" |
+                "article-magazine" |
+                "article-newspaper" |
+                "book" |
+                "chapter" |
+                "collection" |
+                "dataset" |
+                "document" |
+                "entry" |
+                "entry-dictionary" |
+                "entry-encyclopedia" |
+                "manuscript" |
+                "paper-conference" |
+                "patent" |
+                "report" |
+                "review" |
+                "software" |
+                "speech" |
+                "thesis" |
+                "webpage"
             Ibid = element ibid {empty}
             BibYear = element year {text}
             BibJournal = element journal { TextBib }
@@ -1292,6 +1344,56 @@
                 (
                     text
                 )
+                }
+            # CSL contributors carry structured "name" elements only.  The
+            # element names "author"/"editor" are deliberately shared with the
+            # plain-text BibTeX patterns above; the gating "@type" attribute
+            # keeps the two content models apart (a RELAX NG co-occurrence
+            # constraint).
+            CSLAuthor = element author {CSLName+}
+            CSLEditor = element editor {CSLName+}
+            CSLTranslator = element translator {CSLName+}
+            # A CSL "name": recognized parts in any order, or a literal string
+            CSLName =
+                element name {
+                    (BibFamily |
+                    BibGiven |
+                    BibDroppingParticle |
+                    BibNonDroppingParticle |
+                    BibSuffix |
+                    BibStaticOrdering |
+                    BibLiteral)*
+                }
+            BibFamily = element family {text}
+            BibGiven = element given {text}
+            BibDroppingParticle = element dropping-particle {text}
+            BibNonDroppingParticle = element non-dropping-particle {text}
+            BibSuffix = element suffix {text}
+            BibStaticOrdering = element static-ordering {text}
+            BibLiteral = element literal {text}
+            # CSL standard (string) fields
+            BibContainerTitle = element container-title {TextBib}
+            BibCollectionTitle = element collection-title {TextBib}
+            # A CSL "genre" gives a sub-type, e.g. "Ph.D. thesis"
+            BibGenre = element genre {text}
+            BibIssue = element issue {text}
+            BibPage = element page {text}
+            BibPageFirst = element page-first {text}
+            BibNumberOfPages = element number-of-pages {text}
+            BibPublisherPlace = element publisher-place {TextBib}
+            BibDOI = element DOI {text}
+            BibISBN = element ISBN {text}
+            BibISSN = element ISSN {text}
+            BibURL = element URL {text}
+            # CSL date variables; one "date" per point, two for a range
+            BibIssued = element issued {BibDate+}
+            BibAccessed = element accessed {BibDate+}
+            BibDate =
+                element date {
+                    attribute year {text}?,
+                    attribute month {text}?,
+                    attribute day {text}?,
+                    empty
                 }
             
             GlossaryItem =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1266,6 +1266,7 @@
                         BibSeries |
                         BibPublisher |
                         BibPages |
+                        BibPubnote |
                         BibNote)*
                     ))
                 }
@@ -1280,6 +1281,8 @@
             BibEditor = element editor {text}
             BibSeries = element series {text}
             BibPublisher = element publisher {text}
+            # A BibTeX "pubnote" holds free-form publication information
+            BibPubnote = element pubnote {TextBib}
             BibPages = element pages {
                 (
                     attribute start {text},

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -3293,8 +3293,112 @@
             </choice>
           </zeroOrMore>
         </group>
+        <group>
+          <!--
+            A CSL-style entry, modeled on the CSL-JSON data
+            format.  Structured fields, all optional, in a fixed
+            canonical order.  With no CSL style active the fields
+            are rendered in this (document) order; with a style,
+            citeproc-py supplies the order from the CSL-JSON.
+          -->
+          <attribute name="type">
+            <ref name="CSLType"/>
+          </attribute>
+          <optional>
+            <ref name="CSLAuthor"/>
+          </optional>
+          <optional>
+            <ref name="CSLEditor"/>
+          </optional>
+          <optional>
+            <ref name="CSLTranslator"/>
+          </optional>
+          <optional>
+            <ref name="BibTitle"/>
+          </optional>
+          <optional>
+            <ref name="BibContainerTitle"/>
+          </optional>
+          <optional>
+            <ref name="BibCollectionTitle"/>
+          </optional>
+          <optional>
+            <ref name="BibGenre"/>
+          </optional>
+          <optional>
+            <ref name="Edition"/>
+          </optional>
+          <optional>
+            <ref name="BibVolume"/>
+          </optional>
+          <optional>
+            <ref name="BibNumber"/>
+          </optional>
+          <optional>
+            <ref name="BibIssue"/>
+          </optional>
+          <optional>
+            <ref name="BibIssued"/>
+          </optional>
+          <optional>
+            <ref name="BibAccessed"/>
+          </optional>
+          <optional>
+            <ref name="BibPage"/>
+          </optional>
+          <optional>
+            <ref name="BibPageFirst"/>
+          </optional>
+          <optional>
+            <ref name="BibNumberOfPages"/>
+          </optional>
+          <optional>
+            <ref name="BibPublisher"/>
+          </optional>
+          <optional>
+            <ref name="BibPublisherPlace"/>
+          </optional>
+          <optional>
+            <ref name="BibDOI"/>
+          </optional>
+          <optional>
+            <ref name="BibISBN"/>
+          </optional>
+          <optional>
+            <ref name="BibISSN"/>
+          </optional>
+          <optional>
+            <ref name="BibURL"/>
+          </optional>
+        </group>
       </choice>
     </element>
+  </define>
+  <!-- CSL-JSON item types, a curated scholarly subset -->
+  <define name="CSLType">
+    <choice>
+      <value>article</value>
+      <value>article-journal</value>
+      <value>article-magazine</value>
+      <value>article-newspaper</value>
+      <value>book</value>
+      <value>chapter</value>
+      <value>collection</value>
+      <value>dataset</value>
+      <value>document</value>
+      <value>entry</value>
+      <value>entry-dictionary</value>
+      <value>entry-encyclopedia</value>
+      <value>manuscript</value>
+      <value>paper-conference</value>
+      <value>patent</value>
+      <value>report</value>
+      <value>review</value>
+      <value>software</value>
+      <value>speech</value>
+      <value>thesis</value>
+      <value>webpage</value>
+    </choice>
   </define>
   <define name="Ibid">
     <element name="ibid">
@@ -3372,6 +3476,176 @@
         </group>
         <text/>
       </choice>
+    </element>
+  </define>
+  <!--
+    CSL contributors carry structured "name" elements only.  The
+    element names "author"/"editor" are deliberately shared with the
+    plain-text BibTeX patterns above; the gating "@type" attribute
+    keeps the two content models apart (a RELAX NG co-occurrence
+    constraint).
+  -->
+  <define name="CSLAuthor">
+    <element name="author">
+      <oneOrMore>
+        <ref name="CSLName"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="CSLEditor">
+    <element name="editor">
+      <oneOrMore>
+        <ref name="CSLName"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="CSLTranslator">
+    <element name="translator">
+      <oneOrMore>
+        <ref name="CSLName"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <!-- A CSL "name": recognized parts in any order, or a literal string -->
+  <define name="CSLName">
+    <element name="name">
+      <zeroOrMore>
+        <choice>
+          <ref name="BibFamily"/>
+          <ref name="BibGiven"/>
+          <ref name="BibDroppingParticle"/>
+          <ref name="BibNonDroppingParticle"/>
+          <ref name="BibSuffix"/>
+          <ref name="BibStaticOrdering"/>
+          <ref name="BibLiteral"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="BibFamily">
+    <element name="family">
+      <text/>
+    </element>
+  </define>
+  <define name="BibGiven">
+    <element name="given">
+      <text/>
+    </element>
+  </define>
+  <define name="BibDroppingParticle">
+    <element name="dropping-particle">
+      <text/>
+    </element>
+  </define>
+  <define name="BibNonDroppingParticle">
+    <element name="non-dropping-particle">
+      <text/>
+    </element>
+  </define>
+  <define name="BibSuffix">
+    <element name="suffix">
+      <text/>
+    </element>
+  </define>
+  <define name="BibStaticOrdering">
+    <element name="static-ordering">
+      <text/>
+    </element>
+  </define>
+  <define name="BibLiteral">
+    <element name="literal">
+      <text/>
+    </element>
+  </define>
+  <!-- CSL standard (string) fields -->
+  <define name="BibContainerTitle">
+    <element name="container-title">
+      <ref name="TextBib"/>
+    </element>
+  </define>
+  <define name="BibCollectionTitle">
+    <element name="collection-title">
+      <ref name="TextBib"/>
+    </element>
+  </define>
+  <!-- A CSL "genre" gives a sub-type, e.g. "Ph.D. thesis" -->
+  <define name="BibGenre">
+    <element name="genre">
+      <text/>
+    </element>
+  </define>
+  <define name="BibIssue">
+    <element name="issue">
+      <text/>
+    </element>
+  </define>
+  <define name="BibPage">
+    <element name="page">
+      <text/>
+    </element>
+  </define>
+  <define name="BibPageFirst">
+    <element name="page-first">
+      <text/>
+    </element>
+  </define>
+  <define name="BibNumberOfPages">
+    <element name="number-of-pages">
+      <text/>
+    </element>
+  </define>
+  <define name="BibPublisherPlace">
+    <element name="publisher-place">
+      <ref name="TextBib"/>
+    </element>
+  </define>
+  <define name="BibDOI">
+    <element name="DOI">
+      <text/>
+    </element>
+  </define>
+  <define name="BibISBN">
+    <element name="ISBN">
+      <text/>
+    </element>
+  </define>
+  <define name="BibISSN">
+    <element name="ISSN">
+      <text/>
+    </element>
+  </define>
+  <define name="BibURL">
+    <element name="URL">
+      <text/>
+    </element>
+  </define>
+  <!-- CSL date variables; one "date" per point, two for a range -->
+  <define name="BibIssued">
+    <element name="issued">
+      <oneOrMore>
+        <ref name="BibDate"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="BibAccessed">
+    <element name="accessed">
+      <oneOrMore>
+        <ref name="BibDate"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="BibDate">
+    <element name="date">
+      <optional>
+        <attribute name="year"/>
+      </optional>
+      <optional>
+        <attribute name="month"/>
+      </optional>
+      <optional>
+        <attribute name="day"/>
+      </optional>
+      <empty/>
     </element>
   </define>
   <define name="GlossaryItem">

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -3288,6 +3288,7 @@
               <ref name="BibSeries"/>
               <ref name="BibPublisher"/>
               <ref name="BibPages"/>
+              <ref name="BibPubnote"/>
               <ref name="BibNote"/>
             </choice>
           </zeroOrMore>
@@ -3353,6 +3354,12 @@
   <define name="BibPublisher">
     <element name="publisher">
       <text/>
+    </element>
+  </define>
+  <!-- A BibTeX "pubnote" holds free-form publication information -->
+  <define name="BibPubnote">
+    <element name="pubnote">
+      <ref name="TextBib"/>
     </element>
   </define>
   <define name="BibPages">

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2672,7 +2672,7 @@
     <section>
         <title>Bibliography</title>
 
-        <p>This is all stop-gap and will change radically.  But it seems to work for now.  So these rules should not be taken as definitive, at all.</p>
+        <p>This support is in-progress and may be expanded.  The CSL-style entry, in particular, covers a curated scholarly subset of the CSL-JSON model for now, and may grow beyond this initial curation.</p>
 
         <fragment xml:id="bibliography">
             <title>Bibliography</title>
@@ -2706,8 +2706,60 @@
                         BibPages |
                         BibPubnote |
                         BibNote)*
-                    ))
+                    ) |
+                    (
+                        # A CSL-style entry, modeled on the CSL-JSON data
+                        # format.  Structured fields, all optional, in a fixed
+                        # canonical order.  With no CSL style active the fields
+                        # are rendered in this (document) order; with a style,
+                        # citeproc-py supplies the order from the CSL-JSON.
+                        attribute type {CSLType},
+                        CSLAuthor?,
+                        CSLEditor?,
+                        CSLTranslator?,
+                        BibTitle?,
+                        BibContainerTitle?,
+                        BibCollectionTitle?,
+                        BibGenre?,
+                        Edition?,
+                        BibVolume?,
+                        BibNumber?,
+                        BibIssue?,
+                        BibIssued?,
+                        BibAccessed?,
+                        BibPage?,
+                        BibPageFirst?,
+                        BibNumberOfPages?,
+                        BibPublisher?,
+                        BibPublisherPlace?,
+                        BibDOI?,
+                        BibISBN?,
+                        BibISSN?,
+                        BibURL?))
                 }
+            # CSL-JSON item types, a curated scholarly subset
+            CSLType =
+                "article" |
+                "article-journal" |
+                "article-magazine" |
+                "article-newspaper" |
+                "book" |
+                "chapter" |
+                "collection" |
+                "dataset" |
+                "document" |
+                "entry" |
+                "entry-dictionary" |
+                "entry-encyclopedia" |
+                "manuscript" |
+                "paper-conference" |
+                "patent" |
+                "report" |
+                "review" |
+                "software" |
+                "speech" |
+                "thesis" |
+                "webpage"
             Ibid = element ibid {empty}
             BibYear = element year {text}
             BibJournal = element journal { TextBib }
@@ -2730,6 +2782,56 @@
                 (
                     text
                 )
+                }
+            # CSL contributors carry structured "name" elements only.  The
+            # element names "author"/"editor" are deliberately shared with the
+            # plain-text BibTeX patterns above; the gating "@type" attribute
+            # keeps the two content models apart (a RELAX NG co-occurrence
+            # constraint).
+            CSLAuthor = element author {CSLName+}
+            CSLEditor = element editor {CSLName+}
+            CSLTranslator = element translator {CSLName+}
+            # A CSL "name": recognized parts in any order, or a literal string
+            CSLName =
+                element name {
+                    (BibFamily |
+                    BibGiven |
+                    BibDroppingParticle |
+                    BibNonDroppingParticle |
+                    BibSuffix |
+                    BibStaticOrdering |
+                    BibLiteral)*
+                }
+            BibFamily = element family {text}
+            BibGiven = element given {text}
+            BibDroppingParticle = element dropping-particle {text}
+            BibNonDroppingParticle = element non-dropping-particle {text}
+            BibSuffix = element suffix {text}
+            BibStaticOrdering = element static-ordering {text}
+            BibLiteral = element literal {text}
+            # CSL standard (string) fields
+            BibContainerTitle = element container-title {TextBib}
+            BibCollectionTitle = element collection-title {TextBib}
+            # A CSL "genre" gives a sub-type, e.g. "Ph.D. thesis"
+            BibGenre = element genre {text}
+            BibIssue = element issue {text}
+            BibPage = element page {text}
+            BibPageFirst = element page-first {text}
+            BibNumberOfPages = element number-of-pages {text}
+            BibPublisherPlace = element publisher-place {TextBib}
+            BibDOI = element DOI {text}
+            BibISBN = element ISBN {text}
+            BibISSN = element ISSN {text}
+            BibURL = element URL {text}
+            # CSL date variables; one "date" per point, two for a range
+            BibIssued = element issued {BibDate+}
+            BibAccessed = element accessed {BibDate+}
+            BibDate =
+                element date {
+                    attribute year {text}?,
+                    attribute month {text}?,
+                    attribute day {text}?,
+                    empty
                 }
             </code>
         </fragment>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2704,6 +2704,7 @@
                         BibSeries |
                         BibPublisher |
                         BibPages |
+                        BibPubnote |
                         BibNote)*
                     ))
                 }
@@ -2718,6 +2719,8 @@
             BibEditor = element editor {text}
             BibSeries = element series {text}
             BibPublisher = element publisher {text}
+            # A BibTeX "pubnote" holds free-form publication information
+            BibPubnote = element pubnote {TextBib}
             BibPages = element pages {
                 (
                     attribute start {text},


### PR DESCRIPTION
PreTeXt has three styles of markup for the `<biblio>` entries of a `<references>` division: free-form `@type="raw"`, structured `@type="bibtex"`, and a CSL style (structured data modeled on CSL-JSON, processed by `citeproc-py`). This PR brings the CSL style into the production schema and expands the examples so all three styles are exercised and documented.

**Schema**

- Adds a curated CSL `<biblio>` vocabulary to the production grammar (`pretext.rnc`): item types (`book`, `article-journal`, `chapter`, `thesis`, …), structured `author`/`editor`/`translator` names, `issued`/`accessed` dates, and the common scholarly fields (`container-title`, `volume`, `issue`, `page`, `publisher`, `genre`, `edition`, `DOI`, `ISBN`, `ISSN`, `URL`, …). The fields are all optional, in a fixed canonical order.
- The element names `author`/`editor` are shared with the plain-text BibTeX patterns; the `@type` value keeps the two content models apart (a RELAX NG co-occurrence constraint), so a BibTeX entry's author is text while a CSL entry's is one or more structured `<name>`s.
- Admits `<pubnote>` in a BibTeX `<biblio>`, closing a long-standing gap between the schema and the converters (which already render it).
- `pretext.rng` is regenerated. (The W3C `pretext.xsd` is intentionally not regenerated: trang's XSD path cannot follow the PreFigure `externalRef`, so that file is stale repository-wide, independent of this change.)

**Examples**

- `sample-article`: a new "Bibliography Markup Styles" section — an introductory subsection explaining the three styles, followed by three `<references>` divisions (raw, BibTeX, CSL) presenting the same twelve references in each style, with varied entry kinds (book, journal article, chapter, conference paper, thesis, report, software, web page) and one, two, three, and organizational authors. The existing backmatter CSL entries are reordered to the canonical order and updated to use `container-title` and `genre`.
- `pdf-fo-development`: its references are now CSL-style entries, giving the XSL-FO converter a CSL bibliography to develop against.

The new CSL markup validates against the schema in this PR (`jing`, dev grammar). Rendering refinements for the newer CSL fields (the no-CSL fallback and XSL-FO) follow in a separate PR; the schema and example markup land first here.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
