### PR TITLE
Division companions become their own pages (HTML, EPUB, Jupyter)

### DIFF
--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -162,7 +162,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </exercise>
             </exercises>
             <conclusion>
-                <title>Wrapping up</title>
                 <p>This is the conclusion.</p>
             </conclusion>
         </chapter>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -676,7 +676,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 </conclusion>
             </objectives>
 
-            <introduction>
+            <introduction xml:id="introduction-structures">
                 <p>This is a cross-reference to one of the objectives above, forced to use the <c>phrase-global</c> form of the text.  It should describe the objective as belonging to the <em>section</em> (rather than the <em>objectives</em>), since objectives are one-per-subdivision and are numbered based upon the containing division: <xref ref="objective-structure" text="phrase-global"/>.  For comparison this is the (forced) <c>type-global</c> cross-reference: <xref ref="objective-structure" text="type-global"/>.</p>
 
                 <p>The Fundamental Theorem comes in two flavors, where usually one is a corollary of the other.</p>
@@ -1753,7 +1753,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
             </subsection>
 
-            <conclusion>
+            <conclusion xml:id="conclusion-structures">
                 <p>A conclusion here, which we fill with some numbering tests.</p>
 
                 <p>This is a cross-reference to one of the outcomes, forced to use the <c>type-global</c> form of the text.  It should describe the outcome as belonging to the <em>section</em> (rather than the <em>outcomes</em>), since outcomes are one-per-subdivision and are numbered based upon the containing division: <xref ref="outcome-structure" text="phrase-global"/>.  For comparison this is the (forced) <c>type-global</c> cross-reference: <xref ref="outcome-structure" text="type-global"/>.</p>
@@ -10787,6 +10787,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <li><p>A hyperlink to a <tag>subexercises</tag> via its required title (no number is assigned): <xref ref="hard-subexercises" text="title"/></p></li>
                 <li><p>You can request the text to be a type, then a number, then a title: <xref ref="theorem-FTC" text="type-global-title"/></p></li>
                 <li><p>Asking for the text to be a type, then a number, then a title, when there is no title, is not a problem: <xref ref="corollary-FTC-derivative" text="type-local-title"/></p></li>
+                <li><p>A cross-reference to the <tag>introduction</tag> of a (structured) section, and to the <tag>conclusion</tag> of the same section.  There is at most one of each per division, so each takes the number of its parent division, displayed only here in a cross-reference (never where born), and each should be a traditional hyperlink, never a knowl: <xref ref="introduction-structures"/> and <xref ref="conclusion-structures"/>.  In an <init>HTML</init> version chunked so the section becomes a summary page, these lead to the companions' own pages.</p></li>
                 <!-- Accumulate examples here -->
                 <!-- <li><p>: <xref ref="" text=""/></p></li> -->
             </ul></p>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1657,11 +1657,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <title>Introductions and Conclusions</title>
 
                 <introduction>
-                    <title>An Introductory Introduction</title>
 
                     <p>Any subdivision may have a sequence of paragraphs within an <tag>introduction</tag> that precedes subsequent further subdivisions.  You are reading one now.  They are always leaves of the document structure, so are rendered on some pages that reference the following subdivisions.</p>
 
-                    <p>An introduction or conclusion is an extremely restrictive container with simple presentation.  A title is optional (and probably not advisable).  Content is meant to be short and unstructured, in particular, nothing that can be numbered is allowed.  If this feels <em>too</em> restrictive, then place your content in an initial numbered subdivision and perhaps title it <q>Introduction</q>.  Or make your entire subdivion unstructured and place whatever you want into it.</p>
+                    <p>An introduction or conclusion is an extremely restrictive container with simple presentation, and it may not have a title.  Content is meant to be short and unstructured, in particular, nothing that can be numbered is allowed.  If this feels <em>too</em> restrictive, then place your content in an initial numbered subdivision and perhaps title it <q>Introduction</q>.  Or make your entire subdivion unstructured and place whatever you want into it.</p>
 
                     <p>This ends this introduction to introductions.</p>
                 </introduction>
@@ -2761,7 +2760,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </outcomes>
 
             <conclusion>
-                <title>Wrap-up</title>
                 <p>A minimal <tag>conclusion</tag>.</p>
             </conclusion>
         </section>
@@ -11692,7 +11690,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <title>Side-By-Side Panels</title>
 
             <introduction>
-                <title>Introduction</title>
 
                 <p>The flow of a page is almost universally top-to-bottom.  But at times you would like to go <em>across</em> a page, perhaps to compare items (identical content in two different languages), or to make good use of a page real estate by grouping several small items together (<eg/> images).  So the <tag>sidebyside</tag> tag is strictly a layout device, though it does convey some meaning by grouping certain objects together. A variety of different objects can be put side-by-side using the <c>sidebyside</c> element.  Specifically, <c>figure</c>, <c>image</c>, <c>tabular</c>, <c>p</c>, <c>ol</c>, <c>ul</c>, <c>dl</c>, <c>pre</c>, <c>poem</c>, and more.  The individual components of a <tag>sidebyside</tag> are generically called <term>panels</term><idx>panels</idx>.</p>
 
@@ -15356,7 +15353,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <title>Worksheets</title>
 
             <introduction>
-                <title>About Worksheets</title>
 
                 <p>This is a section full of worksheets.  Each is a division of its own, via the <tag>worksheet</tag> element.  This is an optional <tag>introduction</tag> to the current <tag>section</tag>.  In practice you might want to rip out all the worksheets of an entire book and bundle them up as an <q>activity book.</q></p>
 
@@ -16624,7 +16620,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <title>Handouts</title>
 
             <introduction>
-                <title>About Handouts</title>
                 <p>
                     Like worksheets, a <term>handout</term> is a division that is inteded to be printed for use in a classroom.
                     In HTML output, you get the same print preview and page layout as you do with worksheets; in PDF, these will start on a new page with possibly different margins than the rest of the document.

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -25,11 +25,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?),
+                            (Outcomes? & ConclusionCompanion?),
                             ArticleBackMatter?
                         )
                     )
@@ -65,11 +65,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?)
+                            (Outcomes? & ConclusionCompanion?)
                         )
                     )
                 }
@@ -87,11 +87,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Subsection | Printout),
                             (Subsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?)
+                            (Outcomes? & ConclusionCompanion?)
                         )
                     )
                 }
@@ -109,11 +109,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Subsubsection | Printout),
                             (Subsubsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?)
+                            (Outcomes? & ConclusionCompanion?)
                         )
                     )
                 }
@@ -141,11 +141,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Subsection | Printout),
                             (Subsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?)
+                            (Outcomes? & ConclusionCompanion?)
                         )
                     )
                 }
@@ -163,11 +163,11 @@
                         )
                     |
                         (
-                            (Objectives? & IntroductionDivision?),
+                            (Objectives? & IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? & ConclusionDivision?)
+                            (Outcomes? & ConclusionCompanion?)
                         )
                     )
                 }
@@ -499,6 +499,16 @@
                 element introduction {BlockStatement+}
             ConclusionStatement =
                 element conclusion {BlockStatement+}
+            IntroductionCompanion =
+                element introduction {
+                    MetaDataNoTitle,
+                    BlockDivision+
+                }
+            ConclusionCompanion =
+                element conclusion {
+                    MetaDataNoTitle,
+                    BlockDivision+
+                }
             IntroductionDivision =
                 element introduction {
                     MetaDataTitleOptional,
@@ -1581,6 +1591,12 @@
                 (Subtitle | LinedSubtitle)?,
                 ShortTitle?,
                 PlainTitle?,
+                Index*
+            MetaDataNoTitle =
+                UniqueID?,
+                LabelID?,
+                Component?,
+                XMLLang?,
                 Index*
             MetaDataTitleOptional =
                 UniqueID?,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -93,7 +93,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -116,7 +116,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
           <optional>
@@ -214,7 +214,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -237,7 +237,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
         </group>
@@ -291,7 +291,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -314,7 +314,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
         </group>
@@ -368,7 +368,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -391,7 +391,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
         </group>
@@ -486,7 +486,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -509,7 +509,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
         </group>
@@ -564,7 +564,7 @@
               <ref name="Objectives"/>
             </optional>
             <optional>
-              <ref name="IntroductionDivision"/>
+              <ref name="IntroductionCompanion"/>
             </optional>
           </interleave>
           <choice>
@@ -587,7 +587,7 @@
               <ref name="Outcomes"/>
             </optional>
             <optional>
-              <ref name="ConclusionDivision"/>
+              <ref name="ConclusionCompanion"/>
             </optional>
           </interleave>
         </group>
@@ -1402,6 +1402,22 @@
     <element name="conclusion">
       <oneOrMore>
         <ref name="BlockStatement"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="IntroductionCompanion">
+    <element name="introduction">
+      <ref name="MetaDataNoTitle"/>
+      <oneOrMore>
+        <ref name="BlockDivision"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="ConclusionCompanion">
+    <element name="conclusion">
+      <ref name="MetaDataNoTitle"/>
+      <oneOrMore>
+        <ref name="BlockDivision"/>
       </oneOrMore>
     </element>
   </define>
@@ -4119,6 +4135,23 @@
     </optional>
     <optional>
       <ref name="PlainTitle"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="Index"/>
+    </zeroOrMore>
+  </define>
+  <define name="MetaDataNoTitle">
+    <optional>
+      <ref name="UniqueID"/>
+    </optional>
+    <optional>
+      <ref name="LabelID"/>
+    </optional>
+    <optional>
+      <ref name="Component"/>
+    </optional>
+    <optional>
+      <ref name="XMLLang"/>
     </optional>
     <zeroOrMore>
       <ref name="Index"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -119,11 +119,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?),
+                            (Outcomes? &amp; ConclusionCompanion?),
                             ArticleBackMatter?
                         )
                     )
@@ -174,11 +174,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?)
+                            (Outcomes? &amp; ConclusionCompanion?)
                         )
                     )
                 }
@@ -196,11 +196,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Subsection | Printout),
                             (Subsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?)
+                            (Outcomes? &amp; ConclusionCompanion?)
                         )
                     )
                 }
@@ -218,11 +218,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Subsubsection | Printout),
                             (Subsubsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?)
+                            (Outcomes? &amp; ConclusionCompanion?)
                         )
                     )
                 }
@@ -250,11 +250,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Subsection | Printout),
                             (Subsection | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?)
+                            (Outcomes? &amp; ConclusionCompanion?)
                         )
                     )
                 }
@@ -272,11 +272,11 @@
                         )
                     |
                         (
-                            (Objectives? &amp; IntroductionDivision?),
+                            (Objectives? &amp; IntroductionCompanion?),
                             (Section | Printout),
                             (Section | Printout | ReadingQuestions | Exercises |
                              Solutions | References | Glossary)*,
-                            (Outcomes? &amp; ConclusionDivision?)
+                            (Outcomes? &amp; ConclusionCompanion?)
                         )
                     )
                 }
@@ -1057,6 +1057,16 @@
                 element introduction {BlockStatement+}
             ConclusionStatement =
                 element conclusion {BlockStatement+}
+            IntroductionCompanion =
+                element introduction {
+                    MetaDataNoTitle,
+                    BlockDivision+
+                }
+            ConclusionCompanion =
+                element conclusion {
+                    MetaDataNoTitle,
+                    BlockDivision+
+                }
             IntroductionDivision =
                 element introduction {
                     MetaDataTitleOptional,
@@ -3119,6 +3129,12 @@
                 (Subtitle | LinedSubtitle)?,
                 ShortTitle?,
                 PlainTitle?,
+                Index*
+            MetaDataNoTitle =
+                UniqueID?,
+                LabelID?,
+                Component?,
+                XMLLang?,
                 Index*
             MetaDataTitleOptional =
                 UniqueID?,

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -37,12 +37,22 @@
 
 <!ENTITY SPECIALIZED-DIVISION "exercises|worksheet|handout|reading-questions|references|glossary|solutions">
 
+<!-- "Division companions" are the non-structural companions of a      -->
+<!-- structured traditional division: they may earn their own page    -->
+<!-- (and links) when their parent is realized as a summary page in   -->
+<!-- a chunked conversion (HTML and derivatives).  The schema only    -->
+<!-- allows these four elements, division-flavored, in the parents    -->
+<!-- listed.  The filter form presumes context has qualified parents. -->
+<!ENTITY DIVISION-COMPANION "introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|objectives[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|outcomes[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]">
+
 <!-- for filtering nodes, eg *[&STRUCTURAL-FILTER;], *[not(&STRUCTURAL-FILTER;)] -->
 <!ENTITY STRUCTURAL-FILTER "self::book or self::article or self::slideshow or self::letter or self::memo or self::frontmatter or self::part or self::chapter or self::appendix or self::index or self::preface or self::acknowledgement or self::biography or self::foreword or self::dedication or self::colophon or self::section or self::subsection or self::subsubsection or self::slide or self::exercises or self::worksheet or self::handout or self::reading-questions or self::solutions or self::references or self::glossary or self::backmatter">
 
 <!ENTITY TRADITIONAL-DIVISION-FILTER "self::book or self::article or self::part or self::chapter or self::section or self::subsection or self::subsubsection or self::appendix">
 
 <!ENTITY SPECIALIZED-DIVISION-FILTER "self::exercises or self::worksheet or self::handout or self::reading-questions or self::references or self::glossary or self::solutions">
+
+<!ENTITY DIVISION-COMPANION-FILTER "self::introduction or self::conclusion or self::objectives or self::outcomes">
 
 <!-- NB: (2019-06-12)  Only the two metadata "filters" seem to          -->
 <!-- be in use, so only those are being maintained.  grep'ing on        -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3357,6 +3357,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- which have not been schema-compliant since circa 2017   -->
 <xsl:template match="sidebyside/*[&METADATA-FILTER;]" mode="repair"/>
 
+<!-- 2026-07-08  "title" deprecated on "introduction"/"conclusion" of a traditional division -->
+
+<!-- The title is dropped, silently; conversions provide a localized -->
+<!-- heading whenever a heading is called for.  Titles remain within -->
+<!-- specialized divisions, which are never structured, and so are   -->
+<!-- never summary pages (the situation that demands the heading)    -->
+<xsl:template match="introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title" mode="repair"/>
+
 <!-- ########## -->
 <!-- Enrichment -->
 <!-- ########## -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11870,6 +11870,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the &quot;@include-source&quot; attribute has been deprecated and it will be ignored.  No replacement is planned.'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2026-07-08  "title" deprecated on "introduction"/"conclusion" of a traditional division -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title | $document-root//conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title&quot;" />
+        <xsl:with-param name="date-string" select="'2026-07-08'" />
+        <xsl:with-param name="message" select="'a &quot;title&quot; on an &quot;introduction&quot; or &quot;conclusion&quot; of a traditional division has been deprecated, and it will be ignored.'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2267,6 +2267,13 @@ Book (with parts), "section" at level 3
 <!--   Realization: usual presentation, within the enclosing chunk  -->
 
 
+<!-- A conversion opts in to "division companion" chunks: the four   -->
+<!-- elements of &DIVISION-COMPANION; earn their own page (chunk)    -->
+<!-- exactly when their parent division is realized as a summary    -->
+<!-- (intermediate) page.  The HTML conversion opts in; conversions -->
+<!-- with their own chunking (WeBWorK sets, Sage doctest) do not.   -->
+<xsl:variable name="b-division-companion-chunks" select="false()"/>
+
 <!-- An intermediate node is at lesser level -->
 <!-- than chunk-level and is not a leaf      -->
  <xsl:template match="*" mode="is-intermediate">
@@ -2317,6 +2324,22 @@ Book (with parts), "section" at level 3
     </xsl:choose>
 </xsl:template>
 
+<!-- A division companion is a chunk exactly when its parent -->
+<!-- is a summary (intermediate) page, and the conversion    -->
+<!-- has opted in.  It is never an intermediate node itself  -->
+<!-- (the generic template answers correctly), and it is     -->
+<!-- inline content of its parent's page in every other case -->
+<xsl:template match="&DIVISION-COMPANION;" mode="is-chunk">
+    <xsl:choose>
+        <xsl:when test="$b-division-companion-chunks">
+            <xsl:apply-templates select="parent::*" mode="is-intermediate"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="false()"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- #################################### -->
 <!-- Abstract Chunking of Structural Nodes-->
 <!-- #################################### -->
@@ -2363,10 +2386,22 @@ Book (with parts), "section" at level 3
         </xsl:when>
         <xsl:otherwise>
             <xsl:apply-templates select="." mode="intermediate" />
-            <xsl:apply-templates select="&STRUCTURAL;" mode="chunking" />
+            <xsl:apply-templates select="&STRUCTURAL;|&DIVISION-COMPANION;" mode="chunking" />
         </xsl:otherwise>
     </xsl:choose>
  </xsl:template>
+
+<!-- A division companion produces a page (chunk) or nothing: -->
+<!-- it is only visited via the recursion above, so a parent  -->
+<!-- summary page is guaranteed, but the opt-in may be off    -->
+<xsl:template match="&DIVISION-COMPANION;" mode="chunking">
+    <xsl:variable name="chunk">
+        <xsl:apply-templates select="." mode="is-chunk" />
+    </xsl:variable>
+    <xsl:if test="$chunk = 'true'">
+        <xsl:apply-templates select="." mode="chunk" />
+    </xsl:if>
+</xsl:template>
 
 <!-- docinfo, and anything else, is immune and dead-ends -->
 <xsl:template match="*" mode="chunking" />
@@ -2384,7 +2419,7 @@ Book (with parts), "section" at level 3
 <!-- parameter holding the contents of the body of the page -->
 
 <!-- A complete file/page for a structural division         -->
-<xsl:template match="&STRUCTURAL;" mode="chunk">
+<xsl:template match="&STRUCTURAL;|&DIVISION-COMPANION;" mode="chunk">
     <xsl:apply-templates select="." mode="file-wrap">
         <xsl:with-param name="content">
             <xsl:apply-templates select="." />

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -239,7 +239,7 @@
 <!-- EPUB conversion with "chapter" having "section" it gets an -->
 <!-- HTML page of its own as part of the "summary" hack.  Ditto -->
 <!-- for "outcomes" which might appear in a different order.    -->
-<xsl:template match="&STRUCTURAL;|chapter/conclusion|chapter/outcomes[preceding-sibling::section]" mode="file-wrap">
+<xsl:template match="&STRUCTURAL;|&DIVISION-COMPANION;" mode="file-wrap">
     <xsl:param name="content" />
     <xsl:variable name="file">
         <xsl:value-of select="$content-dir" />
@@ -307,23 +307,10 @@
             <section class="{local-name(.)}">
                 <xsl:apply-templates select="." mode="html-id-attribute"/>
                 <xsl:apply-templates select="." mode="section-heading" />
-                <xsl:apply-templates select="author|objectives|introduction|titlepage|abstract" />
+                <xsl:apply-templates select="author|titlepage|abstract" />
                 <!-- deleted "nav" and summary links here -->
+                <!-- division companions become their own files, in the spine -->
             </section>
-            <xsl:if test="conclusion">
-                <xsl:apply-templates select="conclusion" mode="file-wrap">
-                    <xsl:with-param name="content">
-                        <xsl:apply-templates select="conclusion"/>
-                    </xsl:with-param>
-                </xsl:apply-templates>
-            </xsl:if>
-            <xsl:if test="outcomes">
-                <xsl:apply-templates select="outcomes" mode="file-wrap">
-                    <xsl:with-param name="content">
-                        <xsl:apply-templates select="outcomes"/>
-                    </xsl:with-param>
-                </xsl:apply-templates>
-            </xsl:if>
         </xsl:with-param>
     </xsl:apply-templates>
 </xsl:template>
@@ -540,7 +527,26 @@
 <!-- Specialized divisions are terminal in back    -->
 <!-- matter, and only a separate file when within  -->
 <!-- a "chapter", at level 2                       -->
-<xsl:template match="frontmatter|colophon|biography|dedication|acknowledgement|preface|chapter|chapter/conclusion|chapter/outcomes[preceding-sibling::section]|appendix|index|section|exercises|chapter/reading-questions|chapter/solutions|appendix/solutions|backmatter/solutions|chapter/references|appendix/references|backmatter/references" mode="manifest">
+<xsl:template match="frontmatter|colophon|biography|dedication|acknowledgement|preface|chapter|appendix|index|section|exercises|chapter/reading-questions|chapter/solutions|appendix/solutions|backmatter/solutions|chapter/references|appendix/references|backmatter/references" mode="manifest">
+    <xsl:call-template name="manifest-item"/>
+    <!-- recurse, eg from chapter down into a section -->
+    <xsl:apply-templates select="*" mode="manifest" />
+</xsl:template>
+
+<!-- A division companion is a file exactly when it is a chunk -->
+<!-- (its parent is a summary page); it has no children that   -->
+<!-- could ever join the manifest, so there is no recursion    -->
+<xsl:template match="&DIVISION-COMPANION;" mode="manifest">
+    <xsl:variable name="chunk">
+        <xsl:apply-templates select="." mode="is-chunk"/>
+    </xsl:variable>
+    <xsl:if test="$chunk = 'true'">
+        <xsl:call-template name="manifest-item"/>
+    </xsl:if>
+</xsl:template>
+
+<!-- One manifest "item" element for the context node's file -->
+<xsl:template name="manifest-item">
     <!-- Annotate manifest entries -->
     <xsl:comment>
         <xsl:apply-templates select="." mode="long-name" />
@@ -605,7 +611,6 @@
         </xsl:attribute>
     </xsl:element>
     <!-- recurse, eg from chapter down into a section -->
-    <xsl:apply-templates select="*" mode="manifest" />
 </xsl:template>
 
 <!-- How the files are organized into the spine  -->
@@ -627,11 +632,31 @@
     <xsl:apply-templates select="*" mode="spine" />
 </xsl:template>
 
+<!-- A division companion joins the linear reading order exactly -->
+<!-- when it is a file; document order places an "introduction"  -->
+<!-- right after its division's summary page, and a "conclusion" -->
+<!-- after the last subdivision                                  -->
+<xsl:template match="&DIVISION-COMPANION;" mode="spine">
+    <xsl:variable name="chunk">
+        <xsl:apply-templates select="." mode="is-chunk"/>
+    </xsl:variable>
+    <xsl:if test="$chunk = 'true'">
+        <xsl:element name="itemref" xmlns="http://www.idpf.org/2007/opf">
+            <xsl:attribute name="idref">
+                <xsl:apply-templates select="." mode="html-id" />
+            </xsl:attribute>
+            <xsl:attribute name="linear">
+                <xsl:text>yes</xsl:text>
+            </xsl:attribute>
+        </xsl:element>
+    </xsl:if>
+</xsl:template>
+
 <!-- Simplest scenario is spine matches manifest, all with @linear="yes" -->
 <!-- Specialized divisions will only become files in the manifest at     -->
 <!-- chunk level 2, in other words, peers of chapters or sections        -->
 <!-- (book or chapter/appendix as parent, respectively)                  -->
-<xsl:template match="frontmatter|colophon|acknowledgement|biography|dedication|preface|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|chapter/solutions|appendix/solutions|backmatter/solutions|chapter/references|appendix/references|backmatter/references|glossary[parent::book|parent::chapter|parent::appendix]|conclusion[parent::chapter]|outcomes[preceding-sibling::section]" mode="spine">
+<xsl:template match="frontmatter|colophon|acknowledgement|biography|dedication|preface|chapter|appendix|index|section|exercises[parent::book|parent::chapter|parent::appendix]|reading-questions[parent::book|parent::chapter|parent::appendix]|chapter/solutions|appendix/solutions|backmatter/solutions|chapter/references|appendix/references|backmatter/references|glossary[parent::book|parent::chapter|parent::appendix]" mode="spine">
     <xsl:element name="itemref" xmlns="http://www.idpf.org/2007/opf">
         <xsl:attribute name="idref">
             <xsl:apply-templates select="." mode="html-id" />
@@ -805,6 +830,7 @@
                                     </xsl:attribute>
                                     <xsl:apply-templates select="." mode="title-simple" />
                                 </xsl:element>
+                                <xsl:apply-templates select="." mode="nav-companions"/>
                             </li>
                         </xsl:for-each>
                         <!-- following divisions identical for book v. article -->
@@ -840,6 +866,35 @@
             </body>
         </html>
     </exsl:document>
+</xsl:template>
+
+<!-- Division companions of a division, nested in the nav -->
+<!-- document, exactly when they are files of the spine   -->
+<xsl:template match="*" mode="nav-companions">
+    <xsl:variable name="companion-files">
+        <xsl:for-each select="introduction|conclusion|objectives|outcomes">
+            <xsl:apply-templates select="." mode="is-chunk"/>
+        </xsl:for-each>
+    </xsl:variable>
+    <xsl:if test="contains($companion-files, 'true')">
+        <ol>
+            <xsl:for-each select="introduction|conclusion|objectives|outcomes">
+                <xsl:variable name="chunk">
+                    <xsl:apply-templates select="." mode="is-chunk"/>
+                </xsl:variable>
+                <xsl:if test="$chunk = 'true'">
+                    <li class="no-marker">
+                        <xsl:element name="a">
+                            <xsl:attribute name="href">
+                                <xsl:apply-templates select="." mode="containing-filename" />
+                            </xsl:attribute>
+                            <xsl:apply-templates select="." mode="division-companion-text" />
+                        </xsl:element>
+                    </li>
+                </xsl:if>
+            </xsl:for-each>
+        </ol>
+    </xsl:if>
 </xsl:template>
 
 <!-- An abstract named template accepts input text and   -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -495,6 +495,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The "file-wrap" routine should accept a $content       -->
 <!-- parameter holding the contents of the body of the page -->
 
+<!-- The HTML conversion (and hence its derivatives) opts in -->
+<!-- to "division companion" chunks: introduction, conclusion, -->
+<!-- objectives, outcomes of a division realized as a summary -->
+<!-- page become pages themselves (see pretext-common.xsl)    -->
+<xsl:variable name="b-division-companion-chunks" select="true()"/>
+
 <!-- A complete page for a structural division -->
 <xsl:template match="&STRUCTURAL;" mode="chunk">
     <xsl:apply-templates select="." mode="file-wrap">
@@ -527,7 +533,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:if test="self::frontmatter[not(titlepage)]">
                     <xsl:call-template name="frontmatter-title" />
                 </xsl:if>
-                <xsl:apply-templates select="objectives|introduction|titlepage|abstract">
+                <xsl:apply-templates select="titlepage|abstract">
                     <xsl:with-param name="heading-level" select="$chunk-heading-level + 1"/>
                 </xsl:apply-templates>
                 <!-- Links to subsidiary divisions, as a group of button/hyperlinks -->
@@ -536,9 +542,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <xsl:apply-templates select="*" mode="summary-nav" />
                     </ul>
                 </nav>
-                <xsl:apply-templates select="conclusion|outcomes">
-                    <xsl:with-param name="heading-level" select="$chunk-heading-level + 1"/>
-                </xsl:apply-templates>
                 <!-- Insert permalink -->
                 <xsl:apply-templates select="." mode="permalink"/>
             </section>
@@ -573,8 +576,86 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </li>
 </xsl:template>
 
-<!-- introduction (etc.) and conclusion get dropped -->
+<!-- Division companions become links, like the structural children; -->
+<!-- document order places an "introduction" before the subdivision -->
+<!-- links and a "conclusion" after, with no extra machinery        -->
+<xsl:template match="&DIVISION-COMPANION;" mode="summary-nav">
+    <!-- a link only when realized as a page (a conversion that -->
+    <!-- has not opted in renders no link, and no bare content) -->
+    <xsl:variable name="chunk">
+        <xsl:apply-templates select="." mode="is-chunk"/>
+    </xsl:variable>
+    <xsl:if test="$chunk = 'true'">
+        <xsl:variable name="url">
+            <xsl:apply-templates select="." mode="url" />
+        </xsl:variable>
+        <li>
+            <a href="{$url}" class="internal">
+                <span class="title">
+                    <xsl:apply-templates select="." mode="division-companion-text"/>
+                </span>
+            </a>
+        </li>
+    </xsl:if>
+</xsl:template>
+
+<!-- everything else on a summary page gets dropped -->
 <xsl:template match="*" mode="summary-nav" />
+
+<!-- Text for links (and ToC entries) to a division companion page.  -->
+<!-- "introduction"/"conclusion": the localized type-name only (an  -->
+<!-- authored title is silently ignored, pending deprecation).      -->
+<!-- "objectives"/"outcomes": the localized type-name, plus the     -->
+<!-- title when authored, mirroring the inline block headings.      -->
+<xsl:template match="introduction|conclusion" mode="division-companion-text">
+    <xsl:apply-templates select="." mode="type-name"/>
+</xsl:template>
+
+<xsl:template match="objectives|outcomes" mode="division-companion-text">
+    <xsl:apply-templates select="." mode="type-name"/>
+    <xsl:if test="title">
+        <xsl:text>: </xsl:text>
+        <xsl:apply-templates select="." mode="title-short"/>
+    </xsl:if>
+</xsl:template>
+
+<!-- A division companion realized as its own page -->
+<xsl:template match="&DIVISION-COMPANION;" mode="chunk">
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="content">
+            <xsl:apply-templates select="." mode="division-companion-page"/>
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- Page content: a manufactured heading (the link text), then the -->
+<!-- children, much as the inline realization would present them    -->
+<xsl:template match="introduction|conclusion" mode="division-companion-page">
+    <xsl:text>&#xa;</xsl:text>
+    <section>
+        <xsl:attribute name="class">
+            <xsl:value-of select="local-name(.)" />
+        </xsl:attribute>
+        <xsl:apply-templates select="." mode="html-id-attribute"/>
+        <xsl:apply-templates select="." mode="heading-generic">
+            <xsl:with-param name="heading-level" select="$chunk-heading-level"/>
+            <xsl:with-param name="heading-title">
+                <xsl:apply-templates select="." mode="division-companion-text"/>
+            </xsl:with-param>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="*">
+            <xsl:with-param name="heading-level" select="$chunk-heading-level + 1"/>
+        </xsl:apply-templates>
+    </section>
+</xsl:template>
+
+<!-- Page content: the ordinary block realization, whose heading -->
+<!-- already displays the type-name and any authored title       -->
+<xsl:template match="objectives|outcomes" mode="division-companion-page">
+    <xsl:apply-templates select=".">
+        <xsl:with-param name="heading-level" select="$chunk-heading-level"/>
+    </xsl:apply-templates>
+</xsl:template>
 
 <!-- Default template for content of a structural  -->
 <!-- division, which could be an entire page's     -->
@@ -12002,15 +12083,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- TODO: perhaps isolate logic to return nodes and put into "common" -->
 
+<!-- Is a node a unit of the linear page order?  The structural  -->
+<!-- nodes are; so is a division companion realized as a page     -->
+<xsl:template match="*" mode="is-linear-unit">
+    <xsl:apply-templates select="." mode="is-structural"/>
+</xsl:template>
+
+<xsl:template match="&DIVISION-COMPANION;" mode="is-linear-unit">
+    <xsl:apply-templates select="." mode="is-chunk"/>
+</xsl:template>
+
 <!-- Check if the XML tree has a preceding/following/parent node -->
-<!-- Then check if it is a document node (structural)            -->
+<!-- Then check if it is a page of the reading order             -->
 <!-- If so, compute the URL for the node                         -->
 <!-- NB: tree urls maybe enabled as a processing option          -->
 <xsl:template match="*" mode="previous-tree-url">
     <xsl:if test="preceding-sibling::*">
         <xsl:variable name="preceding" select="preceding-sibling::*[1]" />
         <xsl:variable name="structural">
-            <xsl:apply-templates select="$preceding" mode="is-structural" />
+            <xsl:apply-templates select="$preceding" mode="is-linear-unit" />
         </xsl:variable>
         <xsl:if test="$structural='true'">
             <xsl:apply-templates select="$preceding" mode="url" />
@@ -12023,7 +12114,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="following-sibling::*">
         <xsl:variable name="following" select="following-sibling::*[1]" />
         <xsl:variable name="structural">
-            <xsl:apply-templates select="$following" mode="is-structural" />
+            <xsl:apply-templates select="$following" mode="is-linear-unit" />
         </xsl:variable>
         <xsl:if test="$structural='true'">
             <xsl:apply-templates select="$following" mode="url" />
@@ -12061,11 +12152,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <xsl:when test="$intermediate='true'">
             <!-- Descend once, will always have a child that is structural -->
-            <xsl:variable name="first-structural-child" select="*[&STRUCTURAL-FILTER;][1]" />
+            <xsl:variable name="first-structural-child" select="*[&STRUCTURAL-FILTER; or ($b-division-companion-chunks and (&DIVISION-COMPANION-FILTER;))][1]" />
             <xsl:apply-templates select="$first-structural-child" mode="url" />
             <!-- remainder is a basic check, could be removed -->
             <xsl:variable name="structural">
-                <xsl:apply-templates select="$first-structural-child" mode="is-structural" />
+                <xsl:apply-templates select="$first-structural-child" mode="is-linear-unit" />
             </xsl:variable>
             <xsl:if test="$structural='false'">
                 <xsl:message>PTX:ERROR: descending into first node of an intermediate page (<xsl:value-of select="local-name($first-structural-child)" />) that is non-structural; maybe your source has incorrect structure</xsl:message>
@@ -12086,7 +12177,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="following-sibling::*">
             <xsl:variable name="following" select="following-sibling::*[1]" />
             <xsl:variable name="structural">
-                <xsl:apply-templates select="$following" mode="is-structural" />
+                <xsl:apply-templates select="$following" mode="is-linear-unit" />
             </xsl:variable>
             <xsl:if test="$structural='true'">
                 <!-- A normal sibling following -->
@@ -12120,7 +12211,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="preceding-sibling::*">
             <xsl:variable name="preceding" select="preceding-sibling::*[1]" />
             <xsl:variable name="structural">
-                <xsl:apply-templates select="$preceding" mode="is-structural" />
+                <xsl:apply-templates select="$preceding" mode="is-linear-unit" />
             </xsl:variable>
             <xsl:if test="$structural='true'">
                 <!-- A normal sibling precedin, result is just a sentinel-->
@@ -12160,11 +12251,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="url" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:variable name="last-structural-child" select="*[&STRUCTURAL-FILTER;][last()]" />
+            <xsl:variable name="last-structural-child" select="*[&STRUCTURAL-FILTER; or ($b-division-companion-chunks and (&DIVISION-COMPANION-FILTER;))][last()]" />
             <xsl:apply-templates select="$last-structural-child" mode="previous-descent-url" />
             <!-- remainder is a basic check, could be removed -->
             <xsl:variable name="structural">
-                <xsl:apply-templates select="$last-structural-child" mode="is-structural" />
+                <xsl:apply-templates select="$last-structural-child" mode="is-linear-unit" />
             </xsl:variable>
             <xsl:if test="$structural='false'">
                 <xsl:message>PTX:ERROR: descending into last node of an intermediate page (<xsl:value-of select="local-name($last-structural-child)" />) that is non-structural</xsl:message>
@@ -13020,6 +13111,35 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </ul>
         </xsl:if>
     </li>
+</xsl:template>
+
+<!-- A division companion earns a ToC entry when it is a page -->
+<xsl:template match="&DIVISION-COMPANION;" mode="toc-item">
+    <xsl:variable name="chunk">
+        <xsl:apply-templates select="." mode="is-chunk"/>
+    </xsl:variable>
+    <xsl:if test="$chunk = 'true'">
+        <xsl:variable name="the-url">
+            <xsl:apply-templates select="." mode="url"/>
+        </xsl:variable>
+        <li>
+            <xsl:attribute name="class">
+                <xsl:text>toc-item toc-</xsl:text>
+                <xsl:value-of select="local-name()"/>
+            </xsl:attribute>
+            <!-- copy id of this li for use in customization pass -->
+            <xsl:attribute name="uid">
+                <xsl:value-of select="@unique-id"/>
+            </xsl:attribute>
+            <div class="toc-title-box">
+                <a href="{$the-url}" class="internal">
+                    <span class="title">
+                        <xsl:apply-templates select="." mode="division-companion-text"/>
+                    </span>
+                </a>
+            </div>
+        </li>
+    </xsl:if>
 </xsl:template>
 
 <!-- Recurse through un-interesting elements -->

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -152,6 +152,31 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:message>pretext-heading unmatched <xsl:value-of select="local-name(.)" /></xsl:message>
 </xsl:template>
 
+<!-- A division companion as its own notebook: a heading cell from -->
+<!-- the localized type-name (titles ignored, pending deprecation) -->
+<!-- and then the children as cells                                -->
+<xsl:template match="introduction|conclusion" mode="division-companion-page">
+    <xsl:variable name="html-rtf">
+        <h1>
+            <xsl:apply-templates select="." mode="division-companion-text"/>
+        </h1>
+    </xsl:variable>
+    <xsl:variable name="html-node-set" select="exsl:node-set($html-rtf)" />
+    <xsl:call-template name="pretext-cell">
+        <xsl:with-param name="content">
+            <xsl:call-template name="begin-string" />
+                <xsl:apply-templates select="$html-node-set" mode="xml-to-string" />
+            <xsl:call-template name="end-string" />
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- The ordinary block realization is the whole notebook -->
+<xsl:template match="objectives|outcomes" mode="division-companion-page">
+    <xsl:apply-templates select="."/>
+</xsl:template>
+
 <!-- Three modal templates accomodate all document structure nodes -->
 <!-- and all possibilities for chunking.  Read the description     -->
 <!-- in  xsl/pretext-common.xsl  and  -html  to understand these.  -->
@@ -165,7 +190,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="content">
             <!-- should perhaps initialize/pass $heading-level = 2 here -->
             <!-- perhaps irrelevant since headings are done in markown? -->
-            <xsl:apply-templates select="objectives|introduction" />
             <xsl:variable name="html-rtf">
                 <nav class="summary-links">
                     <xsl:apply-templates select="*" mode="summary-nav" />

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -686,12 +686,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Introductions and conclusions are just their contents at their position. -->
 <xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|reading-questions/introduction|references/introduction">
     <xsl:text>% Introduction&#xa;</xsl:text>
+    <!-- an authored @xml:id suggests a cross-reference target -->
+    <xsl:if test="@xml:id">
+        <xsl:apply-templates select="." mode="label"/>
+        <xsl:text>%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="*"/>
     <xsl:text>% end of introduction&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|reading-questions/conclusion|references/conclusion">
     <xsl:text>% Conclusion&#xa;</xsl:text>
+    <!-- an authored @xml:id suggests a cross-reference target -->
+    <xsl:if test="@xml:id">
+        <xsl:apply-templates select="." mode="label"/>
+        <xsl:text>%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="*"/>
     <xsl:text>% end of conclusion&#xa;</xsl:text>
 </xsl:template>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -4325,6 +4325,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text>
     <xsl:apply-templates select="." mode="title-full" />
     <xsl:text>}</xsl:text>
+    <!-- an authored @xml:id suggests a cross-reference target -->
+    <xsl:if test="@xml:id">
+        <xsl:apply-templates select="." mode="label"/>
+    </xsl:if>
     <xsl:text>%&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
     <xsl:text>\end{introduction}%&#xa;</xsl:text>
@@ -4345,6 +4349,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>{</xsl:text>
     <xsl:apply-templates select="." mode="title-full" />
     <xsl:text>}</xsl:text>
+    <!-- an authored @xml:id suggests a cross-reference target -->
+    <xsl:if test="@xml:id">
+        <xsl:apply-templates select="." mode="label"/>
+    </xsl:if>
     <xsl:text>%&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
     <xsl:text>\end{conclusion}%&#xa;</xsl:text>
@@ -8986,7 +8994,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Any target of a PreTeXt cross-reference, which is not naturally -->
 <!-- numbered by a LaTeX \label{} command, needs to go here.         -->
-<xsl:template match="exercises//exercise|worksheet//exercise|reading-questions//exercise|biblio|biblio/note|&PROOF-LIKE;|case|ol/li|dl/li|&SOLUTION-LIKE;|subexercises|exercisegroup|p|paragraphs|blockquote|contributor|colophon|book|article" mode="xref-as-ref">
+<xsl:template match="exercises//exercise|worksheet//exercise|reading-questions//exercise|biblio|biblio/note|&PROOF-LIKE;|case|ol/li|dl/li|&SOLUTION-LIKE;|subexercises|exercisegroup|p|paragraphs|blockquote|contributor|colophon|book|article|introduction|conclusion" mode="xref-as-ref">
     <xsl:value-of select="false()" />
 </xsl:template>
 
@@ -9137,6 +9145,17 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- introduction, so the LaTeX \ref{} mechanism assigns the correct        -->
 <!-- number - that of the enclosing subdivision                             -->
 <xsl:template match="exercises//exercise|worksheet//exercise|reading-questions//exercise|biblio|biblio/note|&PROOF-LIKE;|case|ol/li|dl/li|&SOLUTION-LIKE;|&DISCUSSION-LIKE;|exercisegroup|fn" mode="xref-number">
+    <xsl:param name="xref" select="/.." />
+
+    <xsl:apply-templates select="." mode="xref-number-hardcoded">
+        <xsl:with-param name="xref" select="$xref"/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- A division companion ("introduction"/"conclusion" of a     -->
+<!-- structured division) has its parent's number, which the   -->
+<!-- LaTeX label/ref system cannot produce, so it is hardcoded  -->
+<xsl:template match="introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]" mode="xref-number">
     <xsl:param name="xref" select="/.." />
 
     <xsl:apply-templates select="." mode="xref-number-hardcoded">

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -450,7 +450,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Lists live in paragraphs, exercises, objectives, so       -->
 <!-- should be referenced as part of some enclosing element.   -->
 <!-- "mathbook" helps some tree-climbing routines halt -->
-<xsl:template match="mathbook|pretext|introduction|conclusion|frontmatter|backmatter|sidebyside|sbsgroup|ol|ul|dl|statement" mode="serial-number" />
+<xsl:template match="mathbook|pretext|frontmatter|backmatter|sidebyside|sbsgroup|ol|ul|dl|statement" mode="serial-number" />
+
+<!-- An "introduction" or "conclusion" of a structured division (a   -->
+<!-- "division companion") occurs at most once per division, and so   -->
+<!-- takes its number from the parent, exactly as GOAL-LIKE does.    -->
+<!-- The number is never displayed where born; it only serves to     -->
+<!-- identify the target of a cross-reference.  Every other flavor   -->
+<!-- (in blocks, tasks, exercise groups, ...) has no number at all.  -->
+<xsl:template match="introduction|conclusion" mode="serial-number"/>
+
+<xsl:template match="introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]" mode="serial-number">
+    <xsl:apply-templates select="parent::*" mode="serial-number"/>
+</xsl:template>
+
+<xsl:template match="introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]" mode="structure-number">
+    <xsl:apply-templates select="parent::*" mode="structure-number"/>
+</xsl:template>
 
 <!-- Poems go by their titles, not numbers -->
 <xsl:template match="poem" mode="serial-number" />


### PR DESCRIPTION
**Goal.**  The `introduction`, `conclusion`, `objectives`, and `outcomes` of a structured traditional division — the *division companions* — have been awkward in chunked output: rendered bare on HTML summary pages around the subdivision links, hand-split into files by EPUB for just one case (`chapter/conclusion`), and pseudo-structural in Jupyter.  Now a companion becomes a page of its own exactly when its parent division is realized as a summary page, and sits inline otherwise.  Twelve commits, each a reviewable unit.

**Design.**  One definition at the chunking seam in pretext-common: `is-chunk(companion) = is-intermediate(parent)`, behind an opt-in switch that HTML enables (its derivatives inherit).  Because `containing-filename` walks the same predicates, URLs and cross-references adapt with no further work.  Conversions with their own chunking (WeBWorK sets, Sage doctest) and non-chunking conversions (LaTeX and friends) are untouched by construction — the ten-target LaTeX harness stays byte-identical throughout.

**Per conversion.**  HTML: summary pages show localized links ("Introduction", or "Objectives: Fundamental Structures" when titled) in document order; companion pages carry localized headings; sidebar ToC entries appear under the parent; the prev/next reading order threads through the new pages.  EPUB: companions join the linear reading order, and the old `chapter/conclusion` + `chapter/outcomes` hand-splits are deleted from the intermediate override, the manifest, the spine, and `file-wrap`; the nav document nests companion entries.  Jupyter: companions become notebooks with localized heading cells; the inline realization is retained below the chunk level.  (smc is no longer shielded and simply inherits; it is slated for removal.)

**Cross-references.**  A companion occurs at most once per division, so it takes its *parent's* number, exactly as GOAL-LIKE already does — displayed only in a cross-reference (never where born), so an `xref` reads "Introduction 4", disambiguating in print.  In LaTeX these are hypertarget/hyperlink cross-references with the number hardcoded (LaTeX's label/ref cannot produce a parent's number).  The sample article gains `@xml:id` on companions and xref examples.

**Deprecation.**  A `title` on an `introduction` or `conclusion` of a *traditional* division is deprecated: a dated warning, a silent title-drop in the assembly repair pass, and new title-less schema flavors (`IntroductionCompanion`/`ConclusionCompanion`) for the traditional hosts — specialized divisions are never structured, so never summary pages, and keep their titles.  Fifteen-instance census across examples/: the five traditional titles in the sample article and one in the EPUB sampler removed; the nine worksheet titles retained.

**Verification.**  HTML tree diffs at chunk levels 1–3 on the sample article and book (level 1 is a pure no-op; level 2 grows exactly the expected companion pages); EPUB payload compared file-by-file with manifest/spine/nav consistency checks; Jupyter verified with a temporary out-of-repo driver (deliberately not advertised in `pretext/pretext`); LaTeX ten-target harness byte-identical at every step; and a two-flavor synthetic document confirms the deprecation warns and strips for traditional divisions while worksheets are untouched.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*