### PR TITLE
Runestone page template

### DIFF
--- a/css/components/_pretext-web.scss
+++ b/css/components/_pretext-web.scss
@@ -15,6 +15,7 @@ $navbar-breakpoint: 800px !default;
 
 @use 'google-search';
 @use 'pretext-search';
+@use 'rs-template';
 @use 'interactives/runestone';
 @use 'interactives/other';
 @use 'interactives/webwork';

--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -15,7 +15,7 @@
     display:none;
   }
 
-  .ptx-page, .ptx-main, .ptx-main .ptx-content {
+  .ptx-page, .ptx-main, .ptx-main > .ptx-content {
     all: unset !important;
     width: 100%;
     border: none;

--- a/css/components/_rs-template.scss
+++ b/css/components/_rs-template.scss
@@ -1,0 +1,6 @@
+// styles for the runestone template page
+body.ptx-runestone-template {
+    .ptx-main > .ptx-content {
+        max-width: unset;
+    }
+}

--- a/css/components/page-parts/_body.scss
+++ b/css/components/page-parts/_body.scss
@@ -51,7 +51,7 @@ body {
 
 // Base width/padding
 // ptx-main ensures iframe pages don't get these
-.ptx-main .ptx-content {
+.ptx-main > .ptx-content {
   max-width: $content-with-padding-width;   // bad for worksheets
   padding: 24px $content-side-padding 60px;
   line-height: var(--ptx-content-line-height, normal);
@@ -62,7 +62,7 @@ body {
     margin-right: auto;
   }
 }
-.worksheet .ptx-main .ptx-content {
+.worksheet .ptx-main > .ptx-content {
     max-width: 960px;
 }
 

--- a/css/targets/html/default-modern/_customization.scss
+++ b/css/targets/html/default-modern/_customization.scss
@@ -30,3 +30,9 @@ $wide-rs-elements: ".parsons_section, .ac_section, .codelens";
 .tabular-box {
   @include expandable.expandable;
 }
+
+body.ptx-runestone-template {
+  .ptx-runestone-container:has(#{$wide-rs-elements}) {
+    --max-width: 100%;
+  }
+}

--- a/css/targets/html/default-modern/_parts-default.scss
+++ b/css/targets/html/default-modern/_parts-default.scss
@@ -41,7 +41,7 @@ $content-with-padding-width: $content-width + 2 * $content-side-padding;
 // Decrease the side margins once out of room
 @container ptx-main (width < #{$content-with-padding-width}) {
   .ptx-page > .ptx-main { 
-    .ptx-content {
+    & > .ptx-content {
       padding-left: #{$content-side-padding-tight};
       padding-right: #{$content-side-padding-tight};
       max-width: calc($content-width + 2 * #{$content-side-padding-tight});

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -157,7 +157,7 @@ $page-border-breakpoint: $main-width + $sidebar-width + 2 * $sidebar-right-margi
     margin-right: auto;
 
     // shrink content padding
-    .ptx-content {
+    & .ptx-content {
       padding-left: $content-side-padding-tight;
       padding-right: $content-side-padding-tight;
       max-width: calc($content-width + 2 * $content-side-padding-tight);

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -244,3 +244,9 @@ $sidebar-hide-breakpoint: $content-width + 2 * $content-side-padding-tight + $si
     max-width: 100%;
   }
 }
+
+body.ptx-runestone-template {
+    .ptx-main > .ptx-content {
+        padding: 24px;
+    }
+}

--- a/css/targets/html/salem/_parts-salem.scss
+++ b/css/targets/html/salem/_parts-salem.scss
@@ -104,7 +104,7 @@ $sidebar-breakpoint: $content-width + $sidebar-width + $content-side-padding * 2
 
 @container ptx-main (width < #{$navbar-breakpoint}) {
   .ptx-page > .ptx-main { 
-    .ptx-content {
+    & > .ptx-content {
       padding-left: 20px;
       padding-right: 20px;
       max-width: calc($content-width + 40px);

--- a/css/targets/html/salem/_rs-widen.scss
+++ b/css/targets/html/salem/_rs-widen.scss
@@ -116,3 +116,10 @@ $small-nested-margin-offset: 0px !default;
     margin-right: auto;
   }
 }
+
+.ptx-runestone-template {
+  :is(#{sizing.$grouping-elements}):has(#{sizing.$rs-wide-elements}) {
+    margin-left: unset;
+  }
+
+}

--- a/css/targets/html/tacoma/_parts-tacoma.scss
+++ b/css/targets/html/tacoma/_parts-tacoma.scss
@@ -41,7 +41,7 @@ $content-with-padding-width: $content-width + 2 * $content-side-padding;
 
 // breakpoint to end centering
 @media screen and (width < 1000px) {
-  .ptx-main .ptx-content {
+  .ptx-main > .ptx-content {
     margin: 0;
   }
 }
@@ -49,7 +49,7 @@ $content-with-padding-width: $content-width + 2 * $content-side-padding;
 // Decrease the side margins once out of room
 @container ptx-main (width < #{$content-with-padding-width}) {
   .ptx-page > .ptx-main { 
-    .ptx-content {
+    & > .ptx-content {
       padding-left: #{$content-side-padding-tight};
       padding-right: #{$content-side-padding-tight};
       max-width: calc($content-width + 2 * #{$content-side-padding-tight});

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -3669,6 +3669,14 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     common.xsltproc(extraction_xslt, xml, None, tmp_dir, stringparams)
     time_logger.log("xsltproc complete")
 
+    if common.get_publisher_variable(pub_vars, 'host-platform') == "runestone":
+        log.info("building Runestone page template for {} in {}".format(xml, tmp_dir))
+        runestone_page_template_xslt = os.path.join(
+            common.get_ptx_xsl_path(), "extract-runestone-page-template.xsl"
+        )
+        common.xsltproc(runestone_page_template_xslt, xml, None, tmp_dir, stringparams)
+        time_logger.log("runestone page template extraction complete")
+
     if not(include_static_files):
         # remove latex-image generated directories for portable builds
         shutil.rmtree(os.path.join(tmp_dir, "generated", "latex-image"), ignore_errors=True)

--- a/xsl/extract-runestone-page-template.xsl
+++ b/xsl/extract-runestone-page-template.xsl
@@ -1,0 +1,139 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2026 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Empty shell page that Runestone can use to display content on a page -->
+<!-- that looks like it belongs to the book.                              -->
+
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+>
+
+<!-- Import the HTML conversion for file wrapping and page-part templates,   -->
+<!-- but override its entry point so this extraction only writes _base.html. -->
+<xsl:import href="./pretext-html.xsl"/>
+
+<!-- Override the variable open and close to use normal Jinga syntax      -->
+<!-- This will be used as a template to insert other Jinga content into   -->
+<!-- and that content uses normal variable delimeters.                    -->
+<!-- We are not worried about LaTeX content we don't directly control.    -->
+<xsl:variable name="rso" select="'{{'"/>
+<xsl:variable name="rsc" select="'}}'"/>
+
+<!-- Override latex-macros so we can escape them in bulk -->
+<xsl:template match="*" mode="latex-macros">
+    <xsl:text>{% raw %}&#xa;</xsl:text>
+    <!-- Call the original template -->
+    <xsl:apply-imports/>
+    <xsl:text>{% endraw %}&#xa;</xsl:text>
+</xsl:template>
+
+<!-- Overrride navigation template to prevent next button from being enabled -->
+<xsl:template match="*" mode="next-linear-url"/>
+
+<!-- Override the HTML default so file-wrap emits Runestone template hooks -->
+<xsl:template match="*" mode="file-wrap-head-pre">
+    {% set using_ptx_base = "true" %}
+    <base>
+        <!-- avoid wonkiness with XSL {{ escaping. No spaces is important -->
+        <xsl:attribute name="href">{{base_url}}</xsl:attribute>
+    </base>
+    <!-- Call the original template just in case something is added there -->
+    <xsl:apply-imports/>
+</xsl:template>
+
+<!-- Override canonical link - don't want to generate the same value for  -->
+<!-- all pages and don't need to SEO the internal student pages           -->
+<xsl:template name="canonical-link"/>
+
+<xsl:template match="*" mode="file-wrap-head-post">
+    <!-- Call the original template just in case something is added there -->
+    <xsl:apply-imports/>
+    <link href="/staticAssets/main-ptx-based.css" rel="stylesheet" />
+    <script>
+        window.addEventListener("DOMContentLoaded", () => {
+            const sidebar = document.getElementById("ptx-sidebar");
+            if (sidebar) {
+                sidebar.classList.add("hidden");
+            }
+        });
+    </script>
+    {% block css %}
+    {% endblock %}
+</xsl:template>
+
+<xsl:template match="*" mode="file-wrap-body-attr-extra">
+    <!-- Call the original template just in case something is added there -->
+    <xsl:apply-imports/>
+    <xsl:text> ptx-runestone-template</xsl:text>
+</xsl:template>
+
+<xsl:template match="*" mode="file-wrap-body-post">
+    <!-- Call the original template just in case something is added there -->
+    <xsl:apply-imports/>
+    <!-- rs footer -->
+    {% include 'footer.html' %}
+    <!-- scripts -->
+    <script>
+        <!-- hide sidebar by default in all themes -->
+        const sidebar = document.getElementById("ptx-sidebar");
+        if (sidebar) {
+            sidebar.classList.add("hidden");
+        }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js"></script>
+    {% block js %}
+    {% endblock %}
+</xsl:template>
+
+
+<xsl:output method="html" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat" />
+
+<xsl:template match="/">
+    <xsl:call-template name="runestone-page-template"/>
+</xsl:template>
+
+<xsl:template name="runestone-page-template">
+    <xsl:if test="$b-host-runestone and ($b-is-book or $b-is-article)">
+        <xsl:apply-templates select="$document-root" mode="runestone-page-template"/>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="book|article" mode="runestone-page-template">
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="filename">
+            <xsl:text>_base.html</xsl:text>
+        </xsl:with-param>
+        <xsl:with-param name="title">
+            <xsl:text>{% block title %}</xsl:text>
+            <xsl:apply-templates select="." mode="title-plain" />
+            <xsl:text>{% endblock %}</xsl:text>
+        </xsl:with-param>
+        <xsl:with-param name="b-include-bottom-nav" select="false()"/>
+        <xsl:with-param name="content">
+            {% block content %}
+            {% endblock %}
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/pretext-basic-html.xsl
+++ b/xsl/pretext-basic-html.xsl
@@ -76,7 +76,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:call-template name="mathjax" />
             </head>
             <body>
-                <xsl:call-template name="latex-macros" />
+                <xsl:apply-templates select="." mode="latex-macros" />
                 <xsl:copy-of select="$content" />
             </body>
         </html>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7261,7 +7261,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- assistive "Skip to main content" link    -->
                 <!-- this *must* be first for maximum utility -->
                 <xsl:call-template name="skip-to-content-link" />
-                <xsl:call-template name="latex-macros" />
+                <xsl:apply-templates select="." mode="latex-macros" />
                  <header id="ptx-masthead" class="ptx-masthead">
                     <div class="ptx-banner">
                         <xsl:call-template name="brand-logo" />
@@ -10277,7 +10277,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- Some interactives use slates that are PreTeXt  -->
                 <!-- elements, hence could have math, hence need to -->
                 <!-- know globally available macros from the author -->
-                <xsl:call-template name="latex-macros"/>
+                <xsl:apply-templates select="." mode="latex-macros"/>
                 <xsl:if test="slate|sidebyside|sbsgroup">
                     <div>
                         <!-- aspect ratio will force the proper height for wrapper div                           -->
@@ -11694,7 +11694,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </div>  <!-- banner -->
             </header>  <!-- masthead -->
             <xsl:apply-templates select="." mode="primary-navigation"/>
-            <xsl:call-template name="latex-macros"/>
+            <xsl:apply-templates select="." mode="latex-macros"/>
             <div class="ptx-page">
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
@@ -14569,7 +14569,7 @@ TODO:
 <!-- NB: "math support" macros (fillin-math, sfrac) must  -->
 <!-- be defined here AND in the "extraction-wrapper"      -->
 <!-- template in  support/extract-math.xsl                -->
-<xsl:template name="latex-macros">
+<xsl:template match="*" mode="latex-macros">
     <div id="latex-macros" class="hidden-content process-math" style="display:none">
         <xsl:call-template name="inline-math-wrapper">
             <xsl:with-param name="math">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11584,6 +11584,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="title" select="''"/>
     <xsl:param name="filename" select="''"/>
     <xsl:param name="b-has-printout" select="false()"/>
+    <xsl:param name="b-include-bottom-nav" select="true()"/>
 
     <xsl:variable name="the-filename">
         <xsl:choose>
@@ -11708,23 +11709,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <!-- output. (2023-01-11)                             -->
                         <xsl:copy-of select="$content" />
                     </div>
-                    <div id="ptx-content-footer" class="ptx-content-footer">
-                        <xsl:apply-templates select="." mode="previous-button"/>
-                        <xsl:variable name="top-localization">
-                            <xsl:apply-templates select="." mode="type-name">
-                                <xsl:with-param name="string-id" select="'top'"/>
-                            </xsl:apply-templates>
-                        </xsl:variable>
-                        <a class="top-button button" href="#" title="{$top-localization}">
-                            <xsl:call-template name="insert-symbol">
-                                <xsl:with-param name="name" select="'expand_less'"/>
-                            </xsl:call-template>
-                            <span class="name">
-                                <xsl:value-of select="$top-localization"/>
-                            </span>
-                        </a>
-                        <xsl:apply-templates select="." mode="next-button"/>
-                    </div>
+                    <xsl:if test="$b-include-bottom-nav">
+                        <div id="ptx-content-footer" class="ptx-content-footer">
+                            <xsl:apply-templates select="." mode="previous-button"/>
+                            <xsl:variable name="top-localization">
+                                <xsl:apply-templates select="." mode="type-name">
+                                    <xsl:with-param name="string-id" select="'top'"/>
+                                </xsl:apply-templates>
+                            </xsl:variable>
+                            <a class="top-button button" href="#" title="{$top-localization}">
+                                <xsl:call-template name="insert-symbol">
+                                    <xsl:with-param name="name" select="'expand_less'"/>
+                                </xsl:call-template>
+                                <span class="name">
+                                    <xsl:value-of select="$top-localization"/>
+                                </span>
+                            </a>
+                            <xsl:apply-templates select="." mode="next-button"/>
+                        </div>
+                    </xsl:if>
                 </main>
             </div>
             <!-- formerly "extra" -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11605,6 +11605,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:call-template name="pretext-advertisement-and-style"/>
         <!-- Open Graph Protocol only in "meta" elements, within "head" -->
         <head xmlns:og="http://ogp.me/ns#" xmlns:book="https://ogp.me/ns/book#">
+            <!-- optional head content that needs to come prior to other content -->
+            <xsl:apply-templates select="." mode="file-wrap-head-pre"/>
             <title>
                 <xsl:choose>
                     <xsl:when test="$title != ''">
@@ -11630,6 +11632,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="knowl" />
             <!-- webwork's iframeResizer needs to come before sagecell template -->
             <xsl:apply-templates select="." mode="sagecell" />
+            <!-- optional head content that might override other content-->
+            <xsl:apply-templates select="." mode="file-wrap-head-post"/>
         </head>
         <body>
             <xsl:if test="$b-has-stack">
@@ -11648,6 +11652,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:when test="$root/book">pretext book</xsl:when>
                     <xsl:when test="$root/article">pretext article</xsl:when>
                 </xsl:choose>
+                <xsl:apply-templates select="." mode="file-wrap-body-attr-extra"/>
                 <!-- ignore MathJax signals everywhere, then enable selectively -->
                 <xsl:text> ignore-math</xsl:text>
             </xsl:attribute>
@@ -11742,10 +11747,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:if test="$b-portable-html and $has-native-search">
                 <xsl:call-template name="embedded-search-construction"/>
             </xsl:if>
+            <!-- optional body content that needs to be inserted after all content -->
+            <!-- e.g. script tags to run immediately                               -->
+            <xsl:apply-templates select="." mode="file-wrap-body-post"/>
         </body>
     </html>
     </exsl:document>
 </xsl:template>
+
+<!-- Templates that can be overriden to inject into various      -->
+<!-- points in the HTML page. See file-wrap above for locations. -->
+<xsl:template match="*" mode="file-wrap-head-pre"/>
+<xsl:template match="*" mode="file-wrap-head-post"/>
+<xsl:template match="*" mode="file-wrap-body-attr-extra"/>
+<xsl:template match="*" mode="file-wrap-body-post"/>
 
 <!-- A minimal individual page:                              -->
 <!-- Inputs:                                                 -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11822,16 +11822,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ################### -->
 
 <!-- Canonical Link -->
-<!-- TODO: condition for generic builds at $site-root, need base-url, etc -->
 <xsl:template name="canonical-link">
     <xsl:param name="filename"/>
-
-    <!-- book-wide site URL -->
-    <xsl:variable name="site-root">
-        <xsl:value-of select="concat('https://runestone.academy/ns/books/published/', $document-id, '/')"/>
-    </xsl:variable>
     <!-- just for Runestone builds -->
     <xsl:if test="$b-host-runestone">
+        <xsl:variable name="site-root">
+            <xsl:call-template name="runestone-server-baseurl"/>
+        </xsl:variable>
         <xsl:variable name="full-url" select="concat($site-root, $filename)"/>
         <link rel="canonical" href="{$full-url}"/>
     </xsl:if>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11581,6 +11581,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- * page content (exclusive of banners, navigation etc) -->
 <xsl:template match="*" mode="file-wrap">
     <xsl:param name="content" />
+    <xsl:param name="title" select="''"/>
     <xsl:param name="filename" select="''"/>
     <xsl:param name="b-has-printout" select="false()"/>
 
@@ -11604,12 +11605,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Open Graph Protocol only in "meta" elements, within "head" -->
         <head xmlns:og="http://ogp.me/ns#" xmlns:book="https://ogp.me/ns/book#">
             <title>
-                <!-- Leading with initials is useful for small tabs -->
-                <xsl:if test="$docinfo/initialism">
-                    <xsl:apply-templates select="$docinfo/initialism" />
-                    <xsl:text> </xsl:text>
-                </xsl:if>
-                <xsl:apply-templates select="." mode="title-plain" />
+                <xsl:choose>
+                    <xsl:when test="$title != ''">
+                        <xsl:value-of select="$title"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <!-- Leading with initials is useful for small tabs -->
+                        <xsl:if test="$docinfo/initialism">
+                            <xsl:apply-templates select="$docinfo/initialism" />
+                            <xsl:text> </xsl:text>
+                        </xsl:if>
+                        <xsl:apply-templates select="." mode="title-plain" />
+                    </xsl:otherwise>
+                </xsl:choose>
             </title>
             <!-- canonical link for better SEO -->
             <xsl:call-template name="canonical-link">

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -224,7 +224,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:call-template name="load-css" />
         <!-- load LaTeX macros for MathJax               -->
         <!-- Empty visually, so also provides separation -->
-        <xsl:call-template name="latex-macros" />
+        <xsl:apply-templates select="." mode="latex-macros" />
         <!-- the real content of the page -->
         <xsl:copy-of select="$content" />
     </xsl:variable>
@@ -367,7 +367,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- conversion to LateX.  Bad practice?  Maybe better to  -->
 <!-- go back to -common and rework the entire latex-macro  -->
 <!-- generation scheme?                                    -->
-<xsl:template name="latex-macros">
+<xsl:template match="*" mode="latex-macros">
     <xsl:call-template name="markdown-cell">
         <xsl:with-param name="content">
             <xsl:call-template name="begin-string" />

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -159,7 +159,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <div class="reveal ptx-content">
                 <!-- For mathematics/MathJax, must be located -->
                 <!-- within div.reveal to be effective        -->
-                <xsl:call-template name="latex-macros"/>
+                <xsl:apply-templates select="." mode="latex-macros"/>
                 <div class="slides">
                      <xsl:apply-templates select="frontmatter"/>
                     <xsl:apply-templates select="section|slide"/>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -84,6 +84,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="rso" select="'~._'"/>
 <xsl:variable name="rsc" select="'_.~'"/>
 
+<!-- Determines the base url of a book served on Runestone  -->
+<!-- If there is an authored base url, use it as the author -->
+<!-- may be targetting a non-public server. Otherwise,      -->
+<!-- assume book is hosted on Runestone Academy             -->
+<xsl:template name="runestone-server-baseurl">
+    <xsl:choose>
+        <xsl:when test="$b-has-baseurl">
+            <xsl:value-of select="$baseurl"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>https://runestone.academy/ns/books/published/</xsl:text>
+            <xsl:value-of select="$document-id"/>
+            <xsl:text>/</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- Runestone Services (Javascript)  -->
 <!-- OR, Hosting at Runestone Academy -->
 <xsl:template name="runestone-header">

--- a/xsl/pretext-smc.xsl
+++ b/xsl/pretext-smc.xsl
@@ -348,7 +348,7 @@
 <xsl:template name="html-css-mathjax-setup">
     <xsl:apply-templates select="." mode="smc-html-cell">
         <xsl:with-param name="content">
-            <xsl:call-template name="latex-macros" />
+            <xsl:apply-templates select="." mode="latex-macros" />
         </xsl:with-param>
     </xsl:apply-templates>
 </xsl:template>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -132,6 +132,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$baseurl"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2026-06-25 platform host for html -->
+    <xsl:text>host-platform</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$host-platform"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- -->
 
     <!--


### PR DESCRIPTION
This adds logic to build a file that RS can use as a Jinja template for student facing pages so they better match the book they are generated for.

Currently just looking for a review of the XSL. Biggest yuck is the need to pass `b-runestone-pagetemplate` through `file-wrap` to the helper templates. We don't want the extra content on every page for a runestone book, so we can't just switch on `b-host-runestone`. We need to know that this specifically is the template page.

Maybe the template generation should be an additional conversion? A simple template that pretext.py runs directly on the source as an extra step when building for runestone?