### PR TITLE
Coverage harness: replace shims with an exclusion list (XSL-FO and braille)

### DIFF
--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -2092,89 +2092,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- EXPERIMENTAL -->
 <!-- ############ -->
 
-<!-- Uncaught elements for debugging reporting                     -->
-<!-- These elements have full implementations in -common, or       -->
-<!-- partial/abstract implementations which we extend hee.         -->
-<!-- So we just hit them with "apply-imports" so they do not       -->
-<!-- all into the (temporary, development) template below          -->
-<!-- reporting missed elements.   "Commenting out this template    -->
-<!-- should have zero effect, except to generate more debugging    -->
-<!-- messages, since this reporting template will take precedence. -->
+<!-- These elements are fully handled by common (or by a braille      -->
+<!-- character mode defined above), so the coverage catch-all at      -->
+<!-- the end of this section excludes them in its "not(...)"          -->
+<!-- list and they fall through, rather than report "Overlooked".     -->
+<!-- This replaced a block of one-line "apply-imports" shims.         -->
 
-<!-- "apply-imports" items necessary during development -->
-
-<!-- nbsp, ndash, mdash characters defined above -->
-<xsl:template match="nbsp|ndash|mdash">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- empty elements, characters, defined above -->
-<xsl:template match="copyright|registered|trademark|degree|prime|dblprime|lsq|rsq|lq|rq|langle|rangle|ellipsis|midpoint|pilcrow|section-mark|minus|times|obelus|plusminus">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- These elements/characters lack translations in liblouis.      -->
-<!-- We get/use their versions in -common, which will throw an     -->
-<!-- "unimplemented character" warning, which is accurate now,     -->
-<!-- *and* accurate later when the "overlooked" warning goes away. -->
-<!-- As characters get implemented, move to above template         -->
-<!-- (in proper order) as a way to keep track of the situation.    -->
-<xsl:template match="phonomark|copyleft|servicemark|ldblbracket|rdblbracket|swungdash|permille|solidus">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- Groupings, based on characters defined above -->
-<!-- dblbrackets raises warnings since left/right -->
-<!-- characters are not implemented               -->
-<xsl:template match="q|sq|dblbrackets|angles">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- xref-number, xref-link defined above -->
-<xsl:template match="xref">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- pure text in -common -->
-<xsl:template match="today|timeofday">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- Latin Abbreviations -->
-<!-- Fully defined as text in -common, including an "abbreviation-period" -->
-<xsl:template match="ad|am|bc|ca|eg|etal|etc|ie|nb|pm|ps|vs|viz">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- titles get killed in -common so we don't need to see them here -->
-<xsl:template match="title|subtitle|shorttitle|plaintitle|creator">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- captions get killed in -common so we don't need to see them here -->
-<xsl:template match="caption">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- We expect the simple template in -common to be active -->
-<xsl:template match="cline">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- We expect the simple template in -common to be active -->
-<xsl:template match="c">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- Action is in -common, this will catch all occurences? -->
-<xsl:template match="sage">
-    <xsl:apply-imports/>
-</xsl:template>
-
-<!-- Localizations happen in -common, so need the "rename" template there -->
-<xsl:template match="rename">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- nbsp, ndash, mdash: characters defined above -->
+<!-- copyright, registered, trademark, degree, prime, dblprime, lsq, rsq, lq, rq, langle, rangle, ellipsis, midpoint, pilcrow, section-mark, minus, times, obelus, plusminus: empty character elements defined above -->
+<!-- phonomark, copyleft, servicemark, ldblbracket, rdblbracket, swungdash, permille, solidus: lack liblouis translations, so common's versions emit an accurate unimplemented-character warning (move a character up as it is implemented) -->
+<!-- q, sq, dblbrackets, angles: groupings of the characters above -->
+<!-- xref: xref-number and xref-link defined above -->
+<!-- today, timeofday: pure text in common -->
+<!-- ad, am, bc, ca, eg, etal, etc, ie, nb, pm, ps, vs, viz: Latin abbreviations, defined as text in common -->
+<!-- title, subtitle, shorttitle, plaintitle, creator: killed in common as metadata -->
+<!-- caption: killed in common as metadata -->
+<!-- cline: a simple template in common is active -->
+<!-- c: a simple template in common is active -->
+<!-- sage: handled in common -->
+<!-- rename: localizations happen in common -->
 
 
 <!-- Larger structures, needing implementation, *along with* interior -->
@@ -2251,10 +2187,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- *Every* element needs an implementation, or it ends up here being -->
-<!-- reported as overlooked.  This is temporary during development.    -->
-<xsl:template match="*">
+<!-- reported as overlooked.  Elements handled by common are named in  -->
+<!-- the exclusion list, so they fall through; this is temporary       -->
+<!-- during development and, once the list empties, can be removed.    -->
+<xsl:template priority="-0.5" match="*[not(
+        self::nbsp or self::ndash or self::mdash or
+        self::copyright or self::registered or self::trademark or self::degree or self::prime or self::dblprime or self::lsq or self::rsq or self::lq or self::rq or self::langle or self::rangle or self::ellipsis or self::midpoint or self::pilcrow or self::section-mark or self::minus or self::times or self::obelus or self::plusminus or
+        self::phonomark or self::copyleft or self::servicemark or self::ldblbracket or self::rdblbracket or self::swungdash or self::permille or self::solidus or
+        self::q or self::sq or self::dblbrackets or self::angles or
+        self::xref or
+        self::today or self::timeofday or
+        self::ad or self::am or self::bc or self::ca or self::eg or self::etal or self::etc or self::ie or self::nb or self::pm or self::ps or self::vs or self::viz or
+        self::title or self::subtitle or self::shorttitle or self::plaintitle or self::creator or
+        self::caption or
+        self::cline or
+        self::c or
+        self::sage or
+        self::rename)]">
     <xsl:apply-templates select="." mode="overlooked"/>
-    <!-- <xsl:message>Overlooked: <xsl:value-of select="local-name()"/></xsl:message> -->
     <!-- recurse into child elements to find more "missing" elements -->
     <xsl:apply-templates select="*"/>
 </xsl:template>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2827,10 +2827,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- pretext-common.xsl implements "biblio" entries (raw, BibTeX,  -->
 <!-- and CSL flavors) and the typography of their fields, via the  -->
 <!-- abstract font modes implemented in "Inline Markup".  Here:    -->
-<!-- the entry wrapper, a hanging "[N]" label, and the unshadowing -->
-<!-- of the imported templates.  (A field common does not style    -->
-<!-- falls through apply-imports to the built-in rules, i.e. its   -->
-<!-- text, which is right for raw mixed content.)                  -->
+<!-- the entry wrapper and a hanging "[N]" label.  A biblio's      -->
+<!-- "title", "author", etc. are killed elsewhere as metadata, so  -->
+<!-- this template overrides those kills to route the fields to    -->
+<!-- common's typography; a field common does not style falls      -->
+<!-- through to its text, which is right for raw mixed content.    -->
 <xsl:template match="biblio|biblio/*">
     <xsl:apply-imports/>
 </xsl:template>
@@ -3508,13 +3509,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- characters, Latin abbreviations, quotation constructions,    -->
 <!-- verbatim snippets ("c", "tag", "tage", "attr"), and logos,   -->
 <!-- in terms of abstract "*-character" templates which receive   -->
-<!-- concrete Unicode values below.  The coverage harness shadows -->
-<!-- those default-mode templates, so an  xsl:apply-imports       -->
-<!-- reinstates each element here: an element leaves the harness  -->
-<!-- report only by deliberately joining this list.               -->
-<xsl:template match="pretext|prefigure[not(node())]|webwork[not(* or @copy or @source)]|xetex|xelatex|ad|am|bc|ca|eg|etal|etc|ie|nb|pm|ps|vs|viz|nbsp|ndash|mdash|lsq|rsq|lq|rq|ldblbracket|rdblbracket|langle|rangle|ellipsis|midpoint|swungdash|permille|pilcrow|section-mark|minus|times|solidus|obelus|plusminus|copyright|phonomark|copyleft|registered|trademark|servicemark|degree|prime|dblprime|q|sq|dblbrackets|angles|c|cline|tag|tage|attr|today|timeofday|pi:localize">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- concrete Unicode values below.  So these elements are        -->
+<!-- implemented entirely in common, and need no FO template      -->
+<!-- of their own here.                                           -->
 
 <!-- An <icon> is a FontAwesome 5 glyph, as in the LaTeX route: the -->
 <!-- face follows  iconinfo/@font-awesome-family  and the glyph is  -->
@@ -3931,9 +3928,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- template: an active internal link to the @id of the target.  -->
 <!-- A not-yet-implemented target has no @id in the output, and   -->
 <!-- the link is simply dead until its element joins up.          -->
-<xsl:template match="xref">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- "xref" is implemented in common. -->
+
 
 <xsl:template match="*" mode="xref-link">
     <xsl:param name="target"/>
@@ -4454,10 +4450,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- complete back-of-the-book index emerges in a single pass:     -->
 <!-- no  makeindex , no second run.                                -->
 
-<!-- the harness would otherwise shadow the machinery -->
-<xsl:template match="index-list">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- "index-list" is implemented in common. -->
+
 
 <!-- the body of the index passes through -->
 <xsl:template name="present-index">
@@ -4549,10 +4543,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- sample usage (as mathematics), the narrative description, and -->
 <!-- a cross-reference to the enclosing environment.               -->
 
-<!-- the harness would otherwise shadow the machinery -->
-<xsl:template match="notation-list">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- "notation-list" is implemented in common. -->
+
 
 <xsl:template name="present-notation-list">
     <xsl:param name="content"/>
@@ -4655,10 +4647,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- elements the author requested; here, each element is one    -->
 <!-- line, a live cross-reference followed by any title.         -->
 
-<!-- the harness would otherwise shadow the machinery -->
-<xsl:template match="list-of">
-    <xsl:apply-imports/>
-</xsl:template>
+<!-- "list-of" is implemented in common. -->
+
 
 <!-- no surrounding infrastructure necessary -->
 <xsl:template name="list-of-begin"/>
@@ -4712,16 +4702,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################ -->
 
 <!-- *Every* element needs an implementation, or it lands here and is  -->
-<!-- reported as unimplemented.  This template has the lowest priority -->
-<!-- but the highest import precedence, so it also shadows the         -->
-<!-- default-mode templates of the imported stylesheets: an element is -->
-<!-- only "done" once *this* stylesheet handles it.  We recurse        -->
+<!-- reported as unimplemented.  Elements that common.xsl handles are  -->
+<!-- named in the exclusion list below, so they are not matched here   -->
+<!-- but fall through to common, replacing the per-element             -->
+<!-- "apply-imports" shims.  Emptied, the template can go.  We recurse -->
 <!-- through element children, and drop interior text, so the output   -->
 <!-- is always legal XSL-FO.  Survey what remains to implement, as a   -->
 <!-- counted summary, with something like                              -->
 <!--     pretext/pretext -v ... 2>&1 | grep 'PTX:FO-TODO' \            -->
 <!--         | sort | uniq -c | sort -rn                               -->
-<xsl:template match="*">
+<xsl:template priority="-0.5" match="*[not(
+        self::pretext or self::prefigure[not(node())] or self::webwork[not(* or @copy or @source)] or
+        self::xetex or self::xelatex or
+        self::ad or self::am or self::bc or self::ca or self::eg or self::etal or self::etc or self::ie or self::nb or self::pm or self::ps or self::vs or self::viz or
+        self::nbsp or self::ndash or self::mdash or self::lsq or self::rsq or self::lq or self::rq or self::ldblbracket or self::rdblbracket or self::langle or self::rangle or self::ellipsis or self::midpoint or self::swungdash or self::permille or self::pilcrow or self::section-mark or self::minus or self::times or self::solidus or self::obelus or self::plusminus or self::copyright or self::phonomark or self::copyleft or self::registered or self::trademark or self::servicemark or self::degree or self::prime or self::dblprime or
+        self::q or self::sq or self::dblbrackets or self::angles or
+        self::c or self::cline or self::tag or self::tage or self::attr or self::today or self::timeofday or self::pi:localize or
+        self::xref or self::index-list or self::notation-list or self::list-of)]">
     <xsl:message>PTX:FO-TODO: <xsl:value-of select="local-name()"/> (child of "<xsl:value-of select="local-name(parent::*)"/>")</xsl:message>
     <xsl:apply-templates select="*"/>
 </xsl:template>


### PR DESCRIPTION
Both the XSL-FO and braille converters carry a development "coverage harness" — a catch-all template that reports any element with no implementation (`PTX:FO-TODO` / `Overlooked`), backed by per-element `apply-imports` shims that delegate fully-handled elements to common.

This replaces those shims with an **exclusion list** on the catch-all itself: `match="*[not(self::a or self::b or …)]"`. Excluded elements fall through to common by import precedence; everything else still reports. When a converter matures and the list empties, the whole template deletes cleanly — no scattered shims to chase. Each former shim becomes a one-line comment stating the *real* reason (e.g. "implemented in common"), which stays meaningful after the harness is gone.

- **XSL-FO:** five pure-delegation shims folded in. `biblio` keeps its shim — it's a genuine override, not scaffolding: a biblio's `title`/`author` are killed elsewhere as metadata, and the shim restores common's biblio typography.
- **Braille:** all thirteen shims folded in (all pure delegations). The "categorizer" is retained as-is — the per-element `Overlooked` report, the placeholder templates (`notation-list`→`NOTATIONLIST`, `index-list`, `poem`, `quantity`, `kbd`), and the counted `Unimplemented: X (N times)` summary.
- The catch-all priority is pinned to `-0.5` (a `match="*[…]"` predicate otherwise defaults to `0.5` and would shadow real templates).

Verified equivalent on the sample article, before vs. after: the FO `.fo` and the braille `preprint.xml` are byte-identical (only the build timestamp moves), and the harness message inventory is unchanged (FO: 0 TODO; braille: the same 70 `Overlooked` and 5 `Unimplemented` lines).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
