### PR TITLE
Move five pre-2019 deprecations into the assembly "repair" phase

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1916,7 +1916,7 @@
 </xsl:template>
 
 <!-- Booktitle: slanted normally, we italic here-->
-<xsl:template match="booktitle">
+<xsl:template match="pubtitle">
     <xsl:text>_</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>_</xsl:text>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2493,6 +2493,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:attribute>
 </xsl:template>
 
+<!-- 2018-02-05  "booktitle" replaced by "pubtitle".  Added 2026-06-25. -->
+<xsl:template match="booktitle" mode="repair">
+    <pubtitle>
+        <xsl:apply-templates select="node()|@*" mode="repair"/>
+    </pubtitle>
+</xsl:template>
+
 <!-- 2021-07-02 wrap notation/usage in "m" if not present -->
 <xsl:template match="notation/usage[not(m)]" mode="repair">
     <!-- duplicate "usage" w/ attributes, insert "m" as repair -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2473,6 +2473,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </pretext>
 </xsl:template>
 
+<!-- 2017-02-05  "hyphen" replaced by a bare hyphen.  Added 2026-06-25. -->
+<xsl:template match="hyphen" mode="repair">
+    <xsl:text>-</xsl:text>
+</xsl:template>
+
+<!-- 2017-07-18  "@tex_size" was renamed "@tex-size" (cosmetic), which in  -->
+<!-- turn became ignored (2017-11-09) in favor of a percentage "@width".   -->
+<!-- The legacy attribute now does nothing, so drop it.  Added 2026-06-25. -->
+<xsl:template match="@tex_size" mode="repair"/>
+
 <!-- 2017-07-25  "autoname" on "xref" deprecated in favor of "text".  -->
 <!-- Silently repair the legacy attribute to its modern functional    -->
 <!-- equivalent.  Every other attribute, and any content, is left to  -->
@@ -2492,6 +2502,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:attribute>
 </xsl:template>
+
+<!-- 2017-12-07  "@latexsep" on "c"/"cd" is ignored; drop it.  Added 2026-06-25. -->
+<xsl:template match="c/@latexsep|cd/@latexsep" mode="repair"/>
 
 <!-- 2018-02-05  "booktitle" replaced by "pubtitle".  Added 2026-06-25. -->
 <xsl:template match="booktitle" mode="repair">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2500,6 +2500,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </pubtitle>
 </xsl:template>
 
+<!-- 2019-02-20  "rename/@lang" replaced by "@xml:lang".  Added 2026-06-25. -->
+<xsl:template match="rename/@lang" mode="repair">
+    <xsl:attribute name="xml:lang">
+        <xsl:value-of select="."/>
+    </xsl:attribute>
+</xsl:template>
+
 <!-- 2021-07-02 wrap notation/usage in "m" if not present -->
 <xsl:template match="notation/usage[not(m)]" mode="repair">
     <!-- duplicate "usage" w/ attributes, insert "m" as repair -->

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -401,7 +401,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\newcommand{\terminology}[1]{\textbf{#1}}&#xa;</xsl:text>
   </xsl:if>
   <!-- 2018-02-05: "booktitle" deprecated -->
-  <xsl:if test="$document-root//pubtitle|$document-root//booktitle">
+  <xsl:if test="$document-root//pubtitle">
     <xsl:text>%% Titles of longer works (e.g. books, versus articles)&#xa;</xsl:text>
     <xsl:text>\newcommand{\pubtitle}[1]{\textsl{#1}}&#xa;</xsl:text>
   </xsl:if>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3107,14 +3107,10 @@ Book (with parts), "section" at level 3
             <xsl:when test="$docinfo/rename[@element=$str-id and @xml:lang=$lang]">
                 <xsl:apply-templates select="$docinfo/rename[@element=$str-id and @xml:lang=$lang]"/>
             </xsl:when>
-            <!-- Second, look in docinfo for document-specific rename with correct language, -->
-            <!-- but with @lang attribute which was deprecated on 2019-02-23                 -->
-            <xsl:when test="$docinfo/rename[@element=$str-id and @lang=$lang]">
-                <xsl:apply-templates select="$docinfo/rename[@element=$str-id and @lang=$lang]"/>
-            </xsl:when>
-            <!-- Third, look in docinfo for document-specific rename, but now explicitly language-agnostic -->
-            <xsl:when test="$docinfo/rename[@element=$str-id and not(@lang) and not(@xml:lang)]">
-                <xsl:apply-templates select="$docinfo/rename[@element=$str-id and not(@lang) and not(@xml:lang)]"/>
+            <!-- Second, look in docinfo for document-specific rename, but       -->
+            <!-- now explicitly language-agnostic; "@lang" became "@xml:lang".   -->
+            <xsl:when test="$docinfo/rename[@element=$str-id and not(@xml:lang)]">
+                <xsl:apply-templates select="$docinfo/rename[@element=$str-id and not(@xml:lang)]"/>
             </xsl:when>
             <!-- Finally, default to a lookup from the localization file's nodes -->
             <!-- Use a "for-each" to effect a context switch for the look-up and -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9461,7 +9461,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and other freestanding works are italicized; titles -->
 <!-- of articles, chapters, and other shorter works      -->
 <!-- are set in roman and enclosed in quotation marks.   -->
-<xsl:template match="pubtitle|booktitle">
+<xsl:template match="pubtitle">
     <span class="booktitle">
         <xsl:apply-templates/>
     </span>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1151,7 +1151,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>\newcommand{\terminology}[1]{\textbf{#1}}&#xa;</xsl:text>
     </xsl:if>
     <!-- 2018-02-05: "booktitle" deprecated -->
-    <xsl:if test="$document-root//pubtitle|$document-root//booktitle">
+    <xsl:if test="$document-root//pubtitle">
         <xsl:text>%% Titles of longer works (e.g. books, versus articles)&#xa;</xsl:text>
         <xsl:text>\newcommand{\pubtitle}[1]{\textsl{#1}}&#xa;</xsl:text>
     </xsl:if>
@@ -8739,9 +8739,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- of articles, chapters, and other shorter works      -->
 <!-- are set in roman and enclosed in quotation marks.   -->
 <!-- \pubtitle is a semantic macro defined only if       -->
-<!-- "pubtitle" or "booktitle" is employed.  Adjust if   -->
-<!-- deprecation is removed.                             -->
-<xsl:template match="pubtitle|booktitle">
+<!-- "pubtitle" is employed.                             -->
+<xsl:template match="pubtitle">
     <xsl:text>\pubtitle{</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>}</xsl:text>


### PR DESCRIPTION
Following the `xref/@autoname`→`@text` repair (#2976), this sweeps up the remaining pre-2019 deprecations that still had a clean modern equivalent, moving each silent upgrade into the assembly `repair` phase and ripping out the legacy conversion-time handling where any existed. The deprecation warnings all stay (they run on `$original`, the author's pre-repair source), so authors are still told to update while their documents keep building.

**Repairs that also delete legacy code:**

- **`booktitle`→`pubtitle`** (2018-02-05) — repair added; the five legacy sites collapse: `match="pubtitle|booktitle"`→`match="pubtitle"` (html, latex), the two `//pubtitle|//booktitle` tests (latex, beamer), and `extract-pg`'s `match="booktitle"` template renamed to `pubtitle`.
- **`rename/@lang`→`@xml:lang`** (2019-02-20) — repair added; the legacy `@lang` `when`-clause in the rename lookup is removed, and the surviving language-agnostic clause simplifies from `not(@lang) and not(@xml:lang)` to just `not(@xml:lang)`.

**Pure repairs (no legacy code existed — these only warned before):**

- **`<hyphen/>`→`-`** (2017-02-05), parallel to the existing special-character repairs.
- **`@latexsep`** on `c`/`cd` (2017-12-07) — already ignored, so dropped.
- **`@tex_size`** (2017-07-18) — taken all the way to modern: it was a cosmetic rename to `@tex-size`, which in turn (2017-11-09) became ignored in favor of a percentage `@width`. Since `@tex-size` is consumed nowhere, the attribute does nothing, so it is dropped.

Each repair is placed in deprecation-date order, with its comment leading with the deprecation date(s). Verified with minimal test documents: each deprecated form and its modern equivalent build identically, the repaired assembled tree is correct (attributes/content preserved), and the `PTX:DEPRECATE` warnings still fire.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
