### PR TITLE
CSS: restore italics to theorem-like .para

### DIFF
--- a/css/components/elements/_misc-content.scss
+++ b/css/components/elements/_misc-content.scss
@@ -121,10 +121,19 @@ iframe {
   }
 }
 
-.definition-like .emphasis {
-  font-weight: 700;
+.theorem-like
+{
+  .para {
+    font-style: italic;
+
+    .emphasis {
+      font-weight: 700;
+    }
+  }
 }
-article.theorem-like .emphasis {
+
+
+.definition-like .emphasis {
   font-weight: 700;
 }
 

--- a/css/targets/html/tacoma/_chunks-minimal.scss
+++ b/css/targets/html/tacoma/_chunks-minimal.scss
@@ -29,9 +29,6 @@ $border-radius: 8px !default;
     display: block;
     font-size: 1.1em;
   }
-  .para {
-    font-style: italic;
-  }
 }
 
 .example-like,


### PR DESCRIPTION
Fix for issue identified in:
https://groups.google.com/g/pretext-dev/c/84jEB5ZGWxY/m/XXNlIcr0AQAJ

See Theorem 37.9 in SA for an instance