### PR TITLE
Local validation with "jing" and a consolidated report

### DIFF
--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -22,8 +22,72 @@
 
             <p><c>jing</c> is our recommendation for <acro>RELAX-NG</acro> validation by authors, and works very well.</p>
 
+            <p>The <c>pretext/pretext</c> script will run <c>jing</c> for you, on an assembled version of your source, which is the least amount of work; see <xref ref="jing-pretext-script"/>.</p>
+
             <p><c>jing</c> and <c>trang</c> are packaged (separately) for Debian/Ubuntu Linux, see <xref ref="jing-ubuntu"/>.  Reports of other similarly easy installations for other operating systems, to be included here, are especially welcome.  We have employed the Debian/Ubuntu versions and also versions built from source, see <xref ref="jing-from-source"/>.</p>
         </introduction>
+
+        <subsection xml:id="jing-pretext-script">
+            <title>Validation via the <c>pretext</c> Script</title>
+
+            <p>The easiest route is to let the <c>pretext/pretext</c> script run <c>jing</c> for you, with the <c>-V</c> switch:<cd>
+                <cline>pretext/pretext -V -p publication.xml aota.xml</cline>
+            </cd>This deposits two files, named for your source file.  One, ending <c>-validation.txt</c>, is a consolidated report: messages from <c>jing</c> checking the <acro>RELAX-NG</acro> schema, followed by messages from the validation-plus stylesheet (<xref ref="validation-plus"/>), each batch clearly delineated, and all prefaced by an explanation of how to read the report.  The other file, ending <c>-assembled.xml</c>, is the version of your source that was examined: your modular source files knitted together (<xref ref="processing-modular"/>), <em>after</em> any version support in your publication file has been applied (so, include <c>-p</c> if you use a publication file).  In particular, an element excluded from the version being built cannot raise a message.  There is no need for any of the <c>xinclude</c> command-line gymnastics described in the following subsections<mdash/>the script has already merged your modular source files.</p>
+
+            <p>Each message locates its problem four ways.  A <c>file</c> line names the source file where the problem lies, even when your project is modularized.  A <c>path</c> line locates the problem within the assembled source, counting elements of each name, so<cd>
+                <cline>path: /pretext[1]/book[1]/chapter[7]/section[2]/p[13]/em[2]</cline>
+            </cd>is the second <tag>em</tag> within the thirteenth <tag>p</tag> of the second <tag>section</tag> of the seventh <tag>chapter</tag> of the book.  (Counts are of elements with the same name: that paragraph is the thirteenth <tag>p</tag> of its section, though other elements may precede it or intervene.)  A <c>line</c> line gives a line number, and a <c>text</c> line excerpts the offending content.  Take care: only <c>file</c> points into your own source files<mdash/>the line number is a line of the deposited assembled source, never of one of your files, since assembly shifts everything about.</p>
+
+            <p>The script locates <c>jing</c> through the <c>[executables]</c> section of its configuration file (see the notes at the top of <c>pretext/pretext.cfg</c> about making a copy in <c>user/pretext.cfg</c>).  The default entry,<cd>
+                <cline>jing = jing</cline>
+            </cd>works when <c>jing</c> is installed as a system program, such as the Debian/Ubuntu package described in <xref ref="jing-ubuntu"/>.  <c>jing</c> is really a Java program, so if you only have a <c>jar</c> archive (perhaps built from source, <xref ref="jing-from-source"/>, or from the Debian package, which places one at <c>/usr/share/java/jing.jar</c>), then configure a Java runtime and options as the executable:<cd>
+                <cline>jing = java -jar /usr/share/java/jing.jar</cline>
+            </cd>Anything after the executable name is passed along as options, as for other configured executables.</p>
+
+            <p>Two other methods may be elected with the <c>-M</c> switch.  <c>-M local-dev</c> is identical, but checks against the development schema (<c>pretext-dev.rng</c>), which additionally describes new and experimental parts of the vocabulary.  <c>-M server</c> bundles your source files and ships them to a validation server for processing, so no <c>jing</c> installation is necessary at all.</p>
+
+            <p>Incidentally, the <c>lxml</c> library the script relies on has <acro>RELAX-NG</acro> validation built in, and you might wonder why it is not employed for this purpose.  It cannot process the <c>externalRef</c> construction the schema uses (for PreFigure diagrams), and even given a reduced schema it reports only a small fraction of the problems <c>jing</c> finds, with messages that suggest an arbitrary alternative rather than describe the error.</p>
+        </subsection>
+
+        <subsection xml:id="validation-agent">
+            <title>Validation for Programs</title>
+
+            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The library function underlying the <c>-V</c> switch accepts an <c>agent</c> method for exactly this purpose: the report is one line per message, four tab-separated fields<mdash/>file, path, line, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.)  This method is deliberately not elective from the <c>pretext/pretext</c> command line; instead a driver program calls the library directly.  The following complete driver prints the report on standard output, and is simple enough to serve as a model.<listing>
+                <title>A driver for machine-readable validation</title>
+                <program language="python">
+                    <code>
+#!/usr/bin/env python3
+# A minimal driver for PreTeXt validation with machine-readable
+# output.  Each line of the report is tab-separated:
+# file, path, line, message.
+#
+# Usage:
+#   python3 validate-agent.py /path/to/pretext source.xml [publication.xml]
+
+import os.path
+import sys
+
+distribution = sys.argv[1]
+xml_source = sys.argv[2]
+publication = sys.argv[3] if len(sys.argv) &gt; 3 else None
+
+# the "pretext" module within the PreTeXt distribution
+sys.path.insert(0, os.path.join(distribution, "pretext"))
+from lib import pretext as ptx
+from lib import common
+
+# where to find the "jing" program
+# ("java -jar /path/to/jing.jar" also works)
+common.set_executables({"jing": "jing"})
+
+report = "validation-report.txt"
+ptx.validate(xml_source, publication, {}, report, None, "agent")
+with open(report) as f:
+    sys.stdout.write(f.read())
+                    </code>
+                </program>
+            </listing></p>
+        </subsection>
 
         <subsection xml:id="jing-ubuntu">
             <title><c>jing</c> on Ubuntu and CoCalc</title>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4519,7 +4519,341 @@ def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
 #
 ########################
 
-def validate(xml_source, out_file, dest_dir):
+def validate(xml_source, pub_file, stringparams, out_file, dest_dir, method):
+    """Validate source against the RELAX-NG schema, locally or via a server"""
+
+    if method == "server":
+        _validate_server(xml_source, out_file, dest_dir)
+    else:
+        # "local" validates against the production schema, and
+        # "local-dev" against the development schema, each with a
+        # report meant for an author.  The "agent" method is the
+        # production schema with terse output meant for a program
+        # (and so is not elective from the "pretext/pretext" script).
+        if method == "local-dev":
+            schema_file = "pretext-dev.rng"
+        else:
+            schema_file = "pretext.rng"
+        terse = method == "agent"
+        _validate_local(
+            xml_source, pub_file, stringparams, out_file, dest_dir, schema_file, terse
+        )
+
+
+# the "pi" namespace attribute recording an element's originating file
+PI_SOURCE_URI = "{http://pretextbook.org/2020/pretext/internal}source-uri"
+
+
+def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, schema_file, terse):
+    """Validate the assembled source with an installed "jing" program"""
+
+    # to ensure provided stringparams aren't mutated unintentionally
+    stringparams = stringparams.copy()
+
+    # "jing" is a Java program, so a configuration can be simply the
+    # name of an executable ("jing", say, from a system package), or a
+    # command with options ("java -jar /usr/share/java/jing.jar", say)
+    jing_exec_cmd = common.get_executable_cmd("jing")
+
+    # the consolidated report, and the assembled source deposited
+    # alongside it (wherever the report lands)
+    reportname = common.get_output_filename(
+        xml_source, out_file, dest_dir, "-validation.txt"
+    )
+    assembled_source = os.path.join(
+        os.path.dirname(os.path.abspath(reportname)),
+        os.path.splitext(os.path.basename(xml_source))[0] + "-assembled.xml",
+    )
+
+    tmp_dir = common.get_temporary_directory()
+
+    # Modular source files are knitted together here, rather than
+    # during assembly, so each included file can be recorded on its
+    # root element (as a @pi:source-uri attribute) and problems can
+    # then be attributed to the file where they lie
+    source_dir = os.path.dirname(os.path.abspath(xml_source))
+    main_file = os.path.basename(xml_source)
+
+    def _stamping_loader(href, parse, encoding=None):
+        if parse == "xml":
+            elt = ET.parse(href).getroot()
+            elt.set(PI_SOURCE_URI, href)
+            return elt
+        with open(href, "r", encoding=(encoding or "utf-8")) as f:
+            return f.read()
+
+    merged_source = os.path.join(tmp_dir, "merged.xml")
+    source_tree = ET.parse(xml_source)
+    try:
+        from lxml import ElementInclude
+
+        ElementInclude.include(
+            source_tree.getroot(), loader=_stamping_loader, max_depth=20
+        )
+    except Exception as e:
+        log.warning(
+            "file attribution of validation problems unavailable ({})".format(e)
+        )
+        source_tree = ET.parse(xml_source)
+        source_tree.xinclude()
+    # The temporary merged file must resolve relative references (a
+    # customizations file, say) as the original source would, which is
+    # exactly the job of an @xml:base (assembly drops it from output)
+    source_tree.getroot().set(
+        "{http://www.w3.org/XML/1998/namespace}base", os.path.abspath(xml_source)
+    )
+    source_tree.write(merged_source, encoding="utf-8", xml_declaration=True)
+
+    # Validation is performed on the "version" tree: the merged source
+    # reduced by any "version" support elected in a publication file.
+    # The paths of any messages refer to this assembled source, so it
+    # is deposited next to the report, for cross-referencing, rather
+    # than evaporating with a temporary directory.
+    stringparams["assembly.file-attribution"] = "yes"
+    attributed_source = os.path.join(tmp_dir, "assembled-attributed.xml")
+    assembly(merged_source, pub_file, stringparams, attributed_source, None, "version")
+
+    # Tree "A" retains the file attributions, which are stripped to
+    # make the deposited assembled source (what "jing" examines, since
+    # the schema knows nothing of the attribute).  Tree "B" is that
+    # deposited file re-parsed, so line numbers agree with what "jing"
+    # reports; elements of the two trees correspond in document order.
+    tree_a = ET.parse(attributed_source)
+    file_of_a = {}
+    current_files = {tree_a.getroot(): main_file}
+    for elt in tree_a.iter():
+        if not isinstance(elt.tag, str):
+            continue
+        uri = elt.attrib.pop(PI_SOURCE_URI, None)
+        if uri is not None:
+            filename = os.path.relpath(uri, start=source_dir)
+        else:
+            parent = elt.getparent()
+            filename = file_of_a.get(parent, main_file)
+        file_of_a[elt] = filename
+    tree_a.write(assembled_source, encoding="utf-8", xml_declaration=True)
+    tree_b = ET.parse(assembled_source)
+    a_elements = [e for e in tree_a.iter() if isinstance(e.tag, str)]
+    b_elements = [e for e in tree_b.iter() if isinstance(e.tag, str)]
+    file_of = {b: file_of_a[a] for a, b in zip(a_elements, b_elements)}
+    # the last element to *begin* on each line, in document order
+    opening = {}
+    for elt in b_elements:
+        opening[elt.sourceline] = elt
+    with open(assembled_source) as f:
+        source_lines = f.readlines()
+
+    # fresh schema from the PreTeXt distribution, in XML syntax
+    schema_filename = os.path.join(common.get_ptx_path(), "schema", schema_file)
+
+    full_cmd = jing_exec_cmd + [schema_filename, assembled_source]
+    log.debug("jing command: {}".format(" ".join(full_cmd)))
+    result = subprocess.run(full_cmd, capture_output=True, text=True)
+    # jing exits 0 when the document is valid, 1 when messages result
+    if result.returncode == 0:
+        log.info("the source validates with no schema errors")
+    elif result.returncode > 1:
+        log.warning('the "jing" program failed (code {})'.format(result.returncode))
+    jing_messages = result.stdout.splitlines()
+
+    # The "validation-plus" stylesheet performs checks the RELAX-NG
+    # schema cannot express, and provides advice besides.  Applied to
+    # the same assembled source, so locations are consistent with the
+    # schema messages.  Single-line output, one message per line.
+    plus_xsl = os.path.join(
+        common.get_ptx_path(), "schema", "pretext-validation-plus.xsl"
+    )
+    plus_scratch = os.path.join(tmp_dir, "validation-plus.txt")
+    params = {"single.line.output": "yes"}
+    common.xsltproc(plus_xsl, assembled_source, plus_scratch, None, params)
+    with open(plus_scratch, "r") as f:
+        plus_messages = [line.strip() for line in f if line.startswith("PTX:")]
+
+    # helpers for locating a message's element in tree "B"
+
+    def _numbered_path(elt):
+        parts = []
+        while elt is not None and isinstance(elt.tag, str):
+            name = ET.QName(elt).localname
+            position = 1 + sum(
+                1
+                for sib in elt.itersiblings(preceding=True)
+                if isinstance(sib.tag, str) and ET.QName(sib).localname == name
+            )
+            parts.append("{}[{}]".format(name, position))
+            elt = elt.getparent()
+        return "/" + "/".join(reversed(parts))
+
+    def _element_at_path(path):
+        # follow a numbered path (as validation-plus produces)
+        elt = tree_b.getroot()
+        segments = path.strip("/").split("/")
+        segment_pattern = re.compile(r"(.*)\[(\d+)\]")
+        first = segment_pattern.match(segments[0])
+        if not first or ET.QName(elt).localname != first.group(1):
+            return None
+        for segment in segments[1:]:
+            match = segment_pattern.match(segment)
+            if not match:
+                return None
+            name, position = match.group(1), int(match.group(2))
+            count = 0
+            found = None
+            for child in elt:
+                if isinstance(child.tag, str) and ET.QName(child).localname == name:
+                    count += 1
+                    if count == position:
+                        found = child
+                        break
+            if found is None:
+                return None
+            elt = found
+        return elt
+
+    def _excerpt(line_number):
+        if 0 < line_number <= len(source_lines):
+            text = source_lines[line_number - 1].strip()
+            if len(text) > 100:
+                text = text[:100] + "..."
+            return text
+        return None
+
+    # assemble the consolidated report
+    report = []
+    banner = "=" * 70
+
+    if not terse:
+        report.extend(_validation_report_preamble(schema_filename, assembled_source))
+        report.extend([banner, "Messages: RELAX-NG schema validation, from \"jing\"", banner, ""])
+    # "jing" messages lead with filename:line:column.  The line number
+    # refers to the assembled source (which is deposited alongside the
+    # report), so it is reported as such, supplemented by the
+    # originating file, a path into the assembled source, and an
+    # excerpt of the offending text.  An element's extent is not
+    # available, so for a message about a line where no element begins,
+    # the location is the closest element beginning on an earlier line:
+    # very often the container, and always a good place to start looking.
+    location = re.compile(r"^.*?:(\d+):(\d+): (.*)$")
+    for message in jing_messages:
+        match = location.match(message)
+        if not match:
+            report.append(message)
+            continue
+        line_number = int(match.group(1))
+        body = match.group(3)
+        near = max((n for n in opening if n <= line_number), default=None)
+        elt = opening[near] if near is not None else None
+        filename = file_of.get(elt, main_file)
+        path = _numbered_path(elt) if elt is not None else ""
+        if terse:
+            report.append("{}\t{}\t{}\t{}".format(filename, path, line_number, body))
+        else:
+            report.append(body)
+            report.append("    file: {}".format(filename))
+            report.append("    path: {}".format(path))
+            report.append("    line: {}".format(line_number))
+            excerpt = _excerpt(line_number)
+            if excerpt:
+                report.append("    text: {}".format(excerpt))
+            report.append("")
+    if not terse and not jing_messages:
+        report.extend(["(no messages)", ""])
+
+    if not terse:
+        report.extend([banner, "Messages: PreTeXt \"validation-plus\" stylesheet", banner, ""])
+    plus_form = re.compile(r"^(PTX:[A-Z]+): (/\S+) (.*)$")
+    for message in plus_messages:
+        match = plus_form.match(message)
+        if not match:
+            report.append(message)
+            continue
+        severity, path, body = match.group(1), match.group(2), match.group(3)
+        elt = _element_at_path(path)
+        filename = file_of.get(elt, main_file)
+        line_number = elt.sourceline if elt is not None else ""
+        if terse:
+            report.append(
+                "{}\t{}\t{}\t{}: {}".format(filename, path, line_number, severity, body)
+            )
+        else:
+            report.append("{}: {}".format(severity, body))
+            report.append("    file: {}".format(filename))
+            report.append("    path: {}".format(path))
+            report.append("    line: {}".format(line_number))
+            if elt is not None:
+                excerpt = _excerpt(elt.sourceline)
+                if excerpt:
+                    report.append("    text: {}".format(excerpt))
+            report.append("")
+    if not terse and not plus_messages:
+        report.extend(["(no messages)", ""])
+
+    with open(reportname, "w") as f:
+        f.write("\n".join(report))
+
+    if jing_messages:
+        log.info("schema validation raised {} messages".format(len(jing_messages)))
+    if plus_messages:
+        log.info("validation-plus stylesheet raised {} messages".format(len(plus_messages)))
+    else:
+        log.info("validation-plus stylesheet raised no messages")
+    log.info("consolidated validation report in {}".format(reportname))
+    log.info("locations refer to the assembled source in {}".format(assembled_source))
+
+
+def _validation_report_preamble(schema_filename, assembled_source):
+    """The fixed introductory text of a validation report"""
+
+    return [
+        "Validation Report",
+        "=================",
+        "",
+        "Two tools have examined an assembled version of your source:",
+        "",
+        "  (1) \"jing\" checked conformance with the RELAX-NG schema at",
+        "      {}".format(schema_filename),
+        "      (a schema can only describe parent-child relationships,",
+        "      plus the attributes of each element)",
+        "  (2) the PreTeXt \"validation-plus\" stylesheet made checks that",
+        "      no RELAX-NG schema could ever express, and offers advice",
+        "      besides",
+        "",
+        "Locations refer to the ASSEMBLED version of your source: your",
+        "modular source files have been knitted together, and any version",
+        "support has been applied (as elected by a \"version\" element",
+        "within the \"source\" element of the publication file you",
+        "supplied).  In particular, an element excluded from the version",
+        "being built cannot raise a message here.  The assembled source",
+        "has been deposited at",
+        "    {}".format(assembled_source),
+        "",
+        "Each message locates its problem four ways:",
+        "",
+        "    file:  the source file where the problem lies",
+        "    path:  the location within the assembled source",
+        "    line:  the line number within the assembled source",
+        "    text:  an excerpt of the offending content",
+        "",
+        "Only \"file\" points into your own source files.  In particular,",
+        "\"line\" is a line number of the deposited assembled source named",
+        "above, never of one of your files.",
+        "",
+        "To read a \"path\", count elements of each name.  For example,",
+        "",
+        "    /pretext[1]/book[1]/chapter[7]/section[2]/p[13]/em[2]",
+        "",
+        "is the second \"em\" within the thirteenth \"p\" (paragraph) of the",
+        "second \"section\" of the seventh \"chapter\" of the book.  Counts",
+        "are of elements with the same name: that paragraph is the",
+        "thirteenth \"p\" of its section, though other elements may precede",
+        "it or intervene.",
+        "",
+        "",
+    ]
+
+
+def _validate_server(xml_source, out_file, dest_dir):
+    """Validate original source files with a round-trip to a server"""
 
     try:
         import requests  # post()

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -181,9 +181,26 @@ def string_parameters_as_dict(pairs):
     return params
 
 
-def sanitize_method(method, component, format):
+def sanitize_method(method, component, format, validate):
     """Returns a string appropriate for the component and format, else None"""
-    if component == "asy":
+    if validate:
+        # unset by command-line, use default
+        if not (method):
+            return "local"
+        # set, but illegal
+        elif not (method in ["local", "local-dev", "server"]):
+            msg = "\n".join(
+                [
+                    'the method given for validation ("{}") is not "local", "local-dev", or "server",',
+                    '              so using the default method instead ("local")',
+                ]
+            )
+            log.warning(msg.format(method))
+            return "local"
+        # set correctly
+        else:
+            return method
+    elif component == "asy":
         # unset by command-line, use default
         if not (method):
             return "server"
@@ -516,9 +533,21 @@ def get_cli_arguments():
         action="store_true",
         dest="tgz",
     )
-    # Needs help-file, once public
-    # Will default to False
-    parser.add_argument("-V", "--validate", action="store_true", dest="validate")
+    validate_info = [
+        ("local", 'employs an installed "jing" program (default)'),
+        ("local-dev", 'as "local", but checks against the development schema'),
+        ("server", "a round-trip to a validation server"),
+    ]
+    validate_help = "validate source, methods are:\n" + "\n".join(
+        ["  {} - {}".format(info[0], info[1]) for info in validate_info]
+    )
+    parser.add_argument(
+        "-V",
+        "--validate",
+        help=validate_help,
+        action="store_true",
+        dest="validate",
+    )
     parser.add_argument(
         "xml_file", help="PreTeXt source file with content", action="store"
     )
@@ -615,7 +644,7 @@ def main():
     # method may not be required, but when it may apply we use a
     # routine to error-check and sanitize possible values and defaults
     # varies by component and format
-    method = sanitize_method(args.method, args.component, args.format)
+    method = sanitize_method(args.method, args.component, args.format, args.validate)
     # convert list of string parameters into a dictionary
     # routines in module expect a dictionary, so convert here and now
     stringparams = string_parameters_as_dict(args.stringparams)
@@ -639,7 +668,7 @@ def main():
     # The big switch
     # Validation trumps everything, since it is an easy switch
     if args.validate:
-        ptx.validate(xml_source, out_file, dest_dir)
+        ptx.validate(xml_source, publication_file, stringparams, out_file, dest_dir, method)
     elif args.component == "prefigure":
         if args.format in ["source", "svg", "pdf", "png", "tactile", "all"]:
             ptx.prefigure_conversion(xml_source, publication_file, stringparams, args.xmlid, dest_dir, args.format, None)

--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -54,6 +54,7 @@
 # 2025-01-03  Remove pdfpng key, in favor of pyMuPDF library
 # 2025-05-29  Added perl executable line
 # 2026-06-11  Added fop executable line
+# 2026-07-04  Added jing executable line
 
 
 [executables]
@@ -68,3 +69,4 @@ node = node
 liblouis = file2brl
 perl = perl
 fop = fop
+jing = jing

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -31,7 +31,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:xml="http://www.w3.org/XML/1998/namespace">
 
 <!-- Report on console, or redirect/option to a file -->
-<xsl:output method="text"/>
+<xsl:output method="text" encoding="UTF-8"/>
 
 <!-- Single line output allows for sorting on "fields" with the     -->
 <!-- sort utility. So design messages to *lead* with something      -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -247,6 +247,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="assembly.debug" select="''"/>
 <xsl:variable name="b-assembly-debug" select="$assembly.debug = 'yes'"/>
 
+<!-- Set to 'yes' to convert the @xml:base attributes stamped by the -->
+<!-- xinclude mechanism into @pi:source-uri attributes, so that a    -->
+<!-- diagnostic (validation, say) can name the file where a problem  -->
+<!-- lies.  Not documented as an author or publisher feature.        -->
+<xsl:param name="assembly.file-attribution" select="''"/>
+<xsl:variable name="b-file-attribution" select="$assembly.file-attribution = 'yes'"/>
+
 <!-- convert to a boolean, with error-checking -->
 <xsl:variable name="version-only">
     <xsl:choose>
@@ -813,13 +820,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="pi:*" mode="version"/>
 <xsl:template match="@pi:*" mode="version"/>
 
+<!-- Exception: when file attribution has been requested (below), a -->
+<!-- @pi:source-uri stamped on the source (by the pretext/pretext   -->
+<!-- script's include mechanism, say) rides through the version     -->
+<!-- pass, so a diagnostic can name the file where a problem lies.  -->
+<xsl:template match="@pi:source-uri" mode="version">
+    <xsl:if test="$b-file-attribution">
+        <xsl:copy/>
+    </xsl:if>
+</xsl:template>
+
 <!-- The xinclude mechanism stamps an @xml:base attribute onto the  -->
 <!-- root element of every included file.  We drop it during the    -->
 <!-- version pass, so the assembled source carries none, and the    -->
-<!-- schema need not permit it.  To retain the originating file URI -->
-<!-- (say, for diagnostics) mint a @pi:source-uri here instead,     -->
+<!-- schema need not permit it.  But when file attribution has been -->
+<!-- requested (validation, say, so a problem can be located in the -->
+<!-- file where it lies) we mint a @pi:source-uri instead,          -->
 <!-- consistent with the other "pi:" provenance attributes.         -->
-<xsl:template match="@xml:base" mode="version"/>
+<xsl:template match="@xml:base" mode="version">
+    <xsl:if test="$b-file-attribution">
+        <xsl:attribute name="pi:source-uri">
+            <xsl:value-of select="."/>
+        </xsl:attribute>
+    </xsl:if>
+</xsl:template>
 
 <!-- The "custom" element, with a @name in an auxiliary file,     -->
 <!-- and a @ref in a source file, allows for custom substitutions -->


### PR DESCRIPTION
The `-V` switch now validates locally by default, rather than the round-trip to a validation server (which is currently broken; that behavior is preserved unchanged under `-M server`).

**What `-V` does now.** The source is assembled first — modular files knitted together, version support from the publication file applied — and two tools examine the result: `jing` checks the RELAX-NG schema, and the `validation-plus` stylesheet makes checks a schema cannot express. Two files are deposited: a single consolidated report (`<basename>-validation.txt`) and the assembled source that was examined (`<basename>-assembled.xml`). The report opens with an explanation of how to read it; every message is located four ways:

- `file:` the author's own source file, even in a modularized project (via new, optional `@pi:source-uri` attribution in the assembly stylesheet)
- `path:` a numbered element path into the assembled source, such as `/pretext[1]/book[1]/chapter[7]/section[2]/p[13]/em[2]`
- `line:` a line number into the deposited assembled source (never the author's files, and the report says so)
- `text:` an excerpt of the offending content

**Methods.** `-M local` (default) and `-M local-dev` (development schema) both require an installed `jing`, located through the `[executables]` configuration; `jing = jing` suits the Debian/Ubuntu package, and `jing = java -jar /path/to/jing.jar` works for a bare jar. A fourth method, `agent`, exists only at the library level: a terse report of tab-separated file/path/line/message lines, intended for programs (e.g. AI-assisted conversions) iterating toward valid PreTeXt. It is documented in the Guide with a complete minimal driver program.

**Also.** `lxml`'s built-in RELAX-NG validation was evaluated and rejected: it cannot load the schema (no `externalRef` support), and with a patched schema it reports a small fraction of the problems `jing` finds, with unhelpful messages. A sentence in the Guide records this.

**API note.** The signature of the library's `validate()` changed (publication file, string parameters, and method are new required arguments). A heads-up issue for pretext-CLI will follow.

**Testing.** Sample article: 332 schema messages plus 224 validation-plus messages, spot-checked against the deposited assembled source. Modular sample book: file attribution verified across five source files; `local-dev` consistent with recent dev-schema surveys. A minimal valid document produces a clean report. The agent driver was run end-to-end as listed in the Guide (702 messages). The `java -jar` executable configuration was verified, and the Guide builds cleanly.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
