### PR TITLE
Script: specify utf-8 encoding for FileInputs

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -192,7 +192,7 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format, math_cr
     # Trying to correct baseline for inline math in Kindle, so we
     # insert a \mathstrut into all the inline math before feeding to MathJax
     if math_format == "kindle":
-        with fileinput.FileInput(mjinput, inplace=True) as file:
+        with fileinput.FileInput(mjinput, inplace=True, encoding="utf-8") as file:
             for line in file:
                 print(line.replace(r"\(", r"\(\mathstrut "), end="")
 
@@ -242,7 +242,7 @@ def mathjax_latex(xml_source, pub_file, out_file, dest_dir, math_format, math_cr
     # to kill the "extra" newline that print() creates
     with common.working_directory(tmp_dir):
         html_file = mjoutput
-        with fileinput.FileInput(html_file, inplace=True) as file:
+        with fileinput.FileInput(html_file, inplace=True, encoding="utf-8") as file:
             for line in file:
                 print(xhtml_elt.sub(repl, line), end="")
 
@@ -2859,7 +2859,7 @@ def epub(xml_source, pub_file, out_file, dest_dir, file_format, math_format, str
         html_elt = re.compile(orig)
         for root, dirs, files in os.walk(xhtml_dir):
             for fn in files:
-                with fileinput.FileInput(fn, inplace=True) as file:
+                with fileinput.FileInput(fn, inplace=True, encoding="utf-8") as file:
                     for line in file:
                         print(html_elt.sub(repl, line), end="")
 


### PR DESCRIPTION
On windows, some character encodings cause issues with the default encoding.

Affected builds fail with:
```
  File "C:\Users\Andrew\Programming\pretext\pretext\pretext", line 956, in <module>
    main()
    ~~~~^^
  File "C:\Users\Andrew\Programming\pretext\pretext\pretext", line 888, in main
    ptx.epub(xml_source, publication_file, out_file, dest_dir, "epub", "svg", stringparams)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Andrew\Programming\pretext\pretext\lib\pretext.py", line 2863, in epub
    for line in file:
                ^^^^
  File "C:\Program Files\Python313\Lib\fileinput.py", line 251, in __next__
    line = self._readline()
  File "C:\Program Files\Python313\Lib\fileinput.py", line 372, in _readline
    return self._readline()
           ~~~~~~~~~~~~~~^^
  File "C:\Program Files\Python313\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1070: character maps to <undefined>
```

Fixes by specifying utf-8 encoding.