### PR TITLE
Update PreFigure schema and sample diagrams

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -247,14 +247,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                     </point>
                                 </coordinates>
 
-                                <annotations>
-                                    <annotation ref="figure"
-                                                text="The graph of a function and its tangent line at the point a equals 1">
-                                        <annotation ref="graph-tangent" text="The graph and its tangent line">
-                                            <annotation ref="graph" text="The graph of the function f" sonify="yes"/>
-                                            <annotation ref="point" text="The point a comma f of a"/>
-                                            <annotation ref="tangent" text="The tangent line to the graph of f at the point"/>
-                                        </annotation>
+                                <annotations text="The graph of a function and its tangent line at the point a equals 1">
+                                    <annotation ref="graph-tangent" text="The graph and its tangent line">
+                                        <annotation ref="graph" text="The graph of the function f" sonify="yes"/>
+                                        <annotation ref="point" text="The point a comma f of a"/>
+                                        <annotation ref="tangent" text="The tangent line to the graph of f at the point"/>
                                     </annotation>
                                 </annotations>
                             </diagram>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3658,17 +3658,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             </coordinates>
 
                             <annotations text="The graph of a function and its tangent line at the point a equals 1">
-                                <annotation ref="figure"
-                                            text="The graph of a function and its tangent line at the point a equals 1">
-                                    <annotation ref="graph-tangent"
-                                                text="The graph and its tangent line">
-                                        <annotation ref="graph"
-                                                    text="The graph of the function f" sonify="yes"/>
-                                        <annotation ref="point"
-                                                    text="The point a comma f of a"/>
-                                        <annotation ref="tangent"
-                                                    text="The tangent line to the graph of f at the point"/>
-                                    </annotation>
+                                <annotation ref="graph-tangent"
+                                            text="The graph and its tangent line">
+                                    <annotation ref="graph"
+                                                text="The graph of the function f" sonify="yes"/>
+                                    <annotation ref="point"
+                                                text="The point a comma f of a"/>
+                                    <annotation ref="tangent"
+                                                text="The tangent line to the graph of f at the point"/>
                                 </annotation>
                             </annotations>
 
@@ -3764,36 +3761,33 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                   </coordinates>
 
                                   <annotations text="The set of Fibonacci tiles consists of two tiles denoted by L and S.">
-                                      <annotation ref="figure"
-                                                  text="The set of Fibonacci tiles consists of two tiles denoted by L and S.">
-                                          <annotation ref="top"
-                                                      text="The ratio of the lengths of the tiles is the golden ratio so one tile L is long and the other S is short">
-                                              <annotation ref="top-L"
-                                                          text="The long tile L"/>
-                                              <annotation ref="top-S"
-                                                          text="The short tile S"/>
+                                      <annotation ref="top"
+                                                  text="The ratio of the lengths of the tiles is the golden ratio so one tile L is long and the other S is short">
+                                          <annotation ref="top-L"
+                                                      text="The long tile L"/>
+                                          <annotation ref="top-S"
+                                                      text="The short tile S"/>
+                                      </annotation>
+                                      <annotation ref="arrows"
+                                                  text="A process called deflation replaces each tile by a new set of tiles">
+                                          <annotation ref="left-deflate"
+                                                      text="A long tile is replaced by a long and a short tile">
+                                              <annotation ref="left-arrow"/>
+                                              <annotation ref="top-L"/>
+                                              <annotation ref="bottom-L"
+                                                          text="The length of the new tiles is scaled by the reciprocal of the golden ratio">
+                                                  <annotation ref="bottom-LL"
+                                                              text="The new long tile is on the left"/>
+                                                  <annotation ref="bottom-LS"
+                                                              text="The new short tile is on the right"/>
+                                              </annotation>
                                           </annotation>
-                                          <annotation ref="arrows"
-                                                      text="A process called deflation replaces each tile by a new set of tiles">
-                                              <annotation ref="left-deflate"
-                                                          text="A long tile is replaced by a long and a short tile">
-                                                  <annotation ref="left-arrow"/>
-                                                  <annotation ref="top-L"/>
-                                                  <annotation ref="bottom-L"
-                                                              text="The length of the new tiles is scaled by the reciprocal of the golden ratio">
-                                                      <annotation ref="bottom-LL"
-                                                                  text="The new long tile is on the left"/>
-                                                      <annotation ref="bottom-LS"
-                                                                  text="The new short tile is on the right"/>
-                                                  </annotation>
-                                              </annotation>
-                                              <annotation ref="right-deflate"
-                                                          text="A short tile is replaced by a single long tile">
-                                                  <annotation ref="right-arrow"/>
-                                                  <annotation ref="top-S"/>
-                                                  <annotation ref="bottom-S"
-                                                              text="The length of the new tile is again scaled by the reciprocal of the golden ratio"/>
-                                              </annotation>
+                                          <annotation ref="right-deflate"
+                                                      text="A short tile is replaced by a single long tile">
+                                              <annotation ref="right-arrow"/>
+                                              <annotation ref="top-S"/>
+                                              <annotation ref="bottom-S"
+                                                          text="The length of the new tile is again scaled by the reciprocal of the golden ratio"/>
                                           </annotation>
                                       </annotation>
                                   </annotations>
@@ -3857,52 +3851,45 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                   </coordinates>
 
                                   <annotations text="A Fibonacci tiling is a horizontal sequence of tiles obtained by deflating the tiles in another Fibonacci tiling.  We will explain why these tilings are aperiodic.">
-                                      <annotation ref="figure"
-                                                  text="A Fibonacci tiling is a horizontal sequence of tiles obtained by deflating the tiles in another Fibonacci tiling.  We will explain why these tilings are aperiodic.">
-                                          <annotation ref="down-arrows"/>
-                                          <annotation ref="top-down-arrow"/>
-
+                                      <annotation ref="down-arrows"/>
+                                      <annotation ref="top-down-arrow"/>
+                                      <annotation ref="tiling-row_0"
+                                                  text="We begin with this Fibonacci tiling"/>
+                                      <annotation ref="tiling-row_1"
+                                                  text="Our first Fibonacci tiling is obtained by deflating this second tiling">
+                                          <annotation ref="down-arrow-row_0"/>
+                                      </annotation>
+                                      <annotation ref="tiling-row_2"
+                                                  text="The second tiling is obtained by deflating this third tiling, so we see that there is an infinite hierarchy of tilings.">
+                                          <annotation ref="down-arrow-row_1"/>
+                                      </annotation>
+                                      <annotation ref="bottom-tilings"
+                                                  text="Beginning with one tiling, the tiling above is uniquely determined.">
                                           <annotation ref="tiling-row_0"
-                                                      text="We begin with this Fibonacci tiling"/>
-
+                                                      text="Consider this Fibonacci tiling."/>
                                           <annotation ref="tiling-row_1"
-                                                      text="Our first Fibonacci tiling is obtained by deflating this second tiling">
-                                              <annotation ref="down-arrow-row_0"/>
-                                          </annotation>
-
+                                                      text="By inverting the deflation rules, we can uniquely determine the tiling above."/>
+                                      </annotation>
+                                      <annotation ref="periodic-0"
+                                                  text="Suppose that a Fibonacci tiling is periodic under a horizontal translation.">
+                                          <annotation ref="tiling-row_0"
+                                                      text="For example, suppose this Fibonacci tiling is periodic."/>
+                                          <annotation ref="right-arrow-row_0"
+                                                      text="And that this horizontal translation leaves the tiling unchanged."/>
+                                      </annotation>
+                                      <annotation ref="periodic-1"
+                                                  text="Because the inflated tiling above is unique, it must also be periodic under the same translation.">
+                                          <annotation ref="tiling-row_1"
+                                                      text="This Fibonacci tiling is also periodic."/>
+                                          <annotation ref="right-arrow-row_1"
+                                                      text="The same horizontal translation leaves the tiling unchanged."/>
+                                      </annotation>
+                                      <annotation ref="periodic-2"
+                                                  text="Consequently, every tiling in the hierarchy is periodic by this translation.  This is not possible, which means the original tiling cannot be periodic.">
                                           <annotation ref="tiling-row_2"
-                                                      text="The second tiling is obtained by deflating this third tiling, so we see that there is an infinite hierarchy of tilings.">
-                                              <annotation ref="down-arrow-row_1"/>
-                                          </annotation>
-
-                                          <annotation ref="bottom-tilings"
-                                                      text="Beginning with one tiling, the tiling above is uniquely determined.">
-                                              <annotation ref="tiling-row_0"
-                                                          text="Consider this Fibonacci tiling."/>
-                                              <annotation ref="tiling-row_1"
-                                                          text="By inverting the deflation rules, we can uniquely determine the tiling above."/>
-                                          </annotation>
-                                          <annotation ref="periodic-0"
-                                                      text="Suppose that a Fibonacci tiling is periodic under a horizontal translation.">
-                                              <annotation ref="tiling-row_0"
-                                                          text="For example, suppose this Fibonacci tiling is periodic."/>
-                                              <annotation ref="right-arrow-row_0"
-                                                          text="And that this horizontal translation leaves the tiling unchanged."/>
-                                          </annotation>
-                                          <annotation ref="periodic-1"
-                                                      text="Because the inflated tiling above is unique, it must also be periodic under the same translation.">
-                                              <annotation ref="tiling-row_1"
-                                                          text="This Fibonacci tiling is also periodic."/>
-                                              <annotation ref="right-arrow-row_1"
-                                                          text="The same horizontal translation leaves the tiling unchanged."/>
-                                          </annotation>
-                                          <annotation ref="periodic-2"
-                                                      text="Consequently, every tiling in the hierarchy is periodic by this translation.  This is not possible, which means the original tiling cannot be periodic.">
-                                              <annotation ref="tiling-row_2"
-                                                          text="The size of the tiles grows exponentially as we move up in the hierarchy."/>
-                                              <annotation ref="right-arrow-row_2"
-                                                          text="Eventually the tiles are longer than the translation."/>
-                                          </annotation>
+                                                      text="The size of the tiles grows exponentially as we move up in the hierarchy."/>
+                                          <annotation ref="right-arrow-row_2"
+                                                      text="Eventually the tiles are longer than the translation."/>
                                       </annotation>
                                   </annotations>
                               </diagram>
@@ -16219,17 +16206,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                                 <vector at="vector-b" v="(4,2)" alignment="nw"><m>\vec b</m></vector>
                                             </coordinates>
                                             <annotations text="Two vectors labeled a and b in the coordinate plane">
-                                                <annotation ref="figure"
-                                                            text="Two vectors labeled a and b in the coordinate plane">
-                                                    <annotation ref="grid"
-                                                                text="A one by one grid"/>
-                                                    <annotation ref="axes"
-                                                                text="A set of labeled axes"/>
-                                                    <annotation ref="vector-a"
-                                                                text="The vector a"/>
-                                                    <annotation ref="vector-b"
-                                                                text="The vector b"/>
-                                                </annotation>
+                                                <annotation ref="grid"
+                                                            text="A one by one grid"/>
+                                                <annotation ref="axes"
+                                                            text="A set of labeled axes"/>
+                                                <annotation ref="vector-a"
+                                                            text="The vector a"/>
+                                                <annotation ref="vector-b"
+                                                            text="The vector b"/>
                                             </annotations>
                                         </diagram>
                                     </prefigure>

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -507,51 +507,47 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                     </network>
                                 </coordinates>
 
-                                <annotations>
-                                    <annotation ref="figure"
-                                                text="A network with six nodes and nine edges.  We will remove four edges to form a spanning tree.">
-                                        <annotation ref="nodes"
-                                                    text="The six nodes are labeled from one to six.">
-                                            <annotation ref="node-1"
-                                                        text="The node 1"/>
-                                            <annotation ref="node-2"
-                                                        text="The node 2"/>
-                                            <annotation ref="node-3"
-                                                        text="The node 3"/>
-                                            <annotation ref="node-4"
-                                                        text="The node 4"/>
-                                            <annotation ref="node-5"
-                                                        text="The node 5"/>
-                                            <annotation ref="node-6"
-                                                        text="The node 6"/>
+                                <annotations text="A network with six nodes and nine edges.  We will remove four edges to form a spanning tree.">
+                                    <annotation ref="nodes"
+                                                text="The six nodes are labeled from one to six.">
+                                        <annotation ref="node-1"
+                                                    text="The node 1"/>
+                                        <annotation ref="node-2"
+                                                    text="The node 2"/>
+                                        <annotation ref="node-3"
+                                                    text="The node 3"/>
+                                        <annotation ref="node-4"
+                                                    text="The node 4"/>
+                                        <annotation ref="node-5"
+                                                    text="The node 5"/>
+                                        <annotation ref="node-6"
+                                                    text="The node 6"/>
+                                    </annotation>
+                                    <annotation ref="edges"
+                                                text="There are nine edges, four of which will be removed to form a spanning tree">
+                                        <annotation ref="kept-edges"
+                                                    text="We will keep five edges">
+                                            <annotation ref="edge-1-3"
+                                                        text="We keep the edge connecting nodes 1 and 3"/>
+                                            <annotation ref="edge-1-5"
+                                                        text="We keep the edge connecting nodes 1 and 5"/>
+                                            <annotation ref="edge-2-5"
+                                                        text="We keep the edge connecting nodes 2 and 5"/>
+                                            <annotation ref="edge-6-2"
+                                                        text="We keep the edge connecting nodes 2 and 6"/>
+                                            <annotation ref="edge-3-4"
+                                                        text="We keep the edge connecting nodes 3 and 4"/>
                                         </annotation>
-
-                                        <annotation ref="edges"
-                                                    text="There are nine edges, four of which will be removed to form a spanning tree">
-                                            <annotation ref="kept-edges"
-                                                        text="We will keep five edges">
-                                                <annotation ref="edge-1-3"
-                                                            text="We keep the edge connecting nodes 1 and 3"/>
-                                                <annotation ref="edge-1-5"
-                                                            text="We keep the edge connecting nodes 1 and 5"/>
-                                                <annotation ref="edge-2-5"
-                                                            text="We keep the edge connecting nodes 2 and 5"/>
-                                                <annotation ref="edge-6-2"
-                                                            text="We keep the edge connecting nodes 2 and 6"/>
-                                                <annotation ref="edge-3-4"
-                                                            text="We keep the edge connecting nodes 3 and 4"/>
-                                            </annotation>
-                                            <annotation ref="removed-edges"
-                                                        text="We will remove four edges">
-                                                <annotation ref="edge-1-4"
-                                                            text="We remove the edge connecting nodes 1 and 4"/>
-                                                <annotation ref="edge-2-4"
-                                                            text="We remove the edge connecting nodes 2 and 4"/>
-                                                <annotation ref="edge-3-5"
-                                                            text="We remove the edge connecting nodes 3 and 5"/>
-                                                <annotation ref="edge-6-4"
-                                                            text="We remove the edge connecting nodes 4 and 6"/>
-                                            </annotation>
+                                        <annotation ref="removed-edges"
+                                                    text="We will remove four edges">
+                                            <annotation ref="edge-1-4"
+                                                        text="We remove the edge connecting nodes 1 and 4"/>
+                                            <annotation ref="edge-2-4"
+                                                        text="We remove the edge connecting nodes 2 and 4"/>
+                                            <annotation ref="edge-3-5"
+                                                        text="We remove the edge connecting nodes 3 and 5"/>
+                                            <annotation ref="edge-6-4"
+                                                        text="We remove the edge connecting nodes 4 and 6"/>
                                         </annotation>
                                     </annotation>
                                 </annotations>

--- a/schema/pf_schema.rnc
+++ b/schema/pf_schema.rnc
@@ -15,11 +15,9 @@ Diagram = element diagram {
 
 Caption = element caption {text}
 
-# Annotations are constructed with a single #annotations element,
-# which contains a single #annotation
 Annotations = element annotations {
-    Annotation*,
-    attribute text {text}
+    (attribute text {text}, Annotation*) |
+    Annotation
 }
 
 AnnotationAttributes = 
@@ -41,15 +39,16 @@ Annotation = element annotation {
 # Most elements can be annotated
 CommonAttributes =
     attribute annotate {"yes"|"no"}?,
-    AnnotatedElementAttributes?
+    AnnotatedElementAttributes
 
 # next come some definition elements that can be added anywhere
 DefinitionElements = 
-    Definition?,
-    Derivative?,
-    DE-Solution?,
-    Define-Shapes?,
-    Read?
+    Definition |
+    Derivative |
+    DE-Solution |
+    Define-Shapes |
+    Read |
+    Templates
 
 Definition = element definition {
     text,
@@ -84,6 +83,10 @@ Read = element read {
     attribute quotechar {text}?,
     attribute string-columns {text}?,
     attribute type {text}
+}
+
+Templates = element templates {
+    GraphicalElements+
 }
 
 # the next elements group other elements together
@@ -143,7 +146,7 @@ Clip = element clip {
         DefinitionElements* &
         GraphicalElements* &
         GroupElements* &
-        TransformElements
+        TransformElements*
     )
 }
 
@@ -196,38 +199,31 @@ TactileLabelAttributes =
     attribute tactile-clear-background {"yes"|"no"}?,
     attribute tactile-background-margin {text}?
 
-
 Math = element m {attribute color {text}? & text}
 Bold = element b {attribute color {text}? & text & Italic*}
 Italic = element it {attribute color {text}? & text & Bold*}
-Plain = element plain {attribute color{text}? & text}
+Plain = element plain {attribute color {text}? & text}
 Newline = element newline {empty}
-LabelElements = (
-    Math* &
-    Bold* &
-    Italic* &
-    Plain* &
-    Newline*
-)
-LabelText = (text | LabelElements*)
+
+LabelText = (text | Math | Bold | Italic | Plain | Newline)+
 
 Label = element label {
     attribute at {text}?,
     attribute anchor {text},
     LabelAttributes,
-    LabelText+
+    LabelText
 }
 
 XLabel = element xlabel {
     attribute at {text}?,
     LabelAttributes,
-    LabelText+
+    LabelText
 }
 
 YLabel = element ylabel {
     attribute at {text}?,
     LabelAttributes,
-    LabelText+
+    LabelText
 }
 
 # elements that can go inside a path
@@ -289,18 +285,18 @@ PathElements = (
 )
 
 ShapeElements = (
-    Arc* &
-    Area-Between-Curves* &
-    Area-Under-Curve* &
-    Circle* &
-    Ellipse* &
-    Graph* &
-    Parametric-Curve* &
-    Path* &
-    Polygon* &
-    Rectangle* &
-    Shape* &
-    Spline*
+    Arc |
+    Area-Between-Curves |
+    Area-Under-Curve |
+    Circle |
+    Ellipse |
+    Graph |
+    Parametric-Curve |
+    Path |
+    Polygon |
+    Rectangle |
+    Shape |
+    Spline
 )
 
 # graphical elements can be stroked and possibly filled
@@ -317,7 +313,7 @@ StrokeAttributes =
     attribute outline {"yes"|"no"}?,
     TactileStrokeAttributes?
 
-TactileStrokeAttributes =
+TactileStrokeAttributes = 
     attribute tactile-stroke {text}?,
     attribute tactile-thickness {text}?,
     attribute tactile-miterlimit {text}?,
@@ -330,50 +326,52 @@ FillAttributes =
     StrokeAttributes,
     attribute fill {text}?,
     attribute fill-opacity {text}?,
-    attribute fill-rule {text}?
+    attribute fill-rule {text}?,
+    attribute fill-pattern {"horizontal" | "vertical" | "diagonal" | "backdiagonal" | "dot" | "diamond"}?,
+    TactileFillAttributes?
 
 TactileFillAttributes =
-    TactileStrokeAttributes,
     attribute tactile-fill {text}?,
-    attribute tactile-fill-rule {text}?
+    attribute tactile-fill-rule {text}?,
+    attribute tactile-fill-pattern {"horizontal" | "vertical" | "diagonal" | "backdiagonal" | "dot" | "diamond"}?
 
 # start defining the graphical elements
 GraphicalElements = 
     (
-        Angle-Marker* &
-        Arc* &
-        Area-Between-Curves* &
-        Area-Under-Curve* &
-        Axes* &
-        Circle* &
-        Contour* &
-        Ellipse* &
-        Graph* &
-        Grid* &
-        Grid-Axes* &
-        Histogram* &
-        Image*&
-        Implicit-Curve* &
-        Label* &
-        Legend* &
-        Line* &
-        Network* &
-        Parametric-Curve* &
-        Path* &
-        Plot-DE-Solution* &
-        Point* &
-        Polygon* &
-        Rectangle* &
-        Riemann-Sum* &
-        Scatter* &
-        Shape* &
-        Slope-Field* &
-        Spline* &
-        Tick-Mark* &
-        Tangent-line* &
-        Triangle* &
-        Vector* & 
-        Vector-Field*
+        Angle-Marker |
+        Arc |
+        Area-Between-Curves |
+        Area-Under-Curve |
+        Axes |
+        Circle |
+        Contour |
+        Ellipse |
+        Graph |
+        Grid |
+        Grid-Axes |
+        Histogram |
+        Image |
+        Implicit-Curve |
+        Label |
+        Legend |
+        Line |
+        Network |
+        Parametric-Curve |
+        Path |
+        Plot-DE-Solution |
+        Point |
+        Polygon |
+        Rectangle |
+        Riemann-Sum |
+        Scatter |
+        Shape |
+        Slope-Field |
+        Spline |
+        Tick-Mark |
+        Tangent-line |
+        Triangle |
+        Vector |
+        Vector-Field
     )
 
 Angle-Marker = element angle-marker {
@@ -506,7 +504,8 @@ Tick-Mark = element tick-mark {
     attribute size {text}?,
     StrokeAttributes,
     LabelAttributes,
-    LabelText?
+    LabelText?,
+    CommonAttributes
 }
 
 Contour = element contour {
@@ -535,7 +534,7 @@ Ellipse = element ellipse {
     attribute rotate {text}?,
     attribute degrees {text}?,
     attribute N {text}?,
-    StrokeAttributes,
+    FillAttributes,
     CommonAttributes
 }
 
@@ -544,8 +543,8 @@ Graph = element graph {
     attribute function {text},
     attribute N {text}?,
     attribute domain {text}?,
-    attribute coordinates {"polar"|"coordinates"}?,
-    attribute domain-degress {"yes"|"no"}?,
+    attribute coordinates {"polar"|"cartesian"}?,
+    attribute domain-degrees {"yes"|"no"}?,
     attribute closed {"yes"|"no"}?,
     attribute fill {text}?,
     StrokeAttributes,
@@ -554,14 +553,15 @@ Graph = element graph {
 
 Image = element image {
     attribute at {text}?,
-    attribute source{text},
+    attribute source {text},
     attribute lower-left {text}?,
     attribute center {text}?,
     attribute dimensions {text}?,
     attribute opacity {text}?,
     attribute filetype {"svg"|"png"|"gif"|"jpeg"|"jpg"}?,
     attribute rotate {text}?,
-    attribute scale {text}?
+    attribute scale {text}?,
+    CommonAttributes
 }
 
 Histogram = element histogram {
@@ -596,7 +596,7 @@ Legend = element legend {
     attribute opacity {text}?,
     element item {
         attribute ref {text},
-        LabelText+
+        LabelText
     }+}
 
 Line = element line {
@@ -623,7 +623,7 @@ Network = element network {
     attribute directed {"yes"|"no"}?,
     attribute arrows {"end"|"middle"}?,
     attribute bipartite-set {text}?,
-    attribute alignment {'vertical' | 'horizontal'}?,
+    attribute alignment {"vertical" | "horizontal"}?,
     attribute loop-scale {text}?,
     attribute layout {text}?,
     attribute seed {text}?,
@@ -855,7 +855,7 @@ Vector-Field = element vector-field {
     attribute domain {text}?,
     attribute N {text}?,
     attribute arrow-width {text}?,
-    attribute arrow-angles {text?}?,
+    attribute arrow-angles {text}?,
     StrokeAttributes,
     CommonAttributes
 }

--- a/schema/pf_schema.rng
+++ b/schema/pf_schema.rng
@@ -33,16 +33,17 @@
       <text/>
     </element>
   </define>
-  <!--
-    Annotations are constructed with a single #annotations element,
-    which contains a single #annotation
-  -->
   <define name="Annotations">
     <element name="annotations">
-      <zeroOrMore>
+      <choice>
+        <group>
+          <attribute name="text"/>
+          <zeroOrMore>
+            <ref name="Annotation"/>
+          </zeroOrMore>
+        </group>
         <ref name="Annotation"/>
-      </zeroOrMore>
-      <attribute name="text"/>
+      </choice>
     </element>
   </define>
   <define name="AnnotationAttributes">
@@ -92,27 +93,18 @@
         </choice>
       </attribute>
     </optional>
-    <optional>
-      <ref name="AnnotatedElementAttributes"/>
-    </optional>
+    <ref name="AnnotatedElementAttributes"/>
   </define>
   <!-- next come some definition elements that can be added anywhere -->
   <define name="DefinitionElements">
-    <optional>
+    <choice>
       <ref name="Definition"/>
-    </optional>
-    <optional>
       <ref name="Derivative"/>
-    </optional>
-    <optional>
       <ref name="DE-Solution"/>
-    </optional>
-    <optional>
       <ref name="Define-Shapes"/>
-    </optional>
-    <optional>
       <ref name="Read"/>
-    </optional>
+      <ref name="Templates"/>
+    </choice>
   </define>
   <define name="Definition">
     <element name="definition">
@@ -177,6 +169,13 @@
         <attribute name="string-columns"/>
       </optional>
       <attribute name="type"/>
+    </element>
+  </define>
+  <define name="Templates">
+    <element name="templates">
+      <oneOrMore>
+        <ref name="GraphicalElements"/>
+      </oneOrMore>
     </element>
   </define>
   <!-- the next elements group other elements together -->
@@ -301,7 +300,9 @@
         <zeroOrMore>
           <ref name="GroupElements"/>
         </zeroOrMore>
-        <ref name="TransformElements"/>
+        <zeroOrMore>
+          <ref name="TransformElements"/>
+        </zeroOrMore>
       </interleave>
     </element>
   </define>
@@ -496,32 +497,17 @@
       <empty/>
     </element>
   </define>
-  <define name="LabelElements">
-    <interleave>
-      <zeroOrMore>
-        <ref name="Math"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Bold"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Italic"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Plain"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Newline"/>
-      </zeroOrMore>
-    </interleave>
-  </define>
   <define name="LabelText">
-    <choice>
-      <text/>
-      <zeroOrMore>
-        <ref name="LabelElements"/>
-      </zeroOrMore>
-    </choice>
+    <oneOrMore>
+      <choice>
+        <text/>
+        <ref name="Math"/>
+        <ref name="Bold"/>
+        <ref name="Italic"/>
+        <ref name="Plain"/>
+        <ref name="Newline"/>
+      </choice>
+    </oneOrMore>
   </define>
   <define name="Label">
     <element name="label">
@@ -530,9 +516,7 @@
       </optional>
       <attribute name="anchor"/>
       <ref name="LabelAttributes"/>
-      <oneOrMore>
-        <ref name="LabelText"/>
-      </oneOrMore>
+      <ref name="LabelText"/>
     </element>
   </define>
   <define name="XLabel">
@@ -541,9 +525,7 @@
         <attribute name="at"/>
       </optional>
       <ref name="LabelAttributes"/>
-      <oneOrMore>
-        <ref name="LabelText"/>
-      </oneOrMore>
+      <ref name="LabelText"/>
     </element>
   </define>
   <define name="YLabel">
@@ -552,9 +534,7 @@
         <attribute name="at"/>
       </optional>
       <ref name="LabelAttributes"/>
-      <oneOrMore>
-        <ref name="LabelText"/>
-      </oneOrMore>
+      <ref name="LabelText"/>
     </element>
   </define>
   <!-- elements that can go inside a path -->
@@ -703,44 +683,20 @@
     </interleave>
   </define>
   <define name="ShapeElements">
-    <interleave>
-      <zeroOrMore>
-        <ref name="Arc"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Area-Between-Curves"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Area-Under-Curve"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Circle"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Ellipse"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Graph"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Parametric-Curve"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Path"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Polygon"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Rectangle"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Shape"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Spline"/>
-      </zeroOrMore>
-    </interleave>
+    <choice>
+      <ref name="Arc"/>
+      <ref name="Area-Between-Curves"/>
+      <ref name="Area-Under-Curve"/>
+      <ref name="Circle"/>
+      <ref name="Ellipse"/>
+      <ref name="Graph"/>
+      <ref name="Parametric-Curve"/>
+      <ref name="Path"/>
+      <ref name="Polygon"/>
+      <ref name="Rectangle"/>
+      <ref name="Shape"/>
+      <ref name="Spline"/>
+    </choice>
   </define>
   <!-- graphical elements can be stroked and possibly filled -->
   <define name="StrokeAttributes">
@@ -827,122 +783,80 @@
     <optional>
       <attribute name="fill-rule"/>
     </optional>
+    <optional>
+      <attribute name="fill-pattern">
+        <choice>
+          <value>horizontal</value>
+          <value>vertical</value>
+          <value>diagonal</value>
+          <value>backdiagonal</value>
+          <value>dot</value>
+          <value>diamond</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <ref name="TactileFillAttributes"/>
+    </optional>
   </define>
   <define name="TactileFillAttributes">
-    <ref name="TactileStrokeAttributes"/>
     <optional>
       <attribute name="tactile-fill"/>
     </optional>
     <optional>
       <attribute name="tactile-fill-rule"/>
     </optional>
+    <optional>
+      <attribute name="tactile-fill-pattern">
+        <choice>
+          <value>horizontal</value>
+          <value>vertical</value>
+          <value>diagonal</value>
+          <value>backdiagonal</value>
+          <value>dot</value>
+          <value>diamond</value>
+        </choice>
+      </attribute>
+    </optional>
   </define>
   <!-- start defining the graphical elements -->
   <define name="GraphicalElements">
-    <interleave>
-      <zeroOrMore>
-        <ref name="Angle-Marker"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Arc"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Area-Between-Curves"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Area-Under-Curve"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Axes"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Circle"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Contour"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Ellipse"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Graph"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Grid"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Grid-Axes"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Histogram"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Image"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Implicit-Curve"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Label"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Legend"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Line"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Network"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Parametric-Curve"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Path"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Plot-DE-Solution"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Point"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Polygon"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Rectangle"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Riemann-Sum"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Scatter"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Shape"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Slope-Field"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Spline"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Tick-Mark"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Tangent-line"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Triangle"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Vector"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="Vector-Field"/>
-      </zeroOrMore>
-    </interleave>
+    <choice>
+      <ref name="Angle-Marker"/>
+      <ref name="Arc"/>
+      <ref name="Area-Between-Curves"/>
+      <ref name="Area-Under-Curve"/>
+      <ref name="Axes"/>
+      <ref name="Circle"/>
+      <ref name="Contour"/>
+      <ref name="Ellipse"/>
+      <ref name="Graph"/>
+      <ref name="Grid"/>
+      <ref name="Grid-Axes"/>
+      <ref name="Histogram"/>
+      <ref name="Image"/>
+      <ref name="Implicit-Curve"/>
+      <ref name="Label"/>
+      <ref name="Legend"/>
+      <ref name="Line"/>
+      <ref name="Network"/>
+      <ref name="Parametric-Curve"/>
+      <ref name="Path"/>
+      <ref name="Plot-DE-Solution"/>
+      <ref name="Point"/>
+      <ref name="Polygon"/>
+      <ref name="Rectangle"/>
+      <ref name="Riemann-Sum"/>
+      <ref name="Scatter"/>
+      <ref name="Shape"/>
+      <ref name="Slope-Field"/>
+      <ref name="Spline"/>
+      <ref name="Tick-Mark"/>
+      <ref name="Tangent-line"/>
+      <ref name="Triangle"/>
+      <ref name="Vector"/>
+      <ref name="Vector-Field"/>
+    </choice>
   </define>
   <define name="Angle-Marker">
     <element name="angle-marker">
@@ -1421,6 +1335,7 @@
       <optional>
         <ref name="LabelText"/>
       </optional>
+      <ref name="CommonAttributes"/>
     </element>
   </define>
   <define name="Contour">
@@ -1476,7 +1391,7 @@
       <optional>
         <attribute name="N"/>
       </optional>
-      <ref name="StrokeAttributes"/>
+      <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
     </element>
   </define>
@@ -1496,12 +1411,12 @@
         <attribute name="coordinates">
           <choice>
             <value>polar</value>
-            <value>coordinates</value>
+            <value>cartesian</value>
           </choice>
         </attribute>
       </optional>
       <optional>
-        <attribute name="domain-degress">
+        <attribute name="domain-degrees">
           <choice>
             <value>yes</value>
             <value>no</value>
@@ -1558,6 +1473,7 @@
       <optional>
         <attribute name="scale"/>
       </optional>
+      <ref name="CommonAttributes"/>
     </element>
   </define>
   <define name="Histogram">
@@ -1628,9 +1544,7 @@
       <oneOrMore>
         <element name="item">
           <attribute name="ref"/>
-          <oneOrMore>
-            <ref name="LabelText"/>
-          </oneOrMore>
+          <ref name="LabelText"/>
         </element>
       </oneOrMore>
     </element>
@@ -2311,11 +2225,7 @@
         <attribute name="arrow-width"/>
       </optional>
       <optional>
-        <attribute name="arrow-angles">
-          <optional>
-            <text/>
-          </optional>
-        </attribute>
+        <attribute name="arrow-angles"/>
       </optional>
       <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>


### PR DESCRIPTION
The first commit here provides the latest version of the PreFigure schema while the latter commits amend the PreTeXt sample documents so that all enclosed annotated PreFigure diagrams successfully validate against the schema.

There is no need to update the diagrams themselves since the amended PreFigure source still compiles to the same SVGs and annotations.