### PR TITLE
pdf-fo conversion: load SVG 1.1 compliant PreFigure images

### DIFF
--- a/examples/epub/gen/prefigure/prefigure-tangent-11.svg
+++ b/examples/epub/gen/prefigure/prefigure-tangent-11.svg
@@ -1,0 +1,200 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-tangent-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-tangent-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-tangent-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+  </defs>
+  <g id="prefigure-tangent-grid-axes">
+    <g id="prefigure-tangent-grid" stroke="#ccc" stroke-width="1">
+      <line x1="5.0" y1="305.0" x2="5.0" y2="5.0"/>
+      <line x1="42.5" y1="305.0" x2="42.5" y2="5.0"/>
+      <line x1="80.0" y1="305.0" x2="80.0" y2="5.0"/>
+      <line x1="117.5" y1="305.0" x2="117.5" y2="5.0"/>
+      <line x1="155.0" y1="305.0" x2="155.0" y2="5.0"/>
+      <line x1="192.5" y1="305.0" x2="192.5" y2="5.0"/>
+      <line x1="230.0" y1="305.0" x2="230.0" y2="5.0"/>
+      <line x1="267.5" y1="305.0" x2="267.5" y2="5.0"/>
+      <line x1="305.0" y1="305.0" x2="305.0" y2="5.0"/>
+      <line x1="5.0" y1="305.0" x2="305.0" y2="305.0"/>
+      <line x1="5.0" y1="267.5" x2="305.0" y2="267.5"/>
+      <line x1="5.0" y1="230.0" x2="305.0" y2="230.0"/>
+      <line x1="5.0" y1="192.5" x2="305.0" y2="192.5"/>
+      <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+      <line x1="5.0" y1="117.5" x2="305.0" y2="117.5"/>
+      <line x1="5.0" y1="80.0" x2="305.0" y2="80.0"/>
+      <line x1="5.0" y1="42.5" x2="305.0" y2="42.5"/>
+      <line x1="5.0" y1="5.0" x2="305.0" y2="5.0"/>
+    </g>
+    <g id="prefigure-tangent-axes" stroke="black" stroke-width="2">
+      <line id="prefigure-tangent-__line-18" x1="5.0" y1="155.0" x2="305.0" y2="155.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-tangent-__line-19" x1="80.0" y1="158.0" x2="80.0" y2="152.0"/>
+        <line id="prefigure-tangent-__line-20" x1="230.0" y1="158.0" x2="230.0" y2="152.0"/>
+      </g>
+      <line id="prefigure-tangent-__line-21" x1="155.0" y1="305.0" x2="155.0" y2="5.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-tangent-__line-22" x1="152.0" y1="230.0" x2="158.0" y2="230.0"/>
+        <line id="prefigure-tangent-__line-23" x1="152.0" y1="80.0" x2="158.0" y2="80.0"/>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-0" transform="translate(301.0,151.0) translate(-10.4,-8.2)">
+      <g id="prefigure-tangent-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="10.352px" height="8.200px" role="img" focusable="false" viewBox="0 -442 572 453" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-2-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="x">
+                <use data-c="1D465" xlink:href="#prefigure-tangent-MJX-2-TEX-I-1D465"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-1" transform="translate(159.0,9.0) translate(0.0,-0.0)">
+      <g id="prefigure-tangent-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -3.712px" width="8.872px" height="11.712px" role="img" focusable="false" viewBox="0 -442 490 647" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-3-TEX-I-1D466" d="M21 287Q21 301 36 335T84 406T158 442Q199 442 224 419T250 355Q248 336 247 334Q247 331 231 288T198 191T182 105Q182 62 196 45T238 27Q261 27 281 38T312 61T339 94Q339 95 344 114T358 173T377 247Q415 397 419 404Q432 431 462 431Q475 431 483 424T494 412T496 403Q496 390 447 193T391 -23Q363 -106 294 -155T156 -205Q111 -205 77 -183T43 -117Q43 -95 50 -80T69 -58T89 -48T106 -45Q150 -45 150 -87Q150 -107 138 -122T115 -142T102 -147L99 -148Q101 -153 118 -160T152 -167H160Q177 -167 186 -165Q219 -156 247 -127T290 -65T313 -9T321 21L315 17Q309 13 296 6T270 -6Q250 -11 231 -11Q185 -11 150 11T104 82Q103 89 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="y">
+                <use data-c="1D466" xlink:href="#prefigure-tangent-MJX-3-TEX-I-1D466"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-2" transform="translate(80.0,166.0) translate(-7.5,-0.0)">
+      <g id="prefigure-tangent-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-4-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-tangent-MJX-4-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-tangent-MJX-4-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-4-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-3" transform="translate(230.0,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-tangent-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-5-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-5-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-4" transform="translate(144.0,230.0) translate(-15.1,-6.0)">
+      <g id="prefigure-tangent-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-6-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-tangent-MJX-6-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-tangent-MJX-6-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-6-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-5" transform="translate(144.0,80.0) translate(-9.0,-6.0)">
+      <g id="prefigure-tangent-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-7-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-7-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <path id="prefigure-tangent-graph" stroke="blue" stroke-width="2" fill="none" d="M 5.0 161.5 L 8.0 162.2 L 11.0 163.0 L 14.0 163.7 L 17.0 164.4 L 20.0 165.1 L 23.0 165.8 L 26.0 166.4 L 29.0 166.9 L 32.0 167.4 L 35.0 167.9 L 38.0 168.3 L 41.0 168.5 L 44.0 168.8 L 47.0 168.9 L 50.0 168.9 L 53.0 168.8 L 56.0 168.6 L 59.0 168.3 L 62.0 167.9 L 65.0 167.4 L 68.0 166.8 L 71.0 166.0 L 74.0 165.1 L 77.0 164.1 L 80.0 163.0 L 83.0 161.8 L 86.0 160.4 L 89.0 158.9 L 92.0 157.3 L 95.0 155.6 L 98.0 153.9 L 101.0 152.0 L 104.0 150.0 L 107.0 148.0 L 110.0 145.9 L 113.0 143.8 L 116.0 141.6 L 119.0 139.4 L 122.0 137.2 L 125.0 135.0 L 128.0 132.8 L 131.0 130.7 L 134.0 128.6 L 137.0 126.7 L 140.0 124.8 L 143.0 123.0 L 146.0 121.4 L 149.0 119.9 L 152.0 118.6 L 155.0 117.5 L 158.0 116.6 L 161.0 116.0 L 164.0 115.5 L 167.0 115.4 L 170.0 115.5 L 173.0 116.0 L 176.0 116.7 L 179.0 117.8 L 182.0 119.2 L 185.0 120.9 L 188.0 123.0 L 191.0 125.4 L 194.0 128.2 L 197.0 131.3 L 200.0 134.7 L 203.0 138.5 L 206.0 142.7 L 209.0 147.1 L 212.0 151.8 L 215.0 156.9 L 218.0 162.2 L 221.0 167.7 L 224.0 173.4 L 227.0 179.3 L 230.0 185.4 L 233.0 191.6 L 236.0 197.8 L 239.0 204.1 L 242.0 210.3 L 245.0 216.5 L 248.0 222.6 L 251.0 228.6 L 254.0 234.3 L 257.0 239.7 L 260.0 244.9 L 263.0 249.6 L 266.0 253.9 L 269.0 257.8 L 272.0 261.1 L 275.0 263.8 L 278.0 265.8 L 281.0 267.2 L 284.0 267.8 L 287.0 267.7 L 290.0 266.7 L 293.0 264.8 L 296.0 262.0 L 299.0 258.3 L 302.0 253.6 L 305.0 248.0" clip-path="url(#prefigure-tangent-__clipPath-1)"/>
+  <line id="prefigure-tangent-tangent" x1="60.6" y1="5.0" x2="305.0" y2="230.6" stroke="red" stroke-width="2" fill="none" clip-path="url(#prefigure-tangent-__clipPath-1)"/>
+  <g id="prefigure-tangent-point">
+    <g transform="translate(197.5,121.7) translate(0.0,-18.1)">
+      <g id="prefigure-tangent-__g-6">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="65.312px" height="18.096px" role="img" focusable="false" viewBox="0 -750 3608.7 1000" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-8-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-I-1D453" d="M118 -162Q120 -162 124 -164T135 -167T147 -168Q160 -168 171 -155T187 -126Q197 -99 221 27T267 267T289 382V385H242Q195 385 192 387Q188 390 188 397L195 425Q197 430 203 430T250 431Q298 431 298 432Q298 434 307 482T319 540Q356 705 465 705Q502 703 526 683T550 630Q550 594 529 578T487 561Q443 561 443 603Q443 622 454 636T478 657L487 662Q471 668 457 668Q445 668 434 658T419 630Q412 601 403 552T387 469T380 433Q380 431 435 431Q480 431 487 430T498 424Q499 420 496 407T491 391Q489 386 482 386T428 385H372L349 263Q301 15 282 -47Q255 -132 212 -173Q175 -205 139 -205Q107 -205 81 -186T55 -132Q55 -95 76 -78T118 -61Q162 -61 162 -103Q162 -122 151 -136T127 -157L118 -162Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-2061" d=""/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="12" data-semantic-children="11" data-semantic-content="0,7" data-semantic-speech="left parenthesis a comma f left parenthesis a right parenthesis right parenthesis">
+              <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="0" data-semantic-parent="12" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                <use data-c="28" xlink:href="#prefigure-tangent-MJX-8-TEX-N-28"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="punctuated" data-semantic-role="sequence" data-semantic-id="11" data-semantic-children="1,2,10" data-semantic-content="2" data-semantic-parent="12" data-semantic-speech="a comma f left parenthesis a right parenthesis" transform="translate(389,0)">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="11" data-semantic-speech="a">
+                  <use data-c="1D44E" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D44E"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="comma" data-semantic-id="2" data-semantic-parent="11" data-semantic-operator="punctuated" data-semantic-speech="comma" transform="translate(529,0)">
+                  <use data-c="2C" xlink:href="#prefigure-tangent-MJX-8-TEX-N-2C"/>
+                </g>
+                <g data-mml-node="mrow" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="10" data-semantic-children="3,8" data-semantic-content="9,3" data-semantic-parent="11" data-semantic-speech="f left parenthesis a right parenthesis" transform="translate(973.7,0)">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="3" data-semantic-parent="10" data-semantic-operator="appl" data-semantic-speech="f">
+                    <use data-c="1D453" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D453"/>
+                  </g>
+                  <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="9" data-semantic-parent="10" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(550,0)">
+                    <use data-c="2061" xlink:href="#prefigure-tangent-MJX-8-TEX-N-2061"/>
+                  </g>
+                  <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="8" data-semantic-children="5" data-semantic-content="4,6" data-semantic-parent="10" data-semantic-speech="left parenthesis a right parenthesis" transform="translate(550,0)">
+                    <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="4" data-semantic-parent="8" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                      <use data-c="28" xlink:href="#prefigure-tangent-MJX-8-TEX-N-28"/>
+                    </g>
+                    <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="5" data-semantic-parent="8" data-semantic-speech="a" transform="translate(389,0)">
+                      <use data-c="1D44E" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D44E"/>
+                    </g>
+                    <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="6" data-semantic-parent="8" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(918,0)">
+                      <use data-c="29" xlink:href="#prefigure-tangent-MJX-8-TEX-N-29"/>
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="7" data-semantic-parent="12" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(3219.7,0)">
+                <use data-c="29" xlink:href="#prefigure-tangent-MJX-8-TEX-N-29"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <circle cx="192.5" cy="126.7" r="4" stroke="black" stroke-width="2" fill="red"/>
+  </g>
+</svg>

--- a/examples/pdf-fo-development/generated/prefigure/prefigure-diffeq-11.svg
+++ b/examples/pdf-fo-development/generated/prefigure/prefigure-diffeq-11.svg
@@ -1,0 +1,204 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-diffeq-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-diffeq-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-diffeq-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+  </defs>
+  <g id="prefigure-diffeq-grid-axes">
+    <g id="prefigure-diffeq-grid" stroke="#ccc" stroke-width="1">
+      <line x1="5.0" y1="305.0" x2="5.0" y2="5.0"/>
+      <line x1="47.9" y1="305.0" x2="47.9" y2="5.0"/>
+      <line x1="90.7" y1="305.0" x2="90.7" y2="5.0"/>
+      <line x1="133.6" y1="305.0" x2="133.6" y2="5.0"/>
+      <line x1="176.4" y1="305.0" x2="176.4" y2="5.0"/>
+      <line x1="219.3" y1="305.0" x2="219.3" y2="5.0"/>
+      <line x1="262.1" y1="305.0" x2="262.1" y2="5.0"/>
+      <line x1="305.0" y1="305.0" x2="305.0" y2="5.0"/>
+      <line x1="5.0" y1="305.0" x2="305.0" y2="305.0"/>
+      <line x1="5.0" y1="255.0" x2="305.0" y2="255.0"/>
+      <line x1="5.0" y1="205.0" x2="305.0" y2="205.0"/>
+      <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+      <line x1="5.0" y1="105.0" x2="305.0" y2="105.0"/>
+      <line x1="5.0" y1="55.0" x2="305.0" y2="55.0"/>
+      <line x1="5.0" y1="5.0" x2="305.0" y2="5.0"/>
+    </g>
+    <g id="prefigure-diffeq-axes" stroke="black" stroke-width="2">
+      <line id="prefigure-diffeq-__line-15" x1="5.0" y1="155.0" x2="305.0" y2="155.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-diffeq-__line-16" x1="133.6" y1="158.0" x2="133.6" y2="152.0"/>
+        <line id="prefigure-diffeq-__line-17" x1="219.3" y1="158.0" x2="219.3" y2="152.0"/>
+      </g>
+      <line id="prefigure-diffeq-__line-18" x1="47.9" y1="305.0" x2="47.9" y2="5.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-diffeq-__line-19" x1="44.9" y1="255.0" x2="50.9" y2="255.0"/>
+        <line id="prefigure-diffeq-__line-20" x1="44.9" y1="55.0" x2="50.9" y2="55.0"/>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-0" transform="translate(301.0,151.0) translate(-6.5,-11.5)">
+      <g id="prefigure-diffeq-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="6.536px" height="11.528px" role="img" focusable="false" viewBox="0 -626 361 637" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-2-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="t">
+                <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-2-TEX-I-1D461"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-1" transform="translate(133.6,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-diffeq-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-3-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-3-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-2" transform="translate(219.3,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-diffeq-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.256px" role="img" focusable="false" viewBox="0 -677 500 677" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-4-TEX-N-34" d="M462 0Q444 3 333 3Q217 3 199 0H190V46H221Q241 46 248 46T265 48T279 53T286 61Q287 63 287 115V165H28V211L179 442Q332 674 334 675Q336 677 355 677H373L379 671V211H471V165H379V114Q379 73 379 66T385 54Q393 47 442 46H471V0H462ZM293 211V545L74 212L183 211H293Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="4">
+                <use data-c="34" xlink:href="#prefigure-diffeq-MJX-4-TEX-N-34"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-3" transform="translate(36.9,255.0) translate(-15.1,-6.0)">
+      <g id="prefigure-diffeq-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-5-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-diffeq-MJX-5-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-diffeq-MJX-5-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-5-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-4" transform="translate(36.9,55.0) translate(-9.0,-6.0)">
+      <g id="prefigure-diffeq-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-6-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-6-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <path id="prefigure-diffeq-x" stroke="blue" stroke-width="2" fill="none" d="M 47.9 155.0 L 49.1 152.0 L 50.4 149.0 L 51.7 146.1 L 53.0 143.2 L 54.3 140.4 L 55.6 137.7 L 56.9 135.0 L 58.2 132.4 L 59.5 129.9 L 60.8 127.5 L 62.1 125.2 L 63.4 123.0 L 64.7 120.9 L 65.9 118.9 L 67.2 117.1 L 68.5 115.4 L 69.8 113.8 L 71.1 112.3 L 72.4 110.9 L 73.7 109.7 L 75.0 108.7 L 76.3 107.8 L 77.6 107.0 L 78.9 106.4 L 80.2 105.9 L 81.5 105.5 L 82.7 105.3 L 84.0 105.3 L 85.3 105.4 L 86.6 105.6 L 87.9 106.0 L 89.2 106.4 L 90.5 107.1 L 91.8 107.8 L 93.1 108.7 L 94.4 109.7 L 95.7 110.9 L 97.0 112.1 L 98.3 113.5 L 99.5 114.9 L 100.8 116.5 L 102.1 118.2 L 103.4 119.9 L 104.7 121.8 L 106.0 123.7 L 107.3 125.7 L 108.6 127.7 L 109.9 129.8 L 111.2 132.0 L 112.5 134.2 L 113.8 136.5 L 115.1 138.7 L 116.3 141.0 L 117.6 143.4 L 118.9 145.7 L 120.2 148.0 L 121.5 150.4 L 122.8 152.7 L 124.1 155.0 L 125.4 157.3 L 126.7 159.6 L 128.0 161.8 L 129.3 164.0 L 130.6 166.2 L 131.8 168.3 L 133.1 170.3 L 134.4 172.3 L 135.7 174.2 L 137.0 176.1 L 138.3 177.8 L 139.6 179.5 L 140.9 181.1 L 142.2 182.6 L 143.5 184.0 L 144.8 185.4 L 146.1 186.6 L 147.4 187.7 L 148.6 188.7 L 149.9 189.7 L 151.2 190.5 L 152.5 191.2 L 153.8 191.8 L 155.1 192.2 L 156.4 192.6 L 157.7 192.9 L 159.0 193.0 L 160.3 193.1 L 161.6 193.0 L 162.9 192.8 L 164.2 192.6 L 165.4 192.2 L 166.7 191.7 L 168.0 191.1 L 169.3 190.4 L 170.6 189.6 L 171.9 188.8 L 173.2 187.8 L 174.5 186.8 L 175.8 185.6 L 177.1 184.4 L 178.4 183.2 L 179.7 181.8 L 181.0 180.4 L 182.2 178.9 L 183.5 177.4 L 184.8 175.9 L 186.1 174.2 L 187.4 172.6 L 188.7 170.9 L 190.0 169.2 L 191.3 167.4 L 192.6 165.7 L 193.9 163.9 L 195.2 162.1 L 196.5 160.3 L 197.7 158.5 L 199.0 156.7 L 200.3 155.0 L 201.6 153.2 L 202.9 151.5 L 204.2 149.7 L 205.5 148.1 L 206.8 146.4 L 208.1 144.8 L 209.4 143.2 L 210.7 141.7 L 212.0 140.3 L 213.3 138.9 L 214.5 137.5 L 215.8 136.2 L 217.1 135.0 L 218.4 133.8 L 219.7 132.8 L 221.0 131.7 L 222.3 130.8 L 223.6 129.9 L 224.9 129.2 L 226.2 128.5 L 227.5 127.8 L 228.8 127.3 L 230.1 126.9 L 231.3 126.5 L 232.6 126.2 L 233.9 126.0 L 235.2 125.9 L 236.5 125.9 L 237.8 125.9 L 239.1 126.0 L 240.4 126.3 L 241.7 126.6 L 243.0 126.9 L 244.3 127.4 L 245.6 127.9 L 246.9 128.5 L 248.1 129.2 L 249.4 129.9 L 250.7 130.7 L 252.0 131.6 L 253.3 132.5 L 254.6 133.5 L 255.9 134.5 L 257.2 135.6 L 258.5 136.7 L 259.8 137.9 L 261.1 139.1 L 262.4 140.3 L 263.7 141.6 L 264.9 142.9 L 266.2 144.2 L 267.5 145.5 L 268.8 146.9 L 270.1 148.2 L 271.4 149.6 L 272.7 151.0 L 274.0 152.3 L 275.3 153.7 L 276.6 155.1 L 277.9 156.4 L 279.2 157.7 L 280.4 159.0 L 281.7 160.3 L 283.0 161.6 L 284.3 162.8 L 285.6 164.0 L 286.9 165.2 L 288.2 166.3 L 289.5 167.4 L 290.8 168.4 L 292.1 169.4 L 293.4 170.3 L 294.7 171.2 L 296.0 172.0 L 297.2 172.8 L 298.5 173.5 L 299.8 174.2 L 301.1 174.8 L 302.4 175.3 L 303.7 175.8 L 305.0 176.2" clip-path="url(#prefigure-diffeq-__clipPath-1)"/>
+  <path id="prefigure-diffeq-xprime" stroke="red" stroke-width="2" fill="none" d="M 47.9 55.0 L 49.1 56.0 L 50.4 57.4 L 51.7 58.9 L 53.0 60.8 L 54.3 62.9 L 55.6 65.2 L 56.9 67.8 L 58.2 70.6 L 59.5 73.6 L 60.8 76.8 L 62.1 80.2 L 63.4 83.8 L 64.7 87.5 L 65.9 91.4 L 67.2 95.5 L 68.5 99.7 L 69.8 104.0 L 71.1 108.4 L 72.4 112.9 L 73.7 117.5 L 75.0 122.2 L 76.3 126.9 L 77.6 131.6 L 78.9 136.4 L 80.2 141.2 L 81.5 146.0 L 82.7 150.7 L 84.0 155.4 L 85.3 160.1 L 86.6 164.8 L 87.9 169.3 L 89.2 173.8 L 90.5 178.2 L 91.8 182.5 L 93.1 186.6 L 94.4 190.7 L 95.7 194.5 L 97.0 198.3 L 98.3 201.9 L 99.5 205.3 L 100.8 208.6 L 102.1 211.6 L 103.4 214.5 L 104.7 217.2 L 106.0 219.7 L 107.3 221.9 L 108.6 224.0 L 109.9 225.8 L 111.2 227.5 L 112.5 228.9 L 113.8 230.1 L 115.1 231.1 L 116.3 231.8 L 117.6 232.3 L 118.9 232.6 L 120.2 232.7 L 121.5 232.5 L 122.8 232.2 L 124.1 231.6 L 125.4 230.8 L 126.7 229.8 L 128.0 228.5 L 129.3 227.1 L 130.6 225.5 L 131.8 223.7 L 133.1 221.7 L 134.4 219.6 L 135.7 217.3 L 137.0 214.8 L 138.3 212.2 L 139.6 209.5 L 140.9 206.6 L 142.2 203.6 L 143.5 200.5 L 144.8 197.3 L 146.1 194.0 L 147.4 190.6 L 148.6 187.1 L 149.9 183.6 L 151.2 180.1 L 152.5 176.5 L 153.8 172.8 L 155.1 169.2 L 156.4 165.5 L 157.7 161.9 L 159.0 158.2 L 160.3 154.6 L 161.6 151.0 L 162.9 147.5 L 164.2 144.0 L 165.4 140.6 L 166.7 137.2 L 168.0 133.9 L 169.3 130.7 L 170.6 127.7 L 171.9 124.7 L 173.2 121.8 L 174.5 119.1 L 175.8 116.5 L 177.1 114.0 L 178.4 111.6 L 179.7 109.4 L 181.0 107.4 L 182.2 105.5 L 183.5 103.7 L 184.8 102.2 L 186.1 100.7 L 187.4 99.5 L 188.7 98.4 L 190.0 97.5 L 191.3 96.8 L 192.6 96.2 L 193.9 95.8 L 195.2 95.6 L 196.5 95.5 L 197.7 95.7 L 199.0 96.0 L 200.3 96.4 L 201.6 97.0 L 202.9 97.8 L 204.2 98.7 L 205.5 99.8 L 206.8 101.0 L 208.1 102.4 L 209.4 103.9 L 210.7 105.6 L 212.0 107.3 L 213.3 109.2 L 214.5 111.2 L 215.8 113.3 L 217.1 115.5 L 218.4 117.8 L 219.7 120.2 L 221.0 122.7 L 222.3 125.2 L 223.6 127.8 L 224.9 130.4 L 226.2 133.1 L 227.5 135.9 L 228.8 138.6 L 230.1 141.4 L 231.3 144.2 L 232.6 147.0 L 233.9 149.8 L 235.2 152.6 L 236.5 155.4 L 237.8 158.1 L 239.1 160.8 L 240.4 163.5 L 241.7 166.1 L 243.0 168.7 L 244.3 171.2 L 245.6 173.6 L 246.9 176.0 L 248.1 178.2 L 249.4 180.4 L 250.7 182.5 L 252.0 184.5 L 253.3 186.4 L 254.6 188.2 L 255.9 189.9 L 257.2 191.5 L 258.5 192.9 L 259.8 194.3 L 261.1 195.5 L 262.4 196.5 L 263.7 197.5 L 264.9 198.3 L 266.2 199.0 L 267.5 199.6 L 268.8 200.0 L 270.1 200.3 L 271.4 200.5 L 272.7 200.5 L 274.0 200.4 L 275.3 200.2 L 276.6 199.9 L 277.9 199.4 L 279.2 198.8 L 280.4 198.1 L 281.7 197.2 L 283.0 196.3 L 284.3 195.2 L 285.6 194.1 L 286.9 192.8 L 288.2 191.5 L 289.5 190.0 L 290.8 188.5 L 292.1 186.9 L 293.4 185.2 L 294.7 183.4 L 296.0 181.6 L 297.2 179.7 L 298.5 177.8 L 299.8 175.8 L 301.1 173.8 L 302.4 171.7 L 303.7 169.6 L 305.0 167.5" clip-path="url(#prefigure-diffeq-__clipPath-1)"/>
+  <g id="prefigure-diffeq-legend" transform="translate(301.0,9.0) translate(-72.0,-0.0) scale(0.9,0.9)">
+    <rect x="0" y="0" width="79.99199999999999" height="53.36" stroke="black" fill="white" fill-opacity="0.5"/>
+    <g id="prefigure-diffeq-legend-label-0" transform="translate(39.0,5.0)">
+      <g id="prefigure-diffeq-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="30.968px" height="18.096px" role="img" focusable="false" viewBox="0 -750 1711 1000" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-7-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-2061" d=""/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="6" data-semantic-children="0,4" data-semantic-content="5,0" data-semantic-speech="x left parenthesis t right parenthesis">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="6" data-semantic-operator="appl" data-semantic-speech="x">
+                <use data-c="1D465" xlink:href="#prefigure-diffeq-MJX-7-TEX-I-1D465"/>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="5" data-semantic-parent="6" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(572,0)">
+                <use data-c="2061" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-2061"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="4" data-semantic-children="2" data-semantic-content="1,3" data-semantic-parent="6" data-semantic-speech="left parenthesis t right parenthesis" transform="translate(572,0)">
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="1" data-semantic-parent="4" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                  <use data-c="28" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-28"/>
+                </g>
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="2" data-semantic-parent="4" data-semantic-speech="t" transform="translate(389,0)">
+                  <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-7-TEX-I-1D461"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="3" data-semantic-parent="4" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(750,0)">
+                  <use data-c="29" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-29"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <line stroke="blue" x1="29" y1="14.048" x2="5" y2="14.048" stroke-width="2"/>
+    <g id="prefigure-diffeq-legend-label-1" transform="translate(39.0,30.1)">
+      <g id="prefigure-diffeq-__g-6">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="35.992px" height="18.264px" role="img" focusable="false" viewBox="0 -759 1988.5 1009" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-8-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-V-2032" d="M79 43Q73 43 52 49T30 61Q30 68 85 293T146 528Q161 560 198 560Q218 560 240 545T262 501Q262 496 260 486Q259 479 173 263T84 45T79 43Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-2061" d=""/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="8" data-semantic-children="2,6" data-semantic-content="7,0" data-semantic-speech="x prime left parenthesis t right parenthesis">
+              <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="simple function" data-semantic-id="2" data-semantic-children="0,1" data-semantic-parent="8" data-semantic-speech="x prime">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-operator="appl" data-semantic-speech="x" data-semantic-prefix="Base">
+                  <use data-c="1D465" xlink:href="#prefigure-diffeq-MJX-8-TEX-I-1D465"/>
+                </g>
+                <g data-mml-node="mo" transform="translate(605,363) scale(0.707)" data-semantic-type="punctuation" data-semantic-role="prime" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="prime" data-semantic-prefix="Exponent">
+                  <use data-c="2032" xlink:href="#prefigure-diffeq-MJX-8-TEX-V-2032"/>
+                </g>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="7" data-semantic-parent="8" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(849.5,0)">
+                <use data-c="2061" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-2061"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="6" data-semantic-children="4" data-semantic-content="3,5" data-semantic-parent="8" data-semantic-speech="left parenthesis t right parenthesis" transform="translate(849.5,0)">
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="3" data-semantic-parent="6" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                  <use data-c="28" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-28"/>
+                </g>
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="4" data-semantic-parent="6" data-semantic-speech="t" transform="translate(389,0)">
+                  <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-8-TEX-I-1D461"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="5" data-semantic-parent="6" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(750,0)">
+                  <use data-c="29" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-29"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <line stroke="red" x1="29" y1="39.228" x2="5" y2="39.228" stroke-width="2"/>
+  </g>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-diffeq-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-diffeq-11.svg
@@ -1,0 +1,204 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-diffeq-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-diffeq-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-diffeq-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+  </defs>
+  <g id="prefigure-diffeq-grid-axes">
+    <g id="prefigure-diffeq-grid" stroke="#ccc" stroke-width="1">
+      <line x1="5.0" y1="305.0" x2="5.0" y2="5.0"/>
+      <line x1="47.9" y1="305.0" x2="47.9" y2="5.0"/>
+      <line x1="90.7" y1="305.0" x2="90.7" y2="5.0"/>
+      <line x1="133.6" y1="305.0" x2="133.6" y2="5.0"/>
+      <line x1="176.4" y1="305.0" x2="176.4" y2="5.0"/>
+      <line x1="219.3" y1="305.0" x2="219.3" y2="5.0"/>
+      <line x1="262.1" y1="305.0" x2="262.1" y2="5.0"/>
+      <line x1="305.0" y1="305.0" x2="305.0" y2="5.0"/>
+      <line x1="5.0" y1="305.0" x2="305.0" y2="305.0"/>
+      <line x1="5.0" y1="255.0" x2="305.0" y2="255.0"/>
+      <line x1="5.0" y1="205.0" x2="305.0" y2="205.0"/>
+      <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+      <line x1="5.0" y1="105.0" x2="305.0" y2="105.0"/>
+      <line x1="5.0" y1="55.0" x2="305.0" y2="55.0"/>
+      <line x1="5.0" y1="5.0" x2="305.0" y2="5.0"/>
+    </g>
+    <g id="prefigure-diffeq-axes" stroke="black" stroke-width="2">
+      <line id="prefigure-diffeq-__line-15" x1="5.0" y1="155.0" x2="305.0" y2="155.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-diffeq-__line-16" x1="133.6" y1="158.0" x2="133.6" y2="152.0"/>
+        <line id="prefigure-diffeq-__line-17" x1="219.3" y1="158.0" x2="219.3" y2="152.0"/>
+      </g>
+      <line id="prefigure-diffeq-__line-18" x1="47.9" y1="305.0" x2="47.9" y2="5.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-diffeq-__line-19" x1="44.9" y1="255.0" x2="50.9" y2="255.0"/>
+        <line id="prefigure-diffeq-__line-20" x1="44.9" y1="55.0" x2="50.9" y2="55.0"/>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-0" transform="translate(301.0,151.0) translate(-6.5,-11.5)">
+      <g id="prefigure-diffeq-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="6.536px" height="11.528px" role="img" focusable="false" viewBox="0 -626 361 637" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-2-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="t">
+                <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-2-TEX-I-1D461"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-1" transform="translate(133.6,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-diffeq-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-3-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-3-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-2" transform="translate(219.3,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-diffeq-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.256px" role="img" focusable="false" viewBox="0 -677 500 677" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-4-TEX-N-34" d="M462 0Q444 3 333 3Q217 3 199 0H190V46H221Q241 46 248 46T265 48T279 53T286 61Q287 63 287 115V165H28V211L179 442Q332 674 334 675Q336 677 355 677H373L379 671V211H471V165H379V114Q379 73 379 66T385 54Q393 47 442 46H471V0H462ZM293 211V545L74 212L183 211H293Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="4">
+                <use data-c="34" xlink:href="#prefigure-diffeq-MJX-4-TEX-N-34"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-3" transform="translate(36.9,255.0) translate(-15.1,-6.0)">
+      <g id="prefigure-diffeq-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-5-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-diffeq-MJX-5-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-diffeq-MJX-5-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-5-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-diffeq-__label-4" transform="translate(36.9,55.0) translate(-9.0,-6.0)">
+      <g id="prefigure-diffeq-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-6-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-diffeq-MJX-6-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <path id="prefigure-diffeq-x" stroke="blue" stroke-width="2" fill="none" d="M 47.9 155.0 L 49.1 152.0 L 50.4 149.0 L 51.7 146.1 L 53.0 143.2 L 54.3 140.4 L 55.6 137.7 L 56.9 135.0 L 58.2 132.4 L 59.5 129.9 L 60.8 127.5 L 62.1 125.2 L 63.4 123.0 L 64.7 120.9 L 65.9 118.9 L 67.2 117.1 L 68.5 115.4 L 69.8 113.8 L 71.1 112.3 L 72.4 110.9 L 73.7 109.7 L 75.0 108.7 L 76.3 107.8 L 77.6 107.0 L 78.9 106.4 L 80.2 105.9 L 81.5 105.5 L 82.7 105.3 L 84.0 105.3 L 85.3 105.4 L 86.6 105.6 L 87.9 106.0 L 89.2 106.4 L 90.5 107.1 L 91.8 107.8 L 93.1 108.7 L 94.4 109.7 L 95.7 110.9 L 97.0 112.1 L 98.3 113.5 L 99.5 114.9 L 100.8 116.5 L 102.1 118.2 L 103.4 119.9 L 104.7 121.8 L 106.0 123.7 L 107.3 125.7 L 108.6 127.7 L 109.9 129.8 L 111.2 132.0 L 112.5 134.2 L 113.8 136.5 L 115.1 138.7 L 116.3 141.0 L 117.6 143.4 L 118.9 145.7 L 120.2 148.0 L 121.5 150.4 L 122.8 152.7 L 124.1 155.0 L 125.4 157.3 L 126.7 159.6 L 128.0 161.8 L 129.3 164.0 L 130.6 166.2 L 131.8 168.3 L 133.1 170.3 L 134.4 172.3 L 135.7 174.2 L 137.0 176.1 L 138.3 177.8 L 139.6 179.5 L 140.9 181.1 L 142.2 182.6 L 143.5 184.0 L 144.8 185.4 L 146.1 186.6 L 147.4 187.7 L 148.6 188.7 L 149.9 189.7 L 151.2 190.5 L 152.5 191.2 L 153.8 191.8 L 155.1 192.2 L 156.4 192.6 L 157.7 192.9 L 159.0 193.0 L 160.3 193.1 L 161.6 193.0 L 162.9 192.8 L 164.2 192.6 L 165.4 192.2 L 166.7 191.7 L 168.0 191.1 L 169.3 190.4 L 170.6 189.6 L 171.9 188.8 L 173.2 187.8 L 174.5 186.8 L 175.8 185.6 L 177.1 184.4 L 178.4 183.2 L 179.7 181.8 L 181.0 180.4 L 182.2 178.9 L 183.5 177.4 L 184.8 175.9 L 186.1 174.2 L 187.4 172.6 L 188.7 170.9 L 190.0 169.2 L 191.3 167.4 L 192.6 165.7 L 193.9 163.9 L 195.2 162.1 L 196.5 160.3 L 197.7 158.5 L 199.0 156.7 L 200.3 155.0 L 201.6 153.2 L 202.9 151.5 L 204.2 149.7 L 205.5 148.1 L 206.8 146.4 L 208.1 144.8 L 209.4 143.2 L 210.7 141.7 L 212.0 140.3 L 213.3 138.9 L 214.5 137.5 L 215.8 136.2 L 217.1 135.0 L 218.4 133.8 L 219.7 132.8 L 221.0 131.7 L 222.3 130.8 L 223.6 129.9 L 224.9 129.2 L 226.2 128.5 L 227.5 127.8 L 228.8 127.3 L 230.1 126.9 L 231.3 126.5 L 232.6 126.2 L 233.9 126.0 L 235.2 125.9 L 236.5 125.9 L 237.8 125.9 L 239.1 126.0 L 240.4 126.3 L 241.7 126.6 L 243.0 126.9 L 244.3 127.4 L 245.6 127.9 L 246.9 128.5 L 248.1 129.2 L 249.4 129.9 L 250.7 130.7 L 252.0 131.6 L 253.3 132.5 L 254.6 133.5 L 255.9 134.5 L 257.2 135.6 L 258.5 136.7 L 259.8 137.9 L 261.1 139.1 L 262.4 140.3 L 263.7 141.6 L 264.9 142.9 L 266.2 144.2 L 267.5 145.5 L 268.8 146.9 L 270.1 148.2 L 271.4 149.6 L 272.7 151.0 L 274.0 152.3 L 275.3 153.7 L 276.6 155.1 L 277.9 156.4 L 279.2 157.7 L 280.4 159.0 L 281.7 160.3 L 283.0 161.6 L 284.3 162.8 L 285.6 164.0 L 286.9 165.2 L 288.2 166.3 L 289.5 167.4 L 290.8 168.4 L 292.1 169.4 L 293.4 170.3 L 294.7 171.2 L 296.0 172.0 L 297.2 172.8 L 298.5 173.5 L 299.8 174.2 L 301.1 174.8 L 302.4 175.3 L 303.7 175.8 L 305.0 176.2" clip-path="url(#prefigure-diffeq-__clipPath-1)"/>
+  <path id="prefigure-diffeq-xprime" stroke="red" stroke-width="2" fill="none" d="M 47.9 55.0 L 49.1 56.0 L 50.4 57.4 L 51.7 58.9 L 53.0 60.8 L 54.3 62.9 L 55.6 65.2 L 56.9 67.8 L 58.2 70.6 L 59.5 73.6 L 60.8 76.8 L 62.1 80.2 L 63.4 83.8 L 64.7 87.5 L 65.9 91.4 L 67.2 95.5 L 68.5 99.7 L 69.8 104.0 L 71.1 108.4 L 72.4 112.9 L 73.7 117.5 L 75.0 122.2 L 76.3 126.9 L 77.6 131.6 L 78.9 136.4 L 80.2 141.2 L 81.5 146.0 L 82.7 150.7 L 84.0 155.4 L 85.3 160.1 L 86.6 164.8 L 87.9 169.3 L 89.2 173.8 L 90.5 178.2 L 91.8 182.5 L 93.1 186.6 L 94.4 190.7 L 95.7 194.5 L 97.0 198.3 L 98.3 201.9 L 99.5 205.3 L 100.8 208.6 L 102.1 211.6 L 103.4 214.5 L 104.7 217.2 L 106.0 219.7 L 107.3 221.9 L 108.6 224.0 L 109.9 225.8 L 111.2 227.5 L 112.5 228.9 L 113.8 230.1 L 115.1 231.1 L 116.3 231.8 L 117.6 232.3 L 118.9 232.6 L 120.2 232.7 L 121.5 232.5 L 122.8 232.2 L 124.1 231.6 L 125.4 230.8 L 126.7 229.8 L 128.0 228.5 L 129.3 227.1 L 130.6 225.5 L 131.8 223.7 L 133.1 221.7 L 134.4 219.6 L 135.7 217.3 L 137.0 214.8 L 138.3 212.2 L 139.6 209.5 L 140.9 206.6 L 142.2 203.6 L 143.5 200.5 L 144.8 197.3 L 146.1 194.0 L 147.4 190.6 L 148.6 187.1 L 149.9 183.6 L 151.2 180.1 L 152.5 176.5 L 153.8 172.8 L 155.1 169.2 L 156.4 165.5 L 157.7 161.9 L 159.0 158.2 L 160.3 154.6 L 161.6 151.0 L 162.9 147.5 L 164.2 144.0 L 165.4 140.6 L 166.7 137.2 L 168.0 133.9 L 169.3 130.7 L 170.6 127.7 L 171.9 124.7 L 173.2 121.8 L 174.5 119.1 L 175.8 116.5 L 177.1 114.0 L 178.4 111.6 L 179.7 109.4 L 181.0 107.4 L 182.2 105.5 L 183.5 103.7 L 184.8 102.2 L 186.1 100.7 L 187.4 99.5 L 188.7 98.4 L 190.0 97.5 L 191.3 96.8 L 192.6 96.2 L 193.9 95.8 L 195.2 95.6 L 196.5 95.5 L 197.7 95.7 L 199.0 96.0 L 200.3 96.4 L 201.6 97.0 L 202.9 97.8 L 204.2 98.7 L 205.5 99.8 L 206.8 101.0 L 208.1 102.4 L 209.4 103.9 L 210.7 105.6 L 212.0 107.3 L 213.3 109.2 L 214.5 111.2 L 215.8 113.3 L 217.1 115.5 L 218.4 117.8 L 219.7 120.2 L 221.0 122.7 L 222.3 125.2 L 223.6 127.8 L 224.9 130.4 L 226.2 133.1 L 227.5 135.9 L 228.8 138.6 L 230.1 141.4 L 231.3 144.2 L 232.6 147.0 L 233.9 149.8 L 235.2 152.6 L 236.5 155.4 L 237.8 158.1 L 239.1 160.8 L 240.4 163.5 L 241.7 166.1 L 243.0 168.7 L 244.3 171.2 L 245.6 173.6 L 246.9 176.0 L 248.1 178.2 L 249.4 180.4 L 250.7 182.5 L 252.0 184.5 L 253.3 186.4 L 254.6 188.2 L 255.9 189.9 L 257.2 191.5 L 258.5 192.9 L 259.8 194.3 L 261.1 195.5 L 262.4 196.5 L 263.7 197.5 L 264.9 198.3 L 266.2 199.0 L 267.5 199.6 L 268.8 200.0 L 270.1 200.3 L 271.4 200.5 L 272.7 200.5 L 274.0 200.4 L 275.3 200.2 L 276.6 199.9 L 277.9 199.4 L 279.2 198.8 L 280.4 198.1 L 281.7 197.2 L 283.0 196.3 L 284.3 195.2 L 285.6 194.1 L 286.9 192.8 L 288.2 191.5 L 289.5 190.0 L 290.8 188.5 L 292.1 186.9 L 293.4 185.2 L 294.7 183.4 L 296.0 181.6 L 297.2 179.7 L 298.5 177.8 L 299.8 175.8 L 301.1 173.8 L 302.4 171.7 L 303.7 169.6 L 305.0 167.5" clip-path="url(#prefigure-diffeq-__clipPath-1)"/>
+  <g id="prefigure-diffeq-legend" transform="translate(301.0,9.0) translate(-72.0,-0.0) scale(0.9,0.9)">
+    <rect x="0" y="0" width="79.99199999999999" height="53.36" stroke="black" fill="white" fill-opacity="0.5"/>
+    <g id="prefigure-diffeq-legend-label-0" transform="translate(39.0,5.0)">
+      <g id="prefigure-diffeq-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="30.968px" height="18.096px" role="img" focusable="false" viewBox="0 -750 1711 1000" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-7-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-2061" d=""/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+            <path id="prefigure-diffeq-MJX-7-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="6" data-semantic-children="0,4" data-semantic-content="5,0" data-semantic-speech="x left parenthesis t right parenthesis">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="6" data-semantic-operator="appl" data-semantic-speech="x">
+                <use data-c="1D465" xlink:href="#prefigure-diffeq-MJX-7-TEX-I-1D465"/>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="5" data-semantic-parent="6" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(572,0)">
+                <use data-c="2061" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-2061"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="4" data-semantic-children="2" data-semantic-content="1,3" data-semantic-parent="6" data-semantic-speech="left parenthesis t right parenthesis" transform="translate(572,0)">
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="1" data-semantic-parent="4" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                  <use data-c="28" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-28"/>
+                </g>
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="2" data-semantic-parent="4" data-semantic-speech="t" transform="translate(389,0)">
+                  <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-7-TEX-I-1D461"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="3" data-semantic-parent="4" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(750,0)">
+                  <use data-c="29" xlink:href="#prefigure-diffeq-MJX-7-TEX-N-29"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <line stroke="blue" x1="29" y1="14.048" x2="5" y2="14.048" stroke-width="2"/>
+    <g id="prefigure-diffeq-legend-label-1" transform="translate(39.0,30.1)">
+      <g id="prefigure-diffeq-__g-6">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="35.992px" height="18.264px" role="img" focusable="false" viewBox="0 -759 1988.5 1009" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-diffeq-MJX-8-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-V-2032" d="M79 43Q73 43 52 49T30 61Q30 68 85 293T146 528Q161 560 198 560Q218 560 240 545T262 501Q262 496 260 486Q259 479 173 263T84 45T79 43Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-2061" d=""/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-I-1D461" d="M26 385Q19 392 19 395Q19 399 22 411T27 425Q29 430 36 430T87 431H140L159 511Q162 522 166 540T173 566T179 586T187 603T197 615T211 624T229 626Q247 625 254 615T261 596Q261 589 252 549T232 470L222 433Q222 431 272 431H323Q330 424 330 420Q330 398 317 385H210L174 240Q135 80 135 68Q135 26 162 26Q197 26 230 60T283 144Q285 150 288 151T303 153H307Q322 153 322 145Q322 142 319 133Q314 117 301 95T267 48T216 6T155 -11Q125 -11 98 4T59 56Q57 64 57 83V101L92 241Q127 382 128 383Q128 385 77 385H26Z"/>
+            <path id="prefigure-diffeq-MJX-8-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="8" data-semantic-children="2,6" data-semantic-content="7,0" data-semantic-speech="x prime left parenthesis t right parenthesis">
+              <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="simple function" data-semantic-id="2" data-semantic-children="0,1" data-semantic-parent="8" data-semantic-speech="x prime">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-operator="appl" data-semantic-speech="x" data-semantic-prefix="Base">
+                  <use data-c="1D465" xlink:href="#prefigure-diffeq-MJX-8-TEX-I-1D465"/>
+                </g>
+                <g data-mml-node="mo" transform="translate(605,363) scale(0.707)" data-semantic-type="punctuation" data-semantic-role="prime" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="prime" data-semantic-prefix="Exponent">
+                  <use data-c="2032" xlink:href="#prefigure-diffeq-MJX-8-TEX-V-2032"/>
+                </g>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="7" data-semantic-parent="8" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(849.5,0)">
+                <use data-c="2061" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-2061"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="6" data-semantic-children="4" data-semantic-content="3,5" data-semantic-parent="8" data-semantic-speech="left parenthesis t right parenthesis" transform="translate(849.5,0)">
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="3" data-semantic-parent="6" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                  <use data-c="28" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-28"/>
+                </g>
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="4" data-semantic-parent="6" data-semantic-speech="t" transform="translate(389,0)">
+                  <use data-c="1D461" xlink:href="#prefigure-diffeq-MJX-8-TEX-I-1D461"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="5" data-semantic-parent="6" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(750,0)">
+                  <use data-c="29" xlink:href="#prefigure-diffeq-MJX-8-TEX-N-29"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <line stroke="red" x1="29" y1="39.228" x2="5" y2="39.228" stroke-width="2"/>
+  </g>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-fibonacci-a-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-fibonacci-a-11.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-fibonacci-a-figure" width="200" height="200" viewBox="0 0 200 200">
+  <defs>
+    <clipPath id="prefigure-fibonacci-a-__clipPath-0">
+      <rect x="0.0" y="0.0" width="200.0" height="200.0"/>
+    </clipPath>
+    <clipPath id="prefigure-fibonacci-a-__clipPath-1">
+      <rect x="0.0" y="0.0" width="200.0" height="200.0"/>
+    </clipPath>
+    <marker id="prefigure-fibonacci-a-arrow-head-end-2_None_24_60-black" markerWidth="9.0" markerHeight="8.0" markerUnits="userSpaceOnUse" orient="auto" refX="6.5" refY="4.0">
+      <path d="M 9.0 4.0L 0.0 8.0L 1.7 5.0L 1.7 3.0L 0.0 0.0Z" fill="black" stroke="none"/>
+    </marker>
+    <marker id="prefigure-fibonacci-a-arrow-head-end-2_None_24_60-black-outline" markerWidth="13.0" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="8.5" refY="6.0">
+      <path d="M 11.8 7.8 L 2.8 11.8 A 2 2 0 0 1 0.0 10.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 11.8 4.2 A 2 2 0 0 1 11.8 7.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-fibonacci-a-arrow-head-start-2_None_24_60-black" markerWidth="9.0" markerHeight="8.0" markerUnits="userSpaceOnUse" orient="auto" refX="2.5" refY="4.0">
+      <g transform="rotate(180, 4.5, 4.0)">
+        <path d="M 9.0 4.0L 0.0 8.0L 1.7 5.0L 1.7 3.0L 0.0 0.0Z" fill="black" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-fibonacci-a-arrow-head-start-2_None_24_60-black-outline" markerWidth="13.0" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="4.5" refY="6.0">
+      <g transform="rotate(180, 6.5, 6.0)">
+        <path d="M 11.8 7.8 L 2.8 11.8 A 2 2 0 0 1 0.0 10.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 11.8 4.2 A 2 2 0 0 1 11.8 7.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="prefigure-fibonacci-a-top-L">
+    <path id="prefigure-fibonacci-a-__path-0" d="M 25.0 66.7 L 105.9 66.7 L 105.9 50.0 L 25.0 50.0 Z" stroke="black" stroke-width="2" fill="blue"/>
+    <g id="prefigure-fibonacci-a-__label-0" transform="translate(65.5,46.0) translate(-6.2,-12.4)">
+      <g id="prefigure-fibonacci-a-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="12.328px" height="12.360px" role="img" focusable="false" viewBox="0 -683 681 683" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-a-MJX-2-TEX-I-1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper L">
+                <use data-c="1D43F" xlink:href="#prefigure-fibonacci-a-MJX-2-TEX-I-1D43F"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <g id="prefigure-fibonacci-a-top-S">
+    <path id="prefigure-fibonacci-a-__path-1" d="M 125.0 66.7 L 175.0 66.7 L 175.0 50.0 L 125.0 50.0 Z" stroke="black" stroke-width="2" fill="red"/>
+    <g id="prefigure-fibonacci-a-__label-1" transform="translate(150.0,46.0) translate(-5.8,-13.2)">
+      <g id="prefigure-fibonacci-a-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.400px" width="11.672px" height="13.160px" role="img" focusable="false" viewBox="0 -705 645 727" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-a-MJX-3-TEX-I-1D446" d="M308 24Q367 24 416 76T466 197Q466 260 414 284Q308 311 278 321T236 341Q176 383 176 462Q176 523 208 573T273 648Q302 673 343 688T407 704H418H425Q521 704 564 640Q565 640 577 653T603 682T623 704Q624 704 627 704T632 705Q645 705 645 698T617 577T585 459T569 456Q549 456 549 465Q549 471 550 475Q550 478 551 494T553 520Q553 554 544 579T526 616T501 641Q465 662 419 662Q362 662 313 616T263 510Q263 480 278 458T319 427Q323 425 389 408T456 390Q490 379 522 342T554 242Q554 216 546 186Q541 164 528 137T492 78T426 18T332 -20Q320 -22 298 -22Q199 -22 144 33L134 44L106 13Q83 -14 78 -18T65 -22Q52 -22 52 -14Q52 -11 110 221Q112 227 130 227H143Q149 221 149 216Q149 214 148 207T144 186T142 153Q144 114 160 87T203 47T255 29T308 24Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper S">
+                <use data-c="1D446" xlink:href="#prefigure-fibonacci-a-MJX-3-TEX-I-1D446"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <g id="prefigure-fibonacci-a-bottom-L">
+    <g id="prefigure-fibonacci-a-bottom-LL">
+      <path id="prefigure-fibonacci-a-__path-2" d="M 25.0 133.3 L 75.0 133.3 L 75.0 116.7 L 25.0 116.7 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <g id="prefigure-fibonacci-a-__label-2" transform="translate(50.0,137.3) translate(-6.2,-0.0)">
+        <g id="prefigure-fibonacci-a-__g-2">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="12.328px" height="12.360px" role="img" focusable="false" viewBox="0 -683 681 683" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-fibonacci-a-MJX-4-TEX-I-1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper L">
+                  <use data-c="1D43F" xlink:href="#prefigure-fibonacci-a-MJX-4-TEX-I-1D43F"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-a-bottom-LS">
+      <path id="prefigure-fibonacci-a-__path-3" d="M 75.0 133.3 L 105.9 133.3 L 105.9 116.7 L 75.0 116.7 Z" stroke="black" stroke-width="2" fill="red"/>
+      <g id="prefigure-fibonacci-a-__label-3" transform="translate(90.5,137.3) translate(-5.8,-0.0)">
+        <g id="prefigure-fibonacci-a-__g-3">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.400px" width="11.672px" height="13.160px" role="img" focusable="false" viewBox="0 -705 645 727" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-fibonacci-a-MJX-5-TEX-I-1D446" d="M308 24Q367 24 416 76T466 197Q466 260 414 284Q308 311 278 321T236 341Q176 383 176 462Q176 523 208 573T273 648Q302 673 343 688T407 704H418H425Q521 704 564 640Q565 640 577 653T603 682T623 704Q624 704 627 704T632 705Q645 705 645 698T617 577T585 459T569 456Q549 456 549 465Q549 471 550 475Q550 478 551 494T553 520Q553 554 544 579T526 616T501 641Q465 662 419 662Q362 662 313 616T263 510Q263 480 278 458T319 427Q323 425 389 408T456 390Q490 379 522 342T554 242Q554 216 546 186Q541 164 528 137T492 78T426 18T332 -20Q320 -22 298 -22Q199 -22 144 33L134 44L106 13Q83 -14 78 -18T65 -22Q52 -22 52 -14Q52 -11 110 221Q112 227 130 227H143Q149 221 149 216Q149 214 148 207T144 186T142 153Q144 114 160 87T203 47T255 29T308 24Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper S">
+                  <use data-c="1D446" xlink:href="#prefigure-fibonacci-a-MJX-5-TEX-I-1D446"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g id="prefigure-fibonacci-a-bottom-S">
+    <g id="prefigure-fibonacci-a-bottom-SL">
+      <path id="prefigure-fibonacci-a-__path-4" d="M 125.0 133.3 L 175.0 133.3 L 175.0 116.7 L 125.0 116.7 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <g id="prefigure-fibonacci-a-__label-4" transform="translate(150.0,137.3) translate(-6.2,-0.0)">
+        <g id="prefigure-fibonacci-a-__g-4">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="12.328px" height="12.360px" role="img" focusable="false" viewBox="0 -683 681 683" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-fibonacci-a-MJX-6-TEX-I-1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper L">
+                  <use data-c="1D43F" xlink:href="#prefigure-fibonacci-a-MJX-6-TEX-I-1D43F"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+    </g>
+  </g>
+  <line id="prefigure-fibonacci-a-left-arrow" x1="65.5" y1="69.7" x2="65.5" y2="109.3" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-a-arrow-head-end-2_None_24_60-black)"/>
+  <line id="prefigure-fibonacci-a-right-arrow" x1="150.0" y1="69.7" x2="150.0" y2="109.3" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-a-arrow-head-end-2_None_24_60-black)"/>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-fibonacci-b-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-fibonacci-b-11.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-fibonacci-b-figure" width="360" height="200" viewBox="0 0 360 200">
+  <defs>
+    <clipPath id="prefigure-fibonacci-b-__clipPath-0">
+      <rect x="30.0" y="0.0" width="300.0" height="200.0"/>
+    </clipPath>
+    <clipPath id="prefigure-fibonacci-b-__clipPath-1">
+      <rect x="30.0" y="0.0" width="300.0" height="200.0"/>
+    </clipPath>
+    <marker id="prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black" markerWidth="9.0" markerHeight="8.0" markerUnits="userSpaceOnUse" orient="auto" refX="6.5" refY="4.0">
+      <path d="M 9.0 4.0L 0.0 8.0L 1.7 5.0L 1.7 3.0L 0.0 0.0Z" fill="black" stroke="none"/>
+    </marker>
+    <marker id="prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black-outline" markerWidth="13.0" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="8.5" refY="6.0">
+      <path d="M 11.8 7.8 L 2.8 11.8 A 2 2 0 0 1 0.0 10.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 11.8 4.2 A 2 2 0 0 1 11.8 7.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-fibonacci-b-arrow-head-start-2_None_24_60-black" markerWidth="9.0" markerHeight="8.0" markerUnits="userSpaceOnUse" orient="auto" refX="2.5" refY="4.0">
+      <g transform="rotate(180, 4.5, 4.0)">
+        <path d="M 9.0 4.0L 0.0 8.0L 1.7 5.0L 1.7 3.0L 0.0 0.0Z" fill="black" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-fibonacci-b-arrow-head-start-2_None_24_60-black-outline" markerWidth="13.0" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="4.5" refY="6.0">
+      <g transform="rotate(180, 6.5, 6.0)">
+        <path d="M 11.8 7.8 L 2.8 11.8 A 2 2 0 0 1 0.0 10.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 11.8 4.2 A 2 2 0 0 1 11.8 7.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="prefigure-fibonacci-b-__group-0">
+    <g id="prefigure-fibonacci-b-left-dots-row_0" transform="translate(26.0,168.8) translate(-21.2,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-2-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-2-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-b-tiling-row_0">
+      <path id="prefigure-fibonacci-b-tile-row_0-type_0" d="M 30.0 175.0 L 57.1 175.0 L 57.1 162.5 L 30.0 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_1" d="M 57.1 175.0 L 73.8 175.0 L 73.8 162.5 L 57.1 162.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_2" d="M 73.8 175.0 L 100.8 175.0 L 100.8 162.5 L 73.8 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_3" d="M 100.8 175.0 L 127.9 175.0 L 127.9 162.5 L 100.8 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_4" d="M 127.9 175.0 L 144.6 175.0 L 144.6 162.5 L 127.9 162.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_5" d="M 144.6 175.0 L 171.6 175.0 L 171.6 162.5 L 144.6 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_6" d="M 171.6 175.0 L 188.4 175.0 L 188.4 162.5 L 171.6 162.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_7" d="M 188.4 175.0 L 215.4 175.0 L 215.4 162.5 L 188.4 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_8" d="M 215.4 175.0 L 242.5 175.0 L 242.5 162.5 L 215.4 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_9" d="M 242.5 175.0 L 259.2 175.0 L 259.2 162.5 L 242.5 162.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_10" d="M 259.2 175.0 L 286.2 175.0 L 286.2 162.5 L 259.2 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_11" d="M 286.2 175.0 L 313.3 175.0 L 313.3 162.5 L 286.2 162.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_0-type_12" d="M 313.3 175.0 L 330.0 175.0 L 330.0 162.5 L 313.3 162.5 Z" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-fibonacci-b-right-dots-row_0" transform="translate(334.0,168.8) translate(0.0,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-3-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-3-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-b-left-dots-row_1" transform="translate(26.0,118.8) translate(-21.2,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-4-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-4-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-b-tiling-row_1">
+      <path id="prefigure-fibonacci-b-tile-row_1-type_0" d="M 30.0 125.0 L 73.8 125.0 L 73.8 112.5 L 30.0 112.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_1" d="M 73.8 125.0 L 100.8 125.0 L 100.8 112.5 L 73.8 112.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_2" d="M 100.8 125.0 L 144.6 125.0 L 144.6 112.5 L 100.8 112.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_3" d="M 144.6 125.0 L 188.4 125.0 L 188.4 112.5 L 144.6 112.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_4" d="M 188.4 125.0 L 215.4 125.0 L 215.4 112.5 L 188.4 112.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_5" d="M 215.4 125.0 L 259.2 125.0 L 259.2 112.5 L 215.4 112.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_6" d="M 259.2 125.0 L 286.2 125.0 L 286.2 112.5 L 259.2 112.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_1-type_7" d="M 286.2 125.0 L 330.0 125.0 L 330.0 112.5 L 286.2 112.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+    </g>
+    <g id="prefigure-fibonacci-b-right-dots-row_1" transform="translate(334.0,118.8) translate(0.0,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-5-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-5-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-b-left-dots-row_2" transform="translate(26.0,68.8) translate(-21.2,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-6-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-6-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-fibonacci-b-tiling-row_2">
+      <path id="prefigure-fibonacci-b-tile-row_2-type_0" d="M 30.0 75.0 L 100.8 75.0 L 100.8 62.5 L 30.0 62.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_2-type_1" d="M 100.8 75.0 L 144.6 75.0 L 144.6 62.5 L 100.8 62.5 Z" stroke="black" stroke-width="2" fill="red"/>
+      <path id="prefigure-fibonacci-b-tile-row_2-type_2" d="M 144.6 75.0 L 215.4 75.0 L 215.4 62.5 L 144.6 62.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_2-type_3" d="M 215.4 75.0 L 286.2 75.0 L 286.2 62.5 L 215.4 62.5 Z" stroke="black" stroke-width="2" fill="blue"/>
+      <path id="prefigure-fibonacci-b-tile-row_2-type_4" d="M 286.2 75.0 L 330.0 75.0 L 330.0 62.5 L 286.2 62.5 Z" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-fibonacci-b-right-dots-row_2" transform="translate(334.0,68.8) translate(0.0,-1.1)">
+      <g id="prefigure-fibonacci-b-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="21.216px" height="2.168px" role="img" focusable="false" viewBox="0 -120 1172 120" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-fibonacci-b-MJX-7-TEX-N-2026" d="M78 60Q78 84 95 102T138 120Q162 120 180 104T199 61Q199 36 182 18T139 0T96 17T78 60ZM525 60Q525 84 542 102T585 120Q609 120 627 104T646 61Q646 36 629 18T586 0T543 17T525 60ZM972 60Q972 84 989 102T1032 120Q1056 120 1074 104T1093 61Q1093 36 1076 18T1033 0T990 17T972 60Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="ellipsis" data-semantic-id="0" data-semantic-speech="ellipsis">
+                <use data-c="2026" xlink:href="#prefigure-fibonacci-b-MJX-7-TEX-N-2026"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <g id="prefigure-fibonacci-b-down-arrows">
+    <line id="prefigure-fibonacci-b-down-arrow-row_0" x1="180.0" y1="128.0" x2="180.0" y2="155.1" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+    <line id="prefigure-fibonacci-b-down-arrow-row_1" x1="180.0" y1="78.0" x2="180.0" y2="105.1" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+    <line id="prefigure-fibonacci-b-down-arrow-row_2" x1="180.0" y1="28.0" x2="180.0" y2="55.1" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+  </g>
+  <g id="prefigure-fibonacci-b-right-arrows">
+    <line id="prefigure-fibonacci-b-right-arrow-row_0" x1="280.8" y1="182.5" x2="311.8" y2="182.5" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+    <line id="prefigure-fibonacci-b-right-arrow-row_1" x1="280.8" y1="132.5" x2="311.8" y2="132.5" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+    <line id="prefigure-fibonacci-b-right-arrow-row_2" x1="280.8" y1="82.5" x2="311.8" y2="82.5" stroke="black" stroke-width="2" fill="none" marker-end="url(#prefigure-fibonacci-b-arrow-head-end-2_None_24_60-black)"/>
+  </g>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-projection-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-projection-11.svg
@@ -1,0 +1,267 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-projection-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-projection-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-projection-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-h777" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="9.8" refY="6.0">
+      <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="#777" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-h777-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="11.8" refY="8.0">
+      <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-black" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="9.8" refY="6.0">
+      <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="black" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-black-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="11.8" refY="8.0">
+      <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-red" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="9.8" refY="6.0">
+      <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="red" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-end-3_None_24_60-red-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="11.8" refY="8.0">
+      <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-h777" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="3.6999999999999993" refY="6.0">
+      <g transform="rotate(180, 6.75, 6.0)">
+        <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="#777" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-h777-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="5.699999999999999" refY="8.0">
+      <g transform="rotate(180, 8.75, 8.0)">
+        <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-black" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="3.6999999999999993" refY="6.0">
+      <g transform="rotate(180, 6.75, 6.0)">
+        <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="black" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-black-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="5.699999999999999" refY="8.0">
+      <g transform="rotate(180, 8.75, 8.0)">
+        <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-red" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="3.6999999999999993" refY="6.0">
+      <g transform="rotate(180, 6.75, 6.0)">
+        <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="red" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-projection-arrow-head-start-3_None_24_60-red-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="5.699999999999999" refY="8.0">
+      <g transform="rotate(180, 8.75, 8.0)">
+        <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="prefigure-projection-grid-axes">
+    <g id="prefigure-projection-grid" stroke="#ccc" stroke-width="1">
+      <line x1="5.0" y1="305.0" x2="5.0" y2="5.0"/>
+      <line x1="55.0" y1="305.0" x2="55.0" y2="5.0"/>
+      <line x1="105.0" y1="305.0" x2="105.0" y2="5.0"/>
+      <line x1="155.0" y1="305.0" x2="155.0" y2="5.0"/>
+      <line x1="205.0" y1="305.0" x2="205.0" y2="5.0"/>
+      <line x1="255.0" y1="305.0" x2="255.0" y2="5.0"/>
+      <line x1="305.0" y1="305.0" x2="305.0" y2="5.0"/>
+      <line x1="5.0" y1="305.0" x2="305.0" y2="305.0"/>
+      <line x1="5.0" y1="255.0" x2="305.0" y2="255.0"/>
+      <line x1="5.0" y1="205.0" x2="305.0" y2="205.0"/>
+      <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+      <line x1="5.0" y1="105.0" x2="305.0" y2="105.0"/>
+      <line x1="5.0" y1="55.0" x2="305.0" y2="55.0"/>
+      <line x1="5.0" y1="5.0" x2="305.0" y2="5.0"/>
+    </g>
+    <g id="prefigure-projection-axes" stroke="black" stroke-width="2">
+      <line id="prefigure-projection-__line-14" x1="5.0" y1="255.0" x2="305.0" y2="255.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-projection-__line-15" x1="155.0" y1="258.0" x2="155.0" y2="252.0"/>
+        <line id="prefigure-projection-__line-16" x1="255.0" y1="258.0" x2="255.0" y2="252.0"/>
+      </g>
+      <line id="prefigure-projection-__line-17" x1="55.0" y1="305.0" x2="55.0" y2="5.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-projection-__line-18" x1="52.0" y1="155.0" x2="58.0" y2="155.0"/>
+        <line id="prefigure-projection-__line-19" x1="52.0" y1="55.0" x2="58.0" y2="55.0"/>
+      </g>
+    </g>
+    <g id="prefigure-projection-__label-0" transform="translate(155.0,266.0) translate(-4.5,-0.0)">
+      <g id="prefigure-projection-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-projection-MJX-2-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-projection-MJX-2-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-projection-__label-1" transform="translate(255.0,266.0) translate(-4.5,-0.0)">
+      <g id="prefigure-projection-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.256px" role="img" focusable="false" viewBox="0 -677 500 677" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-projection-MJX-3-TEX-N-34" d="M462 0Q444 3 333 3Q217 3 199 0H190V46H221Q241 46 248 46T265 48T279 53T286 61Q287 63 287 115V165H28V211L179 442Q332 674 334 675Q336 677 355 677H373L379 671V211H471V165H379V114Q379 73 379 66T385 54Q393 47 442 46H471V0H462ZM293 211V545L74 212L183 211H293Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="4">
+                <use data-c="34" xlink:href="#prefigure-projection-MJX-3-TEX-N-34"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-projection-__label-2" transform="translate(44.0,155.0) translate(-9.0,-6.0)">
+      <g id="prefigure-projection-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-projection-MJX-4-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-projection-MJX-4-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-projection-__label-3" transform="translate(44.0,55.0) translate(-9.0,-6.1)">
+      <g id="prefigure-projection-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.256px" role="img" focusable="false" viewBox="0 -677 500 677" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-projection-MJX-5-TEX-N-34" d="M462 0Q444 3 333 3Q217 3 199 0H190V46H221Q241 46 248 46T265 48T279 53T286 61Q287 63 287 115V165H28V211L179 442Q332 674 334 675Q336 677 355 677H373L379 671V211H471V165H379V114Q379 73 379 66T385 54Q393 47 442 46H471V0H462ZM293 211V545L74 212L183 211H293Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="4">
+                <use data-c="34" xlink:href="#prefigure-projection-MJX-5-TEX-N-34"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <line id="prefigure-projection-__line-20" x1="5.0" y1="280.0" x2="305.0" y2="130.0" stroke="blue" stroke-width="2" fill="none"/>
+  <g id="prefigure-projection-__label-4" transform="translate(275.0,130.0) translate(-6.2,-6.2)">
+    <g id="prefigure-projection-__g-4">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="12.328px" height="12.360px" role="img" focusable="false" viewBox="0 -683 681 683" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-projection-MJX-6-TEX-I-1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="upper L">
+              <use data-c="1D43F" xlink:href="#prefigure-projection-MJX-6-TEX-I-1D43F"/>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <path id="prefigure-projection-__path-0" stroke="#777" stroke-width="3" fill="none" marker-end="url(#prefigure-projection-arrow-head-end-3_None_24_60-h777)" d="M 215.0 175.0 L 156.6 58.3"/>
+  <g id="prefigure-projection-__label-5" transform="translate(189.0,111.0) translate(0.0,-15.2)">
+    <g id="prefigure-projection-__g-5">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.112px" width="23.024px" height="15.232px" role="img" focusable="false" viewBox="0 -835.3 1272.1 841.3" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-projection-MJX-7-TEX-B-1D41B" d="M32 686L123 690Q214 694 215 694H221V409Q289 450 378 450Q479 450 539 387T600 221Q600 122 535 58T358 -6H355Q272 -6 203 53L160 1L129 0H98V301Q98 362 98 435T99 525Q99 591 97 604T83 620Q69 624 42 624H29V686H32ZM227 105L232 99Q237 93 242 87T258 73T280 59T306 49T339 45Q380 45 411 66T451 131Q457 160 457 230Q457 264 456 284T448 329T430 367T396 389T343 398Q282 398 235 355L227 348V105Z"/>
+          <path id="prefigure-projection-MJX-7-TEX-N-22A5" d="M369 652Q369 653 370 655T372 658T375 662T379 665T384 667T391 668Q402 666 409 653V40H708Q723 32 723 20T708 0H71Q70 0 67 2T59 9T55 20T59 31T66 38T71 40H369V652Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="latinletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-speech="bold b Superscript up tack">
+              <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="bold" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-attributes="texclass:ORD" data-semantic-speech="bold b" data-semantic-prefix="Base">
+                    <use data-c="1D41B" xlink:href="#prefigure-projection-MJX-7-TEX-B-1D41B"/>
+                  </g>
+                </g>
+              </g>
+              <g data-mml-node="mo" transform="translate(672,363) scale(0.707)" data-semantic-type="operator" data-semantic-role="addition" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="up tack" data-semantic-prefix="Exponent">
+                <use data-c="22A5" xlink:href="#prefigure-projection-MJX-7-TEX-N-22A5"/>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <path id="prefigure-projection-__path-1" stroke="black" stroke-width="3" fill="none" marker-end="url(#prefigure-projection-arrow-head-end-3_None_24_60-black)" d="M 55.0 255.0 L 153.4 58.3"/>
+  <g id="prefigure-projection-__label-6" transform="translate(151.0,51.0) translate(-11.6,-12.7)">
+    <g id="prefigure-projection-__g-6">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.112px" width="11.568px" height="12.672px" role="img" focusable="false" viewBox="0 -694 639 700" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-projection-MJX-8-TEX-B-1D41B" d="M32 686L123 690Q214 694 215 694H221V409Q289 450 378 450Q479 450 539 387T600 221Q600 122 535 58T358 -6H355Q272 -6 203 53L160 1L129 0H98V301Q98 362 98 435T99 525Q99 591 97 604T83 620Q69 624 42 624H29V686H32ZM227 105L232 99Q237 93 242 87T258 73T280 59T306 49T339 45Q380 45 411 66T451 131Q457 160 457 230Q457 264 456 284T448 329T430 367T396 389T343 398Q282 398 235 355L227 348V105Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+              <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="bold" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-attributes="texclass:ORD" data-semantic-speech="bold b">
+                  <use data-c="1D41B" xlink:href="#prefigure-projection-MJX-8-TEX-B-1D41B"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <path id="prefigure-projection-__path-2" stroke="red" stroke-width="3" fill="none" marker-end="url(#prefigure-projection-arrow-head-end-3_None_24_60-red)" d="M 55.0 255.0 L 211.7 176.6"/>
+  <g id="prefigure-projection-__label-7" transform="translate(219.0,179.0) translate(0.0,-0.0)">
+    <g id="prefigure-projection-__g-7">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.112px" width="11.568px" height="19.872px" role="img" focusable="false" viewBox="0 -1092 639 1098" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-projection-MJX-9-TEX-B-1D41B" d="M32 686L123 690Q214 694 215 694H221V409Q289 450 378 450Q479 450 539 387T600 221Q600 122 535 58T358 -6H355Q272 -6 203 53L160 1L129 0H98V301Q98 362 98 435T99 525Q99 591 97 604T83 620Q69 624 42 624H29V686H32ZM227 105L232 99Q237 93 242 87T258 73T280 59T306 49T339 45Q380 45 411 66T451 131Q457 160 457 230Q457 264 456 284T448 329T430 367T396 389T343 398Q282 398 235 355L227 348V105Z"/>
+          <path id="prefigure-projection-MJX-9-TEX-SO-2C6" d="M279 669Q273 669 142 610T9 551L0 569Q-8 585 -8 587Q-8 588 -7 588L12 598Q30 608 66 628T136 666L277 744L564 587L555 569Q549 556 547 554T544 552Q539 555 410 612T279 669Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+              <g data-mml-node="mover" data-semantic-type="overscore" data-semantic-role="latinletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-attributes="texclass:ORD" data-semantic-speech="ModifyingAbove bold b With caret">
+                <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                  <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                    <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="bold" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-attributes="texclass:ORD" data-semantic-speech="bold b" data-semantic-prefix="Base">
+                      <use data-c="1D41B" xlink:href="#prefigure-projection-MJX-9-TEX-B-1D41B"/>
+                    </g>
+                  </g>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="operator" data-semantic-role="overaccent" data-semantic-annotation="accent:unknown" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="caret" data-semantic-prefix="Overscript" transform="translate(319.5,248) translate(-278 0)">
+                  <use data-c="2C6" xlink:href="#prefigure-projection-MJX-9-TEX-SO-2C6"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <path id="prefigure-projection-__path-3" stroke="black" stroke-width="3" fill="none" marker-end="url(#prefigure-projection-arrow-head-end-3_None_24_60-black)" d="M 55.0 255.0 L 151.7 206.6"/>
+  <g id="prefigure-projection-__label-8" transform="translate(159.0,209.0) translate(0.0,-0.0)">
+    <g id="prefigure-projection-__g-8">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="10.984px" height="8.040px" role="img" focusable="false" viewBox="0 -444 607 444" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-projection-MJX-10-TEX-B-1D42F" d="M401 444Q413 441 495 441Q568 441 574 444H580V382H510L409 156Q348 18 339 6Q331 -4 320 -4Q318 -4 313 -4T303 -3H288Q273 -3 264 12T221 102Q206 135 197 156L96 382H26V444H34Q49 441 145 441Q252 441 270 444H279V382H231L284 264Q335 149 338 149Q338 150 389 264T442 381Q442 382 418 382H394V444H401Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+              <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="bold" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-attributes="texclass:ORD" data-semantic-speech="bold v">
+                  <use data-c="1D42F" xlink:href="#prefigure-projection-MJX-10-TEX-B-1D42F"/>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-tangent-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-tangent-11.svg
@@ -1,0 +1,200 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-tangent-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-tangent-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-tangent-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+  </defs>
+  <g id="prefigure-tangent-grid-axes">
+    <g id="prefigure-tangent-grid" stroke="#ccc" stroke-width="1">
+      <line x1="5.0" y1="305.0" x2="5.0" y2="5.0"/>
+      <line x1="42.5" y1="305.0" x2="42.5" y2="5.0"/>
+      <line x1="80.0" y1="305.0" x2="80.0" y2="5.0"/>
+      <line x1="117.5" y1="305.0" x2="117.5" y2="5.0"/>
+      <line x1="155.0" y1="305.0" x2="155.0" y2="5.0"/>
+      <line x1="192.5" y1="305.0" x2="192.5" y2="5.0"/>
+      <line x1="230.0" y1="305.0" x2="230.0" y2="5.0"/>
+      <line x1="267.5" y1="305.0" x2="267.5" y2="5.0"/>
+      <line x1="305.0" y1="305.0" x2="305.0" y2="5.0"/>
+      <line x1="5.0" y1="305.0" x2="305.0" y2="305.0"/>
+      <line x1="5.0" y1="267.5" x2="305.0" y2="267.5"/>
+      <line x1="5.0" y1="230.0" x2="305.0" y2="230.0"/>
+      <line x1="5.0" y1="192.5" x2="305.0" y2="192.5"/>
+      <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+      <line x1="5.0" y1="117.5" x2="305.0" y2="117.5"/>
+      <line x1="5.0" y1="80.0" x2="305.0" y2="80.0"/>
+      <line x1="5.0" y1="42.5" x2="305.0" y2="42.5"/>
+      <line x1="5.0" y1="5.0" x2="305.0" y2="5.0"/>
+    </g>
+    <g id="prefigure-tangent-axes" stroke="black" stroke-width="2">
+      <line id="prefigure-tangent-__line-18" x1="5.0" y1="155.0" x2="305.0" y2="155.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-tangent-__line-19" x1="80.0" y1="158.0" x2="80.0" y2="152.0"/>
+        <line id="prefigure-tangent-__line-20" x1="230.0" y1="158.0" x2="230.0" y2="152.0"/>
+      </g>
+      <line id="prefigure-tangent-__line-21" x1="155.0" y1="305.0" x2="155.0" y2="5.0" stroke="black" stroke-width="2"/>
+      <g>
+        <line id="prefigure-tangent-__line-22" x1="152.0" y1="230.0" x2="158.0" y2="230.0"/>
+        <line id="prefigure-tangent-__line-23" x1="152.0" y1="80.0" x2="158.0" y2="80.0"/>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-0" transform="translate(301.0,151.0) translate(-10.4,-8.2)">
+      <g id="prefigure-tangent-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="10.352px" height="8.200px" role="img" focusable="false" viewBox="0 -442 572 453" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-2-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="x">
+                <use data-c="1D465" xlink:href="#prefigure-tangent-MJX-2-TEX-I-1D465"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-1" transform="translate(159.0,9.0) translate(0.0,-0.0)">
+      <g id="prefigure-tangent-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -3.712px" width="8.872px" height="11.712px" role="img" focusable="false" viewBox="0 -442 490 647" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-3-TEX-I-1D466" d="M21 287Q21 301 36 335T84 406T158 442Q199 442 224 419T250 355Q248 336 247 334Q247 331 231 288T198 191T182 105Q182 62 196 45T238 27Q261 27 281 38T312 61T339 94Q339 95 344 114T358 173T377 247Q415 397 419 404Q432 431 462 431Q475 431 483 424T494 412T496 403Q496 390 447 193T391 -23Q363 -106 294 -155T156 -205Q111 -205 77 -183T43 -117Q43 -95 50 -80T69 -58T89 -48T106 -45Q150 -45 150 -87Q150 -107 138 -122T115 -142T102 -147L99 -148Q101 -153 118 -160T152 -167H160Q177 -167 186 -165Q219 -156 247 -127T290 -65T313 -9T321 21L315 17Q309 13 296 6T270 -6Q250 -11 231 -11Q185 -11 150 11T104 82Q103 89 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="y">
+                <use data-c="1D466" xlink:href="#prefigure-tangent-MJX-3-TEX-I-1D466"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-2" transform="translate(80.0,166.0) translate(-7.5,-0.0)">
+      <g id="prefigure-tangent-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-4-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-tangent-MJX-4-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-tangent-MJX-4-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-4-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-3" transform="translate(230.0,166.0) translate(-4.5,-0.0)">
+      <g id="prefigure-tangent-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-5-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-5-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-4" transform="translate(144.0,230.0) translate(-15.1,-6.0)">
+      <g id="prefigure-tangent-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="15.080px" height="12.056px" role="img" focusable="false" viewBox="0 -666 833 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-6-TEX-N-2D" d="M11 179V252H277V179H11Z"/>
+            <path id="prefigure-tangent-MJX-6-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="unknown" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="hyphen 2">
+                <use data-c="2D" xlink:href="#prefigure-tangent-MJX-6-TEX-N-2D"/>
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-6-TEX-N-32" transform="translate(333,0)"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <g id="prefigure-tangent-__label-5" transform="translate(144.0,80.0) translate(-9.0,-6.0)">
+      <g id="prefigure-tangent-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-7-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mtext" data-semantic-type="text" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:unit" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#prefigure-tangent-MJX-7-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+  <path id="prefigure-tangent-graph" stroke="blue" stroke-width="2" fill="none" d="M 5.0 161.5 L 8.0 162.2 L 11.0 163.0 L 14.0 163.7 L 17.0 164.4 L 20.0 165.1 L 23.0 165.8 L 26.0 166.4 L 29.0 166.9 L 32.0 167.4 L 35.0 167.9 L 38.0 168.3 L 41.0 168.5 L 44.0 168.8 L 47.0 168.9 L 50.0 168.9 L 53.0 168.8 L 56.0 168.6 L 59.0 168.3 L 62.0 167.9 L 65.0 167.4 L 68.0 166.8 L 71.0 166.0 L 74.0 165.1 L 77.0 164.1 L 80.0 163.0 L 83.0 161.8 L 86.0 160.4 L 89.0 158.9 L 92.0 157.3 L 95.0 155.6 L 98.0 153.9 L 101.0 152.0 L 104.0 150.0 L 107.0 148.0 L 110.0 145.9 L 113.0 143.8 L 116.0 141.6 L 119.0 139.4 L 122.0 137.2 L 125.0 135.0 L 128.0 132.8 L 131.0 130.7 L 134.0 128.6 L 137.0 126.7 L 140.0 124.8 L 143.0 123.0 L 146.0 121.4 L 149.0 119.9 L 152.0 118.6 L 155.0 117.5 L 158.0 116.6 L 161.0 116.0 L 164.0 115.5 L 167.0 115.4 L 170.0 115.5 L 173.0 116.0 L 176.0 116.7 L 179.0 117.8 L 182.0 119.2 L 185.0 120.9 L 188.0 123.0 L 191.0 125.4 L 194.0 128.2 L 197.0 131.3 L 200.0 134.7 L 203.0 138.5 L 206.0 142.7 L 209.0 147.1 L 212.0 151.8 L 215.0 156.9 L 218.0 162.2 L 221.0 167.7 L 224.0 173.4 L 227.0 179.3 L 230.0 185.4 L 233.0 191.6 L 236.0 197.8 L 239.0 204.1 L 242.0 210.3 L 245.0 216.5 L 248.0 222.6 L 251.0 228.6 L 254.0 234.3 L 257.0 239.7 L 260.0 244.9 L 263.0 249.6 L 266.0 253.9 L 269.0 257.8 L 272.0 261.1 L 275.0 263.8 L 278.0 265.8 L 281.0 267.2 L 284.0 267.8 L 287.0 267.7 L 290.0 266.7 L 293.0 264.8 L 296.0 262.0 L 299.0 258.3 L 302.0 253.6 L 305.0 248.0" clip-path="url(#prefigure-tangent-__clipPath-1)"/>
+  <line id="prefigure-tangent-tangent" x1="60.6" y1="5.0" x2="305.0" y2="230.6" stroke="red" stroke-width="2" fill="none" clip-path="url(#prefigure-tangent-__clipPath-1)"/>
+  <g id="prefigure-tangent-point">
+    <g transform="translate(197.5,121.7) translate(0.0,-18.1)">
+      <g id="prefigure-tangent-__g-6">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -4.528px" width="65.312px" height="18.096px" role="img" focusable="false" viewBox="0 -750 3608.7 1000" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-tangent-MJX-8-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-2C" d="M78 35T78 60T94 103T137 121Q165 121 187 96T210 8Q210 -27 201 -60T180 -117T154 -158T130 -185T117 -194Q113 -194 104 -185T95 -172Q95 -168 106 -156T131 -126T157 -76T173 -3V9L172 8Q170 7 167 6T161 3T152 1T140 0Q113 0 96 17Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-I-1D453" d="M118 -162Q120 -162 124 -164T135 -167T147 -168Q160 -168 171 -155T187 -126Q197 -99 221 27T267 267T289 382V385H242Q195 385 192 387Q188 390 188 397L195 425Q197 430 203 430T250 431Q298 431 298 432Q298 434 307 482T319 540Q356 705 465 705Q502 703 526 683T550 630Q550 594 529 578T487 561Q443 561 443 603Q443 622 454 636T478 657L487 662Q471 668 457 668Q445 668 434 658T419 630Q412 601 403 552T387 469T380 433Q380 431 435 431Q480 431 487 430T498 424Q499 420 496 407T491 391Q489 386 482 386T428 385H372L349 263Q301 15 282 -47Q255 -132 212 -173Q175 -205 139 -205Q107 -205 81 -186T55 -132Q55 -95 76 -78T118 -61Q162 -61 162 -103Q162 -122 151 -136T127 -157L118 -162Z"/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-2061" d=""/>
+            <path id="prefigure-tangent-MJX-8-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="12" data-semantic-children="11" data-semantic-content="0,7" data-semantic-speech="left parenthesis a comma f left parenthesis a right parenthesis right parenthesis">
+              <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="0" data-semantic-parent="12" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                <use data-c="28" xlink:href="#prefigure-tangent-MJX-8-TEX-N-28"/>
+              </g>
+              <g data-mml-node="mrow" data-semantic-type="punctuated" data-semantic-role="sequence" data-semantic-id="11" data-semantic-children="1,2,10" data-semantic-content="2" data-semantic-parent="12" data-semantic-speech="a comma f left parenthesis a right parenthesis" transform="translate(389,0)">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="11" data-semantic-speech="a">
+                  <use data-c="1D44E" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D44E"/>
+                </g>
+                <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="comma" data-semantic-id="2" data-semantic-parent="11" data-semantic-operator="punctuated" data-semantic-speech="comma" transform="translate(529,0)">
+                  <use data-c="2C" xlink:href="#prefigure-tangent-MJX-8-TEX-N-2C"/>
+                </g>
+                <g data-mml-node="mrow" data-semantic-type="appl" data-semantic-role="simple function" data-semantic-annotation="clearspeak:simple" data-semantic-id="10" data-semantic-children="3,8" data-semantic-content="9,3" data-semantic-parent="11" data-semantic-speech="f left parenthesis a right parenthesis" transform="translate(973.7,0)">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="simple function" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="3" data-semantic-parent="10" data-semantic-operator="appl" data-semantic-speech="f">
+                    <use data-c="1D453" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D453"/>
+                  </g>
+                  <g data-mml-node="mo" data-semantic-type="punctuation" data-semantic-role="application" data-semantic-id="9" data-semantic-parent="10" data-semantic-added="true" data-semantic-operator="appl" data-semantic-speech="of" transform="translate(550,0)">
+                    <use data-c="2061" xlink:href="#prefigure-tangent-MJX-8-TEX-N-2061"/>
+                  </g>
+                  <g data-mml-node="mrow" data-semantic-type="fenced" data-semantic-role="leftright" data-semantic-id="8" data-semantic-children="5" data-semantic-content="4,6" data-semantic-parent="10" data-semantic-speech="left parenthesis a right parenthesis" transform="translate(550,0)">
+                    <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="4" data-semantic-parent="8" data-semantic-operator="fenced" data-semantic-speech="left parenthesis">
+                      <use data-c="28" xlink:href="#prefigure-tangent-MJX-8-TEX-N-28"/>
+                    </g>
+                    <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="5" data-semantic-parent="8" data-semantic-speech="a" transform="translate(389,0)">
+                      <use data-c="1D44E" xlink:href="#prefigure-tangent-MJX-8-TEX-I-1D44E"/>
+                    </g>
+                    <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="6" data-semantic-parent="8" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(918,0)">
+                      <use data-c="29" xlink:href="#prefigure-tangent-MJX-8-TEX-N-29"/>
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g data-mml-node="mo" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="7" data-semantic-parent="12" data-semantic-operator="fenced" data-semantic-speech="right parenthesis" transform="translate(3219.7,0)">
+                <use data-c="29" xlink:href="#prefigure-tangent-MJX-8-TEX-N-29"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <circle cx="192.5" cy="126.7" r="4" stroke="black" stroke-width="2" fill="red"/>
+  </g>
+</svg>

--- a/examples/sample-article/gen/prefigure/prefigure-worksheet-vectors-11.svg
+++ b/examples/sample-article/gen/prefigure/prefigure-worksheet-vectors-11.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-worksheet-vectors-figure" width="345" height="425" viewBox="0 0 345 425">
+  <defs>
+    <clipPath id="prefigure-worksheet-vectors-__clipPath-0">
+      <rect x="5.0" y="20.0" width="320.0" height="400.0"/>
+    </clipPath>
+    <clipPath id="prefigure-worksheet-vectors-__clipPath-1">
+      <rect x="5.0" y="20.0" width="320.0" height="400.0"/>
+    </clipPath>
+    <marker id="prefigure-worksheet-vectors-arrow-head-end-3_None_24_60-black" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="9.8" refY="6.0">
+      <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="black" stroke="none"/>
+    </marker>
+    <marker id="prefigure-worksheet-vectors-arrow-head-end-3_None_24_60-black-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="11.8" refY="8.0">
+      <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+    </marker>
+    <marker id="prefigure-worksheet-vectors-arrow-head-start-3_None_24_60-black" markerWidth="13.5" markerHeight="12.0" markerUnits="userSpaceOnUse" orient="auto" refX="3.6999999999999993" refY="6.0">
+      <g transform="rotate(180, 6.75, 6.0)">
+        <path d="M 13.5 6.0L 0.0 12.0L 2.6 7.5L 2.6 4.5L 0.0 0.0Z" fill="black" stroke="none"/>
+      </g>
+    </marker>
+    <marker id="prefigure-worksheet-vectors-arrow-head-start-3_None_24_60-black-outline" markerWidth="17.5" markerHeight="16.0" markerUnits="userSpaceOnUse" orient="auto" refX="5.699999999999999" refY="8.0">
+      <g transform="rotate(180, 8.75, 8.0)">
+        <path d="M 16.3 9.8 L 2.8 15.8 A 2 2 0 0 1 0.0 14.0 L 0.0 2.0 A 2 2 0 0 1 2.8 0.2 L 16.3 6.2 A 2 2 0 0 1 16.3 9.8 Z" fill="white" stroke="none"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="prefigure-worksheet-vectors-grid" stroke="#ccc" stroke-width="1">
+    <line x1="5.0" y1="420.0" x2="5.0" y2="20.0"/>
+    <line x1="45.0" y1="420.0" x2="45.0" y2="20.0"/>
+    <line x1="85.0" y1="420.0" x2="85.0" y2="20.0"/>
+    <line x1="125.0" y1="420.0" x2="125.0" y2="20.0"/>
+    <line x1="165.0" y1="420.0" x2="165.0" y2="20.0"/>
+    <line x1="205.0" y1="420.0" x2="205.0" y2="20.0"/>
+    <line x1="245.0" y1="420.0" x2="245.0" y2="20.0"/>
+    <line x1="285.0" y1="420.0" x2="285.0" y2="20.0"/>
+    <line x1="325.0" y1="420.0" x2="325.0" y2="20.0"/>
+    <line x1="5.0" y1="420.0" x2="325.0" y2="420.0"/>
+    <line x1="5.0" y1="380.0" x2="325.0" y2="380.0"/>
+    <line x1="5.0" y1="340.0" x2="325.0" y2="340.0"/>
+    <line x1="5.0" y1="300.0" x2="325.0" y2="300.0"/>
+    <line x1="5.0" y1="260.0" x2="325.0" y2="260.0"/>
+    <line x1="5.0" y1="220.0" x2="325.0" y2="220.0"/>
+    <line x1="5.0" y1="180.0" x2="325.0" y2="180.0"/>
+    <line x1="5.0" y1="140.0" x2="325.0" y2="140.0"/>
+    <line x1="5.0" y1="100.0" x2="325.0" y2="100.0"/>
+    <line x1="5.0" y1="60.0" x2="325.0" y2="60.0"/>
+    <line x1="5.0" y1="20.0" x2="325.0" y2="20.0"/>
+  </g>
+  <g id="prefigure-worksheet-vectors-axes" stroke="black" stroke-width="2">
+    <line id="prefigure-worksheet-vectors-__line-20" x1="5.0" y1="420.0" x2="325.0" y2="420.0" stroke="black" stroke-width="2"/>
+    <line id="prefigure-worksheet-vectors-__line-21" x1="5.0" y1="420.0" x2="5.0" y2="20.0" stroke="black" stroke-width="2"/>
+  </g>
+  <g id="prefigure-worksheet-vectors-__label-0" transform="translate(330.0,420.0) translate(0.0,-4.1)">
+    <g id="prefigure-worksheet-vectors-__g-0">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="10.352px" height="8.200px" role="img" focusable="false" viewBox="0 -442 572 453" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-worksheet-vectors-MJX-2-TEX-I-1D465" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="x">
+              <use data-c="1D465" xlink:href="#prefigure-worksheet-vectors-MJX-2-TEX-I-1D465"/>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <g id="prefigure-worksheet-vectors-__label-1" transform="translate(5.0,15.0) translate(-4.4,-11.7)">
+    <g id="prefigure-worksheet-vectors-__g-1">
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -3.712px" width="8.872px" height="11.712px" role="img" focusable="false" viewBox="0 -442 490 647" x="0.0" y="0.0">
+        <defs>
+          <path id="prefigure-worksheet-vectors-MJX-3-TEX-I-1D466" d="M21 287Q21 301 36 335T84 406T158 442Q199 442 224 419T250 355Q248 336 247 334Q247 331 231 288T198 191T182 105Q182 62 196 45T238 27Q261 27 281 38T312 61T339 94Q339 95 344 114T358 173T377 247Q415 397 419 404Q432 431 462 431Q475 431 483 424T494 412T496 403Q496 390 447 193T391 -23Q363 -106 294 -155T156 -205Q111 -205 77 -183T43 -117Q43 -95 50 -80T69 -58T89 -48T106 -45Q150 -45 150 -87Q150 -107 138 -122T115 -142T102 -147L99 -148Q101 -153 118 -160T152 -167H160Q177 -167 186 -165Q219 -156 247 -127T290 -65T313 -9T321 21L315 17Q309 13 296 6T270 -6Q250 -11 231 -11Q185 -11 150 11T104 82Q103 89 103 113Q103 170 138 262T173 379Q173 380 173 381Q173 390 173 393T169 400T158 404H154Q131 404 112 385T82 344T65 302T57 280Q55 278 41 278H27Q21 284 21 287Z"/>
+        </defs>
+        <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+          <g data-mml-node="math">
+            <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="y">
+              <use data-c="1D466" xlink:href="#prefigure-worksheet-vectors-MJX-3-TEX-I-1D466"/>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </g>
+  </g>
+  <g id="prefigure-worksheet-vectors-vector-a">
+    <g transform="translate(131.0,66.0) translate(0.0,-0.0)">
+      <g id="prefigure-worksheet-vectors-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.184px" width="9.576px" height="15.472px" role="img" focusable="false" viewBox="0 -845 529 855" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-worksheet-vectors-MJX-4-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"/>
+            <path id="prefigure-worksheet-vectors-MJX-4-TEX-N-20D7" d="M377 694Q377 702 382 708T397 714Q404 714 409 709Q414 705 419 690Q429 653 460 633Q471 626 471 615Q471 606 468 603T454 594Q411 572 379 531Q377 529 374 525T369 519T364 517T357 516Q350 516 344 521T337 536Q337 555 384 595H213L42 596Q29 605 29 615Q29 622 42 635H401Q377 673 377 694Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                <g data-mml-node="mover" data-semantic-type="overscore" data-semantic-role="latinletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-attributes="texclass:ORD" data-semantic-speech="ModifyingAbove a With right arrow">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-speech="a" data-semantic-prefix="Base">
+                    <use data-c="1D44E" xlink:href="#prefigure-worksheet-vectors-MJX-4-TEX-I-1D44E"/>
+                  </g>
+                  <g data-mml-node="mo" data-semantic-type="relation" data-semantic-role="overaccent" data-semantic-annotation="accent:arrow" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="right arrow" data-semantic-prefix="Overscript" transform="translate(264.5,31) translate(-250 0)">
+                    <use data-c="20D7" xlink:href="#prefigure-worksheet-vectors-MJX-4-TEX-N-20D7"/>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <path stroke="black" stroke-width="3" fill="none" marker-end="url(#prefigure-worksheet-vectors-arrow-head-end-3_None_24_60-black)" d="M 5.0 420.0 L 123.8 63.5"/>
+  </g>
+  <g id="prefigure-worksheet-vectors-vector-b">
+    <g transform="translate(159.0,334.0) translate(-7.8,-20.1)">
+      <g id="prefigure-worksheet-vectors-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="7.768px" height="20.056px" role="img" focusable="false" viewBox="0 -1097 429 1108" x="0.0" y="0.0">
+          <defs>
+            <path id="prefigure-worksheet-vectors-MJX-5-TEX-I-1D44F" d="M73 647Q73 657 77 670T89 683Q90 683 161 688T234 694Q246 694 246 685T212 542Q204 508 195 472T180 418L176 399Q176 396 182 402Q231 442 283 442Q345 442 383 396T422 280Q422 169 343 79T173 -11Q123 -11 82 27T40 150V159Q40 180 48 217T97 414Q147 611 147 623T109 637Q104 637 101 637H96Q86 637 83 637T76 640T73 647ZM336 325V331Q336 405 275 405Q258 405 240 397T207 376T181 352T163 330L157 322L136 236Q114 150 114 114Q114 66 138 42Q154 26 178 26Q211 26 245 58Q270 81 285 114T318 219Q336 291 336 325Z"/>
+            <path id="prefigure-worksheet-vectors-MJX-5-TEX-N-20D7" d="M377 694Q377 702 382 708T397 714Q404 714 409 709Q414 705 419 690Q429 653 460 633Q471 626 471 615Q471 606 468 603T454 594Q411 572 379 531Q377 529 374 525T369 519T364 517T357 516Q350 516 344 521T337 536Q337 555 384 595H213L42 596Q29 605 29 615Q29 622 42 635H401Q377 673 377 694Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="TeXAtom" data-mjx-texclass="ORD">
+                <g data-mml-node="mover" data-semantic-type="overscore" data-semantic-role="latinletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-attributes="texclass:ORD" data-semantic-speech="ModifyingAbove b With right arrow">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-speech="b" data-semantic-prefix="Base">
+                    <use data-c="1D44F" xlink:href="#prefigure-worksheet-vectors-MJX-5-TEX-I-1D44F"/>
+                  </g>
+                  <g data-mml-node="mo" data-semantic-type="relation" data-semantic-role="overaccent" data-semantic-annotation="accent:arrow" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="right arrow" data-semantic-prefix="Overscript" transform="translate(214.5,283) translate(-250 0)">
+                    <use data-c="20D7" xlink:href="#prefigure-worksheet-vectors-MJX-5-TEX-N-20D7"/>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <path stroke="black" stroke-width="3" fill="none" marker-end="url(#prefigure-worksheet-vectors-arrow-head-end-3_None_24_60-black)" d="M 5.0 420.0 L 161.7 341.6"/>
+  </g>
+</svg>

--- a/examples/sample-book/gen/prefigure/prefigure-rtsunity-11.svg
+++ b/examples/sample-book/gen/prefigure/prefigure-rtsunity-11.svg
@@ -1,0 +1,207 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="prefigure-rtsunity-figure" width="310" height="310" viewBox="0 0 310 310">
+  <defs>
+    <clipPath id="prefigure-rtsunity-__clipPath-0">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+    <clipPath id="prefigure-rtsunity-__clipPath-1">
+      <rect x="5.0" y="5.0" width="300.0" height="300.0"/>
+    </clipPath>
+  </defs>
+  <g id="prefigure-rtsunity-grid" stroke="#ccc" stroke-width="1">
+    <line x1="47.9" y1="305.0" x2="47.9" y2="5.0"/>
+    <line x1="101.4" y1="305.0" x2="101.4" y2="5.0"/>
+    <line x1="155.0" y1="305.0" x2="155.0" y2="5.0"/>
+    <line x1="208.6" y1="305.0" x2="208.6" y2="5.0"/>
+    <line x1="262.1" y1="305.0" x2="262.1" y2="5.0"/>
+    <line x1="5.0" y1="262.1" x2="305.0" y2="262.1"/>
+    <line x1="5.0" y1="208.6" x2="305.0" y2="208.6"/>
+    <line x1="5.0" y1="155.0" x2="305.0" y2="155.0"/>
+    <line x1="5.0" y1="101.4" x2="305.0" y2="101.4"/>
+    <line x1="5.0" y1="47.9" x2="305.0" y2="47.9"/>
+  </g>
+  <g id="prefigure-rtsunity-axes" stroke="black" stroke-width="2">
+    <line id="prefigure-rtsunity-__line-10" x1="5.0" y1="155.0" x2="305.0" y2="155.0" stroke="black" stroke-width="2"/>
+    <line id="prefigure-rtsunity-__line-11" x1="155.0" y1="305.0" x2="155.0" y2="5.0" stroke="black" stroke-width="2"/>
+  </g>
+  <path id="prefigure-rtsunity-unit-circle" d="M 262.1 155.0 L 261.9 148.3 L 261.3 141.6 L 260.2 134.9 L 258.8 128.4 L 256.9 121.9 L 254.6 115.6 L 251.9 109.4 L 248.9 103.4 L 245.5 97.6 L 241.7 92.0 L 237.6 86.7 L 233.1 81.7 L 228.3 76.9 L 223.3 72.4 L 218.0 68.3 L 212.4 64.5 L 206.6 61.1 L 200.6 58.1 L 194.4 55.4 L 188.1 53.1 L 181.6 51.2 L 175.1 49.8 L 168.4 48.7 L 161.7 48.1 L 155.0 47.9 L 148.3 48.1 L 141.6 48.7 L 134.9 49.8 L 128.4 51.2 L 121.9 53.1 L 115.6 55.4 L 109.4 58.1 L 103.4 61.1 L 97.6 64.5 L 92.0 68.3 L 86.7 72.4 L 81.7 76.9 L 76.9 81.7 L 72.4 86.7 L 68.3 92.0 L 64.5 97.6 L 61.1 103.4 L 58.1 109.4 L 55.4 115.6 L 53.1 121.9 L 51.2 128.4 L 49.8 134.9 L 48.7 141.6 L 48.1 148.3 L 47.9 155.0 L 48.1 161.7 L 48.7 168.4 L 49.8 175.1 L 51.2 181.6 L 53.1 188.1 L 55.4 194.4 L 58.1 200.6 L 61.1 206.6 L 64.5 212.4 L 68.3 218.0 L 72.4 223.3 L 76.9 228.3 L 81.7 233.1 L 86.7 237.6 L 92.0 241.7 L 97.6 245.5 L 103.4 248.9 L 109.4 251.9 L 115.6 254.6 L 121.9 256.9 L 128.4 258.8 L 134.9 260.2 L 141.6 261.3 L 148.3 261.9 L 155.0 262.1 L 161.7 261.9 L 168.4 261.3 L 175.1 260.2 L 181.6 258.8 L 188.1 256.9 L 194.4 254.6 L 200.6 251.9 L 206.6 248.9 L 212.4 245.5 L 218.0 241.7 L 223.3 237.6 L 228.3 233.1 L 233.1 228.3 L 237.6 223.3 L 241.7 218.0 L 245.5 212.4 L 248.9 206.6 L 251.9 200.6 L 254.6 194.4 L 256.9 188.1 L 258.8 181.6 L 260.2 175.1 L 261.3 168.4 L 261.9 161.7 Z" stroke="blue" stroke-width="2" fill="none"/>
+  <g id="prefigure-rtsunity-__group-0">
+    <g id="prefigure-rtsunity-point-k_0">
+      <g transform="translate(267.1,160.0) translate(0.0,-0.0)">
+        <g id="prefigure-rtsunity-__g-0">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="1">
+                  <use data-c="31" xlink:href="#prefigure-rtsunity-MJX-2-TEX-N-31"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="262.1" cy="155.0" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_1">
+      <g transform="translate(235.8,74.2) translate(0.0,-8.2)">
+        <g id="prefigure-rtsunity-__g-1">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="11.256px" height="8.216px" role="img" focusable="false" viewBox="0 -443 622 454" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-3-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="greekletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="omega">
+                  <use data-c="1D714" xlink:href="#prefigure-rtsunity-MJX-3-TEX-I-1D714"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="230.8" cy="79.2" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_2">
+      <g transform="translate(160.0,42.9) translate(0.0,-12.2)">
+        <g id="prefigure-rtsunity-__g-2">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="6.248px" height="12.160px" role="img" focusable="false" viewBox="0 -661 345 672" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-4-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="i">
+                  <use data-c="1D456" xlink:href="#prefigure-rtsunity-MJX-4-TEX-I-1D456"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="155.0" cy="47.9" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_3">
+      <g transform="translate(74.2,74.2) translate(-19.2,-15.3)">
+        <g id="prefigure-rtsunity-__g-3">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="19.160px" height="15.280px" role="img" focusable="false" viewBox="0 -833.2 1058.6 844.2" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-5-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+              <path id="prefigure-rtsunity-MJX-5-TEX-N-33" d="M127 463Q100 463 85 480T69 524Q69 579 117 622T233 665Q268 665 277 664Q351 652 390 611T430 522Q430 470 396 421T302 350L299 348Q299 347 308 345T337 336T375 315Q457 262 457 175Q457 96 395 37T238 -22Q158 -22 100 21T42 130Q42 158 60 175T105 193Q133 193 151 175T169 130Q169 119 166 110T159 94T148 82T136 74T126 70T118 67L114 66Q165 21 238 21Q293 21 321 74Q338 107 338 175V195Q338 290 274 322Q259 328 213 329L171 330L168 332Q166 335 166 348Q166 366 174 366Q202 366 232 371Q266 376 294 413T322 525V533Q322 590 287 612Q265 626 240 626Q208 626 181 615T143 592T132 580H135Q138 579 143 578T153 573T165 566T175 555T183 540T186 520Q186 498 172 481T127 463Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="greekletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-speech="omega cubed">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="greekletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-speech="omega" data-semantic-prefix="Base">
+                    <use data-c="1D714" xlink:href="#prefigure-rtsunity-MJX-5-TEX-I-1D714"/>
+                  </g>
+                  <g data-mml-node="mn" transform="translate(655,363) scale(0.707)" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="3" data-semantic-prefix="Exponent">
+                    <use data-c="33" xlink:href="#prefigure-rtsunity-MJX-5-TEX-N-33"/>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="79.2" cy="79.2" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_4">
+      <g transform="translate(42.9,160.0) translate(-23.1,-0.0)">
+        <g id="prefigure-rtsunity-__g-4">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.488px" width="23.128px" height="13.536px" role="img" focusable="false" viewBox="0 -666 1278 748" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-6-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+              <path id="prefigure-rtsunity-MJX-6-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math" data-semantic-type="prefixop" data-semantic-role="negative" data-semantic-annotation="clearspeak:simple" data-semantic-id="2" data-semantic-children="1" data-semantic-content="0" data-semantic-speech="negative 1">
+                <g data-mml-node="mo" data-semantic-type="operator" data-semantic-role="subtraction" data-semantic-id="0" data-semantic-parent="2" data-semantic-operator="prefixop,−" data-semantic-speech="minus">
+                  <use data-c="2212" xlink:href="#prefigure-rtsunity-MJX-6-TEX-N-2212"/>
+                </g>
+                <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="1" transform="translate(778,0)">
+                  <use data-c="31" xlink:href="#prefigure-rtsunity-MJX-6-TEX-N-31"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="47.9" cy="155.0" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_5">
+      <g transform="translate(74.2,235.8) translate(-19.2,-0.0)">
+        <g id="prefigure-rtsunity-__g-5">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="19.160px" height="15.296px" role="img" focusable="false" viewBox="0 -833.9 1058.6 844.9" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-7-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+              <path id="prefigure-rtsunity-MJX-7-TEX-N-35" d="M164 157Q164 133 148 117T109 101H102Q148 22 224 22Q294 22 326 82Q345 115 345 210Q345 313 318 349Q292 382 260 382H254Q176 382 136 314Q132 307 129 306T114 304Q97 304 95 310Q93 314 93 485V614Q93 664 98 664Q100 666 102 666Q103 666 123 658T178 642T253 634Q324 634 389 662Q397 666 402 666Q410 666 410 648V635Q328 538 205 538Q174 538 149 544L139 546V374Q158 388 169 396T205 412T256 420Q337 420 393 355T449 201Q449 109 385 44T229 -22Q148 -22 99 32T50 154Q50 178 61 192T84 210T107 214Q132 214 148 197T164 157Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="greekletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-speech="omega Superscript 5">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="greekletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-speech="omega" data-semantic-prefix="Base">
+                    <use data-c="1D714" xlink:href="#prefigure-rtsunity-MJX-7-TEX-I-1D714"/>
+                  </g>
+                  <g data-mml-node="mn" transform="translate(655,363) scale(0.707)" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="5" data-semantic-prefix="Exponent">
+                    <use data-c="35" xlink:href="#prefigure-rtsunity-MJX-7-TEX-N-35"/>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="79.2" cy="230.8" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_6">
+      <g transform="translate(150.0,267.1) translate(-20.3,-0.0)">
+        <g id="prefigure-rtsunity-__g-6">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -1.488px" width="20.328px" height="13.448px" role="img" focusable="false" viewBox="0 -661 1123 743" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-8-TEX-N-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"/>
+              <path id="prefigure-rtsunity-MJX-8-TEX-I-1D456" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math" data-semantic-type="prefixop" data-semantic-role="negative" data-semantic-annotation="clearspeak:simple" data-semantic-id="2" data-semantic-children="1" data-semantic-content="0" data-semantic-speech="negative i">
+                <g data-mml-node="mo" data-semantic-type="operator" data-semantic-role="subtraction" data-semantic-id="0" data-semantic-parent="2" data-semantic-operator="prefixop,−" data-semantic-speech="minus">
+                  <use data-c="2212" xlink:href="#prefigure-rtsunity-MJX-8-TEX-N-2212"/>
+                </g>
+                <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="i" transform="translate(778,0)">
+                  <use data-c="1D456" xlink:href="#prefigure-rtsunity-MJX-8-TEX-I-1D456"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="155.0" cy="262.1" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+    <g id="prefigure-rtsunity-point-k_7">
+      <g transform="translate(235.8,235.8) translate(0.0,-0.0)">
+        <g id="prefigure-rtsunity-__g-7">
+          <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.200px" width="19.160px" height="15.424px" role="img" focusable="false" viewBox="0 -841 1058.6 852" x="0.0" y="0.0">
+            <defs>
+              <path id="prefigure-rtsunity-MJX-9-TEX-I-1D714" d="M495 384Q495 406 514 424T555 443Q574 443 589 425T604 364Q604 334 592 278T555 155T483 38T377 -11Q297 -11 267 66Q266 68 260 61Q201 -11 125 -11Q15 -11 15 139Q15 230 56 325T123 434Q135 441 147 436Q160 429 160 418Q160 406 140 379T94 306T62 208Q61 202 61 187Q61 124 85 100T143 76Q201 76 245 129L253 137V156Q258 297 317 297Q348 297 348 261Q348 243 338 213T318 158L308 135Q309 133 310 129T318 115T334 97T358 83T393 76Q456 76 501 148T546 274Q546 305 533 325T508 357T495 384Z"/>
+              <path id="prefigure-rtsunity-MJX-9-TEX-N-37" d="M55 458Q56 460 72 567L88 674Q88 676 108 676H128V672Q128 662 143 655T195 646T364 644H485V605L417 512Q408 500 387 472T360 435T339 403T319 367T305 330T292 284T284 230T278 162T275 80Q275 66 275 52T274 28V19Q270 2 255 -10T221 -22Q210 -22 200 -19T179 0T168 40Q168 198 265 368Q285 400 349 489L395 552H302Q128 552 119 546Q113 543 108 522T98 479L95 458V455H55V458Z"/>
+            </defs>
+            <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+              <g data-mml-node="math">
+                <g data-mml-node="msup" data-semantic-type="superscript" data-semantic-role="greekletter" data-semantic-id="2" data-semantic-children="0,1" data-semantic-speech="omega Superscript 7">
+                  <g data-mml-node="mi" data-semantic-type="identifier" data-semantic-role="greekletter" data-semantic-font="italic" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-parent="2" data-semantic-speech="omega" data-semantic-prefix="Base">
+                    <use data-c="1D714" xlink:href="#prefigure-rtsunity-MJX-9-TEX-I-1D714"/>
+                  </g>
+                  <g data-mml-node="mn" transform="translate(655,363) scale(0.707)" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="1" data-semantic-parent="2" data-semantic-speech="7" data-semantic-prefix="Exponent">
+                    <use data-c="37" xlink:href="#prefigure-rtsunity-MJX-9-TEX-N-37"/>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </g>
+      </g>
+      <circle cx="230.8" cy="230.8" r="4" stroke="black" stroke-width="2" fill="red"/>
+    </g>
+  </g>
+</svg>

--- a/examples/sample-slideshow/generated/prefigure/annotated-prefigure-network-11.svg
+++ b/examples/sample-slideshow/generated/prefigure/annotated-prefigure-network-11.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="annotated-prefigure-network-figure" width="510" height="410" viewBox="0 0 510 410">
+  <defs>
+    <clipPath id="annotated-prefigure-network-__clipPath-0">
+      <rect x="5.0" y="5.0" width="500.0" height="400.0"/>
+    </clipPath>
+    <clipPath id="annotated-prefigure-network-__clipPath-1">
+      <rect x="5.0" y="5.0" width="500.0" height="400.0"/>
+    </clipPath>
+    <clipPath id="annotated-prefigure-network-__clipPath-2">
+      <rect x="5.0" y="5.0" width="500.0" height="400.0"/>
+    </clipPath>
+  </defs>
+  <g id="annotated-prefigure-network-__group-0">
+    <path id="annotated-prefigure-network-edge-1-3" d="M 455.0 97.8 Q 452.9 134.2 450.9 170.6 Q 448.8 206.9 446.8 243.3" stroke="black" stroke-width="2" stroke-dasharray="none" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-1-4" d="M 455.0 97.8 Q 407.8 143.0 360.6 188.2 Q 313.4 233.4 266.2 278.6" stroke="black" stroke-width="2" stroke-dasharray="9 9" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-1-5" d="M 455.0 97.8 Q 418.0 84.6 380.9 71.4 Q 343.9 58.2 306.8 45.0" stroke="black" stroke-width="2" stroke-dasharray="none" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-2-4" d="M 111.0 162.1 Q 149.8 191.3 188.6 220.3 Q 227.4 249.5 266.2 278.6" stroke="black" stroke-width="2" stroke-dasharray="9 9" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-2-5" d="M 111.0 162.1 Q 160.0 132.9 208.9 103.6 Q 257.9 74.3 306.8 45.0" stroke="black" stroke-width="2" stroke-dasharray="none" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-3-4" d="M 446.8 243.3 Q 401.6 252.1 356.5 260.9 Q 311.4 269.7 266.2 278.6" stroke="black" stroke-width="2" stroke-dasharray="none" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-3-5" d="M 446.8 243.3 Q 411.8 193.7 376.8 144.2 Q 341.8 94.6 306.8 45.0" stroke="black" stroke-width="2" stroke-dasharray="9 9" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-6-2" d="M 55.0 365.0 Q 69.0 314.3 83.0 263.6 Q 97.0 212.9 111.0 162.1" stroke="black" stroke-width="2" stroke-dasharray="none" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+    <path id="annotated-prefigure-network-edge-6-4" d="M 55.0 365.0 Q 107.8 343.4 160.6 321.8 Q 213.4 300.2 266.2 278.6" stroke="black" stroke-width="2" stroke-dasharray="9 9" fill="none" clip-path="url(#annotated-prefigure-network-__clipPath-2)"/>
+  </g>
+  <g id="annotated-prefigure-network-__group-1">
+    <rect id="annotated-prefigure-network-node-1" x="443.0" y="85.8" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-0" transform="translate(455.0,97.8) translate(-4.5,-6.0)">
+      <g id="annotated-prefigure-network-__g-0">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="1">
+                <use data-c="31" xlink:href="#annotated-prefigure-network-MJX-2-TEX-N-31"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <rect id="annotated-prefigure-network-node-2" x="99.0" y="150.1" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-1" transform="translate(111.0,162.1) translate(-4.5,-6.0)">
+      <g id="annotated-prefigure-network-__g-1">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.056px" role="img" focusable="false" viewBox="0 -666 500 666" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-3-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="2">
+                <use data-c="32" xlink:href="#annotated-prefigure-network-MJX-3-TEX-N-32"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <rect id="annotated-prefigure-network-node-3" x="434.8" y="231.3" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-2" transform="translate(446.8,243.3) translate(-4.5,-6.2)">
+      <g id="annotated-prefigure-network-__g-2">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.400px" width="9.048px" height="12.432px" role="img" focusable="false" viewBox="0 -665 500 687" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-4-TEX-N-33" d="M127 463Q100 463 85 480T69 524Q69 579 117 622T233 665Q268 665 277 664Q351 652 390 611T430 522Q430 470 396 421T302 350L299 348Q299 347 308 345T337 336T375 315Q457 262 457 175Q457 96 395 37T238 -22Q158 -22 100 21T42 130Q42 158 60 175T105 193Q133 193 151 175T169 130Q169 119 166 110T159 94T148 82T136 74T126 70T118 67L114 66Q165 21 238 21Q293 21 321 74Q338 107 338 175V195Q338 290 274 322Q259 328 213 329L171 330L168 332Q166 335 166 348Q166 366 174 366Q202 366 232 371Q266 376 294 413T322 525V533Q322 590 287 612Q265 626 240 626Q208 626 181 615T143 592T132 580H135Q138 579 143 578T153 573T165 566T175 555T183 540T186 520Q186 498 172 481T127 463Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="3">
+                <use data-c="33" xlink:href="#annotated-prefigure-network-MJX-4-TEX-N-33"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <rect id="annotated-prefigure-network-node-6" x="43.0" y="353.0" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-3" transform="translate(55.0,365.0) translate(-4.5,-6.2)">
+      <g id="annotated-prefigure-network-__g-3">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.400px" width="9.048px" height="12.456px" role="img" focusable="false" viewBox="0 -666 500 688" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-5-TEX-N-36" d="M42 313Q42 476 123 571T303 666Q372 666 402 630T432 550Q432 525 418 510T379 495Q356 495 341 509T326 548Q326 592 373 601Q351 623 311 626Q240 626 194 566Q147 500 147 364L148 360Q153 366 156 373Q197 433 263 433H267Q313 433 348 414Q372 400 396 374T435 317Q456 268 456 210V192Q456 169 451 149Q440 90 387 34T253 -22Q225 -22 199 -14T143 16T92 75T56 172T42 313ZM257 397Q227 397 205 380T171 335T154 278T148 216Q148 133 160 97T198 39Q222 21 251 21Q302 21 329 59Q342 77 347 104T352 209Q352 289 347 316T329 361Q302 397 257 397Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="6">
+                <use data-c="36" xlink:href="#annotated-prefigure-network-MJX-5-TEX-N-36"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <rect id="annotated-prefigure-network-node-4" x="254.2" y="266.6" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-4" transform="translate(266.2,278.6) translate(-4.5,-6.1)">
+      <g id="annotated-prefigure-network-__g-4">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: 0.000px" width="9.048px" height="12.256px" role="img" focusable="false" viewBox="0 -677 500 677" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-6-TEX-N-34" d="M462 0Q444 3 333 3Q217 3 199 0H190V46H221Q241 46 248 46T265 48T279 53T286 61Q287 63 287 115V165H28V211L179 442Q332 674 334 675Q336 677 355 677H373L379 671V211H471V165H379V114Q379 73 379 66T385 54Q393 47 442 46H471V0H462ZM293 211V545L74 212L183 211H293Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="4">
+                <use data-c="34" xlink:href="#annotated-prefigure-network-MJX-6-TEX-N-34"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+    <rect id="annotated-prefigure-network-node-5" x="294.8" y="33.0" width="24.0" height="24.0" stroke="black" stroke-width="1" fill="#fcf"/>
+    <g id="annotated-prefigure-network-__label-5" transform="translate(306.8,45.0) translate(-4.5,-6.2)">
+      <g id="annotated-prefigure-network-__g-5">
+        <svg xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: -0.400px" width="9.048px" height="12.456px" role="img" focusable="false" viewBox="0 -666 500 688" x="0.0" y="0.0">
+          <defs>
+            <path id="annotated-prefigure-network-MJX-7-TEX-N-35" d="M164 157Q164 133 148 117T109 101H102Q148 22 224 22Q294 22 326 82Q345 115 345 210Q345 313 318 349Q292 382 260 382H254Q176 382 136 314Q132 307 129 306T114 304Q97 304 95 310Q93 314 93 485V614Q93 664 98 664Q100 666 102 666Q103 666 123 658T178 642T253 634Q324 634 389 662Q397 666 402 666Q410 666 410 648V635Q328 538 205 538Q174 538 149 544L139 546V374Q158 388 169 396T205 412T256 420Q337 420 393 355T449 201Q449 109 385 44T229 -22Q148 -22 99 32T50 154Q50 178 61 192T84 210T107 214Q132 214 148 197T164 157Z"/>
+          </defs>
+          <g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)">
+            <g data-mml-node="math">
+              <g data-mml-node="mn" data-semantic-type="number" data-semantic-role="integer" data-semantic-font="normal" data-semantic-annotation="clearspeak:simple" data-semantic-id="0" data-semantic-speech="5">
+                <use data-c="35" xlink:href="#annotated-prefigure-network-MJX-7-TEX-N-35"/>
+              </g>
+            </g>
+          </g>
+        </svg>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2270,7 +2270,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:if>
     <xsl:apply-templates select="latex-image|sageplot|asymptote|pf:prefigure|mermaid" mode="image-source-basename"/>
-    <xsl:text>.svg</xsl:text>
+    <xsl:choose>
+        <xsl:when test="pf:prefigure">
+            <xsl:text>-11.svg</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>.svg</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- ###### -->


### PR DESCRIPTION
Changes to PreFigure mean that when PreFigure assets are generated within the PreTeXt environment, an SVG 1.1 compliant version of each image is created in addition to the usual ones.  If the `prefigure` element has `label="foo"`, then the new SVG 1.1 compliant image is `foo-11.svg`.

This PR includes a number of commits, most of which simply add the SVG 1.1 compliant PreFigure diagrams into the appropriate generated assets directory of the sample documents.

The second commit `dcd81f2ec84245ea2056df47633f5a693bd0d9a1` is the significant one as it modifies the `pretext-fo.xsl` stylesheet to load 1.1 compliant PreFigure images.  

The function `_downgrade_svg2_for_batik` inside pretext.py does not properly handle arrowheads in PreFigure diagrams so this change sidesteps that issue.  That function is still needed, however, for two MOM problems that require SVG 1.1 remediation.