### PR TITLE
PDF-FO development article: schema validity, plus @showspaces on cd

### DIFF
--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -54,6 +54,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <p>This is the first paragraph of a minimal article, used to exercise the conversion of <pretext/> source to <init>XSL</init> Formatting Objects, and then to a <init>PDF</init> by Apache <init>FOP</init>.  A paragraph is the fundamental unit of prose, so it is the first element implemented, and this one is long enough to demonstrate line-breaking and justification.</p>
 
             <p>A second paragraph demonstrates inter-paragraph spacing.  It contains some inline markup, such as <em>emphasized text</em> and a <term>defined term</term>, rendered with italic and bold fonts.  A footnote<fn>The footnote drops to the bottom of the page, below a separator rule.</fn> hangs off this sentence.</p>
+
+            <paragraphs xml:id="paragraphs-history" label="paragraphs-history">
+                <title>A Little History</title>
+                <p>The lightweight <tag>paragraphs</tag> division has just a title, run in to this paragraph.  Cross-references work too: see <xref ref="theorem-pythagoras"/>, <xref ref="definition-hypotenuse"/>, and <xref ref="section-images"/>, all referenced from <xref ref="paragraphs-history" text="title"/>.  Even the starred equation <xref ref="equation-even"/> answers to its decoration.</p>
+            </paragraphs>
         </section>
 
         <section xml:id="section-inline" label="section-inline">
@@ -88,17 +93,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <p>An ordered list nests several levels deep, with an unordered list at the bottom, which exercises the changing labels and the growing indentation.
                 <ol>
                     <li>
-                        <p>Measure the three sides.</p>
-                        <ol>
-                            <li>
-                                <p>Single out the longest side, the candidate hypotenuse, and square it.</p>
-                                <ul>
-                                    <li>record the square</li>
-                                    <li>set it aside</li>
-                                </ul>
-                            </li>
-                            <li><p>Square each of the two shorter sides, and add the results.</p></li>
-                        </ol>
+                        <p>Measure the three sides.
+                            <ol>
+                                <li>
+                                    <p>Single out the longest side, the candidate hypotenuse, and square it.
+                                        <ul>
+                                            <li>record the square</li>
+                                            <li>set it aside</li>
+                                        </ul>
+                                    </p>
+                                </li>
+                                <li><p>Square each of the two shorter sides, and add the results.</p></li>
+                            </ol>
+                        </p>
                     </li>
                     <li><p>Compare the two totals to test for a right angle.</p></li>
                 </ol>
@@ -128,17 +135,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </ol>
             </p>
 
-            <p>A description list pairs short terms with their explanations; a wide label column sets the terms right-aligned against the descriptions.</p>
-            <dl width="wide">
-                <li>
-                    <title>Leg</title>
-                    <p>One of the two sides that meet at the right angle.</p>
-                </li>
-                <li>
-                    <title>Hypotenuse</title>
-                    <p>The side opposite the right angle, and the longest of the three.</p>
-                </li>
-            </dl>
+            <p>A description list pairs short terms with their explanations; a wide label column sets the terms right-aligned against the descriptions.
+                <dl width="wide">
+                    <li>
+                        <title>Leg</title>
+                        <p>One of the two sides that meet at the right angle.</p>
+                    </li>
+                    <li>
+                        <title>Hypotenuse</title>
+                        <p>The side opposite the right angle, and the longest of the three.</p>
+                    </li>
+                </dl>
+            </p>
         </section>
 
         <section xml:id="section-images" label="section-images">
@@ -424,11 +432,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </case>
                 </proof>
             </theorem>
-
-            <paragraphs xml:id="paragraphs-history" label="paragraphs-history">
-                    <title>A Little History</title>
-                    <p>The lightweight <tag>paragraphs</tag> division has just a title, run in to this paragraph.  Cross-references work too: see <xref ref="theorem-pythagoras"/>, <xref ref="definition-hypotenuse"/>, and <xref ref="section-images"/>, all referenced from <xref ref="paragraphs-history" text="title"/>.  Even the starred equation <xref ref="equation-even"/> answers to its decoration.</p>
-                </paragraphs>
 
                 <assemblage xml:id="assemblage-central-identity" label="assemblage-central-identity">
                     <title>The Central Identity</title>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -587,6 +587,8 @@
             CodeDisplay =
                 element cd {
                     attribute latexsep {text}?,
+                    # "all" renders every space as a visible glyph; default "none"
+                    attribute showspaces {"all" | "none"}?,
                     (text | CodeLine+)
                 }
             Preformatted =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1599,6 +1599,15 @@
       <optional>
         <attribute name="latexsep"/>
       </optional>
+      <optional>
+        <!-- "all" renders every space as a visible glyph; default "none" -->
+        <attribute name="showspaces">
+          <choice>
+            <value>all</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
       <choice>
         <text/>
         <oneOrMore>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1284,6 +1284,8 @@
             CodeDisplay =
                 element cd {
                     attribute latexsep {text}?,
+                    # "all" renders every space as a visible glyph; default "none"
+                    attribute showspaces {"all" | "none"}?,
                     (text | CodeLine+)
                 }
             Preformatted =


### PR DESCRIPTION
The `pdf-fo-development` example now validates against the schema (it had five `jing` errors).

- **Article:** bare `ol`/`ul`/`dl` lists are now wrapped in a `<p>`, and the `<paragraphs>` demo moves out of a section's `<introduction>` (which holds blocks, not a division) into the leaf `section-prose`.
- **Schema:** adds `attribute showspaces {"all" | "none"}` to `<cd>`, matching the existing HTML, LaTeX, and FO converters (the example already used it).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
