### PR TITLE
Add `resources/@host` publication variable to use cdn versions of css/js

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -806,8 +806,26 @@
                 <cline>/publication/html/platform/@portable</cline>
             </cd>
             attribute to the value <c>"yes"</c>. 
-            This will result in the HTML using hosted CSS and Javascript files, rather than including them adjacent to the rest of your output.
-            This is especially useful in conjunction with setting the <xref ref="common-chunking-options">chunking variable</xref> to 0 to get a single html file.</p>
+            This will result in the HTML using hosted CSS and Javascript files, rather than including them adjacent to the rest of your output  (identical to selecting <q>cdn</q> as the <c>resources/@host</c> value, see <xref ref="online-resource-host-options"/>).
+            Further, the <xref ref="common-chunking-options">chunking variable</xref> will be set to 0 to get a single html file, and svgs produced from generated assets will be embedded directly in the page.</p>
+        </subsection>
+
+        <subsection xml:id="online-resource-host-options">
+            <title>HTML Resources</title>
+            <idx><h>resource hosting</h><h>HTML</h></idx>
+            <idx><h>host</h><h>HTML resources</h></idx>
+
+            <p>The
+            <cd>
+                <cline>/publication/html/resources</cline>
+            </cd>
+            element can have an attribute <attr>host</attr> with values:
+            <ul>
+                <li><c>local</c>: the default, all css and js files are included in the output directory.</li>
+                <li><c>cdn</c>: all css and js files are hosted remotely on a content delivery network.</li>
+            </ul></p>
+
+            <p>Note that since the css is delivered remotely, only the basic themes are available (you cannot customize the colors as described in <xref ref="online-style-options"/>).</p>
         </subsection>
 
         <subsection xml:id="online-style-options">

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -3636,7 +3636,7 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     tmp_dir = common.get_temporary_directory()
 
     pub_vars = common.get_publisher_variable_report(xml, pub_file, stringparams)
-    include_static_files = common.get_publisher_variable(pub_vars, 'portable-html') != "yes"
+    include_static_files = common.get_publisher_variable(pub_vars, 'b-cdn-resources') != "true"
     time_logger.log("pubvars loaded")
 
     if include_static_files:

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -415,6 +415,7 @@
                         Knowls? &amp;
                         NavigationHTML? &amp;
                         Platform? &amp;
+                        Resources? &amp;
                         Search? &amp;
                         Tableofcontents? &amp;
                         Video? &amp;

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -121,18 +121,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- We use version "latest" unless the CLI provides a version -->
 <xsl:param name="cli.version" select="'latest'"/>
 <xsl:variable name="cdn-prefix">
-    <xsl:if test="$b-portable-html">
+    <xsl:if test="$b-cdn-resources">
         <xsl:text>https://cdn.jsdelivr.net/gh/PreTeXtBook/html-static@</xsl:text>
         <xsl:value-of select="$cli.version"/>
         <xsl:text>/dist/</xsl:text>
     </xsl:if>
 </xsl:variable>
 
-<!-- The css file name is usually "theme.css", but if portable html is selected, -->
-<!-- then we use a minified version and need to give the full theme name.        -->
+<!-- The css file name is usually "theme.css", but if cdn resources are selected, -->
+<!-- then we use a minified version and need to give the full theme name.         -->
 <xsl:variable name="html-css-theme-file">
     <xsl:choose>
-        <xsl:when test="$b-portable-html">
+        <xsl:when test="$b-cdn-resources">
             <xsl:text>theme-</xsl:text>
             <xsl:value-of select="$html-theme-name"/>
             <xsl:text>.min.css</xsl:text>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2934,6 +2934,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="b-portable-html" select="$portable-html = 'yes'"/>
 
+<!-- The css and js can be served locally (default) or by CDN -->
+<xsl:variable name="resources-host">
+    <xsl:apply-templates select="$publisher-attribute-options/html/resources/pi:pub-attribute[@name='host']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<!-- Always use cdn when "b-portable-html" is true or "resources-host" is "cdn" -->
+<xsl:variable name="b-cdn-resources" select="$b-portable-html or $resources-host = 'cdn'"/>
+
 <!-- HTML chunk-level defaults, available to any stylesheet that    -->
 <!-- needs to compute HTML filenames via the "containing-filename"  -->
 <!-- template (pretext-common.xsl) without importing the full       -->
@@ -3596,6 +3603,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <css>
             <pi:pub-attribute name="palette" freeform="yes"/>
         </css>
+        <resources>
+            <pi:pub-attribute name="host" default="local" options="cdn"/>
+        </resources>
         <knowl>
             <pi:pub-attribute name="theorem" default="no" options="yes" legacy-stringparam="html.knowl.theorem"/>
             <pi:pub-attribute name="proof" default="yes" options="no" legacy-stringparam="html.knowl.proof"/>

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -107,6 +107,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text> </xsl:text>
     <xsl:value-of select="$portable-html"/>
     <xsl:text>&#xa;</xsl:text>
+    <!-- 2026-06-30 local/cdn resources -->
+    <xsl:text>b-cdn-resources</xsl:text>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$b-cdn-resources"/>
+    <xsl:text>&#xa;</xsl:text>
     <!-- 2025-05-10 CSL style indicator -->
     <xsl:text>b-using-csl-styles</xsl:text>
     <xsl:text> </xsl:text>


### PR DESCRIPTION
Since the reveal.js publication variables already allows selecting of local vs cdn hosting its javascript, I think this choice of publication variable name makes sense for html too.

This is mostly straight forward, but I did clean up the xsl and python a bit to use a consolidated `$b-cdn-resources` variable that is true when either `portable="yes"` or `host="cdn"` is selected. 