### PR TITLE
Script: repair the "math" component invocation

### DIFF
--- a/pretext/pretext
+++ b/pretext/pretext
@@ -783,7 +783,7 @@ def main():
     elif args.component == "math":
         if args.format in ["svg", "mml", "nemeth", "speech"]:
             ptx.mathjax_latex(
-                xml_source, publication_file, out_file, dest_dir, args.format
+                xml_source, publication_file, out_file, dest_dir, args.format, False
             )
         else:
             raise NotImplementedError(


### PR DESCRIPTION
`mathjax_latex()` gained a required `math_cross_references` argument (bdd582b0, 2026-06-22), but the `-c math` component's call was not updated, so it crashed on every invocation. Supply the argument as `False`, matching prior behavior (no active cross-reference links in the math representations).

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
