### PR TITLE
Schema: allow xref inside creator

### DIFF
--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3182,7 +3182,7 @@
             PlainTitle =
                 element plaintitle {Component?, text}
             Creator =
-                element creator {Component?, TextShort}
+                element creator {Component?, (TextShort | Xref)*}
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,


### PR DESCRIPTION
Small change to the schema to allow xrefs inside of the creator element.

I *think* I did this correctly (I'm a little rusty on schema stuff).