### PR TITLE
Support descriptions on additional interactive

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -9208,6 +9208,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <figure>
                     <caption>GeoGebra: modified material ID</caption>
                     <interactive xml:id="geogebra-train-distance" platform="geogebra" width="75%" aspect="2:1">
+                        <description>
+                            This is a test of text-only description, which gets moved to shortdescription.
+                        </description>
                         <slate xml:id="train-distance" surface="geogebra" material="D4s2v4ft" aspect="2:1">
                             setAxisSteps(1, 1, 5, 1);
                             setCoordSystem(-0.7, 8, -6, 56);
@@ -9389,7 +9392,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <figure xml:id="figure-circuitjs-attribute">
                     <caption>CircuitJS Example (source via an encoded attribute)</caption>
 
-                    <interactive xml:id="interactive-circuitjs-attribute" circuitjs="$ 1 0.000005 10.20027730826997 58 5 50 5e-11%0AR 464 32 464 -16 0 0 40 3.3 0 0 0.5%0Ag 464 224 464 240 0 0%0As 464 32 464 128 0 0 false%0As 464 128 464 224 0 1 false%0Ax 274 181 431 184 4 12 bottom\sswitch\s(to\sground)%0Ax 312 85 426 88 4 12 top\sswitch\s(to\sVdd)%0AO 464 128 544 128 1 0%0Ax 532 110 593 113 4 12 output\spin" width="90%" aspect="4:3"/>
+                    <interactive xml:id="interactive-circuitjs-attribute" circuitjs="$ 1 0.000005 10.20027730826997 58 5 50 5e-11%0AR 464 32 464 -16 0 0 40 3.3 0 0 0.5%0Ag 464 224 464 240 0 0%0As 464 32 464 128 0 0 false%0As 464 128 464 224 0 1 false%0Ax 274 181 431 184 4 12 bottom\sswitch\s(to\sground)%0Ax 312 85 426 88 4 12 top\sswitch\s(to\sVdd)%0AO 464 128 544 128 1 0%0Ax 532 110 593 113 4 12 output\spin" width="90%" aspect="4:3">
+                        <description>
+                            <p>
+                                An interactive CircuitJS embed with a description.
+                            </p>
+                        </description>
+                    </interactive>
                 </figure>
 
                 <figure xml:id="figure-circuitjs">
@@ -9618,7 +9627,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <figure>
                     <caption>Right Triangle Paradox</caption>
-                    <interactive xml:id="geogebra-right-triangle" geogebra="KGn2d4Qd" width="70%" aspect="9:5" reset-icon="yes"/>
+                    <interactive xml:id="geogebra-right-triangle" geogebra="KGn2d4Qd" width="70%" aspect="9:5" reset-icon="yes">
+                        <description>
+                            <p>
+                                An interactive puzzle. The puzzle shows two triangles placed on a square grid. On the left, there is a triangle decomposed into four pices. on the right, there is a triangle with outlines corresponding to the sizes and shapes of the pieces in the left triangle. The pieces from the left triangle can be dragged to the right. However, the triangle on the right has one additional grid square containing a question mark.
+                            </p>
+                        </description>
+                    </interactive>
                 </figure>
 
                 <p>There are some optional control elements that Geogebra provides, such as the presence of the toolbar and the reset button. These can be controlled by adding the following additional attributes to the <c>interactive</c>.
@@ -9643,8 +9658,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <p>The static image employed in the <latex/> version of this article was obtained by viewing the graph at the Desmos site (<ie/>, not the embedded version in the <pretext/> HTML version), and using the Share button to export a <init>PNG</init> image.  In this case, we used a <q>Medium Rectangle</q> and <q>Thick</q> lines.</p>
 
                 <figure>
-                    <caption>Graph of <m>ln(x^2+5)-3</m></caption>
-                    <interactive xml:id="desmos-natural-log" desmos="ttox1bvxku" width="60%" aspect="2:3"/>
+                    <caption>Graph of <m>\ln(x^2+5)-3</m></caption>
+                    <interactive xml:id="desmos-natural-log" desmos="ttox1bvxku" width="60%" aspect="2:3">
+                        <shortdescription>An interactive graph of a function.</shortdescription>
+                        <description>
+                            <p>
+                                An interactive graph of <m>\ln(x^2+5)-3</m>. The function decreases from the left edge of the window until <m>x=0</m>, where the <m>y</m>-value is approximately 1.5. The function then increases to the right edge of the window.
+                            </p>
+                        </description>
+                    </interactive>
                 </figure>
 
                 <p>Note that Desmos has extensive <pubtitle>Terms of Service</pubtitle> which include restrictions on commercial uses.</p>
@@ -9664,12 +9686,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
                 <figure xml:id="figure-intersecting-planes">
                     <caption>Intersection of two planes (minimal embedding)</caption>
-                    <interactive xml:id="calcplot3d-intersection-planes" calcplot3d="type=implicit;equation=2x-y+z~0;cubes=16;visible=true;xmin=-2;xmax=2;ymin=-2;ymax=2;zmin=-2;zmax=2;alpha=-1;format=constant;constcol=rgb(61,133,198)&amp;type=parametric;parametric=2;x=-(u+v)/2;y=(u-v)/2;z=v;visible=true;umin=-3;umax=3;usteps=30;vmin=-2;vmax=2;vsteps=15;alpha=193;format=constant;constcol=rgb(255,161,114)&amp;type=text;text=x%20%2B%20y%20%2B%20z%20~%200;visible=true;point=(.5,-2.5,2.1);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=false;italic=false;fontmath=true;align=Upper-right&amp;type=text;text=2x%20-%20y%20%2B%20z%20~%200;visible=true;point=(2,2.2,-1.25);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=false;italic=false;fontmath=true;align=Upper-right&amp;type=window;hsrmode=0;anaglyph=-1;center=7.006292692220367,5.09036960455127,4.999999999999999,1;focus=0,0,0,1;up=-0.3290568564833397,-0.23907380036690282,0.9135454576426009,1;transparent=true;alpha=140;edgeson=false;faceson=true;showbox=false;showaxes=true;showticks=true;perspective=true;centerxpercent=0.5;centerypercent=0.5;rotationsteps=30;autospin=true;xygrid=false;yzgrid=false;xzgrid=false;gridsonbox=true;gridplanes=false;gridcolor=rgb(128,128,128);xmin=-2;xmax=2;ymin=-2;ymax=2;zmin=-2;zmax=2;xscale=1;yscale=1;zscale=1;zcmin=-4;zcmax=4;zoom=0.655294;xscalefactor=1;yscalefactor=1;zscalefactor=1" variant="minimal" width="80%"/>
+                    <interactive xml:id="calcplot3d-intersection-planes" calcplot3d="type=implicit;equation=2x-y+z~0;cubes=16;visible=true;xmin=-2;xmax=2;ymin=-2;ymax=2;zmin=-2;zmax=2;alpha=-1;format=constant;constcol=rgb(61,133,198)&amp;type=parametric;parametric=2;x=-(u+v)/2;y=(u-v)/2;z=v;visible=true;umin=-3;umax=3;usteps=30;vmin=-2;vmax=2;vsteps=15;alpha=193;format=constant;constcol=rgb(255,161,114)&amp;type=text;text=x%20%2B%20y%20%2B%20z%20~%200;visible=true;point=(.5,-2.5,2.1);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=false;italic=false;fontmath=true;align=Upper-right&amp;type=text;text=2x%20-%20y%20%2B%20z%20~%200;visible=true;point=(2,2.2,-1.25);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=false;italic=false;fontmath=true;align=Upper-right&amp;type=window;hsrmode=0;anaglyph=-1;center=7.006292692220367,5.09036960455127,4.999999999999999,1;focus=0,0,0,1;up=-0.3290568564833397,-0.23907380036690282,0.9135454576426009,1;transparent=true;alpha=140;edgeson=false;faceson=true;showbox=false;showaxes=true;showticks=true;perspective=true;centerxpercent=0.5;centerypercent=0.5;rotationsteps=30;autospin=true;xygrid=false;yzgrid=false;xzgrid=false;gridsonbox=true;gridplanes=false;gridcolor=rgb(128,128,128);xmin=-2;xmax=2;ymin=-2;ymax=2;zmin=-2;zmax=2;xscale=1;yscale=1;zscale=1;zcmin=-4;zcmax=4;zoom=0.655294;xscalefactor=1;yscalefactor=1;zscalefactor=1" variant="minimal" width="80%">
+                        <shortdescription>Two intersecting planes in three-space.
+                        </shortdescription>
+                        <description>
+                            <p>
+                                The planes <m>x+y+z=0</m> and <m>2x-y+z=0</m> are shown in <m>\mathbb{R}^3</m>. The planes intersect in a line passing through the origin.
+                            </p>
+                        </description>
+                    </interactive>
                 </figure>
 
                 <figure xml:id="figure-wavefunction">
                     <caption>Probability wavefunction with contours (includes controls)</caption>
-                    <interactive xml:id="calcplot3d-probability-wavefunction" calcplot3d="type=jaxlabel;position=middle;math=%255Cpsi_%257Bn_x%252Cn_y%257D(x%252Cy);textonly=false&amp;type=z;z=sin(api*x)sin(bpi*y);visible=true;umin=0;umax=1;vmin=0;vmax=1;grid=50;format=normal;alpha=200;constcol=rgb(255,0,0);view=0;contourcolor=rgb(255,0,0);contourplot=true;showcontourplot=true;firstvalue=-1;stepsize=0.2;numlevels=11;xnum=75;ynum=75;show2d=false;hidesurface=false;hidelabels=false;showprojections=false;surfacecontours=true;projectioncolor=rgba(51,153,0,1);showxygrid=false;showxygridonbox=false&amp;type=slider;slider=a;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_x&amp;type=slider;slider=b;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_y&amp;type=text;text=0;visible=true;point=(0,0,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=15pt;bold=true;italic=false;fontmath=true;align=Center-left&amp;type=text;text=L;visible=true;point=(1,-0.025,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=L;visible=true;point=(-0.05,1,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=x;visible=true;point=(0.5,-0.07,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=y;visible=true;point=(-0.08,0.5,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=window;hsrmode=3;anaglyph=-1;center=-7.447051206708178,-2.790794355991455,3.71998429905919,1;focus=0.5,0.5,0.5,1;up=0.39804763218685024,0.14521777837291014,0.9057979241281567,1;transparent=true;alpha=140;twoviews=false;unlinkviews=false;axisextension=0;xaxislabel=%20;yaxislabel=%20;zaxislabel=%20;edgeson=false;faceson=true;showbox=false;showaxes=false;showticks=false;perspective=true;centerxpercent=0.5;centerypercent=0.4;rotationsteps=30;autospin=true;xygrid=false;yzgrid=false;xzgrid=false;gridsonbox=false;gridplanes=true;gridcolor=rgb(128,128,128);xmin=0;xmax=1;ymin=0;ymax=1;zmin=0;zmax=1;xscale=1;yscale=1;zscale=1;zcmin=-4;zcmax=4;zoom=3.543529;xscalefactor=1;yscalefactor=1;zscalefactor=0.5;hidexysliders=true;hidetracevalue=true" variant="controls" width="95%" aspect="3:2"/>
+                    <interactive xml:id="calcplot3d-probability-wavefunction" calcplot3d="type=jaxlabel;position=middle;math=%255Cpsi_%257Bn_x%252Cn_y%257D(x%252Cy);textonly=false&amp;type=z;z=sin(api*x)sin(bpi*y);visible=true;umin=0;umax=1;vmin=0;vmax=1;grid=50;format=normal;alpha=200;constcol=rgb(255,0,0);view=0;contourcolor=rgb(255,0,0);contourplot=true;showcontourplot=true;firstvalue=-1;stepsize=0.2;numlevels=11;xnum=75;ynum=75;show2d=false;hidesurface=false;hidelabels=false;showprojections=false;surfacecontours=true;projectioncolor=rgba(51,153,0,1);showxygrid=false;showxygridonbox=false&amp;type=slider;slider=a;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_x&amp;type=slider;slider=b;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_y&amp;type=text;text=0;visible=true;point=(0,0,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=15pt;bold=true;italic=false;fontmath=true;align=Center-left&amp;type=text;text=L;visible=true;point=(1,-0.025,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=L;visible=true;point=(-0.05,1,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=x;visible=true;point=(0.5,-0.07,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=y;visible=true;point=(-0.08,0.5,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=window;hsrmode=3;anaglyph=-1;center=-7.447051206708178,-2.790794355991455,3.71998429905919,1;focus=0.5,0.5,0.5,1;up=0.39804763218685024,0.14521777837291014,0.9057979241281567,1;transparent=true;alpha=140;twoviews=false;unlinkviews=false;axisextension=0;xaxislabel=%20;yaxislabel=%20;zaxislabel=%20;edgeson=false;faceson=true;showbox=false;showaxes=false;showticks=false;perspective=true;centerxpercent=0.5;centerypercent=0.4;rotationsteps=30;autospin=true;xygrid=false;yzgrid=false;xzgrid=false;gridsonbox=false;gridplanes=true;gridcolor=rgb(128,128,128);xmin=0;xmax=1;ymin=0;ymax=1;zmin=0;zmax=1;xscale=1;yscale=1;zscale=1;zcmin=-4;zcmax=4;zoom=3.543529;xscalefactor=1;yscalefactor=1;zscalefactor=0.5;hidexysliders=true;hidetracevalue=true" variant="controls" width="95%" aspect="3:2">
+                        <description>
+                            <p>
+                                A plot of a function in three-space. The surface is labeled <m>\phi_{n_x,n_y}(x,y)</m>. There are sliders to adjust <m>n_x</m> and <m>n_y</m>.
+                            </p>
+                        </description>
+                    </interactive>
                 </figure>
 
                 <figure xml:id="figure-calcplot3d">

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -9630,7 +9630,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <interactive xml:id="geogebra-right-triangle" geogebra="KGn2d4Qd" width="70%" aspect="9:5" reset-icon="yes">
                         <description>
                             <p>
-                                An interactive puzzle. The puzzle shows two triangles placed on a square grid. On the left, there is a triangle decomposed into four pices. on the right, there is a triangle with outlines corresponding to the sizes and shapes of the pieces in the left triangle. The pieces from the left triangle can be dragged to the right. However, the triangle on the right has one additional grid square containing a question mark.
+                                An interactive puzzle. The puzzle shows two triangles placed on a square grid. On the left, there is a triangle decomposed into four pieces. On the right, there is a triangle with outlines corresponding to the sizes and shapes of the pieces in the left triangle. The pieces from the left triangle can be dragged to the right. However, the triangle on the right has one additional grid square containing a question mark.
                             </p>
                         </description>
                     </interactive>
@@ -9663,7 +9663,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <shortdescription>An interactive graph of a function.</shortdescription>
                         <description>
                             <p>
-                                An interactive graph of <m>\ln(x^2+5)-3</m>. The function decreases from the left edge of the window until <m>x=0</m>, where the <m>y</m>-value is approximately 1.5. The function then increases to the right edge of the window.
+                                An interactive graph of <m>\ln(x^2+5)-3</m>. The function decreases from the left edge of the window until <m>x=0</m>, where the <m>y</m>-value is approximately <m>-1.4</m>. The function then increases to the right edge of the window.
                             </p>
                         </description>
                     </interactive>
@@ -9702,7 +9702,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <interactive xml:id="calcplot3d-probability-wavefunction" calcplot3d="type=jaxlabel;position=middle;math=%255Cpsi_%257Bn_x%252Cn_y%257D(x%252Cy);textonly=false&amp;type=z;z=sin(api*x)sin(bpi*y);visible=true;umin=0;umax=1;vmin=0;vmax=1;grid=50;format=normal;alpha=200;constcol=rgb(255,0,0);view=0;contourcolor=rgb(255,0,0);contourplot=true;showcontourplot=true;firstvalue=-1;stepsize=0.2;numlevels=11;xnum=75;ynum=75;show2d=false;hidesurface=false;hidelabels=false;showprojections=false;surfacecontours=true;projectioncolor=rgba(51,153,0,1);showxygrid=false;showxygridonbox=false&amp;type=slider;slider=a;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_x&amp;type=slider;slider=b;value=1;steps=2;pmin=1;pmax=3;repeat=true;bounce=true;waittime=40;careful=true;noanimate=true;name=n_y&amp;type=text;text=0;visible=true;point=(0,0,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=15pt;bold=true;italic=false;fontmath=true;align=Center-left&amp;type=text;text=L;visible=true;point=(1,-0.025,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=L;visible=true;point=(-0.05,1,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=x;visible=true;point=(0.5,-0.07,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=text;text=y;visible=true;point=(-0.08,0.5,0);color=rgb(0,0,0);font=Times%20New%20Roman;fontsize=14pt;bold=true;italic=false;fontmath=true;align=Center&amp;type=window;hsrmode=3;anaglyph=-1;center=-7.447051206708178,-2.790794355991455,3.71998429905919,1;focus=0.5,0.5,0.5,1;up=0.39804763218685024,0.14521777837291014,0.9057979241281567,1;transparent=true;alpha=140;twoviews=false;unlinkviews=false;axisextension=0;xaxislabel=%20;yaxislabel=%20;zaxislabel=%20;edgeson=false;faceson=true;showbox=false;showaxes=false;showticks=false;perspective=true;centerxpercent=0.5;centerypercent=0.4;rotationsteps=30;autospin=true;xygrid=false;yzgrid=false;xzgrid=false;gridsonbox=false;gridplanes=true;gridcolor=rgb(128,128,128);xmin=0;xmax=1;ymin=0;ymax=1;zmin=0;zmax=1;xscale=1;yscale=1;zscale=1;zcmin=-4;zcmax=4;zoom=3.543529;xscalefactor=1;yscalefactor=1;zscalefactor=0.5;hidexysliders=true;hidetracevalue=true" variant="controls" width="95%" aspect="3:2">
                         <description>
                             <p>
-                                A plot of a function in three-space. The surface is labeled <m>\phi_{n_x,n_y}(x,y)</m>. There are sliders to adjust <m>n_x</m> and <m>n_y</m>.
+                                A plot of a function in three-space. The surface is labeled <m>\psi_{n_x,n_y}(x,y)</m>. There are sliders to adjust <m>n_x</m> and <m>n_y</m>.
                             </p>
                         </description>
                     </interactive>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3462,6 +3462,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:if>
         <!-- Restore all of the original attributes not processed separately -->
         <xsl:copy-of select="@*[not(contains(concat(' ', $interactive-drop-attr, ' '), concat(' ', local-name(), ' ')))]"/>
+        <!-- done with attributes, copy the content -->
+        <xsl:apply-templates select="node()" mode="enrichment"/>
         <slate>
             <xsl:attribute name="xml:id">
                 <xsl:value-of select="@assembly-id"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2778,8 +2778,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- 2023-09-07: move "description" to "shortdescription" -->
-
-<xsl:template match="image/description[not(*[not(self::var)])]" mode="repair">
+<!-- 2026-06-26: support this move for "description" inside "interactive" -->
+<xsl:template match="image/description[not(*[not(self::var)])]|interactive/description[not(*[not(self::var)])]" mode="repair">
     <xsl:element name="shortdescription" namespace="">
         <xsl:apply-templates select="node()|@*" mode="repair"/>
     </xsl:element>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6637,7 +6637,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
-<xsl:template match="image|interactive[@platform]" mode="description">
+<xsl:template match="image|interactive[@platform|@desmos|@calcplot3d|@circuitjs|@iframe]" mode="description">
     <xsl:if test="description">
         <!-- @aria-live means screenreaders will make announcements -->
         <details class="image-description" aria-live="polite">
@@ -6657,7 +6657,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Utility template so "aria-describedby" values are consistent -->
-<xsl:template match="image|interactive[@platform]" mode="describedby-id">
+<xsl:template match="image|interactive[@platform|@desmos|@calcplot3d|@circuitjs|@iframe]" mode="describedby-id">
     <xsl:apply-templates select="." mode="visible-id"/>
     <xsl:text>-description</xsl:text>
 </xsl:template>
@@ -10121,7 +10121,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
         <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
+        <!-- title attribute for accessibility -->
+        <xsl:choose>
+            <xsl:when test="not(string(shortdescription) = '')">
+                <xsl:attribute name="title">
+                    <xsl:apply-templates select="shortdescription" />
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="title">
+                    <xsl:text>described in detail following the image</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
+    <!-- possibly give a long description -->
+    <xsl:apply-templates select="." mode="description"/>
 </xsl:template>
 
 <!-- CalcPlot3D -->
@@ -10152,7 +10171,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <!-- title attribute for accessibility -->
+        <xsl:choose>
+            <xsl:when test="not(string(shortdescription) = '')">
+                <xsl:attribute name="title">
+                    <xsl:apply-templates select="shortdescription" />
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="title">
+                    <xsl:text>described in detail following the image</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
+    <!-- possibly give a long description -->
+    <xsl:apply-templates select="." mode="description"/>
 </xsl:template>
 
 <!-- CircuitJS: https://www.falstad.com -->
@@ -10186,7 +10224,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <!-- title attribute for accessibility -->
+        <xsl:choose>
+            <xsl:when test="not(string(shortdescription) = '')">
+                <xsl:attribute name="title">
+                    <xsl:apply-templates select="shortdescription" />
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="title">
+                    <xsl:text>described in detail following the image</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
+    <!-- possibly give a long description -->
+    <xsl:apply-templates select="." mode="description"/>
 </xsl:template>
 
 <!-- Arbitrary IFrame -->
@@ -10209,7 +10266,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="html-id-attribute"/>
         <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
         <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <!-- title attribute for accessibility -->
+        <xsl:choose>
+            <xsl:when test="not(string(shortdescription) = '')">
+                <xsl:attribute name="title">
+                    <xsl:apply-templates select="shortdescription" />
+                </xsl:attribute>
+            </xsl:when>
+            <xsl:when test="description">
+                <xsl:attribute name="title">
+                    <xsl:text>described in detail following the image</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="aria-describedby">
+                    <xsl:apply-templates select="." mode="describedby-id"/>
+                </xsl:attribute>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
     </iframe>
+    <!-- possibly give a long description -->
+    <xsl:apply-templates select="." mode="description"/>
 </xsl:template>
 
 <!-- For more complicated interactives, we just point to the page we generate -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10118,26 +10118,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The simplest possible example of this type -->
 <xsl:template match="interactive[@desmos]" mode="iframe-interactive">
     <iframe src="https://www.desmos.com/calculator/{@desmos}">
-        <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
-        <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
-        <!-- title attribute for accessibility -->
-        <xsl:choose>
-            <xsl:when test="not(string(shortdescription) = '')">
-                <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription" />
-                </xsl:attribute>
-            </xsl:when>
-            <xsl:when test="description">
-                <xsl:attribute name="title">
-                    <xsl:text>described in detail following the image</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="aria-describedby">
-                    <xsl:apply-templates select="." mode="describedby-id"/>
-                </xsl:attribute>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <xsl:apply-templates select="." mode="iframe-common-attributes" />
+        <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
     <xsl:apply-templates select="." mode="description"/>
@@ -10168,26 +10150,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- TODO: box-sizing, etc does not seem to help with vertical scroll bars -->
     <xsl:variable name="full-url" select="concat($cp3d-endpoint, '?', @calcplot3d)" />
     <iframe src="{$full-url}">
-        <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
-        <!-- title attribute for accessibility -->
-        <xsl:choose>
-            <xsl:when test="not(string(shortdescription) = '')">
-                <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription" />
-                </xsl:attribute>
-            </xsl:when>
-            <xsl:when test="description">
-                <xsl:attribute name="title">
-                    <xsl:text>described in detail following the image</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="aria-describedby">
-                    <xsl:apply-templates select="." mode="describedby-id"/>
-                </xsl:attribute>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <xsl:apply-templates select="." mode="iframe-common-attributes" />
+        <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
     <xsl:apply-templates select="." mode="description"/>
@@ -10221,26 +10185,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <iframe src="https://www.falstad.com/circuit/circuitjs.html?cct='{$url-string}'">
-        <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
-        <!-- title attribute for accessibility -->
-        <xsl:choose>
-            <xsl:when test="not(string(shortdescription) = '')">
-                <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription" />
-                </xsl:attribute>
-            </xsl:when>
-            <xsl:when test="description">
-                <xsl:attribute name="title">
-                    <xsl:text>described in detail following the image</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="aria-describedby">
-                    <xsl:apply-templates select="." mode="describedby-id"/>
-                </xsl:attribute>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <xsl:apply-templates select="." mode="iframe-common-attributes" />
+        <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
     <xsl:apply-templates select="." mode="description"/>
@@ -10263,26 +10209,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="@iframe"/>
     </xsl:variable>
     <iframe src="{$location}">
-        <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
-        <!-- title attribute for accessibility -->
-        <xsl:choose>
-            <xsl:when test="not(string(shortdescription) = '')">
-                <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription" />
-                </xsl:attribute>
-            </xsl:when>
-            <xsl:when test="description">
-                <xsl:attribute name="title">
-                    <xsl:text>described in detail following the image</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="aria-describedby">
-                    <xsl:apply-templates select="." mode="describedby-id"/>
-                </xsl:attribute>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <xsl:apply-templates select="." mode="iframe-common-attributes" />
+        <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
     <xsl:apply-templates select="." mode="description"/>
@@ -10291,31 +10219,42 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- For more complicated interactives, we just point to the page we generate -->
 <xsl:template match="interactive[@platform]" mode="iframe-interactive">
     <iframe>
-        <xsl:apply-templates select="." mode="html-id-attribute"/>
-        <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
+        <xsl:apply-templates select="." mode="iframe-common-attributes" />
         <xsl:attribute name="src">
             <xsl:apply-templates select="." mode="iframe-filename" />
         </xsl:attribute>
-        <!-- title attribute for accessibility -->
-        <xsl:choose>
-            <xsl:when test="not(string(shortdescription) = '')">
-                <xsl:attribute name="title">
-                    <xsl:apply-templates select="shortdescription" />
-                </xsl:attribute>
-            </xsl:when>
-            <xsl:when test="description">
-                <xsl:attribute name="title">
-                    <xsl:text>described in detail following the image</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="aria-describedby">
-                    <xsl:apply-templates select="." mode="describedby-id"/>
-                </xsl:attribute>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+        <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
     <xsl:apply-templates select="." mode="description"/>
+</xsl:template>
+
+<!-- Set the title attribute for accessibility purposes -->
+<!-- If there is a description but not a shortdescription, provide text and aria-describedby -->
+<xsl:template match="*" mode="iframe-accessibility-attributes">
+    <!-- title attribute for accessibility -->
+    <xsl:choose>
+        <xsl:when test="not(string(shortdescription) = '')">
+            <xsl:attribute name="title">
+                <xsl:apply-templates select="shortdescription" />
+            </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="description">
+            <xsl:attribute name="title">
+                <xsl:text>described in detail following the image</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="aria-describedby">
+                <xsl:apply-templates select="." mode="describedby-id"/>
+            </xsl:attribute>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Attributes that are common to the iframe interactives -->
+<xsl:template match="*" mode="iframe-common-attributes">
+    <xsl:apply-templates select="." mode="html-id-attribute"/>
+    <xsl:apply-templates select="." mode="iframe-dark-mode-attribute" />
+    <xsl:apply-templates select="." mode="interactive-sizing-style-attribute" />
 </xsl:template>
 
 <!-- ######################### -->


### PR DESCRIPTION
Sending this as three commits just to make clearer where the changes were. I think this now covers the various interactive elements (Desmos, GeoGebra, CalcPlot3D, CircuitJS, and arbitrary iframe) for descriptions. 

- Two changes in assembly: 
  - Ensure that `interactive[@geogebra]` with children has them copied when restructuring to use `interactive/slate`. 
  - Move an unstructured `description` to be a `shortdescription` when the child of `interactive`
- Changes to `pretext-html.xsl` to replicate earlier work done for `interactive[@platform]` to have descriptions.
- A mixture of test cases (no `shortdescription`, both `shortdescription` and `description`, unstructured `description`) added to the sample article.