### PR TITLE
Warn when Python is older than the 3.10 minimum

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -22,7 +22,7 @@
 #     https://github.com/netromdk/vermin.git
 # 2026-07-06: this module expects Python 3.10 or newer
 #     FileInput(..., encoding="utf-8") added, required Python 3.10
-#     stack.py: str.removeprefix(), str.removeuffix() requires Python 3.9
+#     stack.py: str.removeprefix(), str.removesuffix() requires Python 3.9
 # 2023-10-13: this module expects Python 3.8 or newer
 #     shutil.copytree now has dirs_exist_ok argument
 # 2021-05-21: this module expects Python 3.6 or newer

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4958,7 +4958,7 @@ def python_version():
 
 
 def check_python_version():
-    """Raise error with Python 2 (or less)"""
+    """Raise an error for Python 2 (or less); warn for Python 3 before 3.10"""
 
     # This test could be more precise,
     # but only handling 2to3 switch when introduced
@@ -4971,6 +4971,15 @@ def check_python_version():
     )
     if sys.version_info[0] <= 2:
         raise (OSError(msg.format(python_version())))
+    # Warn, but do not error, for Python 3 older than the minimum below
+    #   2026-07-06: Python 3.10 or newer
+    if sys.version_info[:2] < (3, 10):
+        log.warning(
+            "PreTeXt expects Python 3.10 or newer\n"
+            "You have Python {}, and some operations may fail".format(
+                python_version()
+            )
+        )
 
 
 


### PR DESCRIPTION
Follows the recent move to Python 3.10 as the minimum. Nothing actually checked for it — `check_python_version()` only rejected Python 2 — so this adds a *warning* (not an error) when running on Python 3 older than 3.10, leaving the Python-2 error as-is.

- The version threshold carries a single dated history line in the routine, to copy and adjust when the minimum next moves.
- A second commit fixes a `removesuffix` typo in the version comment — my error, which I introduced in Claude Code analysis and which then got pasted in.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
