### PR TITLE
LaTeX: end engine-specific "siunitx" setup with newlines

### DIFF
--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1226,8 +1226,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>}%&#xa;</xsl:text>
         <xsl:text>\makeatother%&#xa;</xsl:text>
         <xsl:text>\sisetup{inter-unit-product=\cdot}&#xa;</xsl:text>
-        <xsl:text>\ifxetex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
-        <xsl:text>\ifluatex\sisetup{math-micro=\text{µ},text-micro=µ}\fi</xsl:text>
+        <xsl:text>\ifxetex\sisetup{math-micro=\text{µ},text-micro=µ}\fi&#xa;</xsl:text>
+        <xsl:text>\ifluatex\sisetup{math-micro=\text{µ},text-micro=µ}\fi&#xa;</xsl:text>
         <xsl:text>%% Common non-SI units&#xa;</xsl:text>
         <xsl:for-each select="document('pretext-units.xsl')//base[@siunitx]">
             <xsl:text>\DeclareSIUnit\</xsl:text>


### PR DESCRIPTION
The two engine-specific `\sisetup` adjustments for the `quantity` element end without newlines, so they and the following comment run together as one line of the preamble:

```
\ifxetex\sisetup{math-micro=\text{µ},text-micro=µ}\fi\ifluatex\sisetup{math-micro=\text{µ},text-micro=µ}\fi%% Common non-SI units
```

Now each ends with a newline of its own.  For any document containing a `quantity`, the `.tex` output changes by exactly this line split; the LaTeX itself is unchanged.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*