### PR TITLE
Script: upgrade MathJax to version 4

### DIFF
--- a/script/mjsre/README.md
+++ b/script/mjsre/README.md
@@ -1,16 +1,18 @@
 # MathJax (MJ) and Speech Rule Engine (SRE)
 
-Offline support for conversions to EPUB, Kindle, and braille.
+Offline support for conversions to EPUB, Kindle, braille,
+and the XSL-FO PDF.
 
-Requires installations of MathJax and Speech Rule Engine,
+Requires installations of MathJax (version 4, npm package
+"@mathjax/src") and Speech Rule Engine (version 5),
 presumably via the node package manager, `npm`.
 
 ### `mj-sre-page`
-A `node` Javascript program to generate representations of 
+A `node` Javascript program to generate representations of
 mathematics as MathML, SVG, braille, and speech.
 
 ### `update-sre`
-bash script to mange npm installs, so SRE is not pinned to MJ.
+bash script to manage npm installs, so SRE is not pinned to MJ.
 
 ### `package.json`
 Manages dependencies for npm installs.

--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -4,7 +4,7 @@
  *
  *  pretext
  *
- *  Uses MathJax v3 to convert all TeX in an HTML document to forms
+ *  Uses MathJax v4 to convert all TeX in an HTML document to forms
  *  needed by PreTeXt
  *
  * ----------------------------------------------------------------------
@@ -27,23 +27,69 @@
 // Distributed to the PreTeXt project by Davide Cervone, Volker Sorge
 // via https://gist.github.com/dpvc/386e8aac18c010361ef362b9237c71e9
 // AIM braille textbook workshop, 2020-08
+//
+// Upgraded to MathJax v4 (package "@mathjax/src") and Speech Rule
+// Engine v5, 2026-07-04.  The interface is unchanged.
 
 //
 //  Load the packages needed for MathJax
 //
-require('mathjax-full/js/util/asyncLoad/node.js');
-const {mathjax} = require('mathjax-full/js/mathjax.js');
-const {TeX} = require('mathjax-full/js/input/tex.js');
-//  RAB 2021-09-01, MathML only needed for  svgenhanced  mode
-const {MathML} = require('mathjax-full/js/input/mathml.js');
-const {SVG} = require('mathjax-full/js/output/svg.js');
-const {RegisterHTMLHandler} = require('mathjax-full/js/handlers/html.js');
-const {liteAdaptor} = require('mathjax-full/js/adaptors/liteAdaptor.js');
-const {STATE, newState} = require('mathjax-full/js/core/MathItem.js');
-//  RAB 2021-09-01, Enrichhandler only needed for  svgenhanced  mode
-const {EnrichHandler} = require('mathjax-full/js/a11y/semantic-enrich.js');
+//  The node module loader is synchronous, so MathJax (4.1.3 and
+//  later) can load font ranges on demand inside the synchronous
+//  render actions below
+require('@mathjax/src/js/util/asyncLoad/node.js');
+const {mathjax} = require('@mathjax/src/js/mathjax.js');
+const {TeX} = require('@mathjax/src/js/input/tex.js');
+//  MathML input only needed for  svgenhanced  mode
+const {MathML} = require('@mathjax/src/js/input/mathml.js');
+const {SVG} = require('@mathjax/src/js/output/svg.js');
+const {RegisterHTMLHandler} = require('@mathjax/src/js/handlers/html.js');
+const {liteAdaptor} = require('@mathjax/src/js/adaptors/liteAdaptor.js');
+const {STATE, newState} = require('@mathjax/src/js/core/MathItem.js');
+//  MathJax v4 fonts are separate packages; "newcm" is the default font
+const {MathJaxNewcmFont} = require('@mathjax/mathjax-newcm-font/js/svg.js');
 
-const {AllPackages} = require('mathjax-full/js/input/tex/AllPackages.js');
+//
+//  MathJax v4 has no "AllPackages" module.  The component map in
+//  "source.js" is the authoritative list of the TeX extensions
+//  distributed within MathJax itself (the documented replacement for
+//  the version 3 module).  Each extension's configuration module
+//  registers the package when loaded, and is located just as
+//  MathJax's own node demos locate it.  The "base" package is built
+//  into the TeX input jax, but must still be named in the "packages"
+//  option.  Exceptions: "autoload" and "require" presume the
+//  in-browser loader; "colorv2" is superseded by "color" (these were
+//  also absent from version 3's "AllPackages"); "bbm", "bboldx",
+//  and "dsfont" commandeer blackboard bold, wanting font extensions
+//  we do not load; and "physics" hijacks core macros by design
+//  (version 4 lets its \div, divergence, defeat the division sign).
+//
+const {source} = require('@mathjax/src/components/js/source.js');
+const path = require('path');
+const fs = require('fs');
+const texdir = path.join(require.resolve('@mathjax/src/js/input/tex.js'), '..', 'tex');
+const excluded = new Set(['autoload', 'require', 'colorv2', 'bbm', 'bboldx', 'dsfont', 'physics']);
+const extensions = Object.keys(source)
+      .filter((key) => key.substring(0, 6) === '[tex]/')
+      .map((key) => key.substring(6));
+const AllPackages = [];
+for (const name of ['base', ...extensions]) {
+  if (excluded.has(name)) continue;
+  const dir = path.join(texdir, name);
+  const configuration = fs.existsSync(dir)
+        ? fs.readdirSync(dir).find((file) => file.endsWith('Configuration.js'))
+        : null;
+  if (!configuration) {
+    console.error('Could not find TeX package "' + name + '"');
+    continue;
+  }
+  try {
+    require(path.join(dir, configuration));
+    AllPackages.push(name);
+  } catch (err) {
+    console.error('Could not load TeX package "' + name + '": ' + err.message);
+  }
+}
 
 //
 //  Get the command-line arguments
@@ -105,13 +151,21 @@ var argv = require('yargs')
     })
     .argv;
 
-const needsSRE = argv.speech || argv.braille || argv.svgenhanced;
+const sreOutputs = [argv.speech, argv.braille, argv.svgenhanced].filter(Boolean).length;
+const needsSRE = sreOutputs > 0;
 
 //
-//  Load SRE if needed for speech or braille
+//  Load the Speech Rule Engine if needed for speech or braille.
+//  This is the same engine MathJax itself depends upon, used
+//  directly since our conversion is string-to-string.
 //
-const {Sre} = needsSRE ? require('mathjax-full/js/a11y/sre.js') :
-      {Sre: {sreReady: Promise.resolve()}};
+const Sre = needsSRE ? require('speech-rule-engine') : null;
+
+//
+//  The engine configurations for the requested outputs, applied (and
+//  their locales loaded) before rendering begins.
+//
+const sreConfigurations = [];
 
 //
 //  Read the HTML file
@@ -125,12 +179,21 @@ const adaptor = liteAdaptor({fontSize: argv.em});
 const handler = RegisterHTMLHandler(adaptor);
 
 //
-//  Create a MathML serializer
+//  Create MathML serializers.  The version 4 TeX input records the
+//  originating LaTeX on every node as "data-latex" attributes.  The
+//  Speech Rule Engine intends to consult them one day, so they stay
+//  in the internal tree, and in the serialization the engine is
+//  handed; but no PreTeXt consumer has a use for them, they bloat
+//  every output, and a raw "<" inside one is fatal to the XML
+//  parsing downstream.  So MathML destined for output is serialized
+//  by the contextual menu's visitor, which filters them away.
 //
-const {SerializedMmlVisitor} = require('mathjax-full/js/core/MmlTree/SerializedMmlVisitor.js');
+const {SerializedMmlVisitor} = require('@mathjax/src/js/core/MmlTree/SerializedMmlVisitor.js');
 const visitor = new SerializedMmlVisitor();
 const toMathML = (node => visitor.visitTree(node, html));
-
+const {MmlVisitor} = require('@mathjax/src/js/ui/menu/MmlVisitor.js');
+const filteringVisitor = new MmlVisitor();
+const toFilteredMathML = ((node, math) => filteringVisitor.visitTree(node, math));
 
 //
 //  Create a renderAction that calls a function for each math item
@@ -162,8 +225,8 @@ newState('PRETEXTACTION', STATE.PRETEXT + 10);
 //
 const renderActions = {
   //
-  //  An aciton to set up the pretext data array
-  //  and enrich the MathML, if needed
+  //  An action to set up the pretext data array
+  //  and serialize the MathML, if needed
   //
   pretext: action(STATE.PRETEXT, (math, doc, adaptor) => {
     math.outputData.pretext = [adaptor.text('\n')];
@@ -180,39 +243,78 @@ const renderActions = {
 };
 
 //
+//  An author's explicit "\\" (a newline) inside mathematics is
+//  recorded faithfully in the MathML (and so heard in the speech and
+//  braille), but the version 3 SVG output never rendered it, and
+//  honoring it produces percentage-width SVG unusable downstream.  So
+//  the SVG rendering, only, ignores such newlines, as version 3 did.
+//  (A TeX input post-filter could scrub them at parse time, but the
+//  one parse is shared by every output, and the MathML, speech, and
+//  braille must keep the newline when outputs are combined in a
+//  single run.)
+//
+function removeNewlines(root) {
+  root.walkTree((node) => {
+    if (node.attributes?.getExplicit('linebreak') === 'newline') {
+      node.attributes.unset('linebreak');
+    }
+  });
+}
+
+//
 //  If SVG is requested, add an action to add it to the output
 //
 if (argv.svg) {
   renderActions.svg = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
+    removeNewlines(math.root);
     math.outputData.pretext.push(adaptor.firstChild(doc.outputJax.typeset(math, doc)));
     math.outputData.pretext.push(adaptor.text('\n'));
   });
 }
 
 //
-//  If SVG is requested, add an action to add it to the output
-//  RAB 2021-09-01,  svgenhanced  mode not being used (yet)
+//  The SVG output must not carry "data-latex" attributes either (see
+//  the MathML serializers above); the wrapper class is told to skip
+//  them when transcribing node attributes.
 //
+const {CommonWrapper} = require('@mathjax/src/js/output/common/Wrapper.js');
+CommonWrapper.skipAttributes['data-latex'] = true;
+
+//
+//  If enhanced SVG is requested, add an action to add it to the output
+//  (this mode is not currently employed by PreTeXt)
+//
+//
+//  Version 4 breaks in-line mathematics into several SVG fragments for
+//  reflowing, by default.  Our consumers require a single SVG per math
+//  item, as version 3 produced, so in-line breaking is disabled.
+//
+const svgOptions = {
+  fontData: MathJaxNewcmFont,
+  fontCache: (argv.fontPaths ? 'none' : 'local'),
+  linebreaks: {inline: false}
+};
+
 const mmldoc = mathjax.document('', {
   InputJax: new MathML(),
-  OutputJax: new SVG({fontCache: (argv.fontPaths ? 'none' : 'local')}),
+  OutputJax: new SVG(svgOptions),
 });
 if (argv.svgenhanced) {
+  const configuration = {speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules};
+  sreConfigurations.push(configuration);
   renderActions.svg = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
     let out = mmldoc.convert(Sre.toEnriched(math.outputData.mml).toString());
     math.outputData.pretext.push(out);
     math.outputData.pretext.push(adaptor.text('\n'));
-  }, () => {
-    Sre.setupEngine({speech: argv.depth, modality: 'speech', locale: argv.locale, domain: argv.rules});
-  });
+  }, sreOutputs > 1 ? () => Sre.setupEngine(configuration) : null);
 }
 
 //
 //  If MathML is requested, add an action to add it to the output
 //
 if (argv.mathml) {
-  renderActions.mathml = action(STATE.PRETEXTACTION, (math, doc, adpator) => {
-    const mml = adaptor.firstChild(adaptor.body(adaptor.parse(toMathML(math.root), 'text/html')));
+  renderActions.mathml = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
+    const mml = adaptor.firstChild(adaptor.body(adaptor.parse(toFilteredMathML(math.root, math), 'text/html')));
     math.outputData.pretext.push(mml);
     math.outputData.pretext.push(adaptor.text('\n'));
   });
@@ -220,42 +322,31 @@ if (argv.mathml) {
 
 //
 //  If speech is requested, add an action to add it to the output
-//  and set up the speech engine for speech in the correct locale
+//  and record the engine configuration for speech in the correct
+//  locale
 //
 if (argv.speech) {
+  const configuration = {modality: 'speech', locale: argv.locale, domain: argv.rules};
+  sreConfigurations.push(configuration);
   renderActions.speech = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
     const speech = Sre.toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-speech', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
-  }, () => {
-    Sre.setupEngine({modality: 'speech', locale: argv.locale, domain: argv.rules});
-  });
+  }, sreOutputs > 1 ? () => Sre.setupEngine(configuration) : null);
 }
 
 //
 //  If braille is requested, add an action to add it to the output
-//  and set up the speech engine for nemeth braille
+//  and record the engine configuration for nemeth braille
 //
 if (argv.braille) {
+  const configuration = {modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default'};
+  sreConfigurations.push(configuration);
   renderActions.braille = action(STATE.PRETEXTACTION, (math, doc, adaptor) => {
     const speech = Sre.toSpeech(math.outputData.mml);
     math.outputData.pretext.push(adaptor.node('mjx-braille', {}, [adaptor.text(speech)]));
     math.outputData.pretext.push(adaptor.text('\n'));
-  }, () => {
-    Sre.setupEngine({modality: 'braille', locale: 'nemeth', markup: 'layout', domain: 'default'});
-  });
-}
-
-//
-// Patch MathJax 3.0.5 SVG bug:
-//
-if (mathjax.version === '3.0.5') {
-  const {SVGWrapper} = require('mathjax-full/js/output/svg/Wrapper.js');
-  const CommonWrapper = SVGWrapper.prototype.__proto__;
-  SVGWrapper.prototype.unicodeChars = function (text, variant) {
-    if (!variant) variant = this.variant || 'normal';
-    return CommonWrapper.unicodeChars.call(this, text, variant);
-  }
+  }, sreOutputs > 1 ? () => Sre.setupEngine(configuration) : null);
 }
 
 //
@@ -264,7 +355,7 @@ if (mathjax.version === '3.0.5') {
 const html = mathjax.document(htmlfile, {
   renderActions,
   InputJax: new TeX({packages: argv.packages.split(/\s*,\s*/)}),
-  OutputJax: new SVG({fontCache: (argv.fontPaths ? 'none' : 'local')})
+  OutputJax: new SVG(svgOptions)
 });
 
 //
@@ -276,28 +367,33 @@ if (!(argv.svg || argv.svgenhanced)) {
 
 (async function () {
   //
-  //  Wait for SRE, if needed
+  //  Ready the Speech Rule Engine.  setupEngine() is asynchronous,
+  //  complete only when engineReady() resolves, so every
+  //  configuration is applied, and its locale loaded, before
+  //  rendering begins.  A lone configuration is then simply in
+  //  effect.  When outputs need different configurations, each
+  //  render action re-applies its own at the start of its pass:
+  //  formally that call is asynchronous too, but a render action
+  //  must be synchronous, and with no locale left to load the
+  //  switch completes synchronously in current engines.
   //
-  if (needsSRE) {
-    const feature = {
-      xpath: require.resolve('wicked-good-xpath/dist/wgxpath.install-node.js'),
-      json: require.resolve('speech-rule-engine/lib/mathmaps/base.json').replace(/\/base\.json$/, '')
-    };
-    Sre.setupEngine(feature);
-    if (argv.braille) {
-      Sre.setupEngine({locale: 'nemeth'});
-    }
-    if (argv.speech || argv.svgenhanced) {
-      Sre.setupEngine({locale: argv.locale});
-    }
-    await Sre.sreReady();
+  for (const configuration of sreConfigurations) {
+    Sre.setupEngine(configuration);
+    await Sre.engineReady();
   }
   //
   //  Render the document
   //
-  await mathjax.handleRetriesFor(() => html.render());
+  await html.renderPromise();
   //
-  //  Output the resulting document
+  //  Output the resulting document.  This is deliberately the HTML
+  //  serialization: the XML serialization would add the XHTML
+  //  namespace to the bare "html" root of the mock page, and every
+  //  namespace-less element match in the packaging stylesheet
+  //  (xsl/support/package-math.xsl) would then miss.  The attribute
+  //  escaping it would add is not needed: no output attribute can
+  //  hold a raw "<" now that the "data-latex" attributes are
+  //  filtered away.
   //
   console.log(adaptor.outerHTML(adaptor.root(html.document)));
 })()

--- a/script/mjsre/package.json
+++ b/script/mjsre/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "mathjax-full": "^3.2.2",
-    "speech-rule-engine": "4.0.7",
-    "yargs": "^15.4.1"
+    "@mathjax/src": "^4.1.3",
+    "speech-rule-engine": "5.0.0-rc.4",
+    "yargs": "^17.7.2"
   }
 }

--- a/script/mjsre/update-sre
+++ b/script/mjsre/update-sre
@@ -2,4 +2,3 @@
 
 rm -rf node_modules
 npm install
-rm -rf node_modules/mathjax-full/node_modules


### PR DESCRIPTION
Upgrades `script/mjsre/mj-sre-page.js` from `mathjax-full` 3.2.2 + Speech Rule Engine 4.0.7 to `@mathjax/src` 4.1.3 (with the `mathjax-newcm` font) + Speech Rule Engine 5.0.0-rc.4. The command-line interface is unchanged, so the `mathjax_latex()` pipeline needs no adjustment.

Version 4 differences handled in the rewrite:

- No `AllPackages` module: the package list comes from MathJax's component map, and every listed extension is loaded, excluding `autoload`/`require`/`colorv2` (as version 3 did) and the new `bbm`/`bboldx`/`dsfont`/`physics`, which redefine core macros (version 4's `physics` turns `\div` into a divergence).
- The TeX input stamps `data-latex` attributes on every node; they remain in the internal MathML for the Speech Rule Engine's future use, but are filtered from every output (they bloat outputs, and a raw `<` inside one breaks the XML post-processing).
- In-line line-breaking is on by default and splits math into several SVG fragments; disabled.
- An author's explicit `\\` inside in-line math becomes a rendered line break with a percentage-width SVG; the SVG rendering ignores it, as version 3 did, while MathML, speech, and braille retain it.

**Testing.** All four representation formats (`mml`, `svg`, `speech`, `nemeth`) were generated for the sample article (670 math items), the sample book (2,972), and AATA (16,216) under both versions, and every difference classified. Changes come in identifiable clusters: SRE 5 speech refinements ("normal infinity" → "infinity", "c i s" → "cis"), revised Nemeth rule sets (6–8% of items re-encoded), MathML annotation changes with content differences limited to added invisible function-application characters and codepoint normalizations, and SVG dimensions agreeing within 3.6ex except framed arrays (~2.3ex wider). Side-by-side browser renderings of extracted SVG pairs are visually indistinguishable. Full `pdf-fo` (308 pages) and `epub-svg` builds of the sample article complete cleanly on the new version.

Note: Speech Rule Engine is pinned to `5.0.0-rc.4`, matching MathJax's own dependency; the pin should move to 5.0 final when released.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*

