### PR TITLE
Tabular: warn on inconsistent column counts, and share the column-count getter

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3287,6 +3287,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <cell><kbd>?</kbd></cell>
                         <cell><kbd>Shift</kbd></cell>
                         <cell></cell>
+                        <cell></cell>
                     </row>
                     </tabular>
                 </table>
@@ -3355,6 +3356,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <cell><kbd>.</kbd></cell>
                         <cell><kbd>/</kbd></cell>
                         <cell><kbd>Shift</kbd></cell>
+                        <cell></cell>
                         <cell></cell>
                     </row>
                     </tabular>
@@ -12039,7 +12041,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <tabular top="minor" left="minor" halign="center">
                                 <col right="medium"/>
                                 <col right="major"/>
-                                <col/>
                                 <!--  -->
                                 <row bottom="medium">
                                     <cell>1111</cell>
@@ -12060,7 +12061,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <tabular top="minor" left="minor" halign="center">
                                 <col right="medium"/>
                                 <col right="major"/>
-                                <col/>
                                 <!--  -->
                                 <row bottom="medium">
                                     <cell>1111</cell>
@@ -12087,7 +12087,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <tabular top="minor" left="minor" halign="center">
                                 <col right="medium"/>
                                 <col right="major"/>
-                                <col/>
                                 <!--  -->
                                 <row bottom="medium">
                                     <cell>1111</cell>
@@ -12108,7 +12107,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <tabular top="minor" left="minor" halign="center">
                                 <col right="medium"/>
                                 <col right="major"/>
-                                <col/>
                                 <!--  -->
                                 <row bottom="medium">
                                     <cell>1111</cell>
@@ -12136,7 +12134,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>
@@ -12157,7 +12154,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>
@@ -12178,7 +12174,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>
@@ -12209,7 +12204,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>
@@ -12240,7 +12234,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <tabular top="minor" left="minor" halign="center">
                                 <col right="medium"/>
                                 <col right="major"/>
-                                <col/>
                                 <!--  -->
                                 <row bottom="medium">
                                     <cell>1111</cell>
@@ -12276,7 +12269,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>
@@ -12313,7 +12305,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <tabular top="minor" left="minor" halign="center">
                         <col right="medium"/>
                         <col right="major"/>
-                        <col/>
                         <!--  -->
                         <row bottom="medium">
                             <cell>1111</cell>
@@ -12335,7 +12326,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <tabular valign="top" top="minor" left="minor" halign="center">
                         <col right="medium"/>
                         <col right="major"/>
-                        <col/>
                         <!--  -->
                         <row bottom="medium">
                             <cell>1111</cell>
@@ -12353,7 +12343,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <tabular valign="middle" top="minor" left="minor" halign="center">
                         <col right="medium"/>
                         <col right="major"/>
-                        <col/>
                         <!--  -->
                         <row bottom="medium">
                             <cell>1111</cell>
@@ -12371,7 +12360,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <tabular top="minor" left="minor" halign="center">
                         <col right="medium"/>
                         <col right="major"/>
-                        <col/>
                         <!--  -->
                         <row bottom="medium">
                             <cell>1111</cell>
@@ -12523,7 +12511,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <tabular top="minor" left="minor" halign="center">
                             <col right="medium"/>
                             <col right="major"/>
-                            <col/>
                             <!--  -->
                             <row bottom="medium">
                                 <cell>1111</cell>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -203,6 +203,39 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- A "tabular" is ragged when its rows do not all occupy the same    -->
+<!-- number of columns (each cell counting as its @colspan, else one).  -->
+<!-- We detect this against a reference count: the number of "col"      -->
+<!-- elements when a column group is present, otherwise the first row.  -->
+<!-- The reference only makes the test computable; neither it nor any   -->
+<!-- row is declared "correct".  The schema cannot count columns, and   -->
+<!-- a mismatch leaves the output of the "tabular" unpredictable.       -->
+<xsl:template match="tabular">
+    <xsl:variable name="reference-count">
+        <xsl:choose>
+            <xsl:when test="col">
+                <xsl:value-of select="count(col)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="count(row[1]/cell[not(@colspan)]) + sum(row[1]/cell/@colspan)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="row[(count(cell[not(@colspan)]) + sum(cell/@colspan)) != number($reference-count)]">
+        <xsl:apply-templates select="." mode="messaging">
+            <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message">
+                <xsl:text>The rows of this &lt;tabular&gt; do not all span the same number of columns&#xa;</xsl:text>
+                <xsl:text>(counting each cell as its @colspan, or as one column otherwise).&#xa;</xsl:text>
+                <xsl:text>Compare the rows against the number of &lt;col&gt; elements, if present,&#xa;</xsl:text>
+                <xsl:text>or else against the first row.  Results may be unpredictable.</xsl:text>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- recurse further -->
+    <xsl:apply-templates/>
+</xsl:template>
+
 <xsl:template match="title[m]">
     <xsl:if test="parent::chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary|backmatter and not(following-sibling::shorttitle)">
         <xsl:apply-templates select="." mode="messaging">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7379,6 +7379,27 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="$left + $span - 1"/>
 </xsl:template>
 
+<!-- The number of columns in a "tabular": the count of "col" elements  -->
+<!-- when a column group is present, otherwise the widest row (each      -->
+<!-- cell counting as its "@colspan", or one).  A well-formed table has  -->
+<!-- every row that wide; a ragged one (flagged by validation) is given  -->
+<!-- enough columns for its widest row.                                  -->
+<xsl:template match="tabular" mode="column-count">
+    <xsl:choose>
+        <xsl:when test="col">
+            <xsl:value-of select="count(col)"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:for-each select="row">
+                <xsl:sort select="count(cell[not(@colspan)]) + sum(cell/@colspan)" data-type="number" order="descending"/>
+                <xsl:if test="position() = 1">
+                    <xsl:value-of select="count(cell[not(@colspan)]) + sum(cell/@colspan)"/>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- horizontal alignment: cell > row > col > tabular > "left" -->
 <xsl:template match="cell" mode="effective-halign">
     <xsl:variable name="left-number">

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2546,23 +2546,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<!-- The width of a "tabular", in columns: as authored, else the -->
-<!-- widest row, with any @colspan unrolled.                     -->
-<xsl:template match="tabular" mode="column-count">
-    <xsl:choose>
-        <xsl:when test="col">
-            <xsl:value-of select="count(col)"/>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:for-each select="row">
-                <xsl:sort select="count(cell[not(@colspan)]) + sum(cell/@colspan)" data-type="number" order="descending"/>
-                <xsl:if test="position() = 1">
-                    <xsl:value-of select="count(cell[not(@colspan)]) + sum(cell/@colspan)"/>
-                </xsl:if>
-            </xsl:for-each>
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
+<!-- "tabular" mode "column-count" is shared, in pretext-common.xsl -->
 
 <xsl:template match="tabular/row">
     <fo:table-row>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -9804,10 +9804,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!--   follow with right border (optional)                 -->
         <!-- TODO: error check each row for correct number of columns -->
         <xsl:otherwise>
-            <!-- TODO: this inline column count duplicates the reusable -->
-            <!-- "tabular" mode "column-count" in pretext-fo.xsl; the   -->
-            <!-- pair could be lifted to a shared getter in -common.    -->
-            <xsl:variable name="ncols" select="count(row[1]/cell) + sum(row[1]/cell[@colspan]/@colspan) - count(row[1]/cell[@colspan])" />
+            <xsl:variable name="ncols">
+                <xsl:apply-templates select="." mode="column-count"/>
+            </xsl:variable>
             <xsl:call-template name="duplicate-string">
                 <xsl:with-param name="count" select="$ncols" />
                 <xsl:with-param name="text">


### PR DESCRIPTION
Adds an author advisory for ragged tables, cleans up the ones hiding in the sample, and consolidates the column-count computation.

- **Validation** (`9842b297`): `pretext-validation-plus.xsl` now warns when a `tabular`'s rows do not all span the same number of columns (each cell counting as its `@colspan`) — checked against the `col` count if present, else the first row. The schema cannot express this, and a mismatch renders unpredictably.
- **Sample article** (`57e56661`): the new check flagged 17 tables in the sample — two keyboard tables with a short bottom row (fixed by padding to width) and fifteen layout-demo tables carrying a vestigial third `<col/>` over two-cell rows (fixed by dropping it). The well-formed siblings that reach three columns via `colspan` are untouched. Instructive side effect: this changes the LaTeX output (an empty column and a relocated vertical rule disappear) but is a no-op for HTML, which emits one cell per `<cell>` regardless of `col` count.
- **Common** (`73f1ca75`): the `tabular` mode `column-count` moves into `pretext-common.xsl`; XSL-FO drops its local copy and LaTeX drops an inline formula, retiring a `TODO`. LaTeX now uses the widest-row count rather than the first row's, so it is also more robust on ragged input.

**Verification:** built the sample before/after the shared-getter change to LaTeX and XSL-FO — both byte-identical.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
