### PR TITLE
Validate the contents of a "prefigure-preamble"

### DIFF
--- a/schema/pf-preamble-adapter.rnc
+++ b/schema/pf-preamble-adapter.rnc
@@ -1,0 +1,9 @@
+
+                default namespace = "https://prefigure.org"
+                grammar {
+                    include "pf_schema.rnc" {
+                        start =
+                            ( GraphicalElements* & GroupElements* )
+                    }
+                }
+            

--- a/schema/pf-preamble-adapter.rng
+++ b/schema/pf-preamble-adapter.rng
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="https://prefigure.org" xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="pf_schema.rng">
+    <start>
+      <interleave>
+        <zeroOrMore>
+          <ref name="GraphicalElements"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="GroupElements"/>
+        </zeroOrMore>
+      </interleave>
+    </start>
+  </include>
+</grammar>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2014,6 +2014,10 @@
                 element latex-image-preamble {text}
             Configuration |=
                 element asymptote-preamble {text}
+            Configuration |=
+                element pf:prefigure-preamble {
+                    external "pf-preamble-adapter.rnc"
+                }
             
             Configuration |=
                 element macros {text}

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -5199,6 +5199,11 @@
     </element>
   </define>
   <define name="Configuration" combine="choice">
+    <element name="pf:prefigure-preamble">
+      <externalRef href="pf-preamble-adapter.rng"/>
+    </element>
+  </define>
+  <define name="Configuration" combine="choice">
     <element name="macros">
       <text/>
     </element>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3530,6 +3530,10 @@
                 element latex-image-preamble {text}
             Configuration |=
                 element asymptote-preamble {text}
+            Configuration |=
+                element pf:prefigure-preamble {
+                    external "pf-preamble-adapter.rnc"
+                }
             </code>
         </fragment>
 
@@ -3700,7 +3704,7 @@
 
     <section>
         <title>PreFigure Schema
-                Adapter</title>
+                Adapters</title>
 
         <p>The <init>PreFigure</init> project publishes its own <init>RELAX-NG</init> compact schema (<c>pf_schema.rnc</c>), which we copy into this directory nearly verbatim (carrying only a handful of minimal upstream bug fixes needed for the grammar to load).  That schema defines every <init>PreFigure</init> element in no namespace, with a start pattern of the <c>diagram</c> element.  <pretext/>, however, expects <init>PreFigure</init> content in the <c>https://prefigure.org</c> namespace, signalled by the <attr>xmlns</attr> on a <c>prefigure</c> element.</p>
 
@@ -3712,6 +3716,21 @@
                 default namespace = "https://prefigure.org"
                 grammar {
                     include "pf_schema.rnc"
+                }
+            </code>
+        </fragment>
+
+        <p>A <c>prefigure-preamble</c> in the <c>docinfo</c> carries <init>PreFigure</init> content (graphical and group elements) without an enclosing <c>diagram</c>.  Since the upstream start pattern is the <c>diagram</c> element, that content is not reachable through the <c>externalRef</c> above, which exposes only a grammar's start pattern.  A second adapter includes the same upstream grammar but overrides its <c>start</c> to expose exactly the drawing-content patterns, again reusing the upstream definitions verbatim.  Definition elements are deliberately omitted as diagram-specific, rather than preamble, material.</p>
+
+        <fragment filename="pf-preamble-adapter.rnc">
+            <title>PreFigure Preamble Adapter</title>
+            <code>
+                default namespace = "https://prefigure.org"
+                grammar {
+                    include "pf_schema.rnc" {
+                        start =
+                            ( GraphicalElements* &amp; GroupElements* )
+                    }
                 }
             </code>
         </fragment>


### PR DESCRIPTION
Resolves #2979.

A `<prefigure-preamble>` (in `docinfo`) holds PreFigure diagram *contents* —
graphical and group elements — but without an enclosing `<diagram>`. The published
`pf_schema.rnc` starts at the `diagram` element, so that content can't be reached
through an ordinary `externalRef`, which exposes only a grammar's start pattern. Until
now the preamble was simply not validated (and tripped a `docinfo` "not allowed here"
error).

This adds a second PreFigure adapter, `pf-preamble-adapter.rnc`, that `include`s the
upstream grammar and overrides its `start` to expose exactly the drawing-content
patterns, reusing the upstream definitions verbatim so it stays in sync with PreFigure:

    default namespace = "https://prefigure.org"
    grammar {
        include "pf_schema.rnc" {
            start =
                ( GraphicalElements* & GroupElements* )
        }
    }

`pf:prefigure-preamble` is then added to the `docinfo` configuration via
`external "pf-preamble-adapter.rnc"`. Per @davidaustinm's guidance in #2979,
**definition elements are excluded** as diagram-specific rather than preamble material;
graphical and group elements are allowed.

Notes:
- The adapter is defined in the literate `pretext.xml` (as `pf-adapter.rnc` already is),
  and the derived `pretext.rnc` / `pretext.rng` and the new `pf-preamble-adapter.rnc` /
  `.rng` are regenerated from it.
- `prefigure-preamble` lives in the PreFigure namespace, mirroring `pf:prefigure`, so its
  content is authored unprefixed under the container's `xmlns`.

Verified against the sample article: its existing `<prefigure-preamble>` now validates,
and the content is genuinely checked — a stray `<definition>` in a preamble is rejected,
while graphical and group elements are accepted.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
