### PR TITLE
LaTeX: end "image" environment definition with a newline

### DIFF
--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1452,7 +1452,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%% Fourth argument, if nonempty, is a vertical space adjustment&#xa;</xsl:text>
         <xsl:text>%% and implies image will be preceded by \leavevmode\nopagebreak&#xa;</xsl:text>
         <xsl:text>%% Intended use is for alignment with a list marker&#xa;</xsl:text>
-        <xsl:text>\NewDocumentEnvironment{image}{mmmm}{\notblank{#4}{\leavevmode\nopagebreak\vspace{#4}}{}\begin{tcbimage}{#1}{#2}{#3}}{\end{tcbimage}%&#xa;}</xsl:text>
+        <xsl:text>\NewDocumentEnvironment{image}{mmmm}{\notblank{#4}{\leavevmode\nopagebreak\vspace{#4}}{}\begin{tcbimage}{#1}{#2}{#3}}{\end{tcbimage}%&#xa;}&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
The `image-tcolorbox` preamble template ends the `\NewDocumentEnvironment{image}` definition without a final newline, so the closing brace runs into whatever the preamble emits next:

```
\NewDocumentEnvironment{image}{mmmm}{...}{\end{tcbimage}%
}%% For improved tables
```

With the newline added, the output for any document containing an `image` changes by exactly this line split.  The compiled result is unchanged, since the comment already terminated the line.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*