### PR TITLE
Converge the exercise and solutions drivers across HTML, LaTeX, and FO

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6095,9 +6095,11 @@ Book (with parts), "section" at level 3
 <!-- a component cannot show it, hence the $b-showing-* refinements.     -->
 <!-- With no "statement" shown, a "title" may still be presented inline, -->
 <!-- so a separator is necessary in that case as well.                   -->
-<xsl:template match="exercise|&EXAMPLE-LIKE;|&PROJECT-LIKE;|task[not(task)]" mode="exercise-components">
+<xsl:template match="exercise|&EXAMPLE-LIKE;|&PROJECT-LIKE;|task[not(task)]|webwork-reps/static|webwork-reps/static/task|webwork-reps/static/stage" mode="exercise-components">
     <xsl:param name="b-original"/>
     <xsl:param name="purpose"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
     <xsl:param name="b-component-heading"/>
     <xsl:param name="run-in-heading"/>
     <xsl:param name="b-has-statement"/>
@@ -6117,6 +6119,8 @@ Book (with parts), "section" at level 3
                 <xsl:when test="$b-has-statement">
                     <xsl:apply-templates select="." mode="present-exercise-statement">
                         <xsl:with-param name="b-original" select="$b-original"/>
+                        <xsl:with-param name="block-type" select="$block-type"/>
+                        <xsl:with-param name="heading-level" select="$heading-level"/>
                         <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
                     </xsl:apply-templates>
                 </xsl:when>
@@ -6134,7 +6138,10 @@ Book (with parts), "section" at level 3
                 <xsl:apply-templates select="." mode="present-exercise-solutions">
                     <xsl:with-param name="b-original" select="$b-original"/>
                     <xsl:with-param name="purpose" select="$purpose"/>
+                    <xsl:with-param name="block-type" select="$block-type"/>
+                    <xsl:with-param name="heading-level" select="$heading-level"/>
                     <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                    <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
                     <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
                     <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
                     <xsl:with-param name="b-showing-hints" select="$b-showing-hints"/>
@@ -6148,6 +6155,8 @@ Book (with parts), "section" at level 3
             <xsl:if test="$b-has-statement">
                 <xsl:apply-templates select="." mode="present-exercise-statement-bare">
                     <xsl:with-param name="b-original" select="$b-original"/>
+                    <xsl:with-param name="block-type" select="$block-type"/>
+                    <xsl:with-param name="heading-level" select="$heading-level"/>
                     <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
                 </xsl:apply-templates>
                 <!-- no separator, since no trailing components -->
@@ -6163,6 +6172,8 @@ Book (with parts), "section" at level 3
 <xsl:template match="exercise[task]|project[task]|activity[task]|exploration[task]|investigation[task]|example[task]|question[task]|problem[task]|task[task]" mode="exercise-components">
     <xsl:param name="b-original"/>
     <xsl:param name="purpose"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
     <xsl:param name="b-component-heading"/>
     <xsl:param name="run-in-heading"/>
     <xsl:param name="b-has-statement"/>
@@ -6172,6 +6183,9 @@ Book (with parts), "section" at level 3
 
     <xsl:apply-templates select="." mode="present-tasks-introduction">
         <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+        <xsl:with-param name="b-original" select="$b-original"/>
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
         <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
     </xsl:apply-templates>
 
@@ -6204,6 +6218,8 @@ Book (with parts), "section" at level 3
                 <xsl:apply-templates select="." mode="present-task-item">
                     <xsl:with-param name="b-original" select="$b-original"/>
                     <xsl:with-param name="purpose" select="$purpose"/>
+                    <xsl:with-param name="block-type" select="$block-type"/>
+                    <xsl:with-param name="heading-level" select="$heading-level"/>
                     <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
                     <xsl:with-param name="b-has-statement" select="$b-has-statement" />
                     <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
@@ -6215,9 +6231,12 @@ Book (with parts), "section" at level 3
         <xsl:apply-templates select="." mode="end-task-list"/>
     </xsl:if>
 
-    <xsl:if test="$b-has-statement">
-        <xsl:apply-templates select="conclusion"/>
-    </xsl:if>
+    <xsl:apply-templates select="." mode="present-tasks-conclusion">
+        <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+        <xsl:with-param name="b-original" select="$b-original"/>
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- The hooks.  A conversion participating in the drivers above         -->
@@ -6251,11 +6270,20 @@ Book (with parts), "section" at level 3
 <xsl:template match="*" mode="begin-task-list"/>
 <xsl:template match="*" mode="end-task-list"/>
 
-<!-- The introduction (or a stand-in) preceding a sequence of "task" -->
+<!-- The introduction (or a stand-in) preceding a sequence of "task", -->
+<!-- and the conclusion following it; both ride with the statement's   -->
+<!-- visibility                                                        -->
 <xsl:template match="*" mode="present-tasks-introduction">
     <xsl:param name="b-has-statement"/>
     <xsl:if test="$b-has-statement">
         <xsl:apply-templates select="introduction"/>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="*" mode="present-tasks-conclusion">
+    <xsl:param name="b-has-statement"/>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion"/>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6073,6 +6073,76 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="($is-specialized-division = 'false') or ($is-child-of-structured = 'true')"/>
 </xsl:template>
 
+<!-- ##################################### -->
+<!-- Containers of Exercises, in Solutions -->
+<!-- ##################################### -->
+
+<!-- A "subexercises" or an "exercisegroup" echoed in a "solutions"     -->
+<!-- division repeats its infrastructure only when some descendant      -->
+<!-- exercise contributes something: the dry-run decides.  Introduction -->
+<!-- and conclusion ride with the statement's visibility, an item can   -->
+<!-- be withheld entirely, and a "subexercises" has a heading, so its   -->
+<!-- items sit one outline level deeper.  Those decisions are made      -->
+<!-- here; the surrounding structure is the per-conversion              -->
+<!-- "present-solutions-container" hook, which receives the rendered    -->
+<!-- items as its content parameter.                                    -->
+<xsl:template match="subexercises|exercisegroup" mode="solutions">
+    <xsl:param name="purpose"/>
+    <xsl:param name="admit"/>
+    <xsl:param name="b-component-heading"/>
+    <xsl:param name="heading-level"/>
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
+
+    <!-- When we subset exercises for solutions, an entire container -->
+    <!-- can become empty.  So we do a dry-run and if there is no    -->
+    <!-- content at all we bail out.                                 -->
+    <xsl:variable name="dry-run">
+        <xsl:apply-templates select="." mode="dry-run">
+            <xsl:with-param name="admit" select="$admit"/>
+            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
+            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
+            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+
+    <xsl:if test="not($dry-run = '')">
+        <xsl:variable name="child-heading-level">
+            <xsl:choose>
+                <xsl:when test="self::subexercises">
+                    <xsl:value-of select="$heading-level + 1"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$heading-level"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:apply-templates select="." mode="present-solutions-container">
+            <xsl:with-param name="heading-level" select="$heading-level"/>
+            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+            <xsl:with-param name="content">
+                <xsl:apply-templates select="exercise|exercisegroup" mode="solutions">
+                    <xsl:with-param name="purpose" select="$purpose"/>
+                    <xsl:with-param name="admit" select="$admit"/>
+                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                    <xsl:with-param name="heading-level" select="$child-heading-level"/>
+                    <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+                    <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
+                    <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
+                    <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+                </xsl:apply-templates>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="*" mode="present-solutions-container">
+    <xsl:message>PTX:BUG:     a conversion to a new output format requires implementation of the template with match="*" and mode="present-solutions-container"</xsl:message>
+</xsl:template>
+
 <!-- ####################### -->
 <!-- Components of Exercises -->
 <!-- ####################### -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6073,6 +6073,192 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="($is-specialized-division = 'false') or ($is-child-of-structured = 'true')"/>
 </xsl:template>
 
+<!-- ####################### -->
+<!-- Components of Exercises -->
+<!-- ####################### -->
+
+<!-- An exercise (or PROJECT-LIKE, or EXAMPLE-LIKE, or "task") shows     -->
+<!-- some of its components: "statement", "hint", "answer", "solution".  -->
+<!-- Which ones is a *decision*, made from the $b-has-* parameters       -->
+<!-- (a desire, from publisher switches or a "solutions" division) and   -->
+<!-- from what the exercise actually possesses.  The decision procedure  -->
+<!-- lives here, once; the markup is supplied by each conversion through -->
+<!-- the "present-*" hooks below.                                        -->
+<!--                                                                     -->
+<!-- N.B. the HTML conversion does not yet participate: its version of   -->
+<!-- "exercise-components" interleaves Runestone interactive exercises   -->
+<!-- with this generic procedure, and its templates shadow these by      -->
+<!-- import precedence.  Converging it onto these drivers is planned.    -->
+
+<!-- The leaf form: a statement, then chosen appendages.  The $b-has-*   -->
+<!-- parameters express a desire to see a component; an exercise missing -->
+<!-- a component cannot show it, hence the $b-showing-* refinements.     -->
+<!-- With no "statement" shown, a "title" may still be presented inline, -->
+<!-- so a separator is necessary in that case as well.                   -->
+<xsl:template match="exercise|&EXAMPLE-LIKE;|&PROJECT-LIKE;|task[not(task)]" mode="exercise-components">
+    <xsl:param name="b-original"/>
+    <xsl:param name="purpose"/>
+    <xsl:param name="b-component-heading"/>
+    <xsl:param name="run-in-heading"/>
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
+
+    <xsl:variable name="b-showing-statement" select="$b-has-statement or title"/>
+    <xsl:variable name="b-showing-hints" select="$b-has-hint and hint"/>
+    <xsl:variable name="b-showing-answers" select="$b-has-answer and answer"/>
+    <xsl:variable name="b-showing-solutions" select="$b-has-solution and solution"/>
+
+    <!-- structured (with components) versus unstructured (a bare statement) -->
+    <xsl:choose>
+        <xsl:when test="statement">
+            <xsl:choose>
+                <xsl:when test="$b-has-statement">
+                    <xsl:apply-templates select="." mode="present-exercise-statement">
+                        <xsl:with-param name="b-original" select="$b-original"/>
+                        <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
+                    </xsl:apply-templates>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="." mode="present-exercise-statement-omitted">
+                        <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
+                    </xsl:apply-templates>
+                </xsl:otherwise>
+            </xsl:choose>
+            <!-- inline presentation used up, and more coming: a separator -->
+            <xsl:if test="$b-showing-statement and ($b-showing-hints or $b-showing-answers or $b-showing-solutions)">
+                <xsl:apply-templates select="." mode="exercise-component-separator"/>
+            </xsl:if>
+            <xsl:if test="$b-showing-hints or $b-showing-answers or $b-showing-solutions">
+                <xsl:apply-templates select="." mode="present-exercise-solutions">
+                    <xsl:with-param name="b-original" select="$b-original"/>
+                    <xsl:with-param name="purpose" select="$purpose"/>
+                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                    <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
+                    <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+                    <xsl:with-param name="b-showing-hints" select="$b-showing-hints"/>
+                    <xsl:with-param name="b-showing-answers" select="$b-showing-answers"/>
+                    <xsl:with-param name="b-showing-solutions" select="$b-showing-solutions"/>
+                </xsl:apply-templates>
+            </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+            <!-- no explicit "statement", so all content is the statement -->
+            <xsl:if test="$b-has-statement">
+                <xsl:apply-templates select="." mode="present-exercise-statement-bare">
+                    <xsl:with-param name="b-original" select="$b-original"/>
+                    <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
+                </xsl:apply-templates>
+                <!-- no separator, since no trailing components -->
+            </xsl:if>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- The structured form: an optional "introduction", a sequence of      -->
+<!-- "task" (some possibly withheld, so each is checked by a "dry-run"), -->
+<!-- and an optional "conclusion".  The introduction and conclusion ride -->
+<!-- with the statement's visibility.                                    -->
+<xsl:template match="exercise[task]|project[task]|activity[task]|exploration[task]|investigation[task]|example[task]|question[task]|problem[task]|task[task]" mode="exercise-components">
+    <xsl:param name="b-original"/>
+    <xsl:param name="purpose"/>
+    <xsl:param name="b-component-heading"/>
+    <xsl:param name="run-in-heading"/>
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
+
+    <xsl:apply-templates select="." mode="present-tasks-introduction">
+        <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+        <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
+    </xsl:apply-templates>
+
+    <!-- Now we see if the list of contained tasks is empty or not -->
+    <xsl:variable name="task-list-dry-run">
+        <xsl:apply-templates select="task" mode="dry-run">
+            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+            <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+            <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+            <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+        </xsl:apply-templates>
+    </xsl:variable>
+
+    <xsl:if test="not($task-list-dry-run = '')">
+        <xsl:apply-templates select="." mode="begin-task-list"/>
+        <xsl:for-each select="task">
+            <!-- just for this particular task -->
+            <xsl:variable name="dry-run">
+                <xsl:apply-templates select="." mode="dry-run">
+                    <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+                    <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+                    <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+                    <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+                </xsl:apply-templates>
+            </xsl:variable>
+            <!-- The entire task list is non-empty, so some particular task -->
+            <!-- must be non-empty, ensuring a conversion never creates an  -->
+            <!-- empty list structure.                                      -->
+            <xsl:if test="not($dry-run = '')">
+                <xsl:apply-templates select="." mode="present-task-item">
+                    <xsl:with-param name="b-original" select="$b-original"/>
+                    <xsl:with-param name="purpose" select="$purpose"/>
+                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                    <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+                    <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+                    <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+                    <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+                </xsl:apply-templates>
+            </xsl:if>
+        </xsl:for-each>
+        <xsl:apply-templates select="." mode="end-task-list"/>
+    </xsl:if>
+
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion"/>
+    </xsl:if>
+</xsl:template>
+
+<!-- The hooks.  A conversion participating in the drivers above         -->
+<!-- must implement the four essential presentation hooks; the stubs     -->
+<!-- here fail loudly.  The remaining hooks are optional decorations     -->
+<!-- with quiet no-op defaults.                                          -->
+
+<xsl:template match="*" mode="present-exercise-statement">
+    <xsl:message>PTX:BUG:     a conversion to a new output format requires implementation of the template with match="*" and mode="present-exercise-statement"</xsl:message>
+</xsl:template>
+
+<xsl:template match="*" mode="present-exercise-statement-bare">
+    <xsl:message>PTX:BUG:     a conversion to a new output format requires implementation of the template with match="*" and mode="present-exercise-statement-bare"</xsl:message>
+</xsl:template>
+
+<xsl:template match="*" mode="present-exercise-solutions">
+    <xsl:message>PTX:BUG:     a conversion to a new output format requires implementation of the template with match="*" and mode="present-exercise-solutions"</xsl:message>
+</xsl:template>
+
+<xsl:template match="*" mode="present-task-item">
+    <xsl:message>PTX:BUG:     a conversion to a new output format requires implementation of the template with match="*" and mode="present-task-item"</xsl:message>
+</xsl:template>
+
+<!-- A heading with no statement to carry it may still need presenting -->
+<xsl:template match="*" mode="present-exercise-statement-omitted"/>
+
+<!-- Punctuation between components, when more are coming -->
+<xsl:template match="*" mode="exercise-component-separator"/>
+
+<!-- Infrastructure around a sequence of "task" -->
+<xsl:template match="*" mode="begin-task-list"/>
+<xsl:template match="*" mode="end-task-list"/>
+
+<!-- The introduction (or a stand-in) preceding a sequence of "task" -->
+<xsl:template match="*" mode="present-tasks-introduction">
+    <xsl:param name="b-has-statement"/>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction"/>
+    </xsl:if>
+</xsl:template>
+
 <!-- ################ -->
 <!-- Printout Margins -->
 <!-- ################ -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5389,61 +5389,72 @@ Book (with parts), "section" at level 3
 
 <xsl:template match="exercises" mode="dry-run">
     <xsl:param name="admit"/>
-    <xsl:param name="b-divisional-statement" />
-    <xsl:param name="b-divisional-hint" />
-    <xsl:param name="b-divisional-answer" />
-    <xsl:param name="b-divisional-solution" />
+    <xsl:param name="component-spec"/>
 
+    <xsl:variable name="divisional-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'divisional'"/>
+        </xsl:call-template>
+    </xsl:variable>
     <xsl:apply-templates select=".//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
-        <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
-        <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
-        <xsl:with-param name="b-has-solution"  select="$b-divisional-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($divisional-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($divisional-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($divisional-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($divisional-components, 'solution')" />
     </xsl:apply-templates>
 </xsl:template>
 
 <xsl:template match="worksheet" mode="dry-run">
     <xsl:param name="admit"/>
-    <xsl:param name="b-worksheet-statement" />
-    <xsl:param name="b-worksheet-hint" />
-    <xsl:param name="b-worksheet-answer" />
-    <xsl:param name="b-worksheet-solution" />
-    <xsl:param name="b-project-statement" />
-    <xsl:param name="b-project-hint" />
-    <xsl:param name="b-project-answer" />
-    <xsl:param name="b-project-solution" />
+    <xsl:param name="component-spec"/>
 
+    <xsl:variable name="worksheet-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'worksheet'"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="project-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'project'"/>
+        </xsl:call-template>
+    </xsl:variable>
     <xsl:apply-templates select=".//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-worksheet-statement" />
-        <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint" />
-        <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer" />
-        <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($worksheet-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($worksheet-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($worksheet-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($worksheet-components, 'solution')" />
     </xsl:apply-templates>
     <xsl:apply-templates select=".//activity|.//exploration|.//investigation|.//project" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-project-statement" />
-        <xsl:with-param name="b-has-hint"      select="$b-project-hint" />
-        <xsl:with-param name="b-has-answer"    select="$b-project-answer" />
-        <xsl:with-param name="b-has-solution"  select="$b-project-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($project-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($project-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($project-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($project-components, 'solution')" />
     </xsl:apply-templates>
 
 </xsl:template>
 
 <xsl:template match="reading-questions" mode="dry-run">
     <xsl:param name="admit"/>
-    <xsl:param name="b-reading-statement" />
-    <xsl:param name="b-reading-hint" />
-    <xsl:param name="b-reading-answer" />
-    <xsl:param name="b-reading-solution" />
+    <xsl:param name="component-spec"/>
 
+    <xsl:variable name="reading-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'reading'"/>
+        </xsl:call-template>
+    </xsl:variable>
     <xsl:apply-templates select="exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-reading-statement" />
-        <xsl:with-param name="b-has-hint"      select="$b-reading-hint" />
-        <xsl:with-param name="b-has-answer"    select="$b-reading-answer" />
-        <xsl:with-param name="b-has-solution"  select="$b-reading-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($reading-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($reading-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($reading-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($reading-components, 'solution')" />
     </xsl:apply-templates>
 </xsl:template>
 
@@ -5456,62 +5467,73 @@ Book (with parts), "section" at level 3
 <!-- and what switches are passed along.                              -->
 <xsl:template match="part|chapter|section|subsection|subsubsection" mode="dry-run">
     <xsl:param name="admit"/>
-    <xsl:param name="b-inline-statement" />
-    <xsl:param name="b-inline-answer" />
-    <xsl:param name="b-inline-hint" />
-    <xsl:param name="b-inline-solution" />
-    <xsl:param name="b-divisional-statement" />
-    <xsl:param name="b-divisional-answer" />
-    <xsl:param name="b-divisional-hint" />
-    <xsl:param name="b-divisional-solution" />
-    <xsl:param name="b-worksheet-statement" />
-    <xsl:param name="b-worksheet-answer" />
-    <xsl:param name="b-worksheet-hint" />
-    <xsl:param name="b-worksheet-solution" />
-    <xsl:param name="b-reading-statement" />
-    <xsl:param name="b-reading-answer" />
-    <xsl:param name="b-reading-hint" />
-    <xsl:param name="b-reading-solution" />
-    <xsl:param name="b-project-statement" />
-    <xsl:param name="b-project-answer" />
-    <xsl:param name="b-project-hint" />
-    <xsl:param name="b-project-solution" />
+    <xsl:param name="component-spec"/>
 
+    <xsl:variable name="inline-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'inline'"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="divisional-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'divisional'"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="worksheet-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'worksheet'"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="reading-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'reading'"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="project-components">
+        <xsl:call-template name="solutions-components">
+            <xsl:with-param name="component-spec" select="$component-spec"/>
+            <xsl:with-param name="category" select="'project'"/>
+        </xsl:call-template>
+    </xsl:variable>
     <xsl:apply-templates select=".//exercise[boolean(&INLINE-EXERCISE-FILTER;)]" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-inline-statement" />
-        <xsl:with-param name="b-has-answer"    select="$b-inline-answer" />
-        <xsl:with-param name="b-has-hint"      select="$b-inline-hint" />
-        <xsl:with-param name="b-has-solution"  select="$b-inline-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($inline-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($inline-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($inline-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($inline-components, 'solution')" />
     </xsl:apply-templates>
     <xsl:apply-templates select=".//exercises//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
-        <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
-        <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
-        <xsl:with-param name="b-has-solution"  select="$b-divisional-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($divisional-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($divisional-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($divisional-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($divisional-components, 'solution')" />
     </xsl:apply-templates>
     <xsl:apply-templates select=".//worksheet//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-worksheet-statement" />
-        <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer" />
-        <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint" />
-        <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($worksheet-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($worksheet-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($worksheet-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($worksheet-components, 'solution')" />
     </xsl:apply-templates>
     <xsl:apply-templates select=".//reading-questions//exercise" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-reading-statement" />
-        <xsl:with-param name="b-has-answer"    select="$b-reading-answer" />
-        <xsl:with-param name="b-has-hint"      select="$b-reading-hint" />
-        <xsl:with-param name="b-has-solution"  select="$b-reading-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($reading-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($reading-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($reading-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($reading-components, 'solution')" />
     </xsl:apply-templates>
     <!-- &PROJECT-LIKE; "project|activity|exploration|investigation"> -->
     <xsl:apply-templates select=".//project|.//activity|.//exploration|.//investigation" mode="dry-run">
         <xsl:with-param name="admit"           select="$admit"/>
-        <xsl:with-param name="b-has-statement" select="$b-project-statement" />
-        <xsl:with-param name="b-has-answer"    select="$b-project-answer" />
-        <xsl:with-param name="b-has-hint"      select="$b-project-hint" />
-        <xsl:with-param name="b-has-solution"  select="$b-project-solution" />
+        <xsl:with-param name="b-has-statement" select="contains($project-components, 'statement')" />
+        <xsl:with-param name="b-has-hint"      select="contains($project-components, 'hint')" />
+        <xsl:with-param name="b-has-answer"    select="contains($project-components, 'answer')" />
+        <xsl:with-param name="b-has-solution"  select="contains($project-components, 'solution')" />
     </xsl:apply-templates>
 </xsl:template>
 
@@ -5665,92 +5687,81 @@ Book (with parts), "section" at level 3
         </xsl:choose>
     </xsl:variable>
 
+    <!-- The five attributes describing which solution components    -->
+    <!-- are requested, packed into one string parameter.  See the   -->
+    <!-- "solutions-component-spec" template for the packing format. -->
+    <xsl:variable name="component-spec">
+        <xsl:call-template name="solutions-component-spec">
+            <xsl:with-param name="inline"     select="@inline"/>
+            <xsl:with-param name="divisional" select="@divisional"/>
+            <xsl:with-param name="worksheet"  select="@worksheet"/>
+            <xsl:with-param name="reading"    select="@reading"/>
+            <xsl:with-param name="project"    select="@project"/>
+        </xsl:call-template>
+    </xsl:variable>
+
     <xsl:apply-templates select="introduction">
         <xsl:with-param name="b-original" select="true()" />
     </xsl:apply-templates>
-    <!-- We call the solutions-generator one of two ways, either by     -->
-    <!-- looking up a level, to the parent (jumping over "backmatter")  -->
-    <!-- or by respecting a @scope attribute that specifies the parent. -->
-    <!-- The "call" is identical, only the @select is different.        -->
-    <!-- (Maybe there is a better way to use just one call?)            -->
 
-    <xsl:choose>
-        <xsl:when test="@scope">
-            <!-- First check that the scope is reasonable, i.e. it -->
-            <!-- exists and is one of the elements defined for the -->
-            <!-- "solutions-generator" template                    -->
-            <xsl:variable name="scope" select="id(@scope)"/>
-            <xsl:if test="not($scope)">
-                <xsl:message>PTX:WARNING: unresolved @scope ("<xsl:value-of select="@scope"/>") for a &lt;solutions&gt; division</xsl:message>
-                <xsl:apply-templates select="." mode="location-report" />
-            </xsl:if>
-            <xsl:if test="not($scope/self::book|$scope/self::article|$scope/self::chapter|$scope/self::section|$scope/self::subsection|$scope/self::subsubsection|$scope/self::exercises|$scope/self::worksheet|$scope/self::reading-questions)">
-                <xsl:message>PTX:ERROR: the @scope ("<xsl:value-of select="@scope"/>") of a &lt;solutions&gt; division is not a supported division.  If you think your attempt is reasonable, please make a feature request.  Results now will be unpredictable</xsl:message>
-                <xsl:apply-templates select="." mode="location-report" />
-            </xsl:if>
+    <xsl:if test="@scope">
+        <!-- Check that the scope is reasonable, i.e. it exists and is -->
+        <!-- one of the elements defined for the "solutions-generator" -->
+        <!-- template                                                  -->
+        <xsl:variable name="scope" select="id(@scope)"/>
+        <xsl:if test="not($scope)">
+            <xsl:message>PTX:WARNING: unresolved @scope ("<xsl:value-of select="@scope"/>") for a &lt;solutions&gt; division</xsl:message>
+            <xsl:apply-templates select="." mode="location-report" />
+        </xsl:if>
+        <xsl:if test="not($scope/self::book|$scope/self::article|$scope/self::chapter|$scope/self::section|$scope/self::subsection|$scope/self::subsubsection|$scope/self::exercises|$scope/self::worksheet|$scope/self::reading-questions)">
+            <xsl:message>PTX:ERROR: the @scope ("<xsl:value-of select="@scope"/>") of a &lt;solutions&gt; division is not a supported division.  If you think your attempt is reasonable, please make a feature request.  Results now will be unpredictable</xsl:message>
+            <xsl:apply-templates select="." mode="location-report" />
+        </xsl:if>
+    </xsl:if>
 
-            <xsl:apply-templates select="$scope" mode="solutions-generator">
-                <xsl:with-param name="purpose" select="$purpose" />
-                <xsl:with-param name="admit"   select="$admit"/>
-                <xsl:with-param name="heading-level" select="$heading-level"/>
-                <xsl:with-param name="scope" select="$scope"/>
-                <xsl:with-param name="b-inline-statement"     select="contains(@inline,     'statement')" />
-                <xsl:with-param name="b-inline-hint"          select="contains(@inline,     'hint')"      />
-                <xsl:with-param name="b-inline-answer"        select="contains(@inline,     'answer')"    />
-                <xsl:with-param name="b-inline-solution"      select="contains(@inline,     'solution')"  />
-                <xsl:with-param name="b-divisional-statement" select="contains(@divisional, 'statement')" />
-                <xsl:with-param name="b-divisional-hint"      select="contains(@divisional, 'hint')"      />
-                <xsl:with-param name="b-divisional-answer"    select="contains(@divisional, 'answer')"    />
-                <xsl:with-param name="b-divisional-solution"  select="contains(@divisional, 'solution')"  />
-                <xsl:with-param name="b-worksheet-statement"  select="contains(@worksheet,  'statement')" />
-                <xsl:with-param name="b-worksheet-hint"       select="contains(@worksheet,  'hint')"      />
-                <xsl:with-param name="b-worksheet-answer"     select="contains(@worksheet,  'answer')"    />
-                <xsl:with-param name="b-worksheet-solution"   select="contains(@worksheet,  'solution')"  />
-                <xsl:with-param name="b-reading-statement"    select="contains(@reading,    'statement')" />
-                <xsl:with-param name="b-reading-hint"         select="contains(@reading,    'hint')"      />
-                <xsl:with-param name="b-reading-answer"       select="contains(@reading,    'answer')"    />
-                <xsl:with-param name="b-reading-solution"     select="contains(@reading,    'solution')"  />
-                <xsl:with-param name="b-project-statement"    select="contains(@project,    'statement')" />
-                <xsl:with-param name="b-project-hint"         select="contains(@project,    'hint')"      />
-                <xsl:with-param name="b-project-answer"       select="contains(@project,    'answer')"    />
-                <xsl:with-param name="b-project-solution"     select="contains(@project,    'solution')"  />
-            </xsl:apply-templates>
-        </xsl:when>
-        <xsl:otherwise>
-            <!-- the default scope, first ancestor -->
-            <xsl:apply-templates select="ancestor::*[not(self::backmatter)][1]" mode="solutions-generator">
-                <xsl:with-param name="purpose" select="$purpose" />
-                <xsl:with-param name="admit"   select="$admit"/>
-                <xsl:with-param name="heading-level" select="$heading-level"/>
-                <xsl:with-param name="scope" select="ancestor::*[not(self::backmatter)][1]"/>
-                <xsl:with-param name="b-inline-statement"     select="contains(@inline,     'statement')" />
-                <xsl:with-param name="b-inline-hint"          select="contains(@inline,     'hint')"      />
-                <xsl:with-param name="b-inline-answer"        select="contains(@inline,     'answer')"    />
-                <xsl:with-param name="b-inline-solution"      select="contains(@inline,     'solution')"  />
-                <xsl:with-param name="b-divisional-statement" select="contains(@divisional, 'statement')" />
-                <xsl:with-param name="b-divisional-hint"      select="contains(@divisional, 'hint')"      />
-                <xsl:with-param name="b-divisional-answer"    select="contains(@divisional, 'answer')"    />
-                <xsl:with-param name="b-divisional-solution"  select="contains(@divisional, 'solution')"  />
-                <xsl:with-param name="b-worksheet-statement"  select="contains(@worksheet,  'statement')" />
-                <xsl:with-param name="b-worksheet-hint"       select="contains(@worksheet,  'hint')"      />
-                <xsl:with-param name="b-worksheet-answer"     select="contains(@worksheet,  'answer')"    />
-                <xsl:with-param name="b-worksheet-solution"   select="contains(@worksheet,  'solution')"  />
-                <xsl:with-param name="b-reading-statement"    select="contains(@reading,    'statement')" />
-                <xsl:with-param name="b-reading-hint"         select="contains(@reading,    'hint')"      />
-                <xsl:with-param name="b-reading-answer"       select="contains(@reading,    'answer')"    />
-                <xsl:with-param name="b-reading-solution"     select="contains(@reading,    'solution')"  />
-                <xsl:with-param name="b-project-statement"    select="contains(@project,    'statement')" />
-                <xsl:with-param name="b-project-hint"         select="contains(@project,    'hint')"      />
-                <xsl:with-param name="b-project-answer"       select="contains(@project,    'answer')"    />
-                <xsl:with-param name="b-project-solution"     select="contains(@project,    'solution')"  />
-            </xsl:apply-templates>
-        </xsl:otherwise>
-    </xsl:choose>
-
+    <!-- We call the solutions-generator on a single target: either the -->
+    <!-- division specified by @scope, or the parent (jumping over      -->
+    <!-- "backmatter").  The union computing $target has at most one    -->
+    <!-- node, since id() is empty without a @scope attribute, and the  -->
+    <!-- ancestor member is only admitted when @scope is absent.        -->
+    <xsl:variable name="target" select="id(@scope) | ancestor::*[not(self::backmatter)][1][not(current()/@scope)]"/>
+    <xsl:apply-templates select="$target" mode="solutions-generator">
+        <xsl:with-param name="purpose" select="$purpose" />
+        <xsl:with-param name="admit"   select="$admit"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:with-param name="scope" select="$target"/>
+        <xsl:with-param name="component-spec" select="$component-spec"/>
+    </xsl:apply-templates>
 
     <xsl:apply-templates select="conclusion">
         <xsl:with-param name="b-original" select="true()" />
     </xsl:apply-templates>
+</xsl:template>
+
+<!-- The components of solutions ("statement", "hint", "answer",        -->
+<!-- "solution") are requested per category of exercise, matching the   -->
+<!-- five attributes of a "solutions" division: "inline", "divisional", -->
+<!-- "worksheet", "reading", "project".  We pack the five component     -->
+<!-- lists into a single string parameter, rather than threading twenty -->
+<!-- boolean parameters through every template of the generator.  The   -->
+<!-- format, with every piece employed, is                              -->
+<!--                                                                    -->
+<!--   |inline:statement hint|divisional:solution|worksheet:|reading:|project:statement| -->
+<!--                                                                    -->
+<xsl:template name="solutions-component-spec">
+    <xsl:param name="inline"/>
+    <xsl:param name="divisional"/>
+    <xsl:param name="worksheet"/>
+    <xsl:param name="reading"/>
+    <xsl:param name="project"/>
+    <xsl:value-of select="concat('|inline:', $inline, '|divisional:', $divisional, '|worksheet:', $worksheet, '|reading:', $reading, '|project:', $project, '|')"/>
+</xsl:template>
+
+<!-- Extract one category's component list from a packed specification -->
+<xsl:template name="solutions-components">
+    <xsl:param name="component-spec"/>
+    <xsl:param name="category"/>
+    <xsl:value-of select="substring-before(substring-after($component-spec, concat('|', $category, ':')), '|')"/>
 </xsl:template>
 
 <!-- Determine whether an exercise should be admitted, given its serial -->
@@ -5806,26 +5817,7 @@ Book (with parts), "section" at level 3
     <xsl:param name="heading-level"/>
     <xsl:param name="heading-stack" select="."/>
     <xsl:param name="scope"/>
-    <xsl:param name="b-inline-statement"     />
-    <xsl:param name="b-inline-hint"          />
-    <xsl:param name="b-inline-answer"        />
-    <xsl:param name="b-inline-solution"      />
-    <xsl:param name="b-divisional-statement" />
-    <xsl:param name="b-divisional-hint"      />
-    <xsl:param name="b-divisional-answer"    />
-    <xsl:param name="b-divisional-solution"  />
-    <xsl:param name="b-worksheet-statement"  />
-    <xsl:param name="b-worksheet-hint"       />
-    <xsl:param name="b-worksheet-answer"     />
-    <xsl:param name="b-worksheet-solution"   />
-    <xsl:param name="b-reading-statement"    />
-    <xsl:param name="b-reading-hint"         />
-    <xsl:param name="b-reading-answer"       />
-    <xsl:param name="b-reading-solution"     />
-    <xsl:param name="b-project-statement"    />
-    <xsl:param name="b-project-hint"         />
-    <xsl:param name="b-project-answer"       />
-    <xsl:param name="b-project-solution"     />
+    <xsl:param name="component-spec"/>
 
     <!-- See if division has *any* content, at any depth, in light of switches. -->
     <!-- Traditional divisions expect many switches, while specialized          -->
@@ -5833,26 +5825,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="dry-run">
         <xsl:apply-templates select="." mode="dry-run">
             <xsl:with-param name="admit"                  select="$admit"/>
-            <xsl:with-param name="b-inline-statement"     select="$b-inline-statement" />
-            <xsl:with-param name="b-inline-answer"        select="$b-inline-answer" />
-            <xsl:with-param name="b-inline-hint"          select="$b-inline-hint" />
-            <xsl:with-param name="b-inline-solution"      select="$b-inline-solution" />
-            <xsl:with-param name="b-divisional-statement" select="$b-divisional-statement" />
-            <xsl:with-param name="b-divisional-answer"    select="$b-divisional-answer" />
-            <xsl:with-param name="b-divisional-hint"      select="$b-divisional-hint" />
-            <xsl:with-param name="b-divisional-solution"  select="$b-divisional-solution" />
-            <xsl:with-param name="b-worksheet-statement"  select="$b-worksheet-statement" />
-            <xsl:with-param name="b-worksheet-answer"     select="$b-worksheet-answer" />
-            <xsl:with-param name="b-worksheet-hint"       select="$b-worksheet-hint" />
-            <xsl:with-param name="b-worksheet-solution"   select="$b-worksheet-solution" />
-            <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
-            <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
-            <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-            <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
-            <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
-            <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
-            <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
-            <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
+            <xsl:with-param name="component-spec" select="$component-spec"/>
         </xsl:apply-templates>
     </xsl:variable>
 
@@ -5863,26 +5836,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="preceding-sibling-dry-run">
         <xsl:apply-templates select="preceding-sibling::*" mode="dry-run">
             <xsl:with-param name="admit"                  select="$admit"/>
-            <xsl:with-param name="b-inline-statement"     select="$b-inline-statement" />
-            <xsl:with-param name="b-inline-answer"        select="$b-inline-answer" />
-            <xsl:with-param name="b-inline-hint"          select="$b-inline-hint" />
-            <xsl:with-param name="b-inline-solution"      select="$b-inline-solution" />
-            <xsl:with-param name="b-divisional-statement" select="$b-divisional-statement" />
-            <xsl:with-param name="b-divisional-answer"    select="$b-divisional-answer" />
-            <xsl:with-param name="b-divisional-hint"      select="$b-divisional-hint" />
-            <xsl:with-param name="b-divisional-solution"  select="$b-divisional-solution" />
-            <xsl:with-param name="b-worksheet-statement"  select="$b-worksheet-statement" />
-            <xsl:with-param name="b-worksheet-answer"     select="$b-worksheet-answer" />
-            <xsl:with-param name="b-worksheet-hint"       select="$b-worksheet-hint" />
-            <xsl:with-param name="b-worksheet-solution"   select="$b-worksheet-solution" />
-            <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
-            <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
-            <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-            <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
-            <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
-            <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
-            <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
-            <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
+            <xsl:with-param name="component-spec" select="$component-spec"/>
         </xsl:apply-templates>
     </xsl:variable>
     <xsl:variable name="b-preceding-empty" select="$preceding-sibling-dry-run = ''"/>
@@ -5921,16 +5875,16 @@ Book (with parts), "section" at level 3
         <!-- some requested type never appears.                        -->
 
         <xsl:variable name="variety">
-            <xsl:if test="$b-inline-statement or $b-divisional-statement or $b-worksheet-statement or $b-reading-statement or $b-project-statement">
+            <xsl:if test="contains($component-spec, 'statement')">
                 <xsl:text>T</xsl:text>
             </xsl:if>
-            <xsl:if test="$b-inline-hint or $b-divisional-hint or $b-worksheet-hint or $b-reading-hint or $b-project-hint">
+            <xsl:if test="contains($component-spec, 'hint')">
                 <xsl:text>H</xsl:text>
             </xsl:if>
-            <xsl:if test="$b-inline-answer or $b-divisional-answer or $b-worksheet-answer or $b-reading-answer or $b-project-answer">
+            <xsl:if test="contains($component-spec, 'answer')">
                 <xsl:text>A</xsl:text>
             </xsl:if>
-            <xsl:if test="$b-inline-solution or $b-divisional-solution or $b-worksheet-solution or $b-reading-solution or $b-project-solution">
+            <xsl:if test="contains($component-spec, 'solution')">
                 <xsl:text>S</xsl:text>
             </xsl:if>
         </xsl:variable>
@@ -5966,80 +5920,51 @@ Book (with parts), "section" at level 3
                 <!-- "hidden" inside the "paragraphs" pseudo-division -->
                 <!-- Everything below is 1 deeper than the division's heading -->
                 <xsl:for-each select="exercise|subexercises|exercisegroup|&PROJECT-LIKE;|paragraphs/*[self::exercise or &PROJECT-FILTER;]|self::worksheet//*[self::exercise or &PROJECT-FILTER;]">
-                     <xsl:choose>
-                        <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;)">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose" />
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-inline-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-inline-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-inline-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-inline-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                        <xsl:when test="self::subexercises|self::exercisegroup">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose"/>
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-divisional-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                        <xsl:when test="self::exercise and ancestor::exercises">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose"/>
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-divisional-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-divisional-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-divisional-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-divisional-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                        <xsl:when test="self::exercise and ancestor::worksheet">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose"/>
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-worksheet-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-worksheet-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-worksheet-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-worksheet-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                        <xsl:when test="self::exercise and ancestor::reading-questions">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose"/>
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-reading-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-reading-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-reading-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-reading-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                        <xsl:when test="&PROJECT-FILTER;">
-                            <xsl:apply-templates select="." mode="solutions">
-                                <xsl:with-param name="purpose" select="$purpose"/>
-                                <xsl:with-param name="admit"   select="$admit"/>
-                                <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                                <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
-                                <xsl:with-param name="b-has-statement" select="$b-project-statement" />
-                                <xsl:with-param name="b-has-answer"    select="$b-project-answer" />
-                                <xsl:with-param name="b-has-hint"      select="$b-project-hint" />
-                                <xsl:with-param name="b-has-solution"  select="$b-project-solution" />
-                            </xsl:apply-templates>
-                        </xsl:when>
-                    </xsl:choose>
+                    <!-- Classify each item into one of the five categories of  -->
+                    <!-- exercise, which selects the relevant component list.   -->
+                    <!-- The order of the tests mirrors the dispatch this       -->
+                    <!-- replaces.  An element matching no test is unexpected,  -->
+                    <!-- yields no category, and so produces no output.         -->
+                    <xsl:variable name="category">
+                        <xsl:choose>
+                            <xsl:when test="self::exercise and boolean(&INLINE-EXERCISE-FILTER;)">
+                                <xsl:text>inline</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="self::subexercises or self::exercisegroup">
+                                <xsl:text>divisional</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="self::exercise and ancestor::exercises">
+                                <xsl:text>divisional</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="self::exercise and ancestor::worksheet">
+                                <xsl:text>worksheet</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="self::exercise and ancestor::reading-questions">
+                                <xsl:text>reading</xsl:text>
+                            </xsl:when>
+                            <xsl:when test="&PROJECT-FILTER;">
+                                <xsl:text>project</xsl:text>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:variable name="components">
+                        <xsl:call-template name="solutions-components">
+                            <xsl:with-param name="component-spec" select="$component-spec"/>
+                            <xsl:with-param name="category" select="$category"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:if test="not($category = '')">
+                        <xsl:apply-templates select="." mode="solutions">
+                            <xsl:with-param name="purpose" select="$purpose" />
+                            <xsl:with-param name="admit"   select="$admit"/>
+                            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+                            <xsl:with-param name="heading-level"       select="$next-heading-level + 1"/>
+                            <xsl:with-param name="b-has-statement" select="contains($components, 'statement')" />
+                            <xsl:with-param name="b-has-hint"      select="contains($components, 'hint')" />
+                            <xsl:with-param name="b-has-answer"    select="contains($components, 'answer')" />
+                            <xsl:with-param name="b-has-solution"  select="contains($components, 'solution')" />
+                        </xsl:apply-templates>
+                    </xsl:if>
                 </xsl:for-each>
             </xsl:with-param>
         </xsl:apply-templates>
@@ -6058,26 +5983,7 @@ Book (with parts), "section" at level 3
         <xsl:with-param name="heading-level" select="$heading-level"/>
         <xsl:with-param name="heading-stack" select="$next-heading-stack"/>
         <xsl:with-param name="scope" select="$scope" />
-        <xsl:with-param name="b-inline-statement"     select="$b-inline-statement" />
-        <xsl:with-param name="b-inline-answer"        select="$b-inline-answer" />
-        <xsl:with-param name="b-inline-hint"          select="$b-inline-hint" />
-        <xsl:with-param name="b-inline-solution"      select="$b-inline-solution" />
-        <xsl:with-param name="b-divisional-statement" select="$b-divisional-statement" />
-        <xsl:with-param name="b-divisional-answer"    select="$b-divisional-answer" />
-        <xsl:with-param name="b-divisional-hint"      select="$b-divisional-hint" />
-        <xsl:with-param name="b-divisional-solution"  select="$b-divisional-solution" />
-        <xsl:with-param name="b-worksheet-statement"  select="$b-worksheet-statement" />
-        <xsl:with-param name="b-worksheet-answer"     select="$b-worksheet-answer" />
-        <xsl:with-param name="b-worksheet-hint"       select="$b-worksheet-hint" />
-        <xsl:with-param name="b-worksheet-solution"   select="$b-worksheet-solution" />
-        <xsl:with-param name="b-reading-statement"    select="$b-reading-statement" />
-        <xsl:with-param name="b-reading-answer"       select="$b-reading-answer" />
-        <xsl:with-param name="b-reading-hint"         select="$b-reading-hint" />
-        <xsl:with-param name="b-reading-solution"     select="$b-reading-solution" />
-        <xsl:with-param name="b-project-statement"    select="$b-project-statement" />
-        <xsl:with-param name="b-project-answer"       select="$b-project-answer" />
-        <xsl:with-param name="b-project-hint"         select="$b-project-hint" />
-        <xsl:with-param name="b-project-solution"     select="$b-project-solution" />
+        <xsl:with-param name="component-spec" select="$component-spec"/>
     </xsl:apply-templates>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6041,6 +6041,38 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- A division echoed in a "solutions" division (or in a "list-of")     -->
+<!-- shows its number, except when it is a specialized division serving  -->
+<!-- as the unstructured remainder of its parent: there it shares the    -->
+<!-- parent's number, and echoing that number would misattribute it.     -->
+<!-- This is THE decision, shared by every conversion's implementation   -->
+<!-- of the "duplicate-heading" template: 'true' means show the number.  -->
+<!-- A "task" can arrive here via a "list-of"; it is not a division at   -->
+<!-- all, and always keeps its number.                                   -->
+<xsl:template match="*" mode="duplicate-heading-show-number">
+    <xsl:variable name="is-specialized-division">
+        <xsl:choose>
+            <xsl:when test="self::task">
+                <xsl:value-of select="false()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="." mode="is-specialized-division"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="is-child-of-structured">
+        <xsl:choose>
+            <xsl:when test="parent::*[&TRADITIONAL-DIVISION-FILTER;]">
+                <xsl:apply-templates select="parent::*[&TRADITIONAL-DIVISION-FILTER;]" mode="is-structured-division"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:value-of select="($is-specialized-division = 'false') or ($is-child-of-structured = 'true')"/>
+</xsl:template>
+
 <!-- ################ -->
 <!-- Printout Margins -->
 <!-- ################ -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1826,15 +1826,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
               space-after="0.75em"
               keep-with-next.within-page="always">
         <!-- Each division of the stack on its own line, as in the LaTeX -->
-        <!-- conversion: the number and title joined by a middle dot,     -->
-        <!-- with no type-name.  An unnumbered (specialized) division     -->
-        <!-- leads with the dot.                                          -->
+        <!-- conversion: the number and title joined by a middle dot,    -->
+        <!-- with no type-name.  A division whose number is withheld     -->
+        <!-- (see "duplicate-heading-show-number") leads with the dot.   -->
         <xsl:for-each select="$heading-stack">
             <fo:block>
+                <xsl:variable name="show-number">
+                    <xsl:apply-templates select="." mode="duplicate-heading-show-number"/>
+                </xsl:variable>
                 <xsl:variable name="the-number">
                     <xsl:apply-templates select="." mode="number"/>
                 </xsl:variable>
-                <xsl:if test="not($the-number = '')">
+                <xsl:if test="($show-number = 'true') and not($the-number = '')">
                     <xsl:value-of select="$the-number"/>
                     <xsl:text> </xsl:text>
                 </xsl:if>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1910,87 +1910,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- the wrappers pass everything through, with their prose -->
 <!-- gated on statements being shown                        -->
-<xsl:template match="exercisegroup" mode="solutions">
-    <xsl:param name="purpose"/>
-    <xsl:param name="admit"/>
-    <xsl:param name="b-component-heading"/>
-    <xsl:param name="heading-level"/>
+<!-- Containers echoed in a "solutions" division: the generic     -->
+<!-- driver in pretext-common.xsl decides if anything appears at  -->
+<!-- all, and renders the items; the wrapping here                -->
+
+<xsl:template match="exercisegroup" mode="present-solutions-container">
     <xsl:param name="b-has-statement"/>
-    <xsl:param name="b-has-hint"/>
-    <xsl:param name="b-has-answer"/>
-    <xsl:param name="b-has-solution"/>
-    <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-        </xsl:apply-templates>
-    </xsl:variable>
-    <xsl:if test="not($dry-run = '')">
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="introduction"/>
-        </xsl:if>
-        <xsl:apply-templates select="exercise" mode="solutions">
-            <xsl:with-param name="purpose" select="$purpose"/>
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-            <xsl:with-param name="heading-level" select="$heading-level"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-        </xsl:apply-templates>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="conclusion"/>
-        </xsl:if>
+    <xsl:param name="content"/>
+
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction"/>
+    </xsl:if>
+    <xsl:copy-of select="$content"/>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion"/>
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="subexercises" mode="solutions">
-    <xsl:param name="purpose"/>
-    <xsl:param name="admit"/>
-    <xsl:param name="b-component-heading"/>
-    <xsl:param name="heading-level"/>
+<xsl:template match="subexercises" mode="present-solutions-container">
     <xsl:param name="b-has-statement"/>
-    <xsl:param name="b-has-hint"/>
-    <xsl:param name="b-has-answer"/>
-    <xsl:param name="b-has-solution"/>
-    <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-        </xsl:apply-templates>
-    </xsl:variable>
-    <xsl:if test="not($dry-run = '')">
-        <xsl:if test="title">
-            <fo:block font-weight="bold"
-                      space-before="1em"
-                      space-after="0.5em"
-                      keep-with-next.within-page="always">
-                <xsl:apply-templates select="." mode="title-full"/>
-            </fo:block>
-        </xsl:if>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="introduction"/>
-        </xsl:if>
-        <xsl:apply-templates select="exercise|exercisegroup" mode="solutions">
-            <xsl:with-param name="purpose" select="$purpose"/>
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-            <xsl:with-param name="heading-level" select="$heading-level"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-        </xsl:apply-templates>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="conclusion"/>
-        </xsl:if>
+    <xsl:param name="content"/>
+
+    <xsl:if test="title">
+        <fo:block font-weight="bold"
+                  space-before="1em"
+                  space-after="0.5em"
+                  keep-with-next.within-page="always">
+            <xsl:apply-templates select="." mode="title-full"/>
+        </fo:block>
+    </xsl:if>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction"/>
+    </xsl:if>
+    <xsl:copy-of select="$content"/>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion"/>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1432,6 +1432,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text> </xsl:text>
         </xsl:variable>
         <xsl:apply-templates select="." mode="exercise-components">
+            <xsl:with-param name="b-original" select="true()"/>
             <xsl:with-param name="b-has-statement" select="true()"/>
             <xsl:with-param name="b-has-hint">
                 <xsl:apply-templates select="." mode="b-main-text-component">
@@ -1472,6 +1473,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:variable>
         <xsl:apply-templates select="." mode="exercise-components">
             <xsl:with-param name="run-in-heading" select="$heading"/>
+            <xsl:with-param name="b-original" select="true()"/>
+            <xsl:with-param name="b-has-statement" select="true()"/>
+            <xsl:with-param name="b-has-hint" select="true()"/>
+            <xsl:with-param name="b-has-answer" select="true()"/>
+            <xsl:with-param name="b-has-solution" select="true()"/>
         </xsl:apply-templates>
         <!-- writing space below a terminal task, in a printout -->
         <xsl:apply-templates select="." mode="workspace"/>
@@ -1683,14 +1689,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- structured by "task": optional introduction and conclusion -->
 <!-- sandwich the tasks, each with its label and own components -->
-<xsl:template match="exercise[task]|project[task]|activity[task]|exploration[task]|investigation[task]|task[task]" mode="exercise-components">
-    <xsl:param name="b-original" select="true()"/>
-    <xsl:param name="b-has-statement" select="true()"/>
-    <xsl:param name="b-has-hint" select="true()"/>
-    <xsl:param name="b-has-answer" select="true()"/>
-    <xsl:param name="b-has-solution" select="true()"/>
+<!-- The walk over a sequence of "task" is the generic driver in       -->
+<!-- pretext-common.xsl; the hooks here realize the pieces as blocks.  -->
+
+<!-- the block heading: run in to the introduction, else alone -->
+<xsl:template match="*" mode="present-tasks-introduction">
+    <xsl:param name="b-has-statement"/>
     <xsl:param name="run-in-heading"/>
-    <!-- the block heading: run in to the introduction, else alone -->
     <xsl:choose>
         <xsl:when test="$b-has-statement and introduction">
             <xsl:apply-templates select="introduction">
@@ -1703,97 +1708,90 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </fo:block>
         </xsl:otherwise>
     </xsl:choose>
-    <xsl:for-each select="task">
-        <xsl:variable name="dry-run">
-            <xsl:apply-templates select="." mode="dry-run">
-                <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-                <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-                <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-                <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-            </xsl:apply-templates>
-        </xsl:variable>
-        <xsl:if test="not($dry-run = '')">
-            <fo:block space-before="0.75em" space-after="0.75em">
-                <!-- a sub-task indents one step deeper than its parent -->
-                <xsl:attribute name="start-indent">
-                    <xsl:value-of select="count(ancestor-or-self::task) * $task-indentation"/>
-                    <xsl:text>em</xsl:text>
-                </xsl:attribute>
-                <!-- a duplicate (in a solutions division) cannot -->
-                <!-- reuse the @id of the original                -->
-                <xsl:if test="$b-original">
-                    <xsl:apply-templates select="." mode="link-id-attribute"/>
-                </xsl:if>
-                <xsl:variable name="heading">
-                    <fo:inline font-weight="bold" font-style="normal">
-                        <xsl:text>(</xsl:text>
-                        <xsl:apply-templates select="." mode="list-number"/>
-                        <xsl:text>)</xsl:text>
-                        <xsl:if test="title">
-                            <xsl:text> </xsl:text>
-                            <xsl:apply-templates select="." mode="title-full"/>
-                        </xsl:if>
-                    </fo:inline>
-                    <xsl:text> </xsl:text>
-                </xsl:variable>
-                <xsl:apply-templates select="." mode="exercise-components">
-                    <xsl:with-param name="b-original" select="$b-original"/>
-                    <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
-                    <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
-                    <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
-                    <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
-                    <xsl:with-param name="run-in-heading" select="$heading"/>
-                </xsl:apply-templates>
-            </fo:block>
-        </xsl:if>
-    </xsl:for-each>
-    <xsl:if test="$b-has-statement">
-        <xsl:apply-templates select="conclusion"/>
-    </xsl:if>
 </xsl:template>
 
-<!-- the leaf form: a statement, then chosen appendages -->
-<xsl:template match="exercise|&PROJECT-LIKE;|task[not(task)]" mode="exercise-components">
-    <xsl:param name="b-original" select="true()"/>
-    <xsl:param name="b-has-statement" select="true()"/>
-    <xsl:param name="b-has-hint" select="true()"/>
-    <xsl:param name="b-has-answer" select="true()"/>
-    <xsl:param name="b-has-solution" select="true()"/>
+<!-- one surviving task: an indented block, identified, then the guts -->
+<xsl:template match="task" mode="present-task-item">
+    <xsl:param name="b-original"/>
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
+
+    <fo:block space-before="0.75em" space-after="0.75em">
+        <!-- a sub-task indents one step deeper than its parent -->
+        <xsl:attribute name="start-indent">
+            <xsl:value-of select="count(ancestor-or-self::task) * $task-indentation"/>
+            <xsl:text>em</xsl:text>
+        </xsl:attribute>
+        <!-- a duplicate (in a solutions division) cannot -->
+        <!-- reuse the @id of the original                -->
+        <xsl:if test="$b-original">
+            <xsl:apply-templates select="." mode="link-id-attribute"/>
+        </xsl:if>
+        <xsl:variable name="heading">
+            <fo:inline font-weight="bold" font-style="normal">
+                <xsl:text>(</xsl:text>
+                <xsl:apply-templates select="." mode="list-number"/>
+                <xsl:text>)</xsl:text>
+                <xsl:if test="title">
+                    <xsl:text> </xsl:text>
+                    <xsl:apply-templates select="." mode="title-full"/>
+                </xsl:if>
+            </fo:inline>
+            <xsl:text> </xsl:text>
+        </xsl:variable>
+        <xsl:apply-templates select="." mode="exercise-components">
+            <xsl:with-param name="b-original" select="$b-original"/>
+            <xsl:with-param name="b-has-statement" select="$b-has-statement"/>
+            <xsl:with-param name="b-has-hint" select="$b-has-hint"/>
+            <xsl:with-param name="b-has-answer" select="$b-has-answer"/>
+            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+            <xsl:with-param name="run-in-heading" select="$heading"/>
+        </xsl:apply-templates>
+    </fo:block>
+</xsl:template>
+
+<!-- the leaf form is driven from pretext-common.xsl; hooks here -->
+
+<xsl:template match="*" mode="present-exercise-statement">
     <xsl:param name="run-in-heading"/>
-    <xsl:choose>
-        <xsl:when test="statement">
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="statement">
-                    <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
-                </xsl:apply-templates>
-                <!-- a coding exercise's program rides with the statement -->
-                <xsl:apply-templates select="program"/>
-            </xsl:if>
-            <!-- a heading with no statement to carry it stands alone -->
-            <xsl:if test="not($b-has-statement)">
-                <fo:block keep-with-next.within-page="always">
-                    <xsl:copy-of select="$run-in-heading"/>
-                </fo:block>
-            </xsl:if>
-            <xsl:if test="$b-has-hint">
-                <xsl:apply-templates select="hint"/>
-            </xsl:if>
-            <xsl:if test="$b-has-answer">
-                <xsl:apply-templates select="answer"/>
-            </xsl:if>
-            <xsl:if test="$b-has-solution">
-                <xsl:apply-templates select="solution"/>
-            </xsl:if>
-        </xsl:when>
-        <!-- unstructured, a bare statement -->
-        <xsl:otherwise>
-            <xsl:if test="$b-has-statement">
-                <xsl:call-template name="heading-then-content">
-                    <xsl:with-param name="heading" select="$run-in-heading"/>
-                </xsl:call-template>
-            </xsl:if>
-        </xsl:otherwise>
-    </xsl:choose>
+    <xsl:apply-templates select="statement">
+        <xsl:with-param name="run-in-heading" select="$run-in-heading"/>
+    </xsl:apply-templates>
+    <!-- a coding exercise's program rides with the statement -->
+    <xsl:apply-templates select="program"/>
+</xsl:template>
+
+<!-- a heading with no statement to carry it stands alone -->
+<xsl:template match="*" mode="present-exercise-statement-omitted">
+    <xsl:param name="run-in-heading"/>
+    <fo:block keep-with-next.within-page="always">
+        <xsl:copy-of select="$run-in-heading"/>
+    </fo:block>
+</xsl:template>
+
+<!-- unstructured, a bare statement -->
+<xsl:template match="*" mode="present-exercise-statement-bare">
+    <xsl:param name="run-in-heading"/>
+    <xsl:call-template name="heading-then-content">
+        <xsl:with-param name="heading" select="$run-in-heading"/>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="*" mode="present-exercise-solutions">
+    <xsl:param name="b-showing-hints"/>
+    <xsl:param name="b-showing-answers"/>
+    <xsl:param name="b-showing-solutions"/>
+    <xsl:if test="$b-showing-hints">
+        <xsl:apply-templates select="hint"/>
+    </xsl:if>
+    <xsl:if test="$b-showing-answers">
+        <xsl:apply-templates select="answer"/>
+    </xsl:if>
+    <xsl:if test="$b-showing-solutions">
+        <xsl:apply-templates select="solution"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- ################### -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -4513,7 +4513,43 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template match="exercise|&PROJECT-LIKE;|task|&EXAMPLE-LIKE;|webwork-reps/static|webwork-reps/static/task|webwork-reps/static/stage" mode="exercise-components">
+<!-- The decision procedure for which components appear, and in which  -->
+<!-- order, is the generic "exercise-components" driver pair in        -->
+<!-- pretext-common.xsl; the "present-*" hooks below supply the HTML   -->
+<!-- realization.  Runestone interactive exercises are entirely        -->
+<!-- HTML-specific, so they are matched here, ahead of the drivers.    -->
+
+<!-- Select -->
+<!-- Largely a Runestone/database operation referencing -->
+<!-- existing questions supplied by the manifest,       -->
+<!-- so we go straight to an HTML version               -->
+<xsl:template match="*[@exercise-interactive = 'select']" mode="exercise-components">
+    <xsl:apply-templates select="." mode="runestone-to-interactive"/>
+</xsl:template>
+
+<!-- True/False        -->
+<!-- Multiple Choice   -->
+<!-- Parson problems   -->
+<!-- Matching problems -->
+<!-- Clickable Area    -->
+<!-- Fill-In (Basic)   -->
+<!-- Coding Exercise   -->
+<!-- Dual Form Exercise-->
+<!-- Short Answer      -->
+<!-- The "runestone-to-interactive" templates will combine a   -->
+<!-- "regular" PreTeXt statement together with some additional -->
+<!-- interactive material to make a hybrid "statement"         -->
+<xsl:template match="*[(@exercise-interactive = 'truefalse') or
+                       (@exercise-interactive = 'multiplechoice') or
+                       (@exercise-interactive = 'parson') or
+                       (@exercise-interactive = 'parson-horizontal') or
+                       (@exercise-interactive = 'cardsort') or
+                       (@exercise-interactive = 'matching') or
+                       (@exercise-interactive = 'clickablearea') or
+                       (@exercise-interactive = 'fillin-basic') or
+                       (@exercise-interactive = 'coding') or
+                       (@exercise-interactive = 'dual') or
+                       (@exercise-interactive = 'shortanswer')]" mode="exercise-components">
     <xsl:param name="b-original"/>
     <xsl:param name="block-type"/>
     <xsl:param name="heading-level"/>
@@ -4522,97 +4558,132 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-answer" />
     <xsl:param name="b-has-solution" />
 
-    <xsl:choose>
-        <!-- Select -->
-        <!-- Largely a Runestone/database operation referencing -->
-        <!-- existing questions supplied by the manifest,       -->
-        <!-- so we go straight to an HTML version               -->
-        <xsl:when test="@exercise-interactive = 'select'">
-            <xsl:apply-templates select="." mode="runestone-to-interactive"/>
-        </xsl:when>
-        <!-- True/False        -->
-        <!-- Multiple Choice   -->
-        <!-- Parson problems   -->
-        <!-- Matching problems -->
-        <!-- Clickable Area    -->
-        <!-- Fill-In (Basic)   -->
-        <!-- Coding Exercise   -->
-        <!-- Dual Form Exercise-->
-        <!-- Short Answer      -->
-        <!-- The "runestone-to-interactive" templates will combine a   -->
-        <!-- "regular" PreTeXt statement together with some additional -->
-        <!-- interactive material to make a hybrid "statement"         -->
-        <xsl:when test="(@exercise-interactive = 'truefalse') or
-                               (@exercise-interactive = 'multiplechoice') or
-                               (@exercise-interactive = 'parson') or
-                               (@exercise-interactive = 'parson-horizontal') or
-                               (@exercise-interactive = 'cardsort') or
-                               (@exercise-interactive = 'matching') or
-                               (@exercise-interactive = 'clickablearea') or
-                               (@exercise-interactive = 'fillin-basic') or
-                               (@exercise-interactive = 'coding') or
-                               (@exercise-interactive = 'dual') or
-                               (@exercise-interactive = 'shortanswer')"
-                               >
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="." mode="runestone-to-interactive"/>
-            </xsl:if>
-            <xsl:apply-templates select="." mode="solutions-div">
-                <xsl:with-param name="b-original" select="$b-original"/>
-                <xsl:with-param name="block-type" select="$block-type"/>
-                <xsl:with-param name="heading-level" select="$heading-level"/>
-                <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
-                <xsl:with-param name="b-has-answer"  select="$b-has-answer"/>
-                <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
-            </xsl:apply-templates>
-        </xsl:when>
-        <!-- Dynamic fillin is broken out separately because the test for -->
-        <!-- correctness as well as feedback is dynamically chosen.       -->
-        <xsl:when test="@exercise-interactive = 'fillin'">
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="." mode="runestone-to-interactive"/>
-            </xsl:if>
-            <!-- Include hints. Solution/answer get special handling       -->
-            <xsl:apply-templates select="." mode="solutions-div">
-                <xsl:with-param name="b-original" select="$b-original"/>
-                <xsl:with-param name="block-type" select="$block-type"/>
-                <xsl:with-param name="heading-level" select="$heading-level"/>
-                <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
-            </xsl:apply-templates>
-        </xsl:when>
-        <!-- Finally nothing too exceptional, do the usual drill. Consider -->
-        <!-- structured versus unstructured, non-interactive.              -->
-        <xsl:when test="statement">
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="statement">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="block-type" select="$block-type"/>
-                    <xsl:with-param name="heading-level" select="$heading-level"/>
-                </xsl:apply-templates>
-            </xsl:if>
-            <xsl:apply-templates select="." mode="solutions-div">
-                <xsl:with-param name="b-original" select="$b-original"/>
-                <xsl:with-param name="block-type" select="$block-type"/>
-                <xsl:with-param name="heading-level" select="$heading-level"/>
-                <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
-                <xsl:with-param name="b-has-answer"  select="$b-has-answer"/>
-                <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
-            </xsl:apply-templates>
-        </xsl:when>
-        <!-- TODO: contained "if" should just be a new "when"? (look around for similar)" -->
-        <xsl:otherwise>
-            <!-- no explicit "statement", so all content is the statement -->
-            <!-- the "dry-run" templates should prevent an empty shell  -->
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="*">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="block-type" select="$block-type"/>
-                    <xsl:with-param name="heading-level" select="$heading-level"/>
-                </xsl:apply-templates>
-                <!-- no separator, since no trailing components -->
-            </xsl:if>
-        </xsl:otherwise>
-    </xsl:choose>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="." mode="runestone-to-interactive"/>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="solutions-div">
+        <xsl:with-param name="b-original" select="$b-original"/>
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
+        <xsl:with-param name="b-has-answer"  select="$b-has-answer"/>
+        <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- Dynamic fillin is broken out separately because the test for -->
+<!-- correctness as well as feedback is dynamically chosen.       -->
+<xsl:template match="*[@exercise-interactive = 'fillin']" mode="exercise-components">
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+    <xsl:param name="b-has-statement" />
+    <xsl:param name="b-has-hint" />
+
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="." mode="runestone-to-interactive"/>
+    </xsl:if>
+    <!-- Include hints. Solution/answer get special handling       -->
+    <xsl:apply-templates select="." mode="solutions-div">
+        <xsl:with-param name="b-original" select="$b-original"/>
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- Now the hooks for the generic drivers -->
+
+<xsl:template match="*" mode="present-exercise-statement">
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+
+    <xsl:apply-templates select="statement">
+        <xsl:with-param name="b-original" select="$b-original" />
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- no explicit "statement", so all content is the statement -->
+<!-- the "dry-run" templates should prevent an empty shell    -->
+<xsl:template match="*" mode="present-exercise-statement-bare">
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+
+    <xsl:apply-templates select="*">
+        <xsl:with-param name="b-original" select="$b-original" />
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
+    <!-- no separator, since no trailing components -->
+</xsl:template>
+
+<xsl:template match="*" mode="present-exercise-solutions">
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
+
+    <xsl:apply-templates select="." mode="solutions-div">
+        <xsl:with-param name="b-original" select="$b-original"/>
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:with-param name="b-has-hint"  select="$b-has-hint"/>
+        <xsl:with-param name="b-has-answer"  select="$b-has-answer"/>
+        <xsl:with-param name="b-has-solution"  select="$b-has-solution"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- An "introduction", a "task" that survived its dry-run, and a  -->
+<!-- "conclusion" are simply processed as if encountered normally, -->
+<!-- reproducing the wholesale processing that preceded the        -->
+<!-- generic drivers.                                              -->
+
+<xsl:template match="*" mode="present-tasks-introduction">
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction">
+            <xsl:with-param name="b-original" select="$b-original" />
+            <xsl:with-param name="block-type" select="$block-type"/>
+            <xsl:with-param name="heading-level" select="$heading-level"/>
+        </xsl:apply-templates>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="task" mode="present-task-item">
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+
+    <xsl:apply-templates select=".">
+        <xsl:with-param name="b-original" select="$b-original" />
+        <xsl:with-param name="block-type" select="$block-type"/>
+        <xsl:with-param name="heading-level" select="$heading-level"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="*" mode="present-tasks-conclusion">
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-original"/>
+    <xsl:param name="block-type"/>
+    <xsl:param name="heading-level"/>
+
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion">
+            <xsl:with-param name="b-original" select="$b-original" />
+            <xsl:with-param name="block-type" select="$block-type"/>
+            <xsl:with-param name="heading-level" select="$heading-level"/>
+        </xsl:apply-templates>
+    </xsl:if>
 </xsl:template>
 
 <!-- "exercise", EXAMPLE-LIKE, PROJECT-LIKE, "task", and more have a  -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -3559,51 +3559,29 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- For solutions divisions, we mimic and reuse some of the above -->
-<xsl:template match="subexercises" mode="solutions">
-    <xsl:param name="admit"/>
+<!-- The generic driver in pretext-common.xsl decides if anything -->
+<!-- appears at all, and renders the items; the wrapping here      -->
+<xsl:template match="subexercises" mode="present-solutions-container">
     <xsl:param name="heading-level"/>
-    <xsl:param name="b-has-statement" />
-    <xsl:param name="b-has-hint" />
-    <xsl:param name="b-has-answer" />
-    <xsl:param name="b-has-solution" />
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="content"/>
 
-    <!-- we check for content, subject to selection of switches          -->
-    <!-- if there is no content, then we will not output anything at all -->
-     <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
+    <article class="subexercises">
+        <xsl:apply-templates select="." mode="heading-title">
+            <xsl:with-param name="heading-level" select="$heading-level"/>
         </xsl:apply-templates>
-    </xsl:variable>
-
-    <xsl:if test="not($dry-run = '')">
-        <article class="subexercises">
-            <xsl:apply-templates select="." mode="heading-title">
-                <xsl:with-param name="heading-level" select="$heading-level"/>
+        <xsl:if test="$b-has-statement">
+            <xsl:apply-templates select="introduction">
+                <xsl:with-param name="b-original" select="false()" />
             </xsl:apply-templates>
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="introduction">
-                    <xsl:with-param name="b-original" select="false()" />
-                </xsl:apply-templates>
-            </xsl:if>
-            <xsl:apply-templates select="exercise|exercisegroup" mode="solutions">
-                <xsl:with-param name="admit"           select="$admit"/>
-                <xsl:with-param name="heading-level"   select="$heading-level + 1"/>
-                <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+        </xsl:if>
+        <xsl:copy-of select="$content"/>
+        <xsl:if test="$b-has-statement">
+            <xsl:apply-templates select="conclusion">
+                <xsl:with-param name="b-original" select="false()" />
             </xsl:apply-templates>
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="conclusion">
-                    <xsl:with-param name="b-original" select="false()" />
-                </xsl:apply-templates>
-            </xsl:if>
-        </article>
-    </xsl:if>
+        </xsl:if>
+    </article>
 </xsl:template>
 
 <!-- Exercise Group -->
@@ -3676,62 +3654,38 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:apply-templates>
 </xsl:template>
 
-<!-- For solutions divisions, we mimic and reuse some of the above -->
-<xsl:template match="exercisegroup" mode="solutions">
-    <xsl:param name="admit"/>
-    <xsl:param name="heading-level"/>
-    <xsl:param name="b-has-statement" />
-    <xsl:param name="b-has-hint" />
-    <xsl:param name="b-has-answer" />
-    <xsl:param name="b-has-solution" />
+<!-- For solutions divisions, we mimic and reuse some of the above; -->
+<!-- the generic driver in pretext-common.xsl renders the items     -->
+<xsl:template match="exercisegroup" mode="present-solutions-container">
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="content"/>
 
-    <!-- we check for content, subject to selection of switches          -->
-    <!-- if there is no content, then we will not output anything at all -->
-     <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-        </xsl:apply-templates>
-    </xsl:variable>
-
-    <xsl:if test="not($dry-run = '')">
-        <div class="exercisegroup">
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="introduction">
-                    <xsl:with-param name="b-original" select="false()" />
-                </xsl:apply-templates>
-            </xsl:if>
-            <div>
-                <xsl:attribute name="class">
-                    <xsl:text>exercisegroup-exercises</xsl:text>
-                    <xsl:variable name="cols-class-name">
-                        <!-- HTML-specific, but in pretext-common.xsl -->
-                        <xsl:apply-templates select="." mode="number-cols-CSS-class"/>
-                    </xsl:variable>
-                    <xsl:if test="not($cols-class-name = '')">
-                        <xsl:text> </xsl:text>
-                        <xsl:value-of select="$cols-class-name"/>
-                    </xsl:if>
-                </xsl:attribute>
-                <xsl:apply-templates select="exercise" mode="solutions">
-                    <xsl:with-param name="admit"           select="$admit"/>
-                    <xsl:with-param name="heading-level"   select="$heading-level"/>
-                    <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                    <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                    <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                    <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                </xsl:apply-templates>
-            </div>
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="conclusion">
-                    <xsl:with-param name="b-original" select="false()" />
-                </xsl:apply-templates>
-            </xsl:if>
+    <div class="exercisegroup">
+        <xsl:if test="$b-has-statement">
+            <xsl:apply-templates select="introduction">
+                <xsl:with-param name="b-original" select="false()" />
+            </xsl:apply-templates>
+        </xsl:if>
+        <div>
+            <xsl:attribute name="class">
+                <xsl:text>exercisegroup-exercises</xsl:text>
+                <xsl:variable name="cols-class-name">
+                    <!-- HTML-specific, but in pretext-common.xsl -->
+                    <xsl:apply-templates select="." mode="number-cols-CSS-class"/>
+                </xsl:variable>
+                <xsl:if test="not($cols-class-name = '')">
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="$cols-class-name"/>
+                </xsl:if>
+            </xsl:attribute>
+            <xsl:copy-of select="$content"/>
         </div>
-    </xsl:if>
+        <xsl:if test="$b-has-statement">
+            <xsl:apply-templates select="conclusion">
+                <xsl:with-param name="b-original" select="false()" />
+            </xsl:apply-templates>
+        </xsl:if>
+    </div>
 </xsl:template>
 
 <!-- Exercise -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -4106,29 +4106,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:apply-templates>
 
             <xsl:choose>
-                <!-- structured version -->
-                <xsl:when test="task">
-                    <xsl:if test="$b-has-statement">
-                        <xsl:apply-templates select="introduction">
-                            <xsl:with-param name="b-original" select="false()" />
-                            <xsl:with-param name="heading-level" select="$heading-level"/>
-                        </xsl:apply-templates>
-                    </xsl:if>
-                    <xsl:apply-templates select="task" mode="solutions">
-                        <xsl:with-param name="b-original" select="false()" />
-                        <xsl:with-param name="heading-level"   select="$heading-level + 1"/>
-                        <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                        <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                        <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                        <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                    </xsl:apply-templates>
-                    <xsl:if test="$b-has-statement">
-                        <xsl:apply-templates select="conclusion">
-                            <xsl:with-param name="b-original" select="false()" />
-                            <xsl:with-param name="heading-level" select="$heading-level"/>
-                        </xsl:apply-templates>
-                    </xsl:if>
-                </xsl:when>
+                <!-- A native structured version (with "task") is handled  -->
+                <!-- by the generic drivers, in the "otherwise" below.     -->
+                <!-- WeBWorK static representations have their tasks and   -->
+                <!-- stages below "webwork-reps/static", out of reach of   -->
+                <!-- the drivers' selections, so they are handled here.    -->
                 <xsl:when test="webwork-reps/static/task">
                     <xsl:if test="$b-has-statement">
                         <xsl:apply-templates select="webwork-reps/static/introduction">
@@ -4355,40 +4337,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="b-make-link" select="true()"/>
             </xsl:apply-templates>
 
-            <xsl:choose>
-                <!-- introduction?, task+, conclusion? -->
-                <xsl:when test="task">
-                    <xsl:if test="$b-has-statement">
-                        <xsl:apply-templates select="introduction">
-                            <xsl:with-param name="b-original" select="false()" />
-                            <xsl:with-param name="heading-level" select="$heading-level"/>
-                        </xsl:apply-templates>
-                    </xsl:if>
-                    <xsl:apply-templates select="task" mode="solutions">
-                        <xsl:with-param name="heading-level"   select="$heading-level + 1" />
-                        <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                        <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                        <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                        <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                    </xsl:apply-templates>
-                    <xsl:if test="$b-has-statement">
-                        <xsl:apply-templates select="conclusion">
-                            <xsl:with-param name="b-original" select="false()" />
-                            <xsl:with-param name="heading-level" select="$heading-level"/>
-                        </xsl:apply-templates>
-                    </xsl:if>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:apply-templates select="."  mode="exercise-components">
-                        <xsl:with-param name="b-original" select="false()" />
-                        <xsl:with-param name="heading-level" select="$heading-level"/>
-                        <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                        <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                        <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                        <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                    </xsl:apply-templates>
-                </xsl:otherwise>
-            </xsl:choose>
+            <!-- the generic drivers dispatch a terminal task versus -->
+            <!-- one structured by further (nested) "task"            -->
+            <xsl:apply-templates select="."  mode="exercise-components">
+                <xsl:with-param name="b-original" select="false()" />
+                <xsl:with-param name="heading-level" select="$heading-level"/>
+                <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+                <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+                <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+                <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+            </xsl:apply-templates>
         </article>
     </xsl:if>
 </xsl:template>
@@ -4663,12 +4621,32 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-original"/>
     <xsl:param name="block-type"/>
     <xsl:param name="heading-level"/>
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="b-has-hint"/>
+    <xsl:param name="b-has-answer"/>
+    <xsl:param name="b-has-solution"/>
 
-    <xsl:apply-templates select=".">
-        <xsl:with-param name="b-original" select="$b-original" />
-        <xsl:with-param name="block-type" select="$block-type"/>
-        <xsl:with-param name="heading-level" select="$heading-level"/>
-    </xsl:apply-templates>
+    <xsl:choose>
+        <!-- where born, the task is processed as if encountered normally -->
+        <xsl:when test="$b-original">
+            <xsl:apply-templates select=".">
+                <xsl:with-param name="b-original" select="$b-original" />
+                <xsl:with-param name="block-type" select="$block-type"/>
+                <xsl:with-param name="heading-level" select="$heading-level"/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- in a "solutions" division, a heading that links back to the -->
+        <!-- original, then the chosen components, one level deeper      -->
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="solutions">
+                <xsl:with-param name="heading-level"   select="$heading-level + 1"/>
+                <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+                <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+                <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+                <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+            </xsl:apply-templates>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="*" mode="present-tasks-conclusion">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1354,31 +1354,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="*" mode="duplicate-heading-content">
-    <xsl:variable name="is-specialized-division">
-        <xsl:choose>
-            <xsl:when test="self::task">
-                <xsl:value-of select="false()"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="." mode="is-specialized-division"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="is-child-of-structured">
-        <xsl:choose>
-            <xsl:when test="parent::*[&TRADITIONAL-DIVISION-FILTER;]">
-                <xsl:apply-templates select="parent::*[&TRADITIONAL-DIVISION-FILTER;]" mode="is-structured-division"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="false()"/>
-            </xsl:otherwise>
-        </xsl:choose>
+    <xsl:variable name="show-number">
+        <xsl:apply-templates select="." mode="duplicate-heading-show-number"/>
     </xsl:variable>
     <xsl:variable name="title">
         <xsl:apply-templates select="." mode="title-full" />
     </xsl:variable>
     <!-- Since headings stack, we use a "p" to aid screen readers in pausing between headings -->
-    <xsl:if test="$is-specialized-division = 'false' or $is-child-of-structured = 'true'">
+    <xsl:if test="$show-number = 'true'">
         <span class="codenumber">
             <xsl:apply-templates select="." mode="number" />
         </span>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -6638,15 +6638,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Task (for structured exercises and project-like) -->
 <!-- ################################################ -->
 
-<!-- "exercise", PROJECT-LIKE and EXAMPLE-LIKE can be structured     -->
-<!-- with up to three level of "task".  When this is done, each      -->
-<!-- level may have an "introduction" and a "conclusion".  This      -->
-<!-- template handles every structure that can have a "task" child,  -->
-<!-- which includes a "task" itself. We run over each nested "task". -->
-<!-- We make sure a nested list has content, before starting (and    -->
-<!-- later ending) a list to hold the tasks.  Only terminal tasks    -->
-<!-- have statement|hint|answer|solution.                            -->
-<xsl:template match="exercise[task]|project[task]|activity[task]|exploration[task]|investigation[task]|example[task]|question[task]|problem[task]|task[task]" mode="exercise-components">
+<!-- "exercise", PROJECT-LIKE and EXAMPLE-LIKE can be structured          -->
+<!-- with up to three level of "task".  The walk over a sequence of       -->
+<!-- "task" is the generic driver in pretext-common.xsl: it handles the   -->
+<!-- introduction and conclusion, guards against an empty list, and skips -->
+<!-- empty tasks.  It calls back here for each survivor: a LaTeX list     -->
+<!-- item, identified, then the guts by recursion.                        -->
+<xsl:template match="task" mode="present-task-item">
     <xsl:param name="b-original" />
     <xsl:param name="purpose" />
     <xsl:param name="b-component-heading"/>
@@ -6655,95 +6653,53 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-answer"  />
     <xsl:param name="b-has-solution"  />
 
-    <xsl:if test="$b-has-statement">
-        <xsl:apply-templates select="introduction"/>
+    <!-- always a list item -->
+    <xsl:text>\item</xsl:text>
+    <!-- We use the ref/label mechanism for tasks where born. -->
+    <!-- But if in a "solutions" division, we may be skipping -->
+    <!-- some and need to hard-code the task label/number.    -->
+    <xsl:choose>
+        <xsl:when test="$b-original">
+            <!-- \label{} will separate content, if   -->
+            <!-- employed, else we use an empty group -->
+            <xsl:choose>
+                <!-- not quite tight for modal "optional-label" -->
+                <xsl:when test="@xml:id">
+                    <xsl:apply-templates select="." mode="label" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>{}</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise>
+            <!-- hard-code the number when duplicating, since some items -->
+            <!-- are absent, and then automatic numbering would be wrong -->
+            <xsl:text>[(</xsl:text>
+            <xsl:apply-templates select="." mode="list-number" />
+            <xsl:text>)]</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <!-- Something is being output, so include an (optional) title  -->
+    <!-- Semantic macro defined in preamble, mostly for font change -->
+    <xsl:if test="title">
+        <xsl:text>\lititle{</xsl:text>
+        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:text>}\par%&#xa;</xsl:text>
     </xsl:if>
-
-    <!-- Now we see if the list of contained tasks is empty or not -->
-    <xsl:variable name="task-list-dry-run">
-        <xsl:apply-templates select="task" mode="dry-run">
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-            <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-            <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-        </xsl:apply-templates>
-    </xsl:variable>
-    <xsl:variable name="b-has-task-list" select="not($task-list-dry-run = '')"/>
-
-    <xsl:if test="$b-has-task-list">
-        <xsl:apply-templates select="." mode="begin-task-list"/>
-
-        <xsl:for-each select="task">
-            <!-- just for this particular task -->
-            <xsl:variable name="dry-run">
-                <xsl:apply-templates select="." mode="dry-run">
-                    <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                    <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                    <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                    <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                </xsl:apply-templates>
-            </xsl:variable>
-
-            <!-- The entire task list is non-empty, so some particular task -->
-            <!-- must be non-empty, ensuring we never create a list without -->
-            <!-- at least one \item inside it.                              -->
-            <xsl:if test="not($dry-run = '')">
-                <!-- always a list item -->
-                <xsl:text>\item</xsl:text>
-                <!-- We use the ref/label mechanism for tasks where born. -->
-                <!-- But if in a "solutions" division, we may be skipping -->
-                <!-- some and need to hard-code the task label/number.    -->
-                <xsl:choose>
-                    <xsl:when test="$b-original">
-                        <!-- \label{} will separate content, if   -->
-                        <!-- employed, else we use an empty group -->
-                        <xsl:choose>
-                            <!-- not quite tight for modal "optional-label" -->
-                            <xsl:when test="@xml:id">
-                                <xsl:apply-templates select="." mode="label" />
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:text>{}</xsl:text>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <!-- hard-code the number when duplicating, since some items -->
-                        <!-- are absent, and then automatic numbering would be wrong -->
-                        <xsl:text>[(</xsl:text>
-                        <xsl:apply-templates select="." mode="list-number" />
-                        <xsl:text>)]</xsl:text>
-                    </xsl:otherwise>
-                </xsl:choose>
-                <!-- Something is being output, so include an (optional) title  -->
-                <!-- Semantic macro defined in preamble, mostly for font change -->
-                <xsl:if test="title">
-                    <xsl:text>\lititle{</xsl:text>
-                    <xsl:apply-templates select="." mode="title-full"/>
-                    <xsl:text>}\par%&#xa;</xsl:text>
-                </xsl:if>
-                <!-- Identification in place, we can write the generic guts -->
-                <xsl:apply-templates select="." mode="exercise-components">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="purpose" select="$purpose" />
-                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                    <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-                    <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
-                    <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
-                    <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
-                </xsl:apply-templates>
-                <!-- possibly add some workspace for items from a worksheet     -->
-                <!-- an empty result is a signal there is no workspace authored -->
-                <xsl:apply-templates select="." mode="workspace"/>
-            </xsl:if>
-        </xsl:for-each>
-
-        <xsl:apply-templates select="." mode="end-task-list"/>
-    </xsl:if>
-
-    <xsl:if test="$b-has-statement">
-        <xsl:apply-templates select="conclusion"/>
-    </xsl:if>
+    <!-- Identification in place, we can write the generic guts -->
+    <xsl:apply-templates select="." mode="exercise-components">
+        <xsl:with-param name="b-original" select="$b-original" />
+        <xsl:with-param name="purpose" select="$purpose" />
+        <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+        <xsl:with-param name="b-has-statement" select="$b-has-statement" />
+        <xsl:with-param name="b-has-hint"      select="$b-has-hint" />
+        <xsl:with-param name="b-has-answer"    select="$b-has-answer" />
+        <xsl:with-param name="b-has-solution"  select="$b-has-solution" />
+    </xsl:apply-templates>
+    <!-- possibly add some workspace for items from a worksheet     -->
+    <!-- an empty result is a signal there is no workspace authored -->
+    <xsl:apply-templates select="." mode="workspace"/>
 </xsl:template>
 
 <!-- These two templates construct the infrastructure around a sequence  -->
@@ -6782,125 +6738,111 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 
-<!-- An object that reaches here is either just a statement (bare) or        -->
-<!-- is structured as statement|hint|answer|solution.  Likely we could       -->
-<!-- split this into two templates, but a choose seems more convenient.      -->
-<!-- When structured, a forward reference is constructed to the first        -->
-<!-- hint|answer|solution that might appear somewhere else.  Since there     -->
-<!-- could be multiple targets, we use the heuristic of choosing main matter -->
-<!-- over back matter.  Unclear what happens if there are multiple targets.  -->
-<xsl:template match="exercise|&EXAMPLE-LIKE;|&PROJECT-LIKE;|task[not(task)]" mode="exercise-components">
+<!-- The statement/hint/answer/solution decision procedure lives in       -->
+<!-- pretext-common.xsl; the hooks here supply the LaTeX realization.     -->
+<!-- When structured, a forward reference is constructed to the first     -->
+<!-- hint|answer|solution that might appear somewhere else.  Since there  -->
+<!-- could be multiple targets, we use the heuristic of choosing main     -->
+<!-- matter over back matter.  Unclear what happens if there are          -->
+<!-- multiple targets.                                                    -->
+<xsl:template match="*" mode="present-exercise-statement">
+    <xsl:param name="b-original" />
+
+    <xsl:apply-templates select="statement">
+        <xsl:with-param name="b-original" select="$b-original" />
+    </xsl:apply-templates>
+    <!-- we consider a "program" of a coding exercise as part of the "statement" -->
+    <xsl:apply-templates select="program"/>
+    <xsl:if test="$b-original and ($debug.exercises.forward = 'yes')">
+        <!-- if several, all exist together, so just work with first one -->
+        <xsl:for-each select="hint[1]|answer[1]|solution[1]">
+            <!-- closer is better, so mainmatter solutions first -->
+            <xsl:choose>
+                <xsl:when test="count(.|$solutions-mainmatter) = count($solutions-mainmatter)">
+                    <xsl:text>\space</xsl:text>
+                    <xsl:text>\hyperlink{</xsl:text>
+                    <xsl:apply-templates select="." mode="unique-id-duplicate">
+                        <xsl:with-param name="suffix" select="'main'"/>
+                    </xsl:apply-templates>
+                    <xsl:text>}{[</xsl:text>
+                    <xsl:apply-templates select="." mode="type-name"/>
+                    <xsl:text>]}</xsl:text>
+                </xsl:when>
+                <xsl:when test="count(.|$solutions-backmatter) = count($solutions-backmatter)">
+                    <xsl:text>\space</xsl:text>
+                    <xsl:text>\hyperlink{</xsl:text>
+                    <xsl:apply-templates select="." mode="unique-id-duplicate">
+                        <xsl:with-param name="suffix" select="'back'"/>
+                    </xsl:apply-templates>
+                    <xsl:text>}{[</xsl:text>
+                    <xsl:apply-templates select="." mode="type-name"/>
+                    <xsl:text>]}</xsl:text>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:if>
+</xsl:template>
+
+<!-- no explicit "statement", so all content is the statement -->
+<xsl:template match="*" mode="present-exercise-statement-bare">
+    <xsl:param name="b-original" />
+
+    <xsl:apply-templates select="*">
+        <xsl:with-param name="b-original" select="$b-original" />
+    </xsl:apply-templates>
+    <!-- no separator, since no trailing components -->
+</xsl:template>
+
+<!-- The groups of solution-like, in the canonical order, with a -->
+<!-- separator between the groups that appear.                   -->
+<xsl:template match="*" mode="present-exercise-solutions">
     <xsl:param name="b-original" />
     <xsl:param name="purpose" />
     <xsl:param name="b-component-heading"/>
-    <xsl:param name="b-has-statement" />
-    <xsl:param name="b-has-hint" />
-    <xsl:param name="b-has-answer"  />
-    <xsl:param name="b-has-solution"  />
+    <xsl:param name="b-has-answer" />
+    <xsl:param name="b-has-solution" />
+    <xsl:param name="b-showing-hints" />
+    <xsl:param name="b-showing-answers" />
+    <xsl:param name="b-showing-solutions" />
 
-    <!-- The  $b-has-*  variables are a *desire* to see some component.   -->
-    <!-- But if an individual exercise does not have such a component,    -->
-    <!-- then it will not be shown.  So these  $b-showing-*s  variables   -->
-    <!-- are per-exercise indications.                                    -->
-    <!--                                                                  -->
-    <!-- An exercise always has a "statement" and if shown, it is inline. -->
-    <!-- When not shown (like in backmatter solutions) the exercise may   -->
-    <!-- still have a "title" which is shown inline.  So the first        -->
-    <!-- solution-like may be inline (no statement shown, no title        -->
-    <!-- authored), or it may follow the statement/title and need a       -->
-    <!-- separator to begin on a new line with a bit of a break.          -->
+    <xsl:if test="$b-showing-hints">
+        <xsl:apply-templates select="hint">
+            <xsl:with-param name="b-original" select="$b-original" />
+            <xsl:with-param name="purpose" select="$purpose" />
+            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
+            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
+        </xsl:apply-templates>
+        <!-- more coming, add a final separator -->
+        <xsl:if test="$b-showing-answers or $b-showing-solutions">
+            <xsl:call-template name="exercise-component-separator"/>
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="$b-showing-answers">
+        <xsl:apply-templates select="answer">
+            <xsl:with-param name="b-original" select="$b-original" />
+            <xsl:with-param name="purpose" select="$purpose" />
+            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
+        </xsl:apply-templates>
+        <!-- more coming, add a final separator -->
+        <xsl:if test="$b-showing-solutions">
+            <xsl:call-template name="exercise-component-separator"/>
+        </xsl:if>
+    </xsl:if>
+    <xsl:if test="$b-showing-solutions">
+        <xsl:apply-templates select="solution">
+            <xsl:with-param name="b-original" select="$b-original" />
+            <xsl:with-param name="purpose" select="$purpose" />
+            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- done, no final separator is provided -->
+</xsl:template>
 
-    <xsl:variable name="b-showing-statement" select="$b-has-statement or title"/>
-    <xsl:variable name="b-showing-hints" select="$b-has-hint and hint"/>
-    <xsl:variable name="b-showing-answers" select="$b-has-answer and answer"/>
-    <xsl:variable name="b-showing-solutions" select="$b-has-solution and solution"/>
-
-    <!-- structured (with components) versus unstructured (simply a bare statement) -->
-    <xsl:choose>
-        <xsl:when test="statement">
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="statement">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                </xsl:apply-templates>
-                <!-- we consider a "program" of a coding exercise as part of the "statement" -->
-                <xsl:apply-templates select="program"/>
-                <xsl:if test="$b-original and ($debug.exercises.forward = 'yes')">
-                    <!-- if several, all exist together, so just work with first one -->
-                    <xsl:for-each select="hint[1]|answer[1]|solution[1]">
-                        <!-- closer is better, so mainmatter solutions first -->
-                        <xsl:choose>
-                            <xsl:when test="count(.|$solutions-mainmatter) = count($solutions-mainmatter)">
-                                <xsl:text>\space</xsl:text>
-                                <xsl:text>\hyperlink{</xsl:text>
-                                <xsl:apply-templates select="." mode="unique-id-duplicate">
-                                    <xsl:with-param name="suffix" select="'main'"/>
-                                </xsl:apply-templates>
-                                <xsl:text>}{[</xsl:text>
-                                <xsl:apply-templates select="." mode="type-name"/>
-                                <xsl:text>]}</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="count(.|$solutions-backmatter) = count($solutions-backmatter)">
-                                <xsl:text>\space</xsl:text>
-                                <xsl:text>\hyperlink{</xsl:text>
-                                <xsl:apply-templates select="." mode="unique-id-duplicate">
-                                    <xsl:with-param name="suffix" select="'back'"/>
-                                </xsl:apply-templates>
-                                <xsl:text>}{[</xsl:text>
-                                <xsl:apply-templates select="." mode="type-name"/>
-                                <xsl:text>]}</xsl:text>
-                            </xsl:when>
-                        </xsl:choose>
-                    </xsl:for-each>
-                </xsl:if>
-            </xsl:if>
-            <!-- more coming and inline presentation already used up, so add a final separator -->
-            <xsl:if test="$b-showing-statement and ($b-showing-hints or $b-showing-answers or $b-showing-solutions)">
-                <xsl:call-template name="exercise-component-separator"/>
-            </xsl:if>
-            <xsl:if test="$b-showing-hints">
-                <xsl:apply-templates select="hint">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="purpose" select="$purpose" />
-                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                    <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-                    <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-                </xsl:apply-templates>
-                <!-- more coming, add a final separator -->
-                <xsl:if test="$b-showing-answers or $b-showing-solutions">
-                    <xsl:call-template name="exercise-component-separator"/>
-                </xsl:if>
-            </xsl:if>
-            <xsl:if test="$b-showing-answers">
-                <xsl:apply-templates select="answer">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="purpose" select="$purpose" />
-                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                    <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-                </xsl:apply-templates>
-                <!-- more coming, add a final separator -->
-                <xsl:if test="$b-showing-solutions">
-                    <xsl:call-template name="exercise-component-separator"/>
-                </xsl:if>
-            </xsl:if>
-            <xsl:if test="$b-showing-solutions">
-                <xsl:apply-templates select="solution">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                    <xsl:with-param name="purpose" select="$purpose" />
-                    <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-                </xsl:apply-templates>
-            </xsl:if>
-            <!-- done, no final separator is provided -->
-        </xsl:when>
-        <xsl:otherwise>
-            <!-- no explicit "statement", so all content is the statement -->
-            <xsl:if test="$b-has-statement">
-                <xsl:apply-templates select="*">
-                    <xsl:with-param name="b-original" select="$b-original" />
-                </xsl:apply-templates>
-                <!-- no separator, since no trailing components -->
-            </xsl:if>
-        </xsl:otherwise>
-    </xsl:choose>
+<!-- the modal hook from the generic driver defers to the named version -->
+<xsl:template match="*" mode="exercise-component-separator">
+    <xsl:call-template name="exercise-component-separator"/>
 </xsl:template>
 
 <!-- We place a separator *after* an exercise component if, and only if, -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -6023,59 +6023,33 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="idx|notation|introduction|exercisegroup|exercise|conclusion"/>
 </xsl:template>
 
-<xsl:template match="subexercises" mode="solutions">
-    <xsl:param name="purpose"/>
-    <xsl:param name="admit"/>
-    <xsl:param name="b-component-heading"/>
-    <xsl:param name="b-has-statement" />
-    <xsl:param name="b-has-hint" />
-    <xsl:param name="b-has-answer" />
-    <xsl:param name="b-has-solution" />
+<!-- The generic driver in pretext-common.xsl decides if anything -->
+<!-- appears at all, and renders the items; the wrapping here      -->
+<xsl:template match="subexercises" mode="present-solutions-container">
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="content"/>
 
-    <!-- When we subset exercises for solutions, an entire      -->
-    <!-- "subexercises" can become empty.  So we do a dry-run  -->
-    <!-- and if there is no content at all we bail out.         -->
-     <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-        </xsl:apply-templates>
-    </xsl:variable>
-
-    <xsl:if test="not($dry-run = '')">
-        <xsl:if test="title">
-            <xsl:text>\paragraph</xsl:text>
-            <!-- keep optional title if LaTeX source is re-purposed -->
-            <xsl:text>[{</xsl:text>
-            <xsl:apply-templates select="." mode="title-short" />
-            <xsl:text>}]</xsl:text>
-            <xsl:text>{</xsl:text>
-            <xsl:apply-templates select="." mode="title-full" />
-            <xsl:text>}</xsl:text>
-            <!-- no label, as this is a duplicate              -->
-            <!-- no title, no heading, so only line-break here -->
-            <xsl:text>&#xa;</xsl:text>
-        </xsl:if>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="introduction" />
-        </xsl:if>
-        <xsl:apply-templates select="exercise|exercisegroup" mode="solutions">
-            <xsl:with-param name="purpose" select="$purpose" />
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-        </xsl:apply-templates>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="conclusion" />
-        </xsl:if>
-        <xsl:text>\par\medskip\noindent&#xa;</xsl:text>
+    <xsl:if test="title">
+        <xsl:text>\paragraph</xsl:text>
+        <!-- keep optional title if LaTeX source is re-purposed -->
+        <xsl:text>[{</xsl:text>
+        <xsl:apply-templates select="." mode="title-short" />
+        <xsl:text>}]</xsl:text>
+        <xsl:text>{</xsl:text>
+        <xsl:apply-templates select="." mode="title-full" />
+        <xsl:text>}</xsl:text>
+        <!-- no label, as this is a duplicate              -->
+        <!-- no title, no heading, so only line-break here -->
+        <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction" />
+    </xsl:if>
+    <xsl:copy-of select="$content"/>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion" />
+    </xsl:if>
+    <xsl:text>\par\medskip\noindent&#xa;</xsl:text>
 </xsl:template>
 
 <!-- ############### -->
@@ -6146,100 +6120,74 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Nothing produced if there is no content         -->
 <!-- Otherwise, no label, since duplicate            -->
 <!-- Introduction and conclusion iff with statements -->
-<xsl:template match="exercisegroup" mode="solutions">
-    <xsl:param name="purpose"/>
-    <xsl:param name="admit"/>
-    <xsl:param name="b-component-heading"/>
-    <xsl:param name="b-has-statement" />
-    <xsl:param name="b-has-hint" />
-    <xsl:param name="b-has-answer" />
-    <xsl:param name="b-has-solution" />
+<!-- Echoed in a "solutions" division; the generic driver in     -->
+<!-- pretext-common.xsl decides if anything appears at all, and  -->
+<!-- renders the items; the wrapping here                        -->
+<xsl:template match="exercisegroup" mode="present-solutions-container">
+    <xsl:param name="b-has-statement"/>
+    <xsl:param name="content"/>
 
-    <!-- When we subset exercises for solutions, an entire      -->
-    <!-- "exercisegroup" can become empty.  So we do a dry-run  -->
-    <!-- and if there is no content at all we bail out.         -->
-     <xsl:variable name="dry-run">
-        <xsl:apply-templates select="." mode="dry-run">
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-        </xsl:apply-templates>
+    <!-- Determine the number of columns         -->
+    <!-- Restrict to 1-6 via the schema          -->
+    <!-- Override for solutions takes precedence -->
+    <xsl:variable name="ncols">
+        <xsl:choose>
+            <xsl:when test="@solutions-cols">
+                <xsl:value-of select="@solutions-cols"/>
+            </xsl:when>
+            <xsl:when test="@cols">
+                <xsl:value-of select="@cols"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>1</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:variable>
-
-    <xsl:if test="not($dry-run = '')">
-        <!-- Determine the number of columns         -->
-        <!-- Restrict to 1-6 via the schema          -->
-        <!-- Override for solutions takes precedence -->
-        <xsl:variable name="ncols">
-            <xsl:choose>
-                <xsl:when test="@solutions-cols">
-                    <xsl:value-of select="@solutions-cols"/>
-                </xsl:when>
-                <xsl:when test="@cols">
-                    <xsl:value-of select="@cols"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:text>1</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <xsl:if test="title">
-            <xsl:text>\subparagraph</xsl:text>
-            <!-- keep optional title if LaTeX source is re-purposed -->
-            <xsl:text>[{</xsl:text>
-            <xsl:apply-templates select="." mode="title-short" />
-            <xsl:text>}]</xsl:text>
-            <xsl:text>{</xsl:text>
-            <xsl:apply-templates select="." mode="title-full" />
-            <xsl:text>}</xsl:text>
-            <!-- no label, as this is a duplicate              -->
-            <!-- no title, no heading, so only line-break here -->
-            <xsl:text>&#xa;</xsl:text>
-        </xsl:if>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="introduction" />
-        </xsl:if>
-        <!-- the container for the exercisegroup does not need to change -->
-        <!-- when in a solutions list.  The indentation might look odd   -->
-        <!-- without an introduction (when there are no statements), or  -->
-        <!-- it might remind the reader of the grouping                  -->
-        <xsl:choose>
-            <xsl:when test="$ncols = 1">
-                <xsl:text>\begin{exercisegroup}&#xa;</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>\begin{exercisegroupcol}</xsl:text>
-                <xsl:text>{</xsl:text>
-                <xsl:value-of select="$ncols"/>
-                <xsl:text>}&#xa;</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-        <xsl:apply-templates select="exercise" mode="solutions">
-            <xsl:with-param name="purpose" select="$purpose" />
-            <xsl:with-param name="admit" select="$admit"/>
-            <xsl:with-param name="b-component-heading" select="$b-component-heading"/>
-            <xsl:with-param name="b-has-statement" select="$b-has-statement" />
-            <xsl:with-param name="b-has-hint" select="$b-has-hint" />
-            <xsl:with-param name="b-has-answer" select="$b-has-answer" />
-            <xsl:with-param name="b-has-solution" select="$b-has-solution" />
-        </xsl:apply-templates>
-        <xsl:choose>
-            <xsl:when test="$ncols = 1">
-                <xsl:text>\end{exercisegroup}&#xa;</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:text>\end{exercisegroupcol}&#xa;</xsl:text>
-            </xsl:otherwise>
-        </xsl:choose>
-        <xsl:if test="$b-has-statement">
-            <xsl:apply-templates select="conclusion" />
-        </xsl:if>
-        <xsl:text>\par\medskip\noindent&#xa;</xsl:text>
+    <xsl:if test="title">
+        <xsl:text>\subparagraph</xsl:text>
+        <!-- keep optional title if LaTeX source is re-purposed -->
+        <xsl:text>[{</xsl:text>
+        <xsl:apply-templates select="." mode="title-short" />
+        <xsl:text>}]</xsl:text>
+        <xsl:text>{</xsl:text>
+        <xsl:apply-templates select="." mode="title-full" />
+        <xsl:text>}</xsl:text>
+        <!-- no label, as this is a duplicate              -->
+        <!-- no title, no heading, so only line-break here -->
+        <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="introduction" />
+    </xsl:if>
+    <!-- the container for the exercisegroup does not need to change -->
+    <!-- when in a solutions list.  The indentation might look odd   -->
+    <!-- without an introduction (when there are no statements), or  -->
+    <!-- it might remind the reader of the grouping                  -->
+    <xsl:choose>
+        <xsl:when test="$ncols = 1">
+            <xsl:text>\begin{exercisegroup}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>\begin{exercisegroupcol}</xsl:text>
+            <xsl:text>{</xsl:text>
+            <xsl:value-of select="$ncols"/>
+            <xsl:text>}&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:copy-of select="$content"/>
+    <xsl:choose>
+        <xsl:when test="$ncols = 1">
+            <xsl:text>\end{exercisegroup}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>\end{exercisegroupcol}&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:if test="$b-has-statement">
+        <xsl:apply-templates select="conclusion" />
+    </xsl:if>
+    <xsl:text>\par\medskip\noindent&#xa;</xsl:text>
 </xsl:template>
-
 
 <!-- ###################### -->
 <!-- Exercises and Projects -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -5203,8 +5203,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- The "division-in-solutions" modal template from -common   -->
 <!-- calls the "duplicate-heading" modal template.             -->
-<!-- Stacked headings are all \Large, regardless of which      -->
-<!-- level of depth they reflect. This is consistent with      -->
+<!-- Stacked headings all share one size, fixed by the level   -->
+<!-- of the originating "solutions" division, regardless of    -->
+<!-- the depth each entry reflects.  This is consistent with   -->
 <!-- treating stacked headings as a single "squashed" heading. -->
 
 <xsl:template match="*" mode="duplicate-heading">
@@ -5226,28 +5227,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="*" mode="duplicate-heading-content">
     <xsl:param name="heading-stack"/>
-    <xsl:variable name="is-specialized-division">
-        <xsl:choose>
-            <xsl:when test="self::task">
-                <xsl:value-of select="false()"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="." mode="is-specialized-division"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-    <xsl:variable name="is-child-of-structured">
-        <xsl:choose>
-            <xsl:when test="parent::*[&TRADITIONAL-DIVISION-FILTER;]">
-                <xsl:apply-templates select="parent::*[&TRADITIONAL-DIVISION-FILTER;]" mode="is-structured-division"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="false()"/>
-            </xsl:otherwise>
-        </xsl:choose>
+    <xsl:variable name="show-number">
+        <xsl:apply-templates select="." mode="duplicate-heading-show-number"/>
     </xsl:variable>
     <xsl:choose>
-        <xsl:when test="$is-specialized-division = 'true' and $is-child-of-structured = 'false'">
+        <xsl:when test="$show-number = 'false'">
             <xsl:text>\textperiodcentered\space{}</xsl:text>
         </xsl:when>
         <xsl:otherwise>

--- a/xsl/pretext-solution-manual-latex.xsl
+++ b/xsl/pretext-solution-manual-latex.xsl
@@ -121,32 +121,95 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="chapter[1]" />
 </xsl:template>
 
+<!-- The publisher switches for solution components, packed into the -->
+<!-- single string parameter the "solutions-generator" expects       -->
+<xsl:variable name="component-spec">
+    <xsl:variable name="inline-components">
+        <xsl:if test="$b-has-inline-statement">
+            <xsl:text>statement </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-inline-hint">
+            <xsl:text>hint </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-inline-answer">
+            <xsl:text>answer </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-inline-solution">
+            <xsl:text>solution </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="divisional-components">
+        <xsl:if test="$b-has-divisional-statement">
+            <xsl:text>statement </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-divisional-hint">
+            <xsl:text>hint </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-divisional-answer">
+            <xsl:text>answer </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-divisional-solution">
+            <xsl:text>solution </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="worksheet-components">
+        <xsl:if test="$b-has-worksheet-statement">
+            <xsl:text>statement </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-worksheet-hint">
+            <xsl:text>hint </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-worksheet-answer">
+            <xsl:text>answer </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-worksheet-solution">
+            <xsl:text>solution </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="reading-components">
+        <xsl:if test="$b-has-reading-statement">
+            <xsl:text>statement </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-reading-hint">
+            <xsl:text>hint </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-reading-answer">
+            <xsl:text>answer </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-reading-solution">
+            <xsl:text>solution </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="project-components">
+        <xsl:if test="$b-has-project-statement">
+            <xsl:text>statement </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-project-hint">
+            <xsl:text>hint </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-project-answer">
+            <xsl:text>answer </xsl:text>
+        </xsl:if>
+        <xsl:if test="$b-has-project-solution">
+            <xsl:text>solution </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:call-template name="solutions-component-spec">
+        <xsl:with-param name="inline"     select="$inline-components"/>
+        <xsl:with-param name="divisional" select="$divisional-components"/>
+        <xsl:with-param name="worksheet"  select="$worksheet-components"/>
+        <xsl:with-param name="reading"    select="$reading-components"/>
+        <xsl:with-param name="project"    select="$project-components"/>
+    </xsl:call-template>
+</xsl:variable>
+
 <!-- provoke the "solutions-generator" at the first sign of main matter content -->
 <xsl:template match="chapter[1]|article/section[1]">
     <xsl:apply-templates select="$document-root" mode="solutions-generator">
         <xsl:with-param name="purpose" select="'solutionmanual'" />
         <xsl:with-param name="admit" select="'all'" />
         <xsl:with-param name="scope" select="$document-root"/>
-        <xsl:with-param name="b-inline-statement"     select="$b-has-inline-statement" />
-        <xsl:with-param name="b-inline-hint"          select="$b-has-inline-hint"  />
-        <xsl:with-param name="b-inline-answer"        select="$b-has-inline-answer"  />
-        <xsl:with-param name="b-inline-solution"      select="$b-has-inline-solution"  />
-        <xsl:with-param name="b-divisional-statement" select="$b-has-divisional-statement" />
-        <xsl:with-param name="b-divisional-hint"      select="$b-has-divisional-hint"  />
-        <xsl:with-param name="b-divisional-answer"    select="$b-has-divisional-answer"  />
-        <xsl:with-param name="b-divisional-solution"  select="$b-has-divisional-solution"  />
-        <xsl:with-param name="b-worksheet-statement"  select="$b-has-worksheet-statement" />
-        <xsl:with-param name="b-worksheet-hint"       select="$b-has-worksheet-hint"  />
-        <xsl:with-param name="b-worksheet-answer"     select="$b-has-worksheet-answer"  />
-        <xsl:with-param name="b-worksheet-solution"   select="$b-has-worksheet-solution"  />
-        <xsl:with-param name="b-reading-statement"    select="$b-has-reading-statement" />
-        <xsl:with-param name="b-reading-hint"         select="$b-has-reading-hint"  />
-        <xsl:with-param name="b-reading-answer"       select="$b-has-reading-answer"  />
-        <xsl:with-param name="b-reading-solution"     select="$b-has-reading-solution"  />
-        <xsl:with-param name="b-project-statement"    select="$b-has-project-statement" />
-        <xsl:with-param name="b-project-hint"         select="$b-has-project-hint"  />
-        <xsl:with-param name="b-project-answer"       select="$b-has-project-answer"  />
-        <xsl:with-param name="b-project-solution"     select="$b-has-project-solution"  />
+        <xsl:with-param name="component-spec" select="$component-spec"/>
     </xsl:apply-templates>
 </xsl:template>
 


### PR DESCRIPTION
The machinery that lays out exercises and echoes solutions has long been triplicated — each of HTML, LaTeX, and FO carried its own copy of the exercise-components structure, the solutions-component selection logic, and the duplicate-heading number-echo decisions. This drifts and makes any change a three-place edit. This branch lifts that logic into shared drivers in `pretext-common.xsl` and points all three conversions at them.

The commits, in order:

- **Common: pack solutions component switches into one parameter** — the several boolean switches that select which solution components appear become a single bundled parameter.
- **Common: decide a duplicate heading number-echo in one place** — centralize the decision of whether a duplicate heading repeats its number.
- **FO: withhold misattributed numbers on duplicate headings** — an intentional FO fix that falls out of that centralization (FO was echoing numbers it shouldn't).
- **Common: lift the "exercise-components" drivers from LaTeX and FO** — move the shared structure into common.
- **HTML: converge "exercise-components" onto the common drivers** and **HTML: converge "solutions" task recursion onto the common driver** — retire HTML's parallel copies.
- **Common: drive "subexercises" and "exercisegroup" solution echoes** — the last format-specific echo paths join the common driver.

**Output-equivalence.** This is a refactor, not a behavior change (with the one FO fix noted above). Built the sample article on `master` and on this branch: the HTML and the LaTeX are identical apart from build timestamps. The net `+1226/-1126` is almost entirely relocation — copies removed from the per-format stylesheets, one shared driver added.

Consolidating these drivers also gives a single place to correct heading-level seeding on the generated solutions pages, which is otherwise spread across three conversions.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
