### PR TITLE
Update the webwork version check approach.

### DIFF
--- a/pretext/lib/webwork.py
+++ b/pretext/lib/webwork.py
@@ -209,8 +209,13 @@ def webwork_to_xml(
             disableCookies='1',
             outputformat='raw'
         )
-        # Always use html2xml for this; we don't know the server version yet
-        version_determination_json = requests.get(url=webwork2_html2xml, params=params_for_version_determination).json()
+        # Try render_rpc first.  If that fails, then fall back to html2xml.
+        render_rpc_response = requests.get(url=webwork2_render_rpc, params=params_for_version_determination)
+        if render_rpc_response.status_code == 200:
+            version_determination_json = render_rpc_response.json()
+        else:
+            version_determination_json = requests.get(
+                url=webwork2_html2xml, params=params_for_version_determination).json()
         if "ww_version" in version_determination_json:
             webwork2_version = version_determination_json["ww_version"]
             webwork2_version_match = re.search(


### PR DESCRIPTION
The current method makes a request to the deprecated `html2xml` endpoint to get the version.  Then falls back to retrieving and parsing the HTML for the landing page.  The problem with that approach is that the `html2xml` endpoint will eventually be removed.  Most likely this will happen with the next release of WeBWorK. See https://github.com/openwebwork/webwork2/pull/3034.

So this switches to first making a request to the `render_rpc` endpoint.  If that returns a 200 okay response, then get the version from the response.  Otherwise fall back to the `html2xml` endpoint and attempt to get the version from that response.  If that still fails, then try the landing page approach.

The `render_rpc` request will work for version 2.18 or newer of webwork2.  The fallback `html2xml` request will only work for webwork 2.17.  Any older version will not even send the `ww_version` in the `html2xml` request, so the landing page fallback approach is the only thing that could possibly work.