### PR TITLE
Tabular: share cell rule and alignment resolution across converters

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7336,6 +7336,169 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- Effective rule weight and alignment for a "cell" edge.            -->
+<!--                                                                   -->
+<!-- The rule weight ("none"/"minor"/"medium"/"major") and the        -->
+<!-- alignment for a given cell edge are determined by a precedence    -->
+<!-- ladder over the four levels at which the attribute may appear     -->
+<!-- ("cell", "row", "col", "tabular"), with a default.  That          -->
+<!-- resolution is format-independent, so it is performed once here.   -->
+<!-- Each conversion consumes the resulting token and translates it    -->
+<!-- into its own markup (a CSS class, a LaTeX rule macro or column    -->
+<!-- letter, an FO "border" property).                                 -->
+<!--                                                                   -->
+<!--   halign:  cell > row > col > tabular > "left"                    -->
+<!--   valign:  row > tabular > "middle"                               -->
+<!--   bottom:  cell > row > tabular > "none"                          -->
+<!--   right:   cell > col > tabular > "none"                          -->
+<!--   left:    (leading cell only) row > tabular > "none"             -->
+<!--   top:     (first row only)    col > tabular > "none"             -->
+<!--                                                                   -->
+<!-- A "cell" finds its "col" by counting columns occupied by the      -->
+<!-- preceding cells of its row (each contributes its "@colspan", or   -->
+<!-- 1).  The left edge of the cell is in column "column-left-number"; -->
+<!-- a spanning cell's right edge is in "column-right-number".         -->
+<xsl:template match="cell" mode="column-left-number">
+    <xsl:value-of select="1 + sum(preceding-sibling::cell/@colspan) + count(preceding-sibling::cell[not(@colspan)])"/>
+</xsl:template>
+
+<xsl:template match="cell" mode="column-right-number">
+    <xsl:variable name="left">
+        <xsl:apply-templates select="." mode="column-left-number"/>
+    </xsl:variable>
+    <xsl:variable name="span">
+        <xsl:choose>
+            <xsl:when test="@colspan">
+                <xsl:value-of select="@colspan"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>1</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:value-of select="$left + $span - 1"/>
+</xsl:template>
+
+<!-- horizontal alignment: cell > row > col > tabular > "left" -->
+<xsl:template match="cell" mode="effective-halign">
+    <xsl:variable name="left-number">
+        <xsl:apply-templates select="." mode="column-left-number"/>
+    </xsl:variable>
+    <xsl:variable name="left-col" select="ancestor::tabular/col[number($left-number)]"/>
+    <xsl:choose>
+        <xsl:when test="@halign">
+            <xsl:value-of select="@halign"/>
+        </xsl:when>
+        <xsl:when test="ancestor::row/@halign">
+            <xsl:value-of select="ancestor::row/@halign"/>
+        </xsl:when>
+        <xsl:when test="$left-col/@halign">
+            <xsl:value-of select="$left-col/@halign"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@halign">
+            <xsl:value-of select="ancestor::tabular/@halign"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>left</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- vertical alignment: row > tabular > "middle" -->
+<xsl:template match="cell" mode="effective-valign">
+    <xsl:choose>
+        <xsl:when test="ancestor::row/@valign">
+            <xsl:value-of select="ancestor::row/@valign"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@valign">
+            <xsl:value-of select="ancestor::tabular/@valign"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>middle</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- bottom rule: cell > row > tabular > "none" -->
+<xsl:template match="cell" mode="effective-bottom">
+    <xsl:choose>
+        <xsl:when test="@bottom">
+            <xsl:value-of select="@bottom"/>
+        </xsl:when>
+        <xsl:when test="ancestor::row/@bottom">
+            <xsl:value-of select="ancestor::row/@bottom"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@bottom">
+            <xsl:value-of select="ancestor::tabular/@bottom"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>none</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- right rule: cell > col > tabular > "none" -->
+<xsl:template match="cell" mode="effective-right">
+    <xsl:variable name="right-number">
+        <xsl:apply-templates select="." mode="column-right-number"/>
+    </xsl:variable>
+    <xsl:variable name="right-col" select="ancestor::tabular/col[number($right-number)]"/>
+    <xsl:choose>
+        <xsl:when test="@right">
+            <xsl:value-of select="@right"/>
+        </xsl:when>
+        <xsl:when test="$right-col/@right">
+            <xsl:value-of select="$right-col/@right"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@right">
+            <xsl:value-of select="ancestor::tabular/@right"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>none</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- left rule: only the leading cell of a row has one; row > tabular > "none" -->
+<xsl:template match="cell" mode="effective-left">
+    <xsl:choose>
+        <xsl:when test="preceding-sibling::cell">
+            <xsl:text>none</xsl:text>
+        </xsl:when>
+        <xsl:when test="ancestor::row/@left">
+            <xsl:value-of select="ancestor::row/@left"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@left">
+            <xsl:value-of select="ancestor::tabular/@left"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>none</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- top rule: only cells of the first row have one; col > tabular > "none" -->
+<xsl:template match="cell" mode="effective-top">
+    <xsl:variable name="left-number">
+        <xsl:apply-templates select="." mode="column-left-number"/>
+    </xsl:variable>
+    <xsl:variable name="left-col" select="ancestor::tabular/col[number($left-number)]"/>
+    <xsl:choose>
+        <xsl:when test="ancestor::row/preceding-sibling::row">
+            <xsl:text>none</xsl:text>
+        </xsl:when>
+        <xsl:when test="$left-col/@top">
+            <xsl:value-of select="$left-col/@top"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tabular/@top">
+            <xsl:value-of select="ancestor::tabular/@top"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>none</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- ################### -->
 <!-- Structured by Lines -->
 <!-- ################### -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2370,22 +2370,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:attribute>
             </xsl:otherwise>
         </xsl:choose>
-        <!-- The top edge is not a single table border: it rides the     -->
-        <!-- first row's cells (see the "cell" template) so the top rule  -->
-        <!-- can vary by column via "col/@top".  The other three frame    -->
-        <!-- edges stay whole-tabular borders on the table.               -->
-        <xsl:call-template name="rule-attribute">
-            <xsl:with-param name="side" select="'bottom'"/>
-            <xsl:with-param name="thickness" select="@bottom"/>
-        </xsl:call-template>
-        <xsl:call-template name="rule-attribute">
-            <xsl:with-param name="side" select="'left'"/>
-            <xsl:with-param name="thickness" select="@left"/>
-        </xsl:call-template>
-        <xsl:call-template name="rule-attribute">
-            <xsl:with-param name="side" select="'right'"/>
-            <xsl:with-param name="thickness" select="@right"/>
-        </xsl:call-template>
+        <!-- Every rule, interior or perimeter, is drawn per cell in the -->
+        <!-- "cell" template from the effective edge weights resolved in -->
+        <!-- -common (cell, then row/col, then whole-tabular), so no      -->
+        <!-- table-wide border is placed here.                           -->
         <xsl:for-each select="$widths">
             <fo:table-column column-width="proportional-column-width({.})"/>
         </xsl:for-each>
@@ -2614,13 +2602,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:value-of select="@colspan"/>
             </xsl:attribute>
         </xsl:if>
-        <!-- vertical alignment: row, else tabular, else the top -->
+        <!-- vertical alignment, effective value resolved in -common -->
+        <xsl:variable name="valign">
+            <xsl:apply-templates select="." mode="effective-valign"/>
+        </xsl:variable>
         <xsl:attribute name="display-align">
             <xsl:choose>
-                <xsl:when test="parent::row/@valign = 'middle' or (not(parent::row/@valign) and ancestor::tabular/@valign = 'middle')">
+                <xsl:when test="$valign = 'middle'">
                     <xsl:text>center</xsl:text>
                 </xsl:when>
-                <xsl:when test="parent::row/@valign = 'bottom' or (not(parent::row/@valign) and ancestor::tabular/@valign = 'bottom')">
+                <xsl:when test="$valign = 'bottom'">
                     <xsl:text>after</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
@@ -2628,91 +2619,40 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:attribute>
+        <!-- Effective rule weight per edge, resolved in -common; a       -->
+        <!-- "none" yields no border.  Each cell now draws its own four    -->
+        <!-- rules, so interior rules and the whole-tabular fall-through   -->
+        <!-- appear (matching HTML and LaTeX) rather than only an outer    -->
+        <!-- frame.  "effective-left"/"effective-top" return "none" away   -->
+        <!-- from the leading cell / first row, so no guard is needed.     -->
         <xsl:call-template name="rule-attribute">
             <xsl:with-param name="side" select="'bottom'"/>
             <xsl:with-param name="thickness">
-                <xsl:choose>
-                    <xsl:when test="@bottom">
-                        <xsl:value-of select="@bottom"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="parent::row/@bottom"/>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <xsl:apply-templates select="." mode="effective-bottom"/>
             </xsl:with-param>
         </xsl:call-template>
         <xsl:call-template name="rule-attribute">
             <xsl:with-param name="side" select="'right'"/>
             <xsl:with-param name="thickness">
-                <xsl:choose>
-                    <xsl:when test="@right">
-                        <xsl:value-of select="@right"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <!-- a right border comes from the last column the   -->
-                        <!-- cell occupies, so a spanning cell reaches past  -->
-                        <!-- its starting column to the end of its span      -->
-                        <xsl:variable name="start-position" select="count(preceding-sibling::cell[not(@colspan)]) + sum(preceding-sibling::cell/@colspan) + 1"/>
-                        <xsl:variable name="span">
-                            <xsl:choose>
-                                <xsl:when test="@colspan">
-                                    <xsl:value-of select="@colspan"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:text>1</xsl:text>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:variable>
-                        <xsl:value-of select="ancestor::tabular/col[position() = $start-position + $span - 1]/@right"/>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <xsl:apply-templates select="." mode="effective-right"/>
             </xsl:with-param>
         </xsl:call-template>
-        <!-- The left edge of a row lives on its leading cell, taken    -->
-        <!-- from the cell, else the row (mirroring the bottom edge's    -->
-        <!-- fallback); the schema places a per-row left rule on "row",  -->
-        <!-- and the whole-tabular left rule is on the "fo:table".  A    -->
-        <!-- spanning leading cell still owns the single left edge.      -->
-        <xsl:if test="not(preceding-sibling::cell)">
-            <xsl:call-template name="rule-attribute">
-                <xsl:with-param name="side" select="'left'"/>
-                <xsl:with-param name="thickness">
-                    <xsl:choose>
-                        <xsl:when test="@left">
-                            <xsl:value-of select="@left"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="parent::row/@left"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
-        <!-- The top edge of the table rides its first row, per column       -->
-        <!-- ("col/@top"), so the top rule can vary across columns, or even  -->
-        <!-- drop out where "@top" is "none"; a column with no "@top" of its -->
-        <!-- own inherits the whole-tabular "@top".  A spanning leading cell -->
-        <!-- takes the top of the column it starts in.                       -->
-        <xsl:if test="not(parent::row/preceding-sibling::row)">
-            <xsl:variable name="top-position" select="count(preceding-sibling::cell[not(@colspan)]) + sum(preceding-sibling::cell/@colspan) + 1"/>
-            <xsl:call-template name="rule-attribute">
-                <xsl:with-param name="side" select="'top'"/>
-                <xsl:with-param name="thickness">
-                    <xsl:choose>
-                        <xsl:when test="ancestor::tabular/col[position() = $top-position]/@top">
-                            <xsl:value-of select="ancestor::tabular/col[position() = $top-position]/@top"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="ancestor::tabular/@top"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
+        <xsl:call-template name="rule-attribute">
+            <xsl:with-param name="side" select="'left'"/>
+            <xsl:with-param name="thickness">
+                <xsl:apply-templates select="." mode="effective-left"/>
+            </xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="rule-attribute">
+            <xsl:with-param name="side" select="'top'"/>
+            <xsl:with-param name="thickness">
+                <xsl:apply-templates select="." mode="effective-top"/>
+            </xsl:with-param>
+        </xsl:call-template>
         <xsl:variable name="the-block">
             <fo:block>
                 <xsl:attribute name="text-align">
-                    <xsl:apply-templates select="." mode="cell-halign"/>
+                    <xsl:apply-templates select="." mode="effective-halign"/>
                 </xsl:attribute>
                 <!-- headers are bold: a header row (horizontal or  -->
                 <!-- vertical), or the leading cell of each row     -->
@@ -2758,30 +2698,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </fo:table-cell>
-</xsl:template>
-
-<!-- Horizontal alignment: the cell, else its row, else its -->
-<!-- column, else the tabular, else flush left.  ("justify" -->
-<!-- passes through with the same meaning in XSL-FO.)       -->
-<xsl:template match="row/cell" mode="cell-halign">
-    <xsl:variable name="the-position" select="count(preceding-sibling::cell[not(@colspan)]) + sum(preceding-sibling::cell/@colspan) + 1"/>
-    <xsl:choose>
-        <xsl:when test="@halign">
-            <xsl:value-of select="@halign"/>
-        </xsl:when>
-        <xsl:when test="parent::row/@halign">
-            <xsl:value-of select="parent::row/@halign"/>
-        </xsl:when>
-        <xsl:when test="ancestor::tabular/col[position() = $the-position]/@halign">
-            <xsl:value-of select="ancestor::tabular/col[position() = $the-position]/@halign"/>
-        </xsl:when>
-        <xsl:when test="ancestor::tabular/@halign">
-            <xsl:value-of select="ancestor::tabular/@halign"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text>left</xsl:text>
-        </xsl:otherwise>
-    </xsl:choose>
 </xsl:template>
 
 <!-- The schema's rule thicknesses, emitted as a border on the -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8039,143 +8039,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- then write them in a class attribute                       -->
         <!-- we look outward and upward for characteristics of the cell -->
         <!--                                                            -->
-        <!-- horizontal alignment -->
+        <!-- effective alignments and rule weights, resolved in -common; -->
+        <!-- each is a token translated to a CSS class fragment below     -->
         <xsl:variable name="alignment">
-            <xsl:choose>
-                <!-- cell attribute first -->
-                <xsl:when test="$the-cell/@halign">
-                    <xsl:value-of select="$the-cell/@halign" />
-                </xsl:when>
-                <!-- parent row attribute next -->
-                <xsl:when test="$the-cell/ancestor::row/@halign">
-                    <xsl:value-of select="$the-cell/ancestor::row/@halign" />
-                </xsl:when>
-                <!-- col attribute next -->
-                <xsl:when test="$left-col/@halign">
-                    <xsl:value-of select="$left-col/@halign" />
-                </xsl:when>
-                <!-- table attribute last -->
-                <xsl:when test="$the-cell/ancestor::tabular/@halign">
-                    <xsl:value-of select="$the-cell/ancestor::tabular/@halign" />
-                </xsl:when>
-                <!-- HTML default is left, we write it for consistency -->
-                <xsl:otherwise>
-                    <xsl:text>left</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-halign"/>
         </xsl:variable>
-        <!-- vertical alignment -->
         <xsl:variable name="valignment">
-            <xsl:choose>
-                <!-- parent row attribute first -->
-                <xsl:when test="$the-cell/ancestor::row/@valign">
-                    <xsl:value-of select="$the-cell/ancestor::row/@valign" />
-                </xsl:when>
-                <!-- table attribute last -->
-                <xsl:when test="$the-cell/ancestor::tabular/@valign">
-                    <xsl:value-of select="$the-cell/ancestor::tabular/@valign" />
-                </xsl:when>
-                <!-- HTML default is "baseline", not supported by PTX           -->
-                <!-- Instead we default to "middle" to be consistent with LaTeX -->
-                <xsl:otherwise>
-                    <xsl:text>middle</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-valign"/>
         </xsl:variable>
-        <!-- bottom borders -->
         <xsl:variable name="bottom">
-            <xsl:choose>
-                <!-- cell attribute first -->
-                <xsl:when test="$the-cell/@bottom">
-                    <xsl:value-of select="$the-cell/@bottom" />
-                </xsl:when>
-                <!-- parent row attribute next -->
-                <xsl:when test="$the-cell/ancestor::row/@bottom">
-                    <xsl:value-of select="$the-cell/ancestor::row/@bottom" />
-                </xsl:when>
-                <!-- not available on columns, table attribute last -->
-                <xsl:when test="$the-cell/ancestor::tabular/@bottom">
-                    <xsl:value-of select="$the-cell/ancestor::tabular/@bottom" />
-                </xsl:when>
-                <!-- default is none -->
-                <xsl:otherwise>
-                    <xsl:text>none</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-bottom"/>
         </xsl:variable>
-        <!-- right borders -->
         <xsl:variable name="right">
-            <xsl:choose>
-                <!-- cell attribute first -->
-                <xsl:when test="$the-cell/@right">
-                    <xsl:value-of select="$the-cell/@right" />
-                </xsl:when>
-                <!-- not available on rows, col attribute next -->
-                <xsl:when test="$right-col/@right">
-                    <xsl:value-of select="$right-col/@right" />
-                </xsl:when>
-                <!-- table attribute last -->
-                <xsl:when test="$the-cell/ancestor::tabular/@right">
-                    <xsl:value-of select="$the-cell/ancestor::tabular/@right" />
-                </xsl:when>
-                <!-- default is none -->
-                <xsl:otherwise>
-                    <xsl:text>none</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-right"/>
         </xsl:variable>
-        <!-- left borders -->
         <xsl:variable name="left">
-            <xsl:choose>
-                <!-- the first cell of the row, so may have left border -->
-                <xsl:when test="not($the-cell/preceding-sibling::cell)">
-                    <xsl:choose>
-                        <!-- row attribute first -->
-                        <xsl:when test="$the-cell/ancestor::row/@left">
-                            <xsl:value-of select="$the-cell/ancestor::row/@left" />
-                        </xsl:when>
-                        <!-- table attribute last -->
-                        <xsl:when test="$the-cell/ancestor::tabular/@left">
-                            <xsl:value-of select="$the-cell/ancestor::tabular/@left" />
-                        </xsl:when>
-                        <!-- default is none -->
-                        <xsl:otherwise>
-                            <xsl:text>none</xsl:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:when>
-                <!-- not the first cell of the row, so no left border -->
-                <xsl:otherwise>
-                    <xsl:text>none</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-left"/>
         </xsl:variable>
-        <!-- top borders -->
         <xsl:variable name="top">
-            <xsl:choose>
-                <!-- the first row of the table, so may have top border -->
-                <!-- http://ajaxandxml.blogspot.com/2006/11/xsl-detect-first-of-type-element-in.html -->
-                <xsl:when test="not($the-cell/ancestor::row/preceding-sibling::row)">
-                    <xsl:choose>
-                        <!-- col attribute first -->
-                        <xsl:when test="$left-col/@top">
-                            <xsl:value-of select="$left-col/@top" />
-                        </xsl:when>
-                        <!-- table attribute last -->
-                        <xsl:when test="$the-cell/ancestor::tabular/@top">
-                            <xsl:value-of select="$the-cell/ancestor::tabular/@top" />
-                        </xsl:when>
-                        <!-- default is none -->
-                        <xsl:otherwise>
-                            <xsl:text>none</xsl:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:when>
-                <!-- not the first cell of the row, so no left border -->
-                <xsl:otherwise>
-                    <xsl:text>none</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="$the-cell" mode="effective-top"/>
         </xsl:variable>
 
         <!-- a cell of a header row needs to be "th" -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -10014,16 +10014,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="row-bottom">
-        <xsl:choose>
-            <xsl:when test="@bottom">
-                <xsl:value-of select="@bottom" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$table-bottom" />
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
     <!-- Walking the row's cells, write contents and bottom borders -->
     <xsl:apply-templates select="cell[1]">
         <xsl:with-param name="left-col" select="parent::tabular/col[1]" /> <!-- possibly empty -->
@@ -10036,7 +10026,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="table-halign" select="$table-halign" />
         <xsl:with-param name="table-valign" select="$table-valign" />
         <xsl:with-param name="row-left" select="$row-left" />
-        <xsl:with-param name="row-bottom" select="$row-bottom" />
     </xsl:apply-templates>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
@@ -10066,7 +10055,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="table-halign" />
     <xsl:param name="table-valign" />
     <xsl:param name="row-left" />
-    <xsl:param name="row-bottom" />
     <!-- A cell may span several columns, or default to just 1              -->
     <!-- When colspan is not trivial, we identify the left and right ends   -->
     <!-- of the span, both as col elements and as column numbers            -->
@@ -10098,17 +10086,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- determine a custom right border on a cell -->
-    <!-- else default to the column value          -->
+    <!-- the effective right border of the cell (cell > col > tabular); -->
+    <!-- "column-right" above is kept for the multicolumn deviation test -->
     <xsl:variable name="cell-right">
-        <xsl:choose>
-            <xsl:when test="@right">
-                <xsl:value-of select="@right" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$column-right" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:apply-templates select="." mode="effective-right"/>
     </xsl:variable>
     <!-- Use cell attributes, or col attributes for horizontal alignment -->
     <!-- recreate the column specification for horizontal alignment      -->
@@ -10123,34 +10104,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- determine a custom horizontal alignment on a cell        -->
-    <!-- check for row override, else default to the column value -->
+    <!-- the effective horizontal alignment (cell > row > col > tabular); -->
+    <!-- "column-halign" above is kept for the multicolumn deviation test -->
     <xsl:variable name="cell-halign">
-        <xsl:choose>
-            <xsl:when test="@halign">
-                <xsl:value-of select="@halign" />
-            </xsl:when>
-            <!-- look to the row -->
-            <xsl:when test="parent::row/@halign">
-                <xsl:value-of select="parent::row/@halign" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$column-halign" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:apply-templates select="." mode="effective-halign"/>
     </xsl:variable>
-    <!-- Use row attributes for vertical alignment                -->
-    <!-- recreate the row specification for vertical alignment    -->
-    <!-- either a per-row value, or the global, table-wide value  -->
+    <!-- the effective vertical alignment of the cell (row > tabular) -->
     <xsl:variable name="row-valign">
-        <xsl:choose>
-            <xsl:when test="parent::row/@valign">
-                <xsl:value-of select="parent::row/@valign" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$table-valign" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:apply-templates select="." mode="effective-valign"/>
     </xsl:variable>
     <!-- Look ahead to next cell, anticipating recursion     -->
     <!-- but also probing for end of row (empty $next-cell), -->
@@ -10229,34 +10190,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="$next-cell">
         <xsl:text>&amp;</xsl:text>
     </xsl:if>
-    <!-- The desired bottom border style for this cell     -->
+    <!-- the effective bottom border of this cell (cell > row > tabular) -->
     <xsl:variable name="current-bottom">
-        <xsl:choose>
-            <!-- cell specification -->
-            <xsl:when test="@bottom">
-                <xsl:value-of select="@bottom" />
-            </xsl:when>
-            <!-- inherited specification for row -->
-            <xsl:otherwise>
-                <xsl:value-of select="$row-bottom" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:apply-templates select="." mode="effective-bottom"/>
     </xsl:variable>
-    <!-- The desired bottom border style for the next cell     -->
+    <!-- the effective bottom border of the next cell, or a sentinel  -->
+    <!-- at end of row, used below to detect a change in the rule run -->
     <xsl:variable name="next-bottom">
         <xsl:choose>
-            <!-- end of row, no next cell, so      -->
-            <!-- bottom style signals change/flush -->
             <xsl:when test="not($next-cell)">
                 <xsl:text>undefined-bottom</xsl:text>
             </xsl:when>
-            <!-- next cell's specification -->
-            <xsl:when test="$next-cell/@bottom">
-                <xsl:value-of select="$next-cell/@bottom" />
-            </xsl:when>
-            <!-- inherited specification for row -->
             <xsl:otherwise>
-                <xsl:value-of select="$row-bottom" />
+                <xsl:apply-templates select="$next-cell" mode="effective-bottom"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -10314,7 +10260,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="table-halign" select="$table-halign" />
         <xsl:with-param name="table-valign" select="$table-valign" />
         <xsl:with-param name="row-left" select="$table-left" />
-        <xsl:with-param name="row-bottom" select="$row-bottom" />
     </xsl:apply-templates>
 
     <!-- finish the row, dump cline info, etc -->


### PR DESCRIPTION
Each converter independently re-derived a table cell's *effective* border and alignment values — walking the `@top`/`@bottom`/`@left`/`@right`/`@halign`/`@valign` precedence from cell up through row, column, and tabular defaults. The same precedence ladders were spelled out three times (HTML, LaTeX, XSL-FO), often threaded down through templates as parameters.

This lifts that resolution into `pretext-common.xsl` as a set of shared resolvers — `effective-halign`, `effective-valign`, `effective-bottom`, `effective-right`, `effective-left`, plus colspan-aware column numbering — and has each converter adopt them.

- **Common:** the single source of truth for the precedence rules.
- **HTML** and **LaTeX:** adopt the resolvers; output is **byte-identical** on the sample article (which exercises tabular heavily).
- **XSL-FO:** adopting the shared resolution also *fixes* FO tables — previously tabular-level rules were drawn only as an outer frame, so interior rules went missing; now they grid per-cell like HTML and LaTeX, and the vertical-alignment default matches the others (`middle`).

Net ~300 lines of duplicated precedence logic removed across the three converters.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
