### PR TITLE
Schema: panel cleanup, pattern economies, validation-plus repairs

### DIFF
--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -33,8 +33,8 @@
                       ImageDescription? &
                       (
                         Slate |
-                        SideBySideNoCaption |
-                        SideBySideGroupNoCaption
+                        SideBySideNoNumber |
+                        SideBySideGroupNoNumber
                       )* &
                       element script { attribute type { text }?, text }* &
                       element source { text }? &
@@ -78,7 +78,7 @@
                         (
                           Paragraph |
                           Tabular |
-                          SideBySideNoCaption |
+                          SideBySideNoNumber |
                           SlateInput |
                           AnyXhtml |
                           element xhtml:button {
@@ -127,7 +127,7 @@
                 (Interactive | Slate)+
             }
 
-            SideBySideNoCaption |= element sidebyside {
+            SideBySideNoNumber |= element sidebyside {
                 SidebySideAttributes,
                 (Interactive | Slate)+
             }

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -83,8 +83,8 @@
         <zeroOrMore>
           <choice>
             <ref name="Slate"/>
-            <ref name="SideBySideNoCaption"/>
-            <ref name="SideBySideGroupNoCaption"/>
+            <ref name="SideBySideNoNumber"/>
+            <ref name="SideBySideGroupNoNumber"/>
           </choice>
         </zeroOrMore>
         <zeroOrMore>
@@ -167,7 +167,7 @@
             <choice>
               <ref name="Paragraph"/>
               <ref name="Tabular"/>
-              <ref name="SideBySideNoCaption"/>
+              <ref name="SideBySideNoNumber"/>
               <ref name="SlateInput"/>
               <ref name="AnyXhtml"/>
               <optional>
@@ -271,7 +271,7 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="SideBySideNoCaption" combine="choice">
+  <define name="SideBySideNoNumber" combine="choice">
     <element name="sidebyside">
       <ref name="SidebySideAttributes"/>
       <oneOrMore>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -306,7 +306,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Warn if there is a description and @decorative="yes". -->
 <!-- Warn if a description length is over 125 characters.  -->
 <xsl:template match="image">
-    <xsl:if test="not(@decorative = 'yes') and description = ''">
+    <xsl:if test="not(@decorative = 'yes') and (not(description) or description = '')">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
             <xsl:with-param name="message">
@@ -317,7 +317,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:with-param>
         </xsl:apply-templates>
     </xsl:if>
-    <xsl:if test="@decorative = 'yes' and not(description = '')">
+    <xsl:if test="@decorative = 'yes' and description and not(description = '')">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
             <xsl:with-param name="message">

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -182,6 +182,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- An "exercise" as a panel of a "sidebyside" supports compact -->
+<!-- layout of a "worksheet" or a "handout", where workspace is  -->
+<!-- relevant.  The schema allows the arrangement anywhere a     -->
+<!-- "sidebyside" can appear, so we restrict it here.            -->
+<xsl:template match="sidebyside/exercise">
+    <xsl:if test="not(ancestor::worksheet) and not(ancestor::handout)">
+        <xsl:apply-templates select="." mode="messaging">
+            <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message">
+                <xsl:text>An &lt;exercise&gt; as a panel of a &lt;sidebyside&gt; is only supported&#xa;</xsl:text>
+                <xsl:text>within a &lt;worksheet&gt; or a &lt;handout&gt;.  Here, results&#xa;</xsl:text>
+                <xsl:text>may be unpredictable.</xsl:text>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- recurse further -->
+    <xsl:apply-templates/>
+</xsl:template>
+
 <!-- ########## -->
 <!-- Advisories -->
 <!-- ########## -->

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -203,6 +203,36 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- A "figure", "table", "listing", or (named) "list" is numbered and  -->
+<!-- carries a caption or title.  Some locations are meant for strictly -->
+<!-- unnumbered content, and the schema's "NoNumber" patterns exclude   -->
+<!-- these items as immediate children, or as whole panels of a         -->
+<!-- "sidebyside".  But one can still sneak in nested, such as a        -->
+<!-- "figure" within a list item of a "p".  We catch every depth here.  -->
+<!-- The locations: "assemblage", "interactive", "slate", "colophon",   -->
+<!-- "headnote", "gi", "biography", "acknowledgement", "preface", and   -->
+<!-- the "introduction"/"conclusion" of an "exercisegroup".             -->
+<xsl:template match="figure|table|listing|list">
+    <xsl:variable name="unnumbered-context" select="(ancestor::*[self::assemblage or self::interactive or self::slate or self::colophon or self::headnote or self::gi or self::biography or self::acknowledgement or self::preface or ((self::introduction or self::conclusion) and parent::exercisegroup)])[last()]"/>
+    <xsl:if test="$unnumbered-context">
+        <xsl:apply-templates select="." mode="messaging">
+            <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message">
+                <xsl:text>A &lt;</xsl:text>
+                <xsl:value-of select="local-name(.)"/>
+                <xsl:text>&gt; is numbered, but it is located within a container (&lt;</xsl:text>
+                <xsl:value-of select="local-name($unnumbered-context)"/>
+                <xsl:text>&gt;) whose content&#xa;</xsl:text>
+                <xsl:text>is otherwise unnumbered.  The number may be unreliable and the presentation&#xa;</xsl:text>
+                <xsl:text>may suffer.  Consider an unnumbered substitute for the contents (such as&#xa;</xsl:text>
+                <xsl:text>&lt;image&gt;, &lt;tabular&gt;, &lt;program&gt;, &lt;console&gt;) or relocate the item.</xsl:text>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- recurse further -->
+    <xsl:apply-templates/>
+</xsl:template>
+
 <!-- A "tabular" is ragged when its rows do not all occupy the same    -->
 <!-- number of columns (each cell counting as its @colspan, else one).  -->
 <!-- We detect this against a reference count: the number of "col"      -->

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -419,32 +419,8 @@
 
             PrintoutBlock =
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | PrintoutExercise | Project |
+                Axiom | Example | Exercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment | Paragraphs
-
-            # Exercises and tasks can have workspace:
-            PrintoutExercise =
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    attribute workspace {text}?,
-                    (
-                    ExerciseBody |
-                    (StatementExercise, Hint*, Answer*, Solution*) |
-                    (IntroductionText?, WebWork, ConclusionText?) |
-                    (IntroductionStatement?, PrintoutTask+, ConclusionStatement?)
-                    )
-                }
-            PrintoutTask =
-                element task {
-                    MetaDataTitleOptional,
-                    attribute workspace {text}?,
-                    (
-                        BlockStatement+ |
-                        (Statement, Hint*, Answer*, Solution*) |
-                        (IntroductionStatement?, PrintoutTask+, ConclusionStatement?)
-                    )
-                }
 
             # Page can contain a printout block or be empty
             Page =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1571,16 +1571,6 @@
                 ShortTitle?,
                 PlainTitle?,
                 Index*
-            MetaDataSubtitle =
-                UniqueID?,
-                LabelID?,
-                Component?,
-                XMLLang?,
-                Title,
-                Subtitle?,
-                ShortTitle?,
-                PlainTitle?,
-                Index*
             MetaDataLinedSubtitle =
                 UniqueID?,
                 LabelID?,

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -417,40 +417,11 @@
                 attribute right { text }?,
                 attribute left { text }?
 
-            # PrintoutBlockCommon is the block content shared by a "worksheet"
-            # and a "handout".  A worksheet additionally admits an "exercise"
-            # inside a "sidebyside" (WorksheetSideBySide) and uses
-            # WorksheetParagraphs; a handout does neither.  The shared remainder
-            # is factored out here.  (An ordinary "sidebyside" without an
-            # "exercise" is already available to both, through BlockStatement.)
-            PrintoutBlockCommon =
+            PrintoutBlock =
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | PrintoutExercise | Project |
-                Poem | Assemblage | ListGenerator | Fragment
-            PrintoutBlock =
-                PrintoutBlockCommon | Paragraphs
+                Poem | Assemblage | ListGenerator | Fragment | Paragraphs
 
-            # A worksheet "sidebyside" may hold an "exercise" (with workspace).
-            WorksheetSideBySide =
-                element sidebyside {
-                    SidebySideAttributes,
-                    (
-                        Figure |
-                        Poem |
-                        Tabular |
-                        Image |
-                        Video |
-                        Audio |
-                        Program |
-                        Console |
-                        Paragraph |
-                        Preformatted |
-                        List |
-                        Stack |
-                        PrintoutExercise |
-                        PrintoutTask
-                    )+
-                }
             # Exercises and tasks can have workspace:
             PrintoutExercise =
                 element exercise {
@@ -480,22 +451,6 @@
                 element page {
                     PrintoutBlock+ | empty
                 }
-            # A "worksheet" (but not a "handout") may hold a "sidebyside" that
-            # contains an "exercise" (with workspace).  An ordinary "sidebyside"
-            # cannot hold an "exercise", so a worksheet's "paragraphs" gets that
-            # exception here, admitting a WorksheetSideBySide.
-            WorksheetParagraphs =
-                element paragraphs {
-                    MetaDataTitle,
-                    Index*,
-                    (BlockDivision | WorksheetSideBySide)+
-                }
-            WorksheetBlock =
-                PrintoutBlockCommon | WorksheetSideBySide | WorksheetParagraphs
-            WorksheetPage =
-                element page {
-                    WorksheetBlock+ | empty
-                }
             # Main worksheet definition
             Worksheet =
                 element worksheet {
@@ -505,7 +460,7 @@
                     attribute seriescode {text}?,
                     MetaDataAltTitleOptional,
                     (Objectives? & IntroductionDivision?),
-                    (WorksheetPage+ | WorksheetBlock+),
+                    (Page+ | PrintoutBlock+),
                     (Outcomes? & ConclusionDivision?)
                 }
 
@@ -984,7 +939,8 @@
                         Paragraph |
                         Preformatted |
                         List |
-                        Stack
+                        Stack |
+                        Exercise
                     )+
                 }
             SideBySideNoNumber =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -296,7 +296,7 @@
             Biography =
                 element biography {
                     MetaDataTitleOptional,
-                    (BlockStatementNoCaption | ParagraphsNoNumber)+
+                    (BlockStatementNoNumber | ParagraphsNoNumber)+
                 }
             Dedication =
                 element dedication {
@@ -306,21 +306,21 @@
             Acknowledgement =
                 element acknowledgement {
                     MetaDataTitleOptional,
-                    (BlockStatementNoCaption | ParagraphsNoNumber)+
+                    (BlockStatementNoNumber | ParagraphsNoNumber)+
                 }
             Preface =
                 element preface {
                     MetaDataTitleOptional,
                     (
                         (
-                            (BlockStatementNoCaption | ParagraphsNoNumber)+,
+                            (BlockStatementNoNumber | ParagraphsNoNumber)+,
                             Attribution*
                         )
                         |
                         (
-                            (BlockStatementNoCaption | ParagraphsNoNumber )*,
+                            (BlockStatementNoNumber | ParagraphsNoNumber )*,
                             Contributors,
-                            (BlockStatementNoCaption | ParagraphsNoNumber)*
+                            (BlockStatementNoNumber | ParagraphsNoNumber)*
                         )
                     )
                 }
@@ -346,7 +346,7 @@
             ColophonBack =
                 element colophon {
                     MetaDataTarget,
-                    (BlockText | SideBySideNoCaption | SideBySideGroupNoCaption)+
+                    (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
             
             Paragraphs =
@@ -359,7 +359,7 @@
                 element paragraphs {
                     MetaDataTitle,
                     Index*,
-                    BlockStatementNoCaption+
+                    BlockStatementNoNumber+
                 }
             
             ReadingQuestions =
@@ -516,9 +516,9 @@
             BlockText =
                 Paragraph | BlockQuote | Preformatted |
                 Image | Video | Audio | Program | Console | Tabular
-            BlockStatementNoCaption =
+            BlockStatementNoNumber =
                 BlockText | Aside |
-                SideBySideNoCaption | SideBySideGroupNoCaption
+                SideBySideNoNumber | SideBySideGroupNoNumber
             BlockStatement =
                 BlockText |
                 Figure | Aside |
@@ -561,10 +561,10 @@
                 element introduction {BlockText+}
             ConclusionText =
                 element conclusion {BlockText+}
-            IntroductionStatementNoCaption =
-                element introduction {BlockStatementNoCaption+}
-            ConclusionStatementNoCaption =
-                element conclusion {BlockStatementNoCaption+}
+            IntroductionStatementNoNumber =
+                element introduction {BlockStatementNoNumber+}
+            ConclusionStatementNoNumber =
+                element conclusion {BlockStatementNoNumber+}
             IntroductionStatement =
                 element introduction {BlockStatement+}
             ConclusionStatement =
@@ -580,7 +580,7 @@
                     BlockDivision+
                 }
             HeadNote =
-                element headnote {BlockStatementNoCaption+}
+                element headnote {BlockStatementNoNumber+}
             
             Objectives =
                 element objectives {
@@ -905,7 +905,7 @@
             Assemblage =
                 element assemblage {
                     MetaDataTitleOptional,
-                    (BlockText | SideBySideNoCaption | SideBySideGroupNoCaption)+
+                    (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
             
             Caption =
@@ -987,7 +987,7 @@
                         Stack
                     )+
                 }
-            SideBySideNoCaption =
+            SideBySideNoNumber =
                 element sidebyside {
                     SidebySideAttributes,
                     (
@@ -1010,11 +1010,11 @@
                     SidebySideAttributes,
                     SideBySide+
                 }
-            SideBySideGroupNoCaption =
+            SideBySideGroupNoNumber =
                 element sbsgroup {
                     UniqueID?,
                     SidebySideAttributes,
-                    SideBySideNoCaption+
+                    SideBySideNoNumber+
                 }
             
             Image = ImageRaster | ImageCode
@@ -1270,9 +1270,9 @@
                 element exercisegroup {
                     MetaDataTitleOptional,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
-                    IntroductionStatementNoCaption,
+                    IntroductionStatementNoNumber,
                     Exercise+,
-                    ConclusionStatementNoCaption?
+                    ConclusionStatementNoNumber?
                 }
             
             AlignmentPoem = attribute halign {"left" | "center" | "right"}
@@ -1459,7 +1459,7 @@
             GlossaryItem =
                 element gi {
                     MetaDataTitle,
-                    BlockStatementNoCaption+
+                    BlockStatementNoNumber+
                 }
             
             Contributor =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -418,9 +418,7 @@
                 attribute left { text }?
 
             PrintoutBlock =
-                BlockStatement | Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | Exercise | Project |
-                Poem | Assemblage | ListGenerator | Fragment | Paragraphs
+                BlockDivision | Paragraphs
 
             # Page can contain a printout block or be empty
             Page =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -236,6 +236,9 @@
                 TextSimple
             }
             Edition = element edition {text}
+            # "event" is consumed only by the slideshow conversions
+            # (Beamer, reveal.js).  This schema does not yet describe a
+            # "slideshow" document, so the pattern is dormant until then.
             Event = element event {
                 TextLong
             }

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -465,8 +465,6 @@
             
             Prelude =
                 element prelude {BlockText+}
-            Interlude =
-                element interlude {BlockText+}
             Postlude =
                 element postlude {BlockText+}
             Statement =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1198,20 +1198,7 @@
   </define>
   <define name="PrintoutBlock">
     <choice>
-      <ref name="BlockStatement"/>
-      <ref name="Remark"/>
-      <ref name="Computation"/>
-      <ref name="Theorem"/>
-      <ref name="Proof"/>
-      <ref name="Definition"/>
-      <ref name="Axiom"/>
-      <ref name="Example"/>
-      <ref name="Exercise"/>
-      <ref name="Project"/>
-      <ref name="Poem"/>
-      <ref name="Assemblage"/>
-      <ref name="ListGenerator"/>
-      <ref name="Fragment"/>
+      <ref name="BlockDivision"/>
       <ref name="Paragraphs"/>
     </choice>
   </define>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1325,13 +1325,6 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="Interlude">
-    <element name="interlude">
-      <oneOrMore>
-        <ref name="BlockText"/>
-      </oneOrMore>
-    </element>
-  </define>
   <define name="Postlude">
     <element name="postlude">
       <oneOrMore>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1206,7 +1206,7 @@
       <ref name="Definition"/>
       <ref name="Axiom"/>
       <ref name="Example"/>
-      <ref name="PrintoutExercise"/>
+      <ref name="Exercise"/>
       <ref name="Project"/>
       <ref name="Poem"/>
       <ref name="Assemblage"/>
@@ -1214,89 +1214,6 @@
       <ref name="Fragment"/>
       <ref name="Paragraphs"/>
     </choice>
-  </define>
-  <!-- Exercises and tasks can have workspace: -->
-  <define name="PrintoutExercise">
-    <element name="exercise">
-      <ref name="MetaDataTitleOptional"/>
-      <optional>
-        <attribute name="number"/>
-      </optional>
-      <optional>
-        <attribute name="workspace"/>
-      </optional>
-      <choice>
-        <ref name="ExerciseBody"/>
-        <group>
-          <ref name="StatementExercise"/>
-          <zeroOrMore>
-            <ref name="Hint"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Answer"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Solution"/>
-          </zeroOrMore>
-        </group>
-        <group>
-          <optional>
-            <ref name="IntroductionText"/>
-          </optional>
-          <ref name="WebWork"/>
-          <optional>
-            <ref name="ConclusionText"/>
-          </optional>
-        </group>
-        <group>
-          <optional>
-            <ref name="IntroductionStatement"/>
-          </optional>
-          <oneOrMore>
-            <ref name="PrintoutTask"/>
-          </oneOrMore>
-          <optional>
-            <ref name="ConclusionStatement"/>
-          </optional>
-        </group>
-      </choice>
-    </element>
-  </define>
-  <define name="PrintoutTask">
-    <element name="task">
-      <ref name="MetaDataTitleOptional"/>
-      <optional>
-        <attribute name="workspace"/>
-      </optional>
-      <choice>
-        <oneOrMore>
-          <ref name="BlockStatement"/>
-        </oneOrMore>
-        <group>
-          <ref name="Statement"/>
-          <zeroOrMore>
-            <ref name="Hint"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Answer"/>
-          </zeroOrMore>
-          <zeroOrMore>
-            <ref name="Solution"/>
-          </zeroOrMore>
-        </group>
-        <group>
-          <optional>
-            <ref name="IntroductionStatement"/>
-          </optional>
-          <oneOrMore>
-            <ref name="PrintoutTask"/>
-          </oneOrMore>
-          <optional>
-            <ref name="ConclusionStatement"/>
-          </optional>
-        </group>
-      </choice>
-    </element>
   </define>
   <!-- Page can contain a printout block or be empty -->
   <define name="Page">

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -931,7 +931,7 @@
       <ref name="MetaDataTitleOptional"/>
       <oneOrMore>
         <choice>
-          <ref name="BlockStatementNoCaption"/>
+          <ref name="BlockStatementNoNumber"/>
           <ref name="ParagraphsNoNumber"/>
         </choice>
       </oneOrMore>
@@ -953,7 +953,7 @@
       <ref name="MetaDataTitleOptional"/>
       <oneOrMore>
         <choice>
-          <ref name="BlockStatementNoCaption"/>
+          <ref name="BlockStatementNoNumber"/>
           <ref name="ParagraphsNoNumber"/>
         </choice>
       </oneOrMore>
@@ -966,7 +966,7 @@
         <group>
           <oneOrMore>
             <choice>
-              <ref name="BlockStatementNoCaption"/>
+              <ref name="BlockStatementNoNumber"/>
               <ref name="ParagraphsNoNumber"/>
             </choice>
           </oneOrMore>
@@ -977,14 +977,14 @@
         <group>
           <zeroOrMore>
             <choice>
-              <ref name="BlockStatementNoCaption"/>
+              <ref name="BlockStatementNoNumber"/>
               <ref name="ParagraphsNoNumber"/>
             </choice>
           </zeroOrMore>
           <ref name="Contributors"/>
           <zeroOrMore>
             <choice>
-              <ref name="BlockStatementNoCaption"/>
+              <ref name="BlockStatementNoNumber"/>
               <ref name="ParagraphsNoNumber"/>
             </choice>
           </zeroOrMore>
@@ -1044,8 +1044,8 @@
       <oneOrMore>
         <choice>
           <ref name="BlockText"/>
-          <ref name="SideBySideNoCaption"/>
-          <ref name="SideBySideGroupNoCaption"/>
+          <ref name="SideBySideNoNumber"/>
+          <ref name="SideBySideGroupNoNumber"/>
         </choice>
       </oneOrMore>
     </element>
@@ -1068,7 +1068,7 @@
         <ref name="Index"/>
       </zeroOrMore>
       <oneOrMore>
-        <ref name="BlockStatementNoCaption"/>
+        <ref name="BlockStatementNoNumber"/>
       </oneOrMore>
     </element>
   </define>
@@ -1440,12 +1440,12 @@
       <ref name="Tabular"/>
     </choice>
   </define>
-  <define name="BlockStatementNoCaption">
+  <define name="BlockStatementNoNumber">
     <choice>
       <ref name="BlockText"/>
       <ref name="Aside"/>
-      <ref name="SideBySideNoCaption"/>
-      <ref name="SideBySideGroupNoCaption"/>
+      <ref name="SideBySideNoNumber"/>
+      <ref name="SideBySideGroupNoNumber"/>
     </choice>
   </define>
   <define name="BlockStatement">
@@ -1549,17 +1549,17 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="IntroductionStatementNoCaption">
+  <define name="IntroductionStatementNoNumber">
     <element name="introduction">
       <oneOrMore>
-        <ref name="BlockStatementNoCaption"/>
+        <ref name="BlockStatementNoNumber"/>
       </oneOrMore>
     </element>
   </define>
-  <define name="ConclusionStatementNoCaption">
+  <define name="ConclusionStatementNoNumber">
     <element name="conclusion">
       <oneOrMore>
-        <ref name="BlockStatementNoCaption"/>
+        <ref name="BlockStatementNoNumber"/>
       </oneOrMore>
     </element>
   </define>
@@ -1598,7 +1598,7 @@
   <define name="HeadNote">
     <element name="headnote">
       <oneOrMore>
-        <ref name="BlockStatementNoCaption"/>
+        <ref name="BlockStatementNoNumber"/>
       </oneOrMore>
     </element>
   </define>
@@ -2503,8 +2503,8 @@
       <oneOrMore>
         <choice>
           <ref name="BlockText"/>
-          <ref name="SideBySideNoCaption"/>
-          <ref name="SideBySideGroupNoCaption"/>
+          <ref name="SideBySideNoNumber"/>
+          <ref name="SideBySideGroupNoNumber"/>
         </choice>
       </oneOrMore>
     </element>
@@ -2646,7 +2646,7 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="SideBySideNoCaption">
+  <define name="SideBySideNoNumber">
     <element name="sidebyside">
       <ref name="SidebySideAttributes"/>
       <oneOrMore>
@@ -2677,14 +2677,14 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="SideBySideGroupNoCaption">
+  <define name="SideBySideGroupNoNumber">
     <element name="sbsgroup">
       <optional>
         <ref name="UniqueID"/>
       </optional>
       <ref name="SidebySideAttributes"/>
       <oneOrMore>
-        <ref name="SideBySideNoCaption"/>
+        <ref name="SideBySideNoNumber"/>
       </oneOrMore>
     </element>
   </define>
@@ -3359,12 +3359,12 @@
           </choice>
         </attribute>
       </optional>
-      <ref name="IntroductionStatementNoCaption"/>
+      <ref name="IntroductionStatementNoNumber"/>
       <oneOrMore>
         <ref name="Exercise"/>
       </oneOrMore>
       <optional>
-        <ref name="ConclusionStatementNoCaption"/>
+        <ref name="ConclusionStatementNoNumber"/>
       </optional>
     </element>
   </define>
@@ -3833,7 +3833,7 @@
     <element name="gi">
       <ref name="MetaDataTitle"/>
       <oneOrMore>
-        <ref name="BlockStatementNoCaption"/>
+        <ref name="BlockStatementNoNumber"/>
       </oneOrMore>
     </element>
   </define>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1196,15 +1196,7 @@
       <attribute name="left"/>
     </optional>
   </define>
-  <!--
-    PrintoutBlockCommon is the block content shared by a "worksheet"
-    and a "handout".  A worksheet additionally admits an "exercise"
-    inside a "sidebyside" (WorksheetSideBySide) and uses
-    WorksheetParagraphs; a handout does neither.  The shared remainder
-    is factored out here.  (An ordinary "sidebyside" without an
-    "exercise" is already available to both, through BlockStatement.)
-  -->
-  <define name="PrintoutBlockCommon">
+  <define name="PrintoutBlock">
     <choice>
       <ref name="BlockStatement"/>
       <ref name="Remark"/>
@@ -1220,37 +1212,8 @@
       <ref name="Assemblage"/>
       <ref name="ListGenerator"/>
       <ref name="Fragment"/>
-    </choice>
-  </define>
-  <define name="PrintoutBlock">
-    <choice>
-      <ref name="PrintoutBlockCommon"/>
       <ref name="Paragraphs"/>
     </choice>
-  </define>
-  <!-- A worksheet "sidebyside" may hold an "exercise" (with workspace). -->
-  <define name="WorksheetSideBySide">
-    <element name="sidebyside">
-      <ref name="SidebySideAttributes"/>
-      <oneOrMore>
-        <choice>
-          <ref name="Figure"/>
-          <ref name="Poem"/>
-          <ref name="Tabular"/>
-          <ref name="Image"/>
-          <ref name="Video"/>
-          <ref name="Audio"/>
-          <ref name="Program"/>
-          <ref name="Console"/>
-          <ref name="Paragraph"/>
-          <ref name="Preformatted"/>
-          <ref name="List"/>
-          <ref name="Stack"/>
-          <ref name="PrintoutExercise"/>
-          <ref name="PrintoutTask"/>
-        </choice>
-      </oneOrMore>
-    </element>
   </define>
   <!-- Exercises and tasks can have workspace: -->
   <define name="PrintoutExercise">
@@ -1346,43 +1309,6 @@
       </choice>
     </element>
   </define>
-  <!--
-    A "worksheet" (but not a "handout") may hold a "sidebyside" that
-    contains an "exercise" (with workspace).  An ordinary "sidebyside"
-    cannot hold an "exercise", so a worksheet's "paragraphs" gets that
-    exception here, admitting a WorksheetSideBySide.
-  -->
-  <define name="WorksheetParagraphs">
-    <element name="paragraphs">
-      <ref name="MetaDataTitle"/>
-      <zeroOrMore>
-        <ref name="Index"/>
-      </zeroOrMore>
-      <oneOrMore>
-        <choice>
-          <ref name="BlockDivision"/>
-          <ref name="WorksheetSideBySide"/>
-        </choice>
-      </oneOrMore>
-    </element>
-  </define>
-  <define name="WorksheetBlock">
-    <choice>
-      <ref name="PrintoutBlockCommon"/>
-      <ref name="WorksheetSideBySide"/>
-      <ref name="WorksheetParagraphs"/>
-    </choice>
-  </define>
-  <define name="WorksheetPage">
-    <element name="page">
-      <choice>
-        <oneOrMore>
-          <ref name="WorksheetBlock"/>
-        </oneOrMore>
-        <empty/>
-      </choice>
-    </element>
-  </define>
   <!-- Main worksheet definition -->
   <define name="Worksheet">
     <element name="worksheet">
@@ -1407,10 +1333,10 @@
       </interleave>
       <choice>
         <oneOrMore>
-          <ref name="WorksheetPage"/>
+          <ref name="Page"/>
         </oneOrMore>
         <oneOrMore>
-          <ref name="WorksheetBlock"/>
+          <ref name="PrintoutBlock"/>
         </oneOrMore>
       </choice>
       <interleave>
@@ -2642,6 +2568,7 @@
           <ref name="Preformatted"/>
           <ref name="List"/>
           <ref name="Stack"/>
+          <ref name="Exercise"/>
         </choice>
       </oneOrMore>
     </element>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4093,33 +4093,6 @@
       <ref name="Index"/>
     </zeroOrMore>
   </define>
-  <define name="MetaDataSubtitle">
-    <optional>
-      <ref name="UniqueID"/>
-    </optional>
-    <optional>
-      <ref name="LabelID"/>
-    </optional>
-    <optional>
-      <ref name="Component"/>
-    </optional>
-    <optional>
-      <ref name="XMLLang"/>
-    </optional>
-    <ref name="Title"/>
-    <optional>
-      <ref name="Subtitle"/>
-    </optional>
-    <optional>
-      <ref name="ShortTitle"/>
-    </optional>
-    <optional>
-      <ref name="PlainTitle"/>
-    </optional>
-    <zeroOrMore>
-      <ref name="Index"/>
-    </zeroOrMore>
-  </define>
   <define name="MetaDataLinedSubtitle">
     <optional>
       <ref name="UniqueID"/>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -778,6 +778,11 @@
       <text/>
     </element>
   </define>
+  <!--
+    "event" is consumed only by the slideshow conversions
+    (Beamer, reveal.js).  This schema does not yet describe a
+    "slideshow" document, so the pattern is dormant until then.
+  -->
   <define name="Event">
     <element name="event">
       <ref name="TextLong"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -424,32 +424,8 @@
 
             PrintoutBlock =
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | PrintoutExercise | Project |
+                Axiom | Example | Exercise | Project |
                 Poem | Assemblage | ListGenerator | Fragment | Paragraphs
-
-            # Exercises and tasks can have workspace:
-            PrintoutExercise =
-                element exercise {
-                    MetaDataTitleOptional,
-                    attribute number {text}?,
-                    attribute workspace {text}?,
-                    (
-                    ExerciseBody |
-                    (StatementExercise, Hint*, Answer*, Solution*) |
-                    (IntroductionText?, WebWork, ConclusionText?) |
-                    (IntroductionStatement?, PrintoutTask+, ConclusionStatement?)
-                    )
-                }
-            PrintoutTask =
-                element task {
-                    MetaDataTitleOptional,
-                    attribute workspace {text}?,
-                    (
-                        BlockStatement+ |
-                        (Statement, Hint*, Answer*, Solution*) |
-                        (IntroductionStatement?, PrintoutTask+, ConclusionStatement?)
-                    )
-                }
 
             # Page can contain a printout block or be empty
             Page =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -422,40 +422,11 @@
                 attribute right { text }?,
                 attribute left { text }?
 
-            # PrintoutBlockCommon is the block content shared by a "worksheet"
-            # and a "handout".  A worksheet additionally admits an "exercise"
-            # inside a "sidebyside" (WorksheetSideBySide) and uses
-            # WorksheetParagraphs; a handout does neither.  The shared remainder
-            # is factored out here.  (An ordinary "sidebyside" without an
-            # "exercise" is already available to both, through BlockStatement.)
-            PrintoutBlockCommon =
+            PrintoutBlock =
                 BlockStatement | Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | PrintoutExercise | Project |
-                Poem | Assemblage | ListGenerator | Fragment
-            PrintoutBlock =
-                PrintoutBlockCommon | Paragraphs
+                Poem | Assemblage | ListGenerator | Fragment | Paragraphs
 
-            # A worksheet "sidebyside" may hold an "exercise" (with workspace).
-            WorksheetSideBySide =
-                element sidebyside {
-                    SidebySideAttributes,
-                    (
-                        Figure |
-                        Poem |
-                        Tabular |
-                        Image |
-                        Video |
-                        Audio |
-                        Program |
-                        Console |
-                        Paragraph |
-                        Preformatted |
-                        List |
-                        Stack |
-                        PrintoutExercise |
-                        PrintoutTask
-                    )+
-                }
             # Exercises and tasks can have workspace:
             PrintoutExercise =
                 element exercise {
@@ -485,22 +456,6 @@
                 element page {
                     PrintoutBlock+ | empty
                 }
-            # A "worksheet" (but not a "handout") may hold a "sidebyside" that
-            # contains an "exercise" (with workspace).  An ordinary "sidebyside"
-            # cannot hold an "exercise", so a worksheet's "paragraphs" gets that
-            # exception here, admitting a WorksheetSideBySide.
-            WorksheetParagraphs =
-                element paragraphs {
-                    MetaDataTitle,
-                    Index*,
-                    (BlockDivision | WorksheetSideBySide)+
-                }
-            WorksheetBlock =
-                PrintoutBlockCommon | WorksheetSideBySide | WorksheetParagraphs
-            WorksheetPage =
-                element page {
-                    WorksheetBlock+ | empty
-                }
             # Main worksheet definition
             Worksheet =
                 element worksheet {
@@ -510,7 +465,7 @@
                     attribute seriescode {text}?,
                     MetaDataAltTitleOptional,
                     (Objectives? &amp; IntroductionDivision?),
-                    (WorksheetPage+ | WorksheetBlock+),
+                    (Page+ | PrintoutBlock+),
                     (Outcomes? &amp; ConclusionDivision?)
                 }
 
@@ -1881,6 +1836,8 @@
 
         <p>A <tag>stack</tag> allows non-captioned, non-titled elements to accumulate vertically in a single panel.  It is a basic container.</p>
 
+        <p>An <tag>exercise</tag> may be a panel, in support of compact layout of a <tag>worksheet</tag> or a <tag>handout</tag>, where workspace is relevant.  The schema does not restrict the arrangement to those locations, but the validation-plus stylesheet warns about others.</p>
+
         <p>A group of side-by-sides is designed to stack vertically with common controls on widths, etc.  Its implementation is entirely experimental right now, even if we are relatively confident of the markup.</p>
 
         <fragment xml:id="sidebyside">
@@ -1924,7 +1881,8 @@
                         Paragraph |
                         Preformatted |
                         List |
-                        Stack
+                        Stack |
+                        Exercise
                     )+
                 }
             SideBySideNoNumber =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -411,7 +411,7 @@
 
         <p>The attributes on a printout include margin information to control layout.  Inside a printout we can have either a number of <tag>page</tag> elements that holding the content or just the content itself.</p>
 
-        <p>The contents of a printout can include the same blocks as a division, namely BlockDivision.</p>
+        <p>The contents of a printout can include the same blocks as a division, namely BlockDivision, plus the <tag>paragraphs</tag> division.</p>
         <fragment xml:id="printout">
             <title>Printout</title>
             <code>
@@ -423,9 +423,7 @@
                 attribute left { text }?
 
             PrintoutBlock =
-                BlockStatement | Remark | Computation | Theorem | Proof | Definition |
-                Axiom | Example | Exercise | Project |
-                Poem | Assemblage | ListGenerator | Fragment | Paragraphs
+                BlockDivision | Paragraphs
 
             # Page can contain a printout block or be empty
             Page =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3052,9 +3052,8 @@
             <li><c>MetaDataTarget</c> is for items that are targets of cross-references, but without even optional titles.  Since they will be knowled, they can appear in an index.  But without the potential to be titled, we do not set them up as possible root elements of a file to <c>xinclude</c>.</li>
             <li><c>MetaDataTitle</c> has a required <tag>title</tag>.</li>
             <li><c>MetaDataAltTitle</c> has a required <tag>title</tag>, and allows optional <tag>shorttitle</tag> and <tag>plaintitle</tag>.</li>
-            <li><c>MetaDataSubtitle</c> implicitly has a required <tag>title</tag>, and allows optional <tag>subtitle</tag>, <tag>shorttitle</tag> and <tag>plaintitle</tag>.</li>
             <li>A <tag>plaintitle</tag> means no markup whatsoever in the content, this is what <q>plain</q> means.</li>
-            <li><c>MetaDataLinedTitle</c> and <c>MetaDataLinedSubtitle</c> are variants of the <c>AltTitle</c> or <c>Subtitle</c> versions for use on larger divisions with <tag>line</tag> elements used to suggest line breaks in titles.</li>
+            <li><c>MetaDataLinedTitle</c> and <c>MetaDataLinedSubtitle</c> are variants of the <c>AltTitle</c> version for use on larger divisions with <tag>line</tag> elements used to suggest line breaks in titles; the latter also allows an optional <tag>subtitle</tag>.</li>
             <li><c>MetaDataCaption</c> implicitly has an optional title.</li>
             <li>Titles may contain external references (<c>url</c>) or internal cross-references (<c>xref</c>), but implementers need not make them active (<ie/>, they maybe text only), since titles are prone to migrating to other locations.</li>
         </ul></p>
@@ -3110,16 +3109,6 @@
                 Component?,
                 XMLLang?,
                 (Title | LinedTitle),
-                ShortTitle?,
-                PlainTitle?,
-                Index*
-            MetaDataSubtitle =
-                UniqueID?,
-                LabelID?,
-                Component?,
-                XMLLang?,
-                Title,
-                Subtitle?,
                 ShortTitle?,
                 PlainTitle?,
                 Index*

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -409,7 +409,7 @@
 
         <p>A printout division (currently only a <tag>worksheet</tag>) is a specialized division, allowing for some additional control of spacing and page delineation, to allow for workspace.</p>
 
-        <p>The attributes on a printout include margin information to control layout.  Inside a printout we can have either a number of <tag>page</tag> elements that holding the content or just the content itself.</p>
+        <p>The attributes on a printout include margin information to control layout.  Inside a printout we can have either a number of <tag>page</tag> elements that hold the content or just the content itself.</p>
 
         <p>The contents of a printout can include the same blocks as a division, namely BlockDivision, plus the <tag>paragraphs</tag> division.</p>
         <fragment xml:id="printout">
@@ -455,9 +455,9 @@
 
         <p>A handout is a specialized division very similar to a worksheet, allowing for some additional control of spacing, to allow for workspace.</p>
 
-        <p>The attributes on a handout include margin information to control layout, just like worksheets.  Also like worksheets, a handout we can contain either a number of <tag>page</tag> elements that holding the content or just the content itself.</p>
+        <p>The attributes on a handout include margin information to control layout, just like worksheets.  Also like worksheets, a handout can contain either a number of <tag>page</tag> elements that hold the content or just the content itself.</p>
 
-        <p>The contents of a handout can include the same blocks as a division, namely BlockDivision.  Any such division can get a <attr>workspace</attr> attribute.  This is currently not implemented in the schema (stable or experimental), but the plan is to allow <attr>workspace</attr> to be placed on any element that will be respected inside a handout, treating this as a hint that will be ignored when not inside a printout.</p>
+        <p>The contents of a handout can include the same blocks as a division, namely BlockDivision.  Many of these blocks (theorems, definitions, examples, projects, exercises, tasks, proofs) can get a <attr>workspace</attr> attribute.  It is treated as a hint: respected inside a printout, and ignored elsewhere (which the validation-plus stylesheet will point out).</p>
 
         <p>Note: when handouts moves to the stable schema, we will need to go to every division and for the option of an unstructured division, include Worksheet and Handout as separate elements so an unstructured division can have one of each.</p>
 

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3289,6 +3289,9 @@
                 TextSimple
             }
             Edition = element edition {text}
+            # "event" is consumed only by the slideshow conversions
+            # (Beamer, reveal.js).  This schema does not yet describe a
+            # "slideshow" document, so the pattern is dormant until then.
             Event = element event {
                 TextLong
             }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1001,7 +1001,7 @@
             </code>
         </fragment>
 
-        <p>Blocks are often structured, in a light way.  Hints, answers, and solutions adorn exercises, examples, and projects.  A simple introduction or conclusion is sometimes useful.  A <c>prelude</c> or <c>postlude</c> are authored inside a block and so are associated with it.  But they are presented before and after the block visually.  An <c>interlude</c> will be used between the statement of a theorem and its proof.</p>
+        <p>Blocks are often structured, in a light way.  Hints, answers, and solutions adorn exercises, examples, and projects.  A simple introduction or conclusion is sometimes useful.  A <c>prelude</c> or <c>postlude</c> are authored inside a block and so are associated with it.  But they are presented before and after the block visually.</p>
 
         <p>When a block is structured to allow some of the ancillary parts, a <c>statement</c> element is used to structure the main part.  Hints, answers, and solutions can be the target of cross-references, but do not get author-supplied titles.</p>
 
@@ -1010,8 +1010,6 @@
             <code>
             Prelude =
                 element prelude {BlockText+}
-            Interlude =
-                element interlude {BlockText+}
             Postlude =
                 element postlude {BlockText+}
             Statement =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -314,7 +314,7 @@
                 element paragraphs {
                     MetaDataTitle,
                     Index*,
-                    BlockStatementNoCaption+
+                    BlockStatementNoNumber+
                 }
             </code>
         </fragment>
@@ -1055,9 +1055,9 @@
             BlockText =
                 Paragraph | BlockQuote | Preformatted |
                 Image | Video | Audio | Program | Console | Tabular
-            BlockStatementNoCaption =
+            BlockStatementNoNumber =
                 BlockText | Aside |
-                SideBySideNoCaption | SideBySideGroupNoCaption
+                SideBySideNoNumber | SideBySideGroupNoNumber
             BlockStatement =
                 BlockText |
                 Figure | Aside |
@@ -1111,7 +1111,7 @@
     <section>
         <title>Introductions, Conclusions, and Headnotes</title>
 
-        <p>The <c>introduction</c> and <c>conclusion</c> containers can be used in a variety of other structured elements.  They come in three levels, according to what they can contain, and are meant to be consonant with their surroundings.  As children of a division, they may carry a <c>title</c>, which in turn allows them to be cross-referenced by that text.</p>
+        <p>The <c>introduction</c> and <c>conclusion</c> containers can be used in a variety of other structured elements.  They come in four levels, according to what they can contain, and are meant to be consonant with their surroundings.  As children of a division, they may carry a <c>title</c>, which in turn allows them to be cross-referenced by that text.</p>
 
         <p>A <tag>headnote</tag> is like an <tag>introduction</tag>, but does not have a symmetric concluding element, and is typically meant for specialized divisions, such as a <tag>glossary</tag>.</p>
 
@@ -1122,10 +1122,10 @@
                 element introduction {BlockText+}
             ConclusionText =
                 element conclusion {BlockText+}
-            IntroductionStatementNoCaption =
-                element introduction {BlockStatementNoCaption+}
-            ConclusionStatementNoCaption =
-                element conclusion {BlockStatementNoCaption+}
+            IntroductionStatementNoNumber =
+                element introduction {BlockStatementNoNumber+}
+            ConclusionStatementNoNumber =
+                element conclusion {BlockStatementNoNumber+}
             IntroductionStatement =
                 element introduction {BlockStatement+}
             ConclusionStatement =
@@ -1141,7 +1141,7 @@
                     BlockDivision+
                 }
             HeadNote =
-                element headnote {BlockStatementNoCaption+}
+                element headnote {BlockStatementNoNumber+}
             </code>
         </fragment>
     </section>
@@ -1725,7 +1725,7 @@
             Assemblage =
                 element assemblage {
                     MetaDataTitleOptional,
-                    (BlockText | SideBySideNoCaption | SideBySideGroupNoCaption)+
+                    (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
             </code>
         </fragment>
@@ -1927,7 +1927,7 @@
                         Stack
                     )+
                 }
-            SideBySideNoCaption =
+            SideBySideNoNumber =
                 element sidebyside {
                     SidebySideAttributes,
                     (
@@ -1950,11 +1950,11 @@
                     SidebySideAttributes,
                     SideBySide+
                 }
-            SideBySideGroupNoCaption =
+            SideBySideGroupNoNumber =
                 element sbsgroup {
                     UniqueID?,
                     SidebySideAttributes,
-                    SideBySideNoCaption+
+                    SideBySideNoNumber+
                 }
             </code>
         </fragment>
@@ -2146,8 +2146,8 @@
                       ImageDescription? &amp;
                       (
                         Slate |
-                        SideBySideNoCaption |
-                        SideBySideGroupNoCaption
+                        SideBySideNoNumber |
+                        SideBySideGroupNoNumber
                       )* &amp;
                       element script { attribute type { text }?, text }* &amp;
                       element source { text }? &amp;
@@ -2191,7 +2191,7 @@
                         (
                           Paragraph |
                           Tabular |
-                          SideBySideNoCaption |
+                          SideBySideNoNumber |
                           SlateInput |
                           AnyXhtml |
                           element xhtml:button {
@@ -2240,7 +2240,7 @@
                 (Interactive | Slate)+
             }
 
-            SideBySideNoCaption |= element sidebyside {
+            SideBySideNoNumber |= element sidebyside {
                 SidebySideAttributes,
                 (Interactive | Slate)+
             }
@@ -2394,9 +2394,9 @@
                 element exercisegroup {
                     MetaDataTitleOptional,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
-                    IntroductionStatementNoCaption,
+                    IntroductionStatementNoNumber,
                     Exercise+,
-                    ConclusionStatementNoCaption?
+                    ConclusionStatementNoNumber?
                 }
             </code>
         </fragment>
@@ -2926,7 +2926,7 @@
             GlossaryItem =
                 element gi {
                     MetaDataTitle,
-                    BlockStatementNoCaption+
+                    BlockStatementNoNumber+
                 }
             </code>
         </fragment>
@@ -3428,7 +3428,7 @@
             Biography =
                 element biography {
                     MetaDataTitleOptional,
-                    (BlockStatementNoCaption | ParagraphsNoNumber)+
+                    (BlockStatementNoNumber | ParagraphsNoNumber)+
                 }
             Dedication =
                 element dedication {
@@ -3438,21 +3438,21 @@
             Acknowledgement =
                 element acknowledgement {
                     MetaDataTitleOptional,
-                    (BlockStatementNoCaption | ParagraphsNoNumber)+
+                    (BlockStatementNoNumber | ParagraphsNoNumber)+
                 }
             Preface =
                 element preface {
                     MetaDataTitleOptional,
                     (
                         (
-                            (BlockStatementNoCaption | ParagraphsNoNumber)+,
+                            (BlockStatementNoNumber | ParagraphsNoNumber)+,
                             Attribution*
                         )
                         |
                         (
-                            (BlockStatementNoCaption | ParagraphsNoNumber )*,
+                            (BlockStatementNoNumber | ParagraphsNoNumber )*,
                             Contributors,
-                            (BlockStatementNoCaption | ParagraphsNoNumber)*
+                            (BlockStatementNoNumber | ParagraphsNoNumber)*
                         )
                     )
                 }
@@ -3548,7 +3548,7 @@
             ColophonBack =
                 element colophon {
                     MetaDataTarget,
-                    (BlockText | SideBySideNoCaption | SideBySideGroupNoCaption)+
+                    (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
             </code>
         </fragment>


### PR DESCRIPTION
A follow-on to #2989, reworking how the schema treats `sidebyside` panels and retiring duplicated or unreachable patterns, with the advisory checks strengthened in `pretext-validation-plus.xsl`. Eleven commits, meant to be read in order.

**Panels and the "NoNumber" series.** The five `*NoCaption` patterns are renamed to the `*NoNumber` series, matching `ParagraphsNoNumber` and naming their real purpose: keeping numbered items out of strictly unnumbered locations. The schema continues to reject the obvious constructions (a whole panel, or an immediate child, that is FIGURE-LIKE); a new validation-plus rule catches what the schema cannot — a numbered item nested at any depth, such as `p > ol > li > figure` inside an `assemblage`.

**Exercise panels.** An `exercise` may now be a panel of any `sidebyside` in the base schema, replacing the worksheet-only threading (`WorksheetSideBySide`/`WorksheetBlock`/`WorksheetPage`) from #2989 with a validation-plus rule restricting the arrangement to a `worksheet` or `handout`. A `task` is *not* a panel: task-as-panel dated to the dev-schema worksheet era, and no example document ever used it.

**Economies.** `PrintoutExercise`/`PrintoutTask` had become character-identical to `Exercise`/`Task` (both now carry `@workspace`) and are removed; `PrintoutBlock` collapses to `BlockDivision | Paragraphs`, as the surrounding prose always claimed (this admits `openproblem` and friends in printouts — the one deliberate widening); the unused `MetaDataSubtitle` and unreachable `Interlude` patterns are gone; the dormant `Event` pattern gains a comment explaining it awaits `slideshow` coverage.

**Validation-plus repairs.** The image-description accessibility check tested `description = ''`, which is false for an *absent* element — so images with no description at all were never flagged, while decorative images without one drew a bogus warning. Both directions fixed; on the sample article the corrected check surfaces ~190 genuinely description-less images (a cleanup for a separate PR).

**Verification.** At every commit, `pretext.rnc`/`pretext.rng`/`pretext-dev.rnc`/`pretext-dev.rng` regenerate exactly from `schema/pretext.xml`. The sample article and The Guide were assembled and validated with jing against both schemas before and after: error sets are identical throughout (sample: dev 27, production 334; Guide: dev 0, production 1), with jing's "expected element" suggestion text the only difference. The new advisory rules were exercised on purpose-built torture documents and are silent on the sample article except where intended.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
