### PR TITLE
Tabular: resolve cell properties by lookup, not threaded parameters

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -7987,225 +7987,205 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:attribute>
         </xsl:if>
         <!-- Walk the cells of the row -->
-        <xsl:call-template name="row-cells">
+        <xsl:apply-templates select="cell" mode="row-cell">
             <xsl:with-param name="b-original" select="$b-original" />
-            <xsl:with-param name="ambient-relative-width">
-                <xsl:value-of select="$ambient-relative-width" />
-            </xsl:with-param>
-            <xsl:with-param name="the-cell" select="cell[1]" />
-            <xsl:with-param name="left-col" select="ancestor::tabular/col[1]" />  <!-- possibly empty -->
-        </xsl:call-template>
+            <xsl:with-param name="ambient-relative-width" select="$ambient-relative-width" />
+        </xsl:apply-templates>
     </xsl:element>
 </xsl:template>
 
-<xsl:template name="row-cells">
+<!-- One cell of a table row.  The cell is the context node, so it resolves -->
+<!-- its own effective alignments and rule weights (see pretext-common.xsl) -->
+<!-- and finds its governing "col" by column number, with no cell cursor or -->
+<!-- column pointer threaded in.  Only the two genuinely ambient values     -->
+<!-- pass through: the original-vs-knowl-copy flag and the containing width. -->
+<xsl:template match="cell" mode="row-cell">
     <xsl:param name="b-original" select="true()" />
     <xsl:param name="ambient-relative-width" />
-    <xsl:param name="the-cell" />
-    <xsl:param name="left-col" />
-    <!-- A cell may span several columns, or default to just 1              -->
-    <!-- When colspan is not trivial, we identify the col elements          -->
-    <!-- for the left and right ends of the span                            -->
-    <!-- When colspan is trivial, the left and right versions are identical -->
-    <!-- Left is used for left border and for horizontal alignment          -->
-    <!-- Right is used for right border                                     -->
+    <!-- A cell may span several columns, or default to just 1.  Its left  -->
+    <!-- end sits in column "column-left-number" (resolved in -common,     -->
+    <!-- honoring the colspans of preceding cells), which identifies the   -->
+    <!-- governing "col" for left border, alignment, and paragraph width.  -->
+    <!-- That "col" may be absent (an empty $left-col).                    -->
     <xsl:variable name="column-span">
         <xsl:choose>
-            <xsl:when test="$the-cell/@colspan">
-                <xsl:value-of select="$the-cell/@colspan" />
+            <xsl:when test="@colspan">
+                <xsl:value-of select="@colspan" />
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>1</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- For a "normal" 1-column cell this variable effectively makes a copy -->
-    <!-- position()  added in 026d6d6d9f69f4de17a012aa32c4e8dee77519fb,      -->
-    <!-- unclear if it can be removed/replaced                               -->
-    <xsl:variable name="right-col" select="($left-col/self::*|$left-col/following-sibling::col)[position()=$column-span]" />
-    <!-- Look ahead one column, anticipating recursion   -->
-    <!-- but also probing for end of row (no more cells) -->
-    <xsl:variable name="next-cell" select="$the-cell/following-sibling::cell[1]" />
-    <xsl:variable name="next-col"  select="$right-col/following-sibling::col[1]" /> <!-- possibly empty -->
+    <xsl:variable name="left-column-number">
+        <xsl:apply-templates select="." mode="column-left-number"/>
+    </xsl:variable>
+    <xsl:variable name="left-col" select="ancestor::tabular/col[number($left-column-number)]"/>
 
     <!-- Check if row-headers are requested -->
-    <xsl:variable name="b-row-headers" select="boolean($the-cell/parent::row/parent::tabular[@row-headers = 'yes'])"/>
+    <xsl:variable name="b-row-headers" select="boolean(parent::row/parent::tabular[@row-headers = 'yes'])"/>
     <!-- And if we are at the first cell -->
-    <xsl:variable name="b-row-header" select="$b-row-headers and not($the-cell/preceding-sibling::cell)"/>
+    <xsl:variable name="b-row-header" select="$b-row-headers and not(preceding-sibling::cell)"/>
 
-    <xsl:if test="$the-cell">
-        <!-- build an HTML data cell, with CSS decorations              -->
-        <!-- we set properties in various variables,                    -->
-        <!-- then write them in a class attribute                       -->
-        <!-- we look outward and upward for characteristics of the cell -->
-        <!--                                                            -->
-        <!-- effective alignments and rule weights, resolved in -common; -->
-        <!-- each is a token translated to a CSS class fragment below     -->
-        <xsl:variable name="alignment">
-            <xsl:apply-templates select="$the-cell" mode="effective-halign"/>
-        </xsl:variable>
-        <xsl:variable name="valignment">
-            <xsl:apply-templates select="$the-cell" mode="effective-valign"/>
-        </xsl:variable>
-        <xsl:variable name="bottom">
-            <xsl:apply-templates select="$the-cell" mode="effective-bottom"/>
-        </xsl:variable>
-        <xsl:variable name="right">
-            <xsl:apply-templates select="$the-cell" mode="effective-right"/>
-        </xsl:variable>
-        <xsl:variable name="left">
-            <xsl:apply-templates select="$the-cell" mode="effective-left"/>
-        </xsl:variable>
-        <xsl:variable name="top">
-            <xsl:apply-templates select="$the-cell" mode="effective-top"/>
-        </xsl:variable>
+    <!-- build an HTML data cell, with CSS decorations              -->
+    <!-- we set properties in various variables,                    -->
+    <!-- then write them in a class attribute                       -->
+    <!-- we look outward and upward for characteristics of the cell -->
+    <!--                                                            -->
+    <!-- effective alignments and rule weights, resolved in -common; -->
+    <!-- each is a token translated to a CSS class fragment below     -->
+    <xsl:variable name="alignment">
+        <xsl:apply-templates select="." mode="effective-halign"/>
+    </xsl:variable>
+    <xsl:variable name="valignment">
+        <xsl:apply-templates select="." mode="effective-valign"/>
+    </xsl:variable>
+    <xsl:variable name="bottom">
+        <xsl:apply-templates select="." mode="effective-bottom"/>
+    </xsl:variable>
+    <xsl:variable name="right">
+        <xsl:apply-templates select="." mode="effective-right"/>
+    </xsl:variable>
+    <xsl:variable name="left">
+        <xsl:apply-templates select="." mode="effective-left"/>
+    </xsl:variable>
+    <xsl:variable name="top">
+        <xsl:apply-templates select="." mode="effective-top"/>
+    </xsl:variable>
 
-        <!-- a cell of a header row needs to be "th" -->
-        <!-- else the HTML mark up is "td"           -->
-        <!-- NB: Named templates means context is a  -->
-        <!-- row, which is really wrong.  Tests      -->
-        <!-- should be on  parent::row/@header       -->
-        <xsl:variable name="header-row-elt">
+    <!-- a cell of a header row needs to be "th" -->
+    <!-- else the HTML mark up is "td"           -->
+    <xsl:variable name="header-row-elt">
+        <xsl:choose>
+            <xsl:when test="parent::row/@header = 'yes'">
+                <xsl:text>th</xsl:text>
+            </xsl:when>
+            <xsl:when test="parent::row/@header = 'vertical'">
+                <xsl:text>th</xsl:text>
+            </xsl:when>
+            <xsl:when test="$b-row-header">
+                <xsl:text>th</xsl:text>
+            </xsl:when>
+            <!-- "no" is other choice, or no attribute at all -->
+            <!-- controlled by schema, so no error-check here -->
+            <xsl:otherwise>
+                <xsl:text>td</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+    <!-- the HTML element for the cell -->
+    <!-- newline inserted to encourage formatted output -->
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:element name="{$header-row-elt}">
+        <!-- Scope attribute helps with accessibility: what          -->
+        <!-- is the table element/cell describing?                   -->
+        <!-- if this is a row of column headers, declare scope="col" -->
+        <!-- if this is a column of row headers, declare scope="row" -->
+        <xsl:if test="$header-row-elt = 'th'">
+            <xsl:attribute name="scope">
+                <!-- If in upper-left corner, let column headings dominate -->
+                <xsl:choose>
+                    <xsl:when test="(parent::row/@header = 'yes') or (parent::row/@header = 'vertical')">
+                        <xsl:text>col</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$b-row-header">
+                        <xsl:text>row</xsl:text>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:attribute>
+        </xsl:if>
+        <!-- and the class attribute -->
+        <xsl:attribute name="class">
+            <!-- always write alignment, so *precede* all subsequent with a space -->
             <xsl:choose>
-                <xsl:when test="@header = 'yes'">
-                    <xsl:text>th</xsl:text>
+                <xsl:when test="p and $alignment='justify'">
+                    <xsl:text>j</xsl:text>
                 </xsl:when>
-                <xsl:when test="@header = 'vertical'">
-                    <xsl:text>th</xsl:text>
-                </xsl:when>
-                <xsl:when test="$b-row-header">
-                    <xsl:text>th</xsl:text>
-                </xsl:when>
-                <!-- "no" is other choice, or no attribute at all -->
-                <!-- controlled by schema, so no error-check here -->
                 <xsl:otherwise>
-                    <xsl:text>td</xsl:text>
+                    <xsl:call-template name="halign-specification">
+                        <xsl:with-param name="align" select="$alignment" />
+                    </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
-        </xsl:variable>
-
-        <!-- the HTML element for the cell -->
-        <!-- newline inserted to encourage formatted output -->
-        <xsl:text>&#xa;</xsl:text>
-        <xsl:element name="{$header-row-elt}">
-            <!-- Scope attribute helps with accessibility: what          -->
-            <!-- is the table element/cell describing?                   -->
-            <!-- if this is a row of column headers, declare scope="col" -->
-            <!-- if this is a column of row headers, declare scope="row" -->
-            <xsl:if test="$header-row-elt = 'th'">
-                <xsl:attribute name="scope">
-                    <!-- If in upper-left corner, let column headings dominate -->
-                    <xsl:choose>
-                        <xsl:when test="(@header = 'yes') or (@header = 'vertical')">
-                            <xsl:text>col</xsl:text>
-                        </xsl:when>
-                        <xsl:when test="$b-row-header">
-                            <xsl:text>row</xsl:text>
-                        </xsl:when>
-                    </xsl:choose>
-                </xsl:attribute>
+            <!-- vertical alignment -->
+            <xsl:text> </xsl:text>
+            <xsl:call-template name="valign-specification">
+                <xsl:with-param name="align" select="$valignment" />
+            </xsl:call-template>
+            <!-- bottom border -->
+            <xsl:text> b</xsl:text>
+            <xsl:call-template name="thickness-specification">
+                <xsl:with-param name="width" select="$bottom" />
+            </xsl:call-template>
+            <!-- right border -->
+            <xsl:text> r</xsl:text>
+            <xsl:call-template name="thickness-specification">
+                <xsl:with-param name="width" select="$right" />
+            </xsl:call-template>
+            <!-- left border -->
+            <xsl:text> l</xsl:text>
+            <xsl:call-template name="thickness-specification">
+                <xsl:with-param name="width" select="$left" />
+            </xsl:call-template>
+            <!-- top border -->
+            <xsl:text> t</xsl:text>
+            <xsl:call-template name="thickness-specification">
+                <xsl:with-param name="width" select="$top" />
+            </xsl:call-template>
+            <!-- no wrapping unless paragraph cell -->
+            <xsl:if test="not(p)">
+                <xsl:text> lines</xsl:text>
             </xsl:if>
-            <!-- and the class attribute -->
-            <xsl:attribute name="class">
-                <!-- always write alignment, so *precede* all subsequent with a space -->
+        </xsl:attribute>
+        <xsl:if test="not($column-span = 1)">
+            <xsl:attribute name="colspan">
+                <xsl:value-of select="$column-span" />
+            </xsl:attribute>
+        </xsl:if>
+        <xsl:if test="p">
+            <xsl:attribute name="style">
+                <xsl:text>max-width:</xsl:text>
                 <xsl:choose>
-                    <xsl:when test="$the-cell/p and $alignment='justify'">
-                        <xsl:text>j</xsl:text>
+                    <xsl:when test="$left-col/@width">
+                        <xsl:variable name="width">
+                            <xsl:call-template name="normalize-percentage">
+                                <xsl:with-param name="percentage" select="$left-col/@width" />
+                            </xsl:call-template>
+                        </xsl:variable>
+                        <xsl:value-of select="$design-width * substring-before($width, '%') div 100 * substring-before($ambient-relative-width, '%') div 100" />
+                        <xsl:text>px;</xsl:text>
                     </xsl:when>
+                    <!-- If there is no $left-col/@width, silently use 20% as default -->
+                    <!-- We get some ill-formed WW exercises here, so a less-precise  -->
+                    <!-- warning is given on the author's source.                     -->
                     <xsl:otherwise>
-                        <xsl:call-template name="halign-specification">
-                            <xsl:with-param name="align" select="$alignment" />
-                        </xsl:call-template>
+                        <xsl:value-of select="$design-width * 0.2 * substring-before($ambient-relative-width, '%') div 100" />
                     </xsl:otherwise>
                 </xsl:choose>
-                <!-- vertical alignment -->
-                <xsl:text> </xsl:text>
-                <xsl:call-template name="valign-specification">
-                    <xsl:with-param name="align" select="$valignment" />
-                </xsl:call-template>
-                <!-- bottom border -->
-                <xsl:text> b</xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="$bottom" />
-                </xsl:call-template>
-                <!-- right border -->
-                <xsl:text> r</xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="$right" />
-                </xsl:call-template>
-                <!-- left border -->
-                <xsl:text> l</xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="$left" />
-                </xsl:call-template>
-                <!-- top border -->
-                <xsl:text> t</xsl:text>
-                <xsl:call-template name="thickness-specification">
-                    <xsl:with-param name="width" select="$top" />
-                </xsl:call-template>
-                <!-- no wrapping unless paragraph cell -->
-                <xsl:if test="not($the-cell/p)">
-                    <xsl:text> lines</xsl:text>
-                </xsl:if>
             </xsl:attribute>
-            <xsl:if test="not($column-span = 1)">
-                <xsl:attribute name="colspan">
-                    <xsl:value-of select="$column-span" />
-                </xsl:attribute>
-            </xsl:if>
-            <xsl:if test="$the-cell/p">
-                <xsl:attribute name="style">
-                    <xsl:text>max-width:</xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="$left-col/@width">
-                            <xsl:variable name="width">
-                                <xsl:call-template name="normalize-percentage">
-                                    <xsl:with-param name="percentage" select="$left-col/@width" />
-                                </xsl:call-template>
-                            </xsl:variable>
-                            <xsl:value-of select="$design-width * substring-before($width, '%') div 100 * substring-before($ambient-relative-width, '%') div 100" />
-                            <xsl:text>px;</xsl:text>
-                        </xsl:when>
-                        <!-- If there is no $left-col/@width, silently use 20% as default -->
-                        <!-- We get some ill-formed WW exercises here, so a less-precise  -->
-                        <!-- warning is given on the author's source.                     -->
-                        <xsl:otherwise>
-                            <xsl:value-of select="$design-width * 0.2 * substring-before($ambient-relative-width, '%') div 100" />
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:attribute>
-            </xsl:if>
-            <!-- process the actual contents           -->
-            <!-- condition on indicators of structure  -->
-            <!-- All "line", all "p", or mixed content -->
-            <!-- TODO: is it important to pass $b-original -->
-            <!-- flag into template for "line" elements?   -->
-            <xsl:choose>
-                <xsl:when test="$the-cell/line">
-                    <xsl:apply-templates select="$the-cell/line"/>
-                </xsl:when>
-                <xsl:when test="$the-cell/p">
-                    <xsl:apply-templates select="$the-cell/p">
-                        <xsl:with-param name="b-original" select="$b-original"/>
-                    </xsl:apply-templates>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:apply-templates select="$the-cell">
-                        <xsl:with-param name="b-original" select="$b-original"/>
-                    </xsl:apply-templates>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:element>
-        <!-- recurse forward, perhaps to an empty cell -->
-        <xsl:call-template name="row-cells">
-            <xsl:with-param name="b-original" select="$b-original" />
-            <xsl:with-param name="ambient-relative-width" select="$ambient-relative-width" />
-            <xsl:with-param name="the-cell" select="$next-cell" />
-            <xsl:with-param name="left-col" select="$next-col" />
-        </xsl:call-template>
-    </xsl:if>
-    <!-- Arrive here only when we have no cell so      -->
-    <!-- we bail out of recursion with no action taken -->
+        </xsl:if>
+        <!-- process the actual contents           -->
+        <!-- condition on indicators of structure  -->
+        <!-- All "line", all "p", or mixed content -->
+        <!-- TODO: is it important to pass $b-original -->
+        <!-- flag into template for "line" elements?   -->
+        <xsl:choose>
+            <xsl:when test="line">
+                <xsl:apply-templates select="line"/>
+            </xsl:when>
+            <xsl:when test="p">
+                <xsl:apply-templates select="p">
+                    <xsl:with-param name="b-original" select="$b-original"/>
+                </xsl:apply-templates>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select=".">
+                    <xsl:with-param name="b-original" select="$b-original"/>
+                </xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:element>
 </xsl:template>
 
 <!-- ############################ -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -9705,16 +9705,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="table-bottom">
-        <xsl:choose>
-            <xsl:when test="@bottom">
-                <xsl:value-of select="@bottom" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>none</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
     <xsl:variable name="table-right">
         <xsl:choose>
             <xsl:when test="@right">
@@ -9732,16 +9722,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>left</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="table-valign">
-        <xsl:choose>
-            <xsl:when test="@valign">
-                <xsl:value-of select="@valign" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>middle</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -9845,12 +9825,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- A col element might indicate top border customizations   -->
         <!-- so we walk the cols to build a cline-style specification -->
         <!-- $clines accumulates the specification when complicated   -->
-        <!-- For convenience, recursion passes along the $table-top   -->
         <xsl:when test="col/@top">
             <xsl:apply-templates select="col[1]" mode="column-cols">
-                <xsl:with-param name="col-number" select="1" />
                 <xsl:with-param name="clines" select="''" />
-                <xsl:with-param name="table-top" select="$table-top"/>
                 <xsl:with-param name="start-run" select="1" />
             </xsl:apply-templates>
         </xsl:when>
@@ -9864,24 +9841,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
     <!-- now ready to build rows -->
     <xsl:text>&#xa;</xsl:text>
-    <!-- table-wide values are needed to reconstruct/determine overrides -->
-    <!-- We *actively* enforce header rows being (a) initial, and        -->
-    <!-- (b) contiguous.  So following two-part match will do no harm    -->
-    <!-- to correct source, but will definitely harm incorrect source.   -->
-    <xsl:apply-templates select="row[@header]">
-        <xsl:with-param name="table-left" select="$table-left" />
-        <xsl:with-param name="table-bottom" select="$table-bottom" />
-        <xsl:with-param name="table-right" select="$table-right" />
-        <xsl:with-param name="table-halign" select="$table-halign" />
-        <xsl:with-param name="table-valign" select="$table-valign" />
-    </xsl:apply-templates>
-    <xsl:apply-templates select="row[not(@header)]">
-        <xsl:with-param name="table-left" select="$table-left" />
-        <xsl:with-param name="table-bottom" select="$table-bottom" />
-        <xsl:with-param name="table-right" select="$table-right" />
-        <xsl:with-param name="table-halign" select="$table-halign" />
-        <xsl:with-param name="table-valign" select="$table-valign" />
-    </xsl:apply-templates>
+    <!-- Each row and cell resolves its own effective properties, so no  -->
+    <!-- table-wide values need be threaded here.  We *actively* enforce -->
+    <!-- header rows being (a) initial, and (b) contiguous.  So the      -->
+    <!-- following two-part selection will do no harm to correct source, -->
+    <!-- but will definitely harm incorrect source.                      -->
+    <xsl:apply-templates select="row[@header]"/>
+    <xsl:apply-templates select="row[not(@header)]"/>
     <!-- mandatory finish, exclusive of any final row specifications -->
     <xsl:text>\end{</xsl:text>
     <xsl:value-of select="$tabular-environment"/>
@@ -9895,49 +9861,51 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
-<!-- We recursively traverse the "col" elements of the "column" group         -->
-<!-- The cline specification is accumulated in the clines variable            -->
-<!-- A similar strategy is used to traverse the "cell" elements of each "row" -->
-<!-- but becomes much more involved, see the "row-cells" template             -->
+<!-- We recursively traverse the "col" elements of the "column" group,   -->
+<!-- accumulating a cline specification for the top border in the $clines -->
+<!-- parameter.  A similar, but more involved, strategy traverses the     -->
+<!-- "cell" elements of each "row"; see the "cell" template.             -->
 <xsl:template match="col" mode="column-cols">
-    <xsl:param name="col-number" />
     <xsl:param name="clines" />
-    <xsl:param name="table-top" />
     <xsl:param name="start-run" />
 
-    <!-- Look ahead one column, anticipating recursion           -->
-    <!-- but also probing for end of column group (no more cols) -->
-    <!-- An empty node-set will signal final "col" element       -->
+    <!-- This column's number, and a look ahead one column, anticipating  -->
+    <!-- recursion, but also probing for the end of the column group (no  -->
+    <!-- more cols).  An empty node-set signals the final "col" element.  -->
+    <xsl:variable name="col-number" select="count(preceding-sibling::col) + 1"/>
     <xsl:variable name="next-col"  select="following-sibling::col[1]"/>
     <xsl:variable name="b-final-col" select="not($next-col)"/>
-    <!-- The desired top border styles for columns, both -->
-    <!-- current and next, so as to recognize a change   -->
+    <!-- The desired top border styles for columns, both current and next, -->
+    <!-- so as to recognize a change: the col's own specification, else    -->
+    <!-- the tabular default, else "none".  On the final column the next   -->
+    <!-- value is empty, a sentinel that matches no specification.         -->
     <xsl:variable name="current-top">
         <xsl:choose>
-            <!-- cell specification -->
             <xsl:when test="@top">
                 <xsl:value-of select="@top" />
             </xsl:when>
-            <!-- inherited specification for top -->
+            <xsl:when test="parent::tabular/@top">
+                <xsl:value-of select="parent::tabular/@top" />
+            </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="$table-top" />
+                <xsl:text>none</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="next-top">
-        <xsl:choose>
-            <!-- empty is sentinel for currently on the final -->
-             <!-- "col", and will not match any specification -->
-            <xsl:when test="$b-final-col"/>
-            <!-- cell specification -->
-            <xsl:when test="$next-col/@top">
-                <xsl:value-of select="$next-col/@top" />
-            </xsl:when>
-            <!-- inherited specification for top -->
-            <xsl:otherwise>
-                <xsl:value-of select="$table-top" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:if test="not($b-final-col)">
+            <xsl:choose>
+                <xsl:when test="$next-col/@top">
+                    <xsl:value-of select="$next-col/@top" />
+                </xsl:when>
+                <xsl:when test="parent::tabular/@top">
+                    <xsl:value-of select="parent::tabular/@top" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>none</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
     </xsl:variable>
     <!-- Formulate any necessary update to    -->
     <!-- cline information for the top border -->
@@ -9989,78 +9957,39 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Recursive call of this template on next "col",    -->
     <!-- which if empty will be a no-op and recursion ends -->
     <xsl:apply-templates select="$next-col" mode="column-cols">
-        <xsl:with-param name="col-number" select="$col-number + 1" />
         <xsl:with-param name="clines" select="$updated-cline" />
-        <xsl:with-param name="table-top" select="$table-top" />
         <xsl:with-param name="start-run" select="$new-start-run" />
     </xsl:apply-templates>
 </xsl:template>
 
 <xsl:template match="row">
-    <xsl:param name="table-left" />
-    <xsl:param name="table-bottom" />
-    <xsl:param name="table-right" />
-    <xsl:param name="table-halign" />
-    <xsl:param name="table-valign" />
-    <!-- inherit global table-wide values    -->
-    <!-- or replace with row-specific values -->
-    <xsl:variable name="row-left">
-        <xsl:choose>
-            <xsl:when test="@left">
-                <xsl:value-of select="@left" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$table-left" />
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <!-- Walking the row's cells, write contents and bottom borders -->
+    <!-- Walking the row's cells, write contents and bottom borders. -->
+    <!-- Each cell resolves its own effective properties, so only    -->
+    <!-- the cline accumulator and its run start need be seeded.     -->
     <xsl:apply-templates select="cell[1]">
-        <xsl:with-param name="left-col" select="parent::tabular/col[1]" /> <!-- possibly empty -->
-        <xsl:with-param name="left-column-number" select="1" />
         <xsl:with-param name="clines" select="''" />
         <xsl:with-param name="start-run" select="1" />
-        <xsl:with-param name="table-left" select="$table-left"/>
-        <xsl:with-param name="table-bottom" select="$table-bottom"/>
-        <xsl:with-param name="table-right" select="$table-right" />
-        <xsl:with-param name="table-halign" select="$table-halign" />
-        <xsl:with-param name="table-valign" select="$table-valign" />
-        <xsl:with-param name="row-left" select="$row-left" />
     </xsl:apply-templates>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<!-- Recursively traverse the "cell" of a "row" while simultaneously       -->
-<!-- traversing the "col" elements of the column group, if present.        -->
-<!-- Inspect the (previously) built column specifications to see if        -->
-<!-- a \multicolumn is necessary for an override on a table entry          -->
-<!-- Accumulate cline information to write at the end of the line/row.     -->
-<!-- Study the "column-cols" template for a less-involved template         -->
-<!-- that uses an identical strategy, if you want to see something simpler -->
-<!-- NB: column numbers are always accurate.  There may be either (1) no   -->
-<!-- tabular/col or (2) one tabular/col for each column of the table.  So  -->
-<!-- the $left-col parameter might  be empty through the entire recursion. -->
-<!-- NB: the $table-* and $row-* parameters could be recomputed inside     -->
-<!-- this template by looking outward and implmenting the same effective   -->
-<!-- override and defaults strategy.  They are left in place as a          -->
-<!-- historical artifact, and they might be just a smidge more efficient.  -->
+<!-- Recursively traverse the "cell" elements of a "row", accumulating   -->
+<!-- cline information for the bottom border in the $clines parameter, to -->
+<!-- be written once the whole row is built.  Only $clines and its run    -->
+<!-- start need be threaded; every other property a cell needs is an      -->
+<!-- effective value it resolves for itself, through a shared resolver in -->
+<!-- pretext-common.xsl, or, for the two column-only values the           -->
+<!-- \multicolumn deviation test compares against, locally just below.    -->
+<!-- Compare the "column-cols" template, which uses the identical cline   -->
+<!-- strategy over the "col" elements, but with much less to compute.     -->
 <xsl:template match="cell">
-    <xsl:param name="left-col" />
-    <xsl:param name="left-column-number" />
     <xsl:param name="clines" />
     <xsl:param name="start-run" />
-    <xsl:param name="table-left" />
-    <xsl:param name="table-bottom" />
-    <xsl:param name="table-right" />
-    <xsl:param name="table-halign" />
-    <xsl:param name="table-valign" />
-    <xsl:param name="row-left" />
-    <!-- A cell may span several columns, or default to just 1              -->
-    <!-- When colspan is not trivial, we identify the left and right ends   -->
-    <!-- of the span, both as col elements and as column numbers            -->
-    <!-- When colspan is trivial, the left and right versions are identical -->
-    <!-- Left is used for left border and for horizontal alignment          -->
-    <!-- Right is used for right border                                     -->
+    <!-- A cell may span several columns, or default to just one.  The    -->
+    <!-- leftmost column governs the left border and horizontal alignment; -->
+    <!-- the rightmost governs the right border.  A "col" may be absent    -->
+    <!-- (an empty $left-col / $right-col), in which case the effective    -->
+    <!-- values fall back to table-wide values.                           -->
     <xsl:variable name="column-span">
         <xsl:choose>
             <xsl:when test="@colspan">
@@ -10072,46 +10001,71 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <xsl:variable name="b-multiple-columns" select="$column-span > 1"/>
-    <xsl:variable name="right-column-number" select="$left-column-number + $column-span - 1"/>
-    <xsl:variable name="right-col" select="(parent::row/parent::tabular/col)[$right-column-number]"/>
-    <!-- recreate the column specification for a right border       -->
-    <!-- either a per-column value, or the global, table-wide value -->
-    <xsl:variable name="column-right">
-        <xsl:choose>
-            <xsl:when test="$right-col/@right">
-                <xsl:value-of select="$right-col/@right" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="$table-right" />
-            </xsl:otherwise>
-        </xsl:choose>
+    <xsl:variable name="b-first-cell" select="not(preceding-sibling::cell)"/>
+    <xsl:variable name="left-column-number">
+        <xsl:apply-templates select="." mode="column-left-number"/>
     </xsl:variable>
-    <!-- the effective right border of the cell (cell > col > tabular); -->
-    <!-- "column-right" above is kept for the multicolumn deviation test -->
-    <xsl:variable name="cell-right">
-        <xsl:apply-templates select="." mode="effective-right"/>
+    <xsl:variable name="right-column-number">
+        <xsl:apply-templates select="." mode="column-right-number"/>
     </xsl:variable>
-    <!-- Use cell attributes, or col attributes for horizontal alignment -->
-    <!-- recreate the column specification for horizontal alignment      -->
-    <!-- either a per-column value, or the global, table-wide value      -->
+    <xsl:variable name="left-col" select="parent::row/parent::tabular/col[number($left-column-number)]"/>
+    <xsl:variable name="right-col" select="parent::row/parent::tabular/col[number($right-column-number)]"/>
+    <!-- The column specification alone provides these two values (col,   -->
+    <!-- else tabular, else the hard default).  A cell whose effective    -->
+    <!-- horizontal alignment or right border differs from its column's   -->
+    <!-- needs a \multicolumn to realize the override.                    -->
     <xsl:variable name="column-halign">
         <xsl:choose>
             <xsl:when test="$left-col/@halign">
                 <xsl:value-of select="$left-col/@halign" />
             </xsl:when>
+            <xsl:when test="parent::row/parent::tabular/@halign">
+                <xsl:value-of select="parent::row/parent::tabular/@halign" />
+            </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="$table-halign" />
+                <xsl:text>left</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- the effective horizontal alignment (cell > row > col > tabular); -->
-    <!-- "column-halign" above is kept for the multicolumn deviation test -->
+    <xsl:variable name="column-right">
+        <xsl:choose>
+            <xsl:when test="$right-col/@right">
+                <xsl:value-of select="$right-col/@right" />
+            </xsl:when>
+            <xsl:when test="parent::row/parent::tabular/@right">
+                <xsl:value-of select="parent::row/parent::tabular/@right" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>none</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <!-- the cell's actual effective values (see pretext-common.xsl) -->
     <xsl:variable name="cell-halign">
         <xsl:apply-templates select="." mode="effective-halign"/>
     </xsl:variable>
-    <!-- the effective vertical alignment of the cell (row > tabular) -->
+    <xsl:variable name="cell-right">
+        <xsl:apply-templates select="." mode="effective-right"/>
+    </xsl:variable>
     <xsl:variable name="row-valign">
         <xsl:apply-templates select="." mode="effective-valign"/>
+    </xsl:variable>
+    <!-- The left border lives only at the very start of the column      -->
+    <!-- specification, so it is a property of the first cell of a row,   -->
+    <!-- needing a \multicolumn when the row overrides the table's left.  -->
+    <!-- "effective-left" already yields "none" for a non-leading cell.   -->
+    <xsl:variable name="cell-left">
+        <xsl:apply-templates select="." mode="effective-left"/>
+    </xsl:variable>
+    <xsl:variable name="table-left">
+        <xsl:choose>
+            <xsl:when test="parent::row/parent::tabular/@left">
+                <xsl:value-of select="parent::row/parent::tabular/@left" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>none</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:variable>
     <!-- Look ahead to next cell, anticipating recursion     -->
     <!-- but also probing for end of row (empty $next-cell), -->
@@ -10125,17 +10079,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!--         conflict with the column specification                  -->
     <!--    -if we have a colspan                                        -->
     <!--    -if there are paragraphs in the cell                         -->
-    <!-- $table-left and $row-left *can* differ on first use,            -->
-    <!-- but row-left is subsequently set to $table-left.                -->
+    <!-- A left-border override is only possible on the first cell, where -->
+    <!-- the row's effective left may differ from the table-wide left.    -->
     <xsl:choose>
-        <xsl:when test="not($table-left = $row-left) or not($column-halign = $cell-halign) or not($column-right = $cell-right) or $b-multiple-columns or p">
+        <xsl:when test="($b-first-cell and not($table-left = $cell-left)) or not($column-halign = $cell-halign) or not($column-right = $cell-right) or $b-multiple-columns or p">
             <xsl:text>\multicolumn{</xsl:text>
             <xsl:value-of select="$column-span" />
             <xsl:text>}{</xsl:text>
             <!-- only place latex allows/needs a left border -->
-            <xsl:if test="$left-column-number = 1">
+            <xsl:if test="$b-first-cell">
                 <xsl:call-template name="vrule-specification">
-                    <xsl:with-param name="width" select="$row-left" />
+                    <xsl:with-param name="width" select="$cell-left" />
                 </xsl:call-template>
             </xsl:if>
             <xsl:choose>
@@ -10247,19 +10201,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
 
     <!-- Always attempt a recursive call.  If cells are exhausted, -->
-    <!-- $next-cell is empty/false and nothing happens here        -->
-    <!-- Leap forward to column element just beyond end of colspan -->
+    <!-- $next-cell is empty/false and nothing happens here.       -->
     <xsl:apply-templates select="$next-cell">
-        <xsl:with-param name="left-col" select="$right-col/following-sibling::col[1]" />
-        <xsl:with-param name="left-column-number" select="$right-column-number + 1" />
         <xsl:with-param name="clines" select="$updated-cline" />
         <xsl:with-param name="start-run" select="$new-start-run" />
-        <xsl:with-param name="table-left" select="$table-left" />
-        <xsl:with-param name="table-bottom" select="$table-bottom" />
-        <xsl:with-param name="table-right" select="$table-right" />
-        <xsl:with-param name="table-halign" select="$table-halign" />
-        <xsl:with-param name="table-valign" select="$table-valign" />
-        <xsl:with-param name="row-left" select="$table-left" />
     </xsl:apply-templates>
 
     <!-- finish the row, dump cline info, etc -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -9804,6 +9804,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!--   follow with right border (optional)                 -->
         <!-- TODO: error check each row for correct number of columns -->
         <xsl:otherwise>
+            <!-- TODO: this inline column count duplicates the reusable -->
+            <!-- "tabular" mode "column-count" in pretext-fo.xsl; the   -->
+            <!-- pair could be lifted to a shared getter in -common.    -->
             <xsl:variable name="ncols" select="count(row[1]/cell) + sum(row[1]/cell[@colspan]/@colspan) - count(row[1]/cell[@colspan])" />
             <xsl:call-template name="duplicate-string">
                 <xsl:with-param name="count" select="$ncols" />


### PR DESCRIPTION
Follow-up to #2986. That PR lifted the tabular border/alignment precedence into shared `effective-*` resolvers in `pretext-common.xsl`, but left the LaTeX and HTML converters *threading* table-wide and row-wide context down through their `row`/`cell` templates as parameters. This removes that threading: each cell now resolves everything it needs by looking outward, exactly as the resolvers already do — and as the (newest) XSL-FO converter already did.

**LaTeX** (`e1f87a3c`)
- `cell`: 11 params → 2, `row`: 5 → 0, `column-cols`: 4 → 2; all 30 `with-param` threads gone.
- Cells self-compute their column numbers (via common's `column-left/right-number`) and resolve effective values on demand. Only the genuine `\cline` run-length accumulator (`clines`/`start-run`) still threads, since that's inherently sequential.

**HTML** (`c9b127ce`)
- Converted the named-template recursion `row-cells` into a moded `match="cell" mode="row-cell"`, so each cell is the context node.
- 4 params → 2 (only the genuinely ambient `b-original` and `ambient-relative-width` remain); the `the-cell` cursor and `left-col`/`right-col`/`next-col` column pointer are gone.
- Fixes the latent wart the code flagged ("Named templates means context is a row, which is really wrong"): `@header` tests are now the intended `parent::row/@header`.

**Flag** (`2e5f07f1`)
- A small unrelated duplication noticed along the way: the LaTeX converter computes a tabular's column count inline, duplicating XSL-FO's reusable `column-count`. Left an in-code `TODO` marking the pair as a future consolidation into `-common`.

After this, all three visual converters (LaTeX, HTML, XSL-FO) resolve tabular cell properties the same way. Braille is intentionally excluded (it linearizes tables); EPUB/Runestone/beamer/Jupyter inherit the HTML or LaTeX path.

**Verification:** built the sample article (heavy tabular coverage) before and after. Both LaTeX (`.tex`) and HTML (all 202 files) are **byte-identical** except build timestamps.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
