### PR TITLE
Bibliography rendering: CSL fallback fields, BibTeX punctuation, and XSL-FO names

### DIFF
--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -774,6 +774,43 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </issued>
                 <publisher>U.S. Department of Commerce</publisher>
             </biblio>
+
+            <biblio xml:id="csl-strang" type="book">
+                <author>
+                    <name>
+                        <given>Gilbert</given>
+                        <family>Strang</family>
+                    </name>
+                </author>
+                <title>Introduction to Linear Algebra</title>
+                <edition>5th</edition>
+                <issued>
+                    <date year="2016"/>
+                </issued>
+                <number-of-pages>584</number-of-pages>
+                <publisher>Wellesley-Cambridge Press</publisher>
+                <publisher-place>Wellesley, MA</publisher-place>
+                <ISBN>978-0-9802327-7-6</ISBN>
+            </biblio>
+
+            <biblio xml:id="csl-trefethen" type="article-journal">
+                <author>
+                    <name>
+                        <given>L. N.</given>
+                        <family>Trefethen</family>
+                    </name>
+                </author>
+                <title>A Brief Note on Spectral Methods</title>
+                <container-title>SIAM Review</container-title>
+                <volume>50</volume>
+                <issue>1</issue>
+                <issued>
+                    <date year="2008"/>
+                </issued>
+                <page-first>67</page-first>
+                <DOI>10.1137/060657716</DOI>
+                <ISSN>0036-1445</ISSN>
+            </biblio>
         </references>
 
         <backmatter xml:id="backmatter" label="backmatter">

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17483,7 +17483,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <subsection xml:id="bibliography-styles-intro" label="bibliography-styles-intro">
                 <title>The Three Styles</title>
 
-                <p>PreTeXt supports three styles of markup for the <tag>biblio</tag> entries of a <tag>references</tag> division.  To compare them, the same ten references appear three times in the divisions that follow, once in each style.  The references are deliberately varied: books and journal articles, a chapter and a conference paper, a thesis, a report, a software system, and a web page; with one, two, and three authors, as well as organizational authors.</p>
+                <p>PreTeXt supports three styles of markup for the <tag>biblio</tag> entries of a <tag>references</tag> division.  To compare them, the same twelve references appear three times in the divisions that follow, once in each style.  The references are deliberately varied: books and journal articles, a chapter and a conference paper, a thesis, a report, a software system, and a web page; with one, two, and three authors, as well as organizational authors.</p>
 
                 <p>A <term>raw</term> entry (<c>type="raw"</c>) is free-form mixed content: the author supplies the order, the punctuation, and almost all of the formatting, while PreTeXt styles only a few recognized elements, such as an italicized <tag>title</tag>, a bold <tag>volume</tag>, a parenthesized <tag>year</tag>, and a <tag>number</tag> prefixed by <q>no.</q></p>
 
@@ -17495,7 +17495,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <references xml:id="references-raw" label="references-raw">
                 <title>Raw Entries</title>
                 <introduction>
-                    <p>The ten references as <c>type="raw"</c> entries.</p>
+                    <p>The twelve references as <c>type="raw"</c> entries.</p>
                 </introduction>
 
                 <biblio xml:id="raw-judson" type="raw">Thomas W. Judson, <title>Abstract Algebra: Theory and Applications</title>, Orthogonal Publishing, Ann Arbor, MI, 2022.</biblio>
@@ -17517,12 +17517,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <biblio xml:id="raw-sage" type="raw">The Sage Developers, <title>SageMath, the Sage Mathematics Software System (Version 10.3)</title>, 2024, <c>https://www.sagemath.org</c>.</biblio>
 
                 <biblio xml:id="raw-nist" type="raw">National Institute of Standards and Technology, <title>Digital Signature Standard (DSS)</title>, FIPS PUB 186-4, U.S. Department of Commerce, 2013.</biblio>
+
+                <biblio xml:id="raw-strang" type="raw">Gilbert Strang, <title>Introduction to Linear Algebra</title>, 5th edition, Wellesley<ndash/>Cambridge Press, Wellesley, MA, 2016, 584 pages, ISBN 978-0-9802327-7-6.</biblio>
+
+                <biblio xml:id="raw-trefethen" type="raw">L. N. Trefethen, <q>A Brief Note on Spectral Methods</q>, <journal>SIAM Review</journal> <volume>50</volume> <number>1</number> <year>2008</year>, p. 67, doi:10.1137/060657716, ISSN 0036-1445.</biblio>
             </references>
 
             <references xml:id="references-bibtex" label="references-bibtex">
                 <title>BibTeX-Style Entries</title>
                 <introduction>
-                    <p>The ten references as <c>type="bibtex"</c> entries.</p>
+                    <p>The twelve references as <c>type="bibtex"</c> entries.</p>
                 </introduction>
 
                 <biblio xml:id="bibtex-judson" type="bibtex">
@@ -17604,12 +17608,32 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <year>2013</year>
                     <pubnote>FIPS PUB 186-4</pubnote>
                 </biblio>
+
+                <biblio xml:id="bibtex-strang" type="bibtex">
+                    <author>Gilbert Strang</author>
+                    <title>Introduction to Linear Algebra</title>
+                    <publisher>Wellesley-Cambridge Press, Wellesley, MA</publisher>
+                    <year>2016</year>
+                    <pages>584</pages>
+                    <pubnote>5th edition; ISBN 978-0-9802327-7-6</pubnote>
+                </biblio>
+
+                <biblio xml:id="bibtex-trefethen" type="bibtex">
+                    <author>L. N. Trefethen</author>
+                    <title>A Brief Note on Spectral Methods</title>
+                    <journal>SIAM Review</journal>
+                    <volume>50</volume>
+                    <number>1</number>
+                    <year>2008</year>
+                    <pages>67</pages>
+                    <pubnote>doi:10.1137/060657716; ISSN 0036-1445</pubnote>
+                </biblio>
             </references>
 
             <references xml:id="references-csl" label="references-csl">
                 <title>CSL-Style Entries</title>
                 <introduction>
-                    <p>The ten references as CSL-style entries.</p>
+                    <p>The twelve references as CSL-style entries.</p>
                 </introduction>
 
                 <biblio xml:id="csl-judson" type="book">
@@ -17783,6 +17807,43 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <date year="2013"/>
                     </issued>
                     <publisher>U.S. Department of Commerce</publisher>
+                </biblio>
+
+                <biblio xml:id="csl-strang" type="book">
+                    <author>
+                        <name>
+                            <given>Gilbert</given>
+                            <family>Strang</family>
+                        </name>
+                    </author>
+                    <title>Introduction to Linear Algebra</title>
+                    <edition>5th</edition>
+                    <issued>
+                        <date year="2016"/>
+                    </issued>
+                    <number-of-pages>584</number-of-pages>
+                    <publisher>Wellesley-Cambridge Press</publisher>
+                    <publisher-place>Wellesley, MA</publisher-place>
+                    <ISBN>978-0-9802327-7-6</ISBN>
+                </biblio>
+
+                <biblio xml:id="csl-trefethen" type="article-journal">
+                    <author>
+                        <name>
+                            <given>L. N.</given>
+                            <family>Trefethen</family>
+                        </name>
+                    </author>
+                    <title>A Brief Note on Spectral Methods</title>
+                    <container-title>SIAM Review</container-title>
+                    <volume>50</volume>
+                    <issue>1</issue>
+                    <issued>
+                        <date year="2008"/>
+                    </issued>
+                    <page-first>67</page-first>
+                    <DOI>10.1137/060657716</DOI>
+                    <ISSN>0036-1445</ISSN>
                 </biblio>
             </references>
         </section>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9859,10 +9859,45 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:message>PTX:WARNING:  a child of "biblio" (<xsl:value-of select="local-name()"/>) is not being processed.  Please report me so this can be fixed.</xsl:message>
 </xsl:template>
 
-<!-- Authors, no lead-in, no trailing space -->
+<!-- Authors: no lead-in, names via the shared "contributor-names" -->
 <xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/author">
+    <xsl:apply-templates select="." mode="contributor-names"/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Editors and translators: a leading separator, the names, then a -->
+<!-- parenthetical role label (pluralized by the count of "name").   -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/editor">
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="contributor-names"/>
+    <xsl:choose>
+        <xsl:when test="count(name) &gt; 1">
+            <xsl:text> (eds.)</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text> (ed.)</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/translator">
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="contributor-names"/>
+    <xsl:text> (trans.)</xsl:text>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Private mode: format the "name" list of a CSL contributor.      -->
+<!-- The first name is family-first, the rest given-first, with      -->
+<!-- "and"/";" separators; a "literal" name is printed verbatim.     -->
+<xsl:template match="*" mode="contributor-names">
     <xsl:for-each select="name">
         <xsl:choose>
+            <!-- An organizational or otherwise literal name -->
+            <xsl:when test="literal">
+                <xsl:apply-templates select="literal"/>
+            </xsl:when>
             <!-- First, name with family name first -->
             <xsl:when test="not(preceding-sibling::name)">
                 <xsl:apply-templates select="family"/>
@@ -9887,7 +9922,6 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
             </xsl:otherwise>
         </xsl:choose>
     </xsl:for-each>
-    <xsl:apply-templates select="." mode="plain-biblio-period"/>
 </xsl:template>
 
 <!-- Title, in italics -->
@@ -9920,12 +9954,27 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:apply-templates select="." mode="plain-biblio-period"/>
 </xsl:template>
 
-<!-- Collection title -->
-<!-- Once had "lq-character" and "rq-character", but -->
-<!-- removed for consistency with other formats      -->
-<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/collection-title">
+<!-- Container title (a journal, proceedings, or the book of a -->
+<!-- chapter); rendered plain, like a collection title         -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/container-title">
     <xsl:text>, </xsl:text>
     <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Genre, a sub-type such as "Ph.D. thesis" -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/genre">
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Edition, with the word spelled out (so the abbreviation's -->
+<!-- period does not collide with a final period)             -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/edition">
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text> edition</xsl:text>
     <xsl:apply-templates select="." mode="plain-biblio-period"/>
 </xsl:template>
 
@@ -9949,6 +9998,22 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:text>(</xsl:text>
     <xsl:value-of select="date/@year"/>
     <xsl:text>)</xsl:text>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Access date, for online material; month and day are padded to -->
+<!-- two digits, for an ISO 8601 (YYYY-MM-DD) appearance           -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/accessed">
+    <xsl:text>, accessed </xsl:text>
+    <xsl:value-of select="date/@year"/>
+    <xsl:if test="date/@month">
+        <xsl:text>-</xsl:text>
+        <xsl:value-of select="format-number(date/@month, '00')"/>
+    </xsl:if>
+    <xsl:if test="date/@day">
+        <xsl:text>-</xsl:text>
+        <xsl:value-of select="format-number(date/@day, '00')"/>
+    </xsl:if>
     <xsl:apply-templates select="." mode="plain-biblio-period"/>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10076,6 +10076,46 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:apply-templates select="." mode="plain-biblio-period"/>
 </xsl:template>
 
+<!-- Issue, parenthesized, directly following the volume -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/issue">
+    <xsl:text>(</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>)</xsl:text>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- First page, when no range is recorded -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/page-first">
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Total page count, as for a book -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/number-of-pages">
+    <xsl:text>, </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text> pages</xsl:text>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
+<!-- Identifiers: a DOI in monospace, an ISBN or ISSN labelled -->
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/DOI">
+    <xsl:text>, doi:</xsl:text>
+    <xsl:apply-templates select="." mode="monospace"/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/ISBN">
+    <xsl:text>, ISBN </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+<xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/ISSN">
+    <xsl:text>, ISSN </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="plain-biblio-period"/>
+</xsl:template>
+
 <xsl:template match="*" mode="plain-biblio-period">
     <xsl:if test="not(following-sibling::*)">
         <xsl:text>.</xsl:text>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9767,89 +9767,131 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 </xsl:template>
 
 
-<!-- Fully marked-up bibtex-style bibliographic entry formatting -->
-<!-- Current treatment assumes elements are in the correct order -->
+<!-- Fully marked-up bibtex-style bibliographic entry formatting.    -->
+<!-- Current treatment assumes elements are in the correct order.    -->
+<!-- Each field is followed by its own separator, except the last,   -->
+<!-- which is finished with a period (see "bibtex-separator").       -->
 
-<!-- Comma after author or editor -->
+<!-- Trailing punctuation for a BibTeX field: the given separator   -->
+<!-- when another field follows, otherwise a period.  An annotation -->
+<!-- "note" is not an inline field, so it does not count here.       -->
+<xsl:template match="*" mode="bibtex-separator">
+    <xsl:param name="separator"/>
+    <xsl:choose>
+        <xsl:when test="following-sibling::*[not(self::note)]">
+            <xsl:value-of select="$separator"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>.</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Author, comma after -->
 <xsl:template match="biblio[@type='bibtex']/author">
     <xsl:apply-templates select="text()"/>
-    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
+
+<!-- Editor, labelled, comma after -->
 <xsl:template match="biblio[@type='bibtex']/editor">
     <xsl:apply-templates select="text()"/>
-    <xsl:text>, </xsl:text>
+    <xsl:text> (ed.)</xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Title in italics, followed by comma -->
+<!-- Title in italics, comma after -->
 <xsl:template match="biblio[@type='bibtex']/title">
     <xsl:apply-templates select="." mode="italic"/>
-    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Space after journal -->
+<!-- Journal, space after -->
 <xsl:template match="biblio[@type='bibtex']/journal">
     <xsl:apply-templates select="text()|m"/>
-    <xsl:text> </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="' '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Volume in bold -->
+<!-- Volume in bold, space after -->
 <xsl:template match="biblio[@type='bibtex']/volume">
     <xsl:apply-templates select="." mode="bold"/>
-    <xsl:text> </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="' '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Series is plain (but space after) -->
+<!-- Series, comma after (so it separates from a following publisher) -->
 <xsl:template match="biblio[@type='bibtex']/series">
     <xsl:apply-templates select="text()"/>
-    <xsl:text> </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Publisher is plain (but semicolon after) -->
+<!-- Publisher, comma after -->
 <xsl:template match="biblio[@type='bibtex']/publisher">
     <xsl:apply-templates select="text()"/>
-    <xsl:text>; </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Year in parentheses -->
+<!-- Year in parentheses, space after -->
 <xsl:template match="biblio[@type='bibtex']/year">
     <xsl:text>(</xsl:text>
     <xsl:apply-templates select="text()"/>
-    <xsl:text>) </xsl:text>
+    <xsl:text>)</xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="' '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Number: no. and comma after -->
-<!-- Note: original pure LaTeX implemenation did not have -->
-<!-- a trailing comma, the pure HTML implementation did   -->
+<!-- Number, as "no. N", space after -->
 <xsl:template match="biblio[@type='bibtex']/number">
     <xsl:text>no</xsl:text>
     <xsl:call-template name="biblio-period"/>
     <xsl:call-template name="thin-space-character"/>
     <xsl:apply-templates select="text()"/>
-    <xsl:text>, </xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="' '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- A "pubnote", which could contain any publication information. -->
-<!-- Render all content (not just "text()") so inline markup, such -->
-<!-- as an "ndash" in a page or place range, is not dropped.       -->
+<!-- A "pubnote" holds free-form publication information.  Render all -->
+<!-- content (not just "text()") so inline markup such as an "ndash"  -->
+<!-- is not dropped; comma after.                                     -->
 <xsl:template match="biblio[@type='bibtex']/pubnote">
-    <xsl:text> [</xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>]</xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
-<!-- Pages should come last, so put a period.    -->
-<!-- Two forms: @start and @end,                 -->
-<!-- or total number as content (as for a book). -->
+<!-- Pages, two forms: a total count (a book), or a @start/@end       -->
+<!-- range.  Comma after, unless last, when "bibtex-separator" ends   -->
+<!-- the entry with a period.                                         -->
 <xsl:template match="biblio[@type='bibtex']/pages[not(@start)]">
     <xsl:apply-templates select="text()"/>
-    <xsl:text>.</xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 <xsl:template match="biblio[@type='bibtex']/pages[@start]">
     <xsl:text>pp</xsl:text>
     <xsl:call-template name="biblio-period"/>
     <xsl:call-template name="thin-space-character"/>
     <xsl:value-of select="@start"/><xsl:text>-</xsl:text><xsl:value-of select="@end"/>
-    <xsl:text>.</xsl:text>
+    <xsl:apply-templates select="." mode="bibtex-separator">
+        <xsl:with-param name="separator" select="', '"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- Always: authors first, no leading separator -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9828,10 +9828,12 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
     <xsl:text>, </xsl:text>
 </xsl:template>
 
-<!-- A "pubnote", which could contain any publication information -->
+<!-- A "pubnote", which could contain any publication information. -->
+<!-- Render all content (not just "text()") so inline markup, such -->
+<!-- as an "ndash" in a page or place range, is not dropped.       -->
 <xsl:template match="biblio[@type='bibtex']/pubnote">
     <xsl:text> [</xsl:text>
-    <xsl:apply-templates select="text()"/>
+    <xsl:apply-templates/>
     <xsl:text>]</xsl:text>
 </xsl:template>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2854,6 +2854,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- Render the parts of a CSL "name"; the catch-all "*" harness -->
+<!-- below drops their text, but only until it is removed.       -->
+<xsl:template match="biblio/author/name/* | biblio/editor/name/* | biblio/translator/name/*">
+    <xsl:apply-templates/>
+</xsl:template>
+
 <xsl:template match="biblio" mode="bibentry-wrapper">
     <xsl:param name="content"/>
     <fo:list-block provisional-distance-between-starts="2.5em"


### PR DESCRIPTION
Follow-up to #2969, which added the CSL `<biblio>` vocabulary to the schema and the example markup. This PR makes the converters render that markup well, focused on the **no-CSL-style fallback** — how a structured CSL entry is formatted when no CSL style is configured in the publication file (PreTeXt's own templates, in the canonical/document order), rather than the `citeproc`-driven path.

**CSL no-style fallback** (`pretext-common.xsl`)

- Renders the full curated CSL vocabulary that the schema now allows but the fallback was dropping silently: `container-title`, `editor`/`translator` (with `(ed.)`/`(eds.)`/`(trans.)` role labels), organizational/literal author names, `genre`, `edition`, `accessed` (ISO `YYYY-MM-DD`, zero-padded), `issue`, `page-first`, `number-of-pages`, `DOI`, `ISBN`, `ISSN`.
- A shared template formats the `<name>` list of any contributor (author/editor/translator), with literal-name support; also removes a duplicate `collection-title` template.

**XSL-FO** (`pretext-fo.xsl`)

- Renders the structured CSL names (`family`/`given`/…), which the FO development catch-all — a temporary harness that drops interior text — was swallowing. The added rule mirrors the built-ins, so it is non-load-bearing and becomes redundant once that harness is removed.

**BibTeX punctuation** (`pretext-common.xsl`)

- Reworked so each field is followed by its own separator, except the last field of an entry, which ends with a period — whichever field that is, no longer dependent on `pages` being present. `series` and `publisher` are now comma-separated; `pubnote` renders inline (no brackets) and keeps inline markup such as an `<ndash/>`; `editor` is labelled.

**Examples**

- The three `<references>` divisions in `sample-article` and the `pdf-fo-development` references each gain two items — a book and a journal article — exercising the newer CSL fields (`ISBN`, `number-of-pages`, `issue`, `DOI`, `ISSN`, `page-first`).

The sample article (HTML, LaTeX-PDF, XSL-FO) and the FO development article (XSL-FO) all build with the three styles rendering, via `pretext/pretext`.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
