### PR TITLE
Runestone: thread "heading-level" through WeBWorK manifest rendering

### DIFF
--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -782,6 +782,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:when test="@exercise-interactive = 'webwork'">
                         <xsl:apply-templates select="." mode="webwork-core">
                             <xsl:with-param name="b-original" select="true()"/>
+                            <xsl:with-param name="heading-level" select="2"/>
                         </xsl:apply-templates>
                     </xsl:when>
                     <xsl:otherwise>
@@ -798,6 +799,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <xsl:apply-templates select="." mode="exercise-components">
                             <xsl:with-param name="b-original" select="true()"/>
                             <xsl:with-param name="block-type" select="'visible'"/>
+                            <xsl:with-param name="heading-level" select="2"/>
                             <xsl:with-param name="b-has-statement" select="true()"/>
                             <xsl:with-param name="b-has-hint" select="$ex-components-report/@has-hint = 'true'"/>
                             <xsl:with-param name="b-has-answer" select="$ex-components-report/@has-answer = 'true'"/>


### PR DESCRIPTION
Fixes #3008.

Building HTML for a Runestone-hosted book that contains a WeBWorK problem structured with `<task>` emits, once per task:

> `PTX:BUG: "hN" template reached without a $heading-level parameter on element <task> at …/exploration/webwork-reps/static/task; defaulting to h2`

As the reporter noticed, the on-page headings are nonetheless correct (the tasks render at `h5`, their `exploration` at `h4`). The discrepancy is the tell: the message comes from a *second* rendering of the same tasks — the `<htmlsrc>` copy written into `runestone-manifest.xml` — which is not the HTML the reader inspects.

The visible WeBWorK rendering was taught to thread `heading-level` in commit 25b65361 ("HTML: thread 'heading-level' through WeBWorK 'task' rendering"), but the manifest builder (`exercise|&PROJECT-LIKE;|task` in `mode="runestone-manifest"`) was not updated: it invokes `webwork-core` with no `heading-level`, so the WeBWorK `static/task`s reach the `hN` template untethered and hit its guard. This only surfaces when all of these hold — a Runestone host (so the manifest is generated), a WeBWorK problem, structured by `task`.

The fix threads a base `heading-level` of `2` into that call, the same standalone-fragment convention already used when a block is manufactured into its own knowl file. The sibling non-WeBWorK branch of the same manifest template had the identical latent gap (a task-structured native exercise), so it is threaded too. A survey of the rest of the manifest builder confirms these are the only two `<htmlsrc>` paths that reach a block heading; the video, program, datafile, and interactive-exercise paths render atomic widgets that never do.

Verified by reproducing the reporter's exploration in a Runestone book build: before, the message fired three times and the manifest tasks came out `h2`; after, the message is gone, the manifest headings are threaded deliberately, and the visible page is unchanged (tasks still `h5`).

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
