### PR TITLE
SVG downgrade: extend Batik compatibility fixes for mermaid diagrams

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4340,6 +4340,8 @@ def _downgrade_svg2_for_batik(directory):
     * dominant-baseline="central/middle" and alignment-baseline on <text>:
       converted to an explicit numeric y coordinate (alphabetic baseline),
       with all dy attributes removed to avoid Batik dy/tspan quirks.
+    * <foreignObject> containing XHTML spans (mermaid class diagrams):
+      replaced by SVG <text> elements with equivalent content and position.
     """
     # TODO (2026-07-03) This function may modify SVG 1.1 files coming
     # from PreFigure that are known to be good for Batik to ingest.
@@ -4350,6 +4352,7 @@ def _downgrade_svg2_for_batik(directory):
 
     SVG           = "http://www.w3.org/2000/svg"
     XLINK         = "http://www.w3.org/1999/xlink"
+    XHTML         = "http://www.w3.org/1999/xhtml"
     ET.register_namespace("xlink", XLINK)
     tag           = lambda t: f"{{{SVG}}}{t}"
     xhref         = f"{{{XLINK}}}href"
@@ -4358,6 +4361,7 @@ def _downgrade_svg2_for_batik(directory):
     _HSL_RE       = re.compile(r"hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)")
     _RGB_RE       = re.compile(r"rgb\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)")
     _FILTER_FN_RE = re.compile(r"(filter\s*:)\s*([^;{}]+)")
+    _TRANS_RE     = re.compile(r"translate\(\s*([-\d.]+)\s*,\s*([-\d.]+)\s*\)")
 
     def parse_style(el):
         d = {}
@@ -4526,6 +4530,42 @@ def _downgrade_svg2_for_batik(directory):
                 continue
             el.set("y", ts_dy)
             del ts.attrib["dy"]
+            changed = True
+
+        # Convert <foreignObject> elements used by mermaid class diagrams to
+        # SVG <text> elements that Batik can render.  Each foreignObject holds
+        # an XHTML div/span whose text content needs to become an SVG text
+        # node.  The foreignObject's transform gives its (tx, ty) offset within
+        # the parent <g>, and its width/height determine the text position.
+        # classTitle elements are horizontally centred; all others are left-
+        # aligned from the foreignObject's left edge.
+        fo_tag   = tag("foreignObject")
+        xspan    = f"{{{XHTML}}}span"
+        for fo in list(root.iter(fo_tag)):
+            text = "".join((el.text or "") for el in fo.iter(xspan)).strip()
+            if not text:
+                continue  # leave empty foreignObjects in place; Batik ignores them
+            t   = fo.get("transform", "")
+            m   = _TRANS_RE.search(t)
+            tx  = float(m.group(1)) if m else 0.0
+            ty  = float(m.group(2)) if m else 0.0
+            w   = float(fo.get("width",  0))
+            h   = float(fo.get("height", 18))
+            if fo.get("class") == "classTitle":
+                x, anchor = tx + w / 2, "middle"
+            else:
+                x, anchor = tx, "start"
+            y = ty + h - 3          # approximate SVG alphabetic baseline
+            tel = ET.Element(tag("text"))
+            tel.set("x", f"{x:.4g}")
+            tel.set("y", f"{y:.4g}")
+            tel.set("text-anchor", anchor)
+            tel.text = text
+            parent = fo.getparent()
+            if parent is not None:
+                idx = list(parent).index(fo)
+                parent.remove(fo)
+                parent.insert(idx, tel)
             changed = True
 
         bad = {el.get("id"): el for el in root.iter(tag("marker"))

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4325,52 +4325,52 @@ def _pdf_fo_accessibility_repairs(pdfname):
 
 
 def _downgrade_svg2_for_batik(directory):
-    """Rewrite the SVG 2 constructs that Apache Batik cannot render.
+    """Rewrite SVG 2 constructs that Apache Batik (via FOP) cannot render.
 
-    Apache FOP rasterizes SVG with Batik, an SVG 1.1 implementation, so
-    SVG 2 syntax inside an image aborts the whole graphic.  Two such
-    constructs occur in PreFigure output; this rewrites the SVG copies
-    staged for FOP, leaving the managed source assets untouched.
-
-      * "orient" of "auto-start-reverse" on a "marker".  Its value
-        differs from "auto" only at a "marker-start" placement, so the
-        marker becomes plain "auto"; a marker actually placed at a start
-        also gets a companion rotated 180 degrees, with that start
-        reference repointed to the companion.
-
-      * a "use" element carrying a plain "href" rather than "xlink:href".
+    * orient="auto-start-reverse": changed to "auto"; elements that use
+      the marker as marker-start get a rotated (180°) copy (id suffix
+      "-start").
+    * Plain href on <use>: migrated to xlink:href.
     """
     # TODO (2026-07-03) This function may modify SVG 1.1 files coming
     # from PreFigure that are known to be good for Batik to ingest.
     # With access to source, we can determine filenames to avoid.
 
-    import glob
-    import copy
+    import glob, copy
     import lxml.etree as ET
 
-    svg_namespace = "http://www.w3.org/2000/svg"
-    xlink_namespace = "http://www.w3.org/1999/xlink"
-    ET.register_namespace("xlink", xlink_namespace)
-    use_tag = "{{{}}}use".format(svg_namespace)
-    marker_tag = "{{{}}}marker".format(svg_namespace)
-    group_tag = "{{{}}}g".format(svg_namespace)
-    xlink_href = "{{{}}}href".format(xlink_namespace)
+    SVG   = "http://www.w3.org/2000/svg"
+    XLINK = "http://www.w3.org/1999/xlink"
+    ET.register_namespace("xlink", XLINK)
+    tag   = lambda t: f"{{{SVG}}}{t}"
+    xhref = f"{{{XLINK}}}href"
 
-    for svg_file in glob.glob(os.path.join(directory, "**", "*.svg"), recursive=True):
+    def parse_style(el):
+        d = {}
+        for part in (el.get("style") or "").split(";"):
+            k, sep, v = part.partition(":")
+            if sep: d[k.strip()] = v.strip()
+        return d
+
+    def emit_style(d): return ";".join(f"{k}:{v}" for k, v in d.items())
+
+    def get_prop(el, prop):
+        return parse_style(el).get(prop) or el.get(prop)
+
+    for svg_file in glob.glob(
+        os.path.join(directory, "**", "*.svg"), recursive=True
+    ):
         try:
             tree = ET.parse(svg_file)
         except ET.XMLSyntaxError:
             continue
-        root = tree.getroot()
+        root    = tree.getroot()
         changed = False
 
-        # SVG 2 plain "href" on a "use" becomes SVG 1.1 "xlink:href"
-        for use in root.iter(use_tag):
-            target = use.get("href")
-            if target is not None and use.get(xlink_href) is None:
-                use.set(xlink_href, target)
-                del use.attrib["href"]
-                changed = True
+        for use in root.iter(tag("use")):
+            href = use.get("href")
+            if href and use.get(xhref) is None:
+                use.set(xhref, href); del use.attrib["href"]; changed = True
 
         # a marker placed at a "marker-start" needs a 180-degree twin,
         # since SVG 1.1 "auto" cannot express the reversal "auto-start-reverse"
@@ -4380,7 +4380,7 @@ def _downgrade_svg2_for_batik(directory):
             if element.get("marker-start")
         )
         reversed_twin = {}
-        for marker in list(root.iter(marker_tag)):
+        for marker in list(root.iter(tag("marker"))):
             if marker.get("orient") != "auto-start-reverse":
                 continue
             marker.set("orient", "auto")
@@ -4390,7 +4390,7 @@ def _downgrade_svg2_for_batik(directory):
             if reference and reference in start_references:
                 twin = copy.deepcopy(marker)
                 twin.set("id", "{}-start".format(marker_id))
-                rotation = ET.Element(group_tag)
+                rotation = ET.Element(tag("g"))
                 rotation.set(
                     "transform",
                     "rotate(180 {} {})".format(twin.get("refX", "0"), twin.get("refY", "0")),

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4506,6 +4506,28 @@ def _downgrade_svg2_for_batik(directory):
             if db:
                 del el.attrib["dominant-baseline"]; changed = True
 
+        # Mermaid git diagrams position branch labels via
+        #   <text><tspan dy="1em">label</tspan></text>
+        # (no y attribute on the <text> element).  Batik ignores the tspan's
+        # dy in this case and places the text at y=0 in the parent g's space.
+        # Fix: promote the first tspan's dy to an explicit y on the <text>
+        # element, so Batik picks up the correct baseline.
+        for el in root.iter(tag("text")):
+            if el.get("y") is not None:
+                continue
+            if el.get("dominant-baseline") or el.get("alignment-baseline"):
+                continue   # already handled above
+            tspans = [c for c in el if c.tag == tag("tspan")]
+            if not tspans:
+                continue
+            ts    = tspans[0]
+            ts_dy = ts.get("dy", "")
+            if not ts_dy:
+                continue
+            el.set("y", ts_dy)
+            del ts.attrib["dy"]
+            changed = True
+
         bad = {el.get("id"): el for el in root.iter(tag("marker"))
                if el.get("id") and is_svg2_marker(el)}
         if bad:

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4337,6 +4337,9 @@ def _downgrade_svg2_for_batik(directory):
     * fill="transparent" → fill="none"; hsl()/rgb() colour functions and
       CSS filter functions in <style> blocks rewritten to values Batik
       accepts.
+    * dominant-baseline="central/middle" and alignment-baseline on <text>:
+      converted to an explicit numeric y coordinate (alphabetic baseline),
+      with all dy attributes removed to avoid Batik dy/tspan quirks.
     """
     # TODO (2026-07-03) This function may modify SVG 1.1 files coming
     # from PreFigure that are known to be good for Batik to ingest.
@@ -4466,6 +4469,42 @@ def _downgrade_svg2_for_batik(directory):
             t = _FILTER_FN_RE.sub(_strip_filter_fn, t)
             if t != el.text:
                 el.text = t; changed = True
+
+        # alignment-baseline is not valid on <text> in SVG 1.1 and
+        # dominant-baseline is not reliably supported by Batik on <text>.
+        # For centering values, compute the intended visual centre from
+        # y + dy (resolving em to px), add a fixed 0.35em baseline offset
+        # for centering, write the result as a plain numeric y on the
+        # <text>, and strip all dy attributes.  Using explicit px avoids
+        # all the Batik dy/tspan interaction quirks.
+        def _em_px(val, font_px):
+            try:
+                if (val or "").endswith("em"): return float(val[:-2]) * font_px
+                if (val or "").endswith("px"): return float(val[:-2])
+                return 0.0
+            except (ValueError, TypeError):
+                return 0.0
+
+        for el in root.iter(tag("text")):
+            if el.get("alignment-baseline"):
+                del el.attrib["alignment-baseline"]; changed = True
+            db = el.get("dominant-baseline")
+            if db in ("central", "middle"):
+                sty = parse_style(el)
+                fs  = sty.get("font-size") or el.get("font-size", "16px")
+                try:
+                    font_px = float(fs[:-2]) if fs.endswith("px") else 16.0
+                except ValueError:
+                    font_px = 16.0
+                centre = float(el.get("y", 0)) + _em_px(el.get("dy"), font_px)
+                el.set("y", f"{centre + 0.35 * font_px:.4g}")
+                if "dy" in el.attrib: del el.attrib["dy"]
+                for ts in el:
+                    if ts.tag == tag("tspan") and "dy" in ts.attrib:
+                        del ts.attrib["dy"]
+                changed = True
+            if db:
+                del el.attrib["dominant-baseline"]; changed = True
 
         bad = {el.get("id"): el for el in root.iter(tag("marker"))
                if el.get("id") and is_svg2_marker(el)}

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4327,6 +4327,9 @@ def _pdf_fo_accessibility_repairs(pdfname):
 def _downgrade_svg2_for_batik(directory):
     """Rewrite SVG 2 constructs that Apache Batik (via FOP) cannot render.
 
+    * context-stroke / context-fill in marker content: for each referencing
+      element a resolved copy is created using that element's concrete
+      stroke / fill; copies with the same colour pair are shared.
     * orient="auto-start-reverse": changed to "auto"; elements that use
       the marker as marker-start get a rotated (180°) copy (id suffix
       "-start").
@@ -4336,14 +4339,16 @@ def _downgrade_svg2_for_batik(directory):
     # from PreFigure that are known to be good for Batik to ingest.
     # With access to source, we can determine filenames to avoid.
 
-    import glob, copy
+    import glob, copy, re
     import lxml.etree as ET
 
-    SVG   = "http://www.w3.org/2000/svg"
-    XLINK = "http://www.w3.org/1999/xlink"
+    SVG       = "http://www.w3.org/2000/svg"
+    XLINK     = "http://www.w3.org/1999/xlink"
     ET.register_namespace("xlink", XLINK)
-    tag   = lambda t: f"{{{SVG}}}{t}"
-    xhref = f"{{{XLINK}}}href"
+    tag       = lambda t: f"{{{SVG}}}{t}"
+    xhref     = f"{{{XLINK}}}href"
+    POSITIONS = ("marker-start", "marker-end", "marker-mid")
+    _URL_RE   = re.compile(r"^url\(#([^)]+)\)$")
 
     def parse_style(el):
         d = {}
@@ -4356,6 +4361,53 @@ def _downgrade_svg2_for_batik(directory):
 
     def get_prop(el, prop):
         return parse_style(el).get(prop) or el.get(prop)
+
+    def has_context_paint(marker):
+        return any(
+            get_prop(el, attr) in ("context-stroke", "context-fill")
+            for el in marker.iter() for attr in ("fill", "stroke")
+        )
+
+    def is_svg2_marker(m):
+        return has_context_paint(m) or m.get("orient") == "auto-start-reverse"
+
+    def resolve_paint(v, stroke, fill):
+        if v == "context-stroke": return stroke
+        if v == "context-fill":   return fill
+        return v
+
+    def make_marker(orig, new_id, stroke, fill, rotate):
+        m = copy.deepcopy(orig)
+        m.set("id", new_id)
+        if m.get("orient") == "auto-start-reverse":
+            m.set("orient", "auto")
+        if rotate:
+            g = ET.Element(tag("g"))
+            g.set("transform",
+                  f"rotate(180 {m.get('refX', '0')} {m.get('refY', '0')})")
+            for child in list(m): m.remove(child); g.append(child)
+            m.append(g)
+        for el in m.iter():
+            sty = parse_style(el)
+            sty2 = {k: resolve_paint(v, stroke, fill) for k, v in sty.items()}
+            if sty2 != sty: el.set("style", emit_style(sty2))
+            for attr in ("fill", "stroke"):
+                v = el.get(attr)
+                if v: el.set(attr, resolve_paint(v, stroke, fill))
+        return m
+
+    def get_marker_ref(el, pos):
+        sty = parse_style(el)
+        raw = (sty.get(pos) or el.get(pos) or "").strip()
+        mo  = _URL_RE.match(raw)
+        return mo.group(1) if mo else None
+
+    def set_marker_ref(el, pos, url):
+        sty = parse_style(el)
+        if pos in sty:
+            sty[pos] = url; el.set("style", emit_style(sty))
+        else:
+            el.set(pos, url)
 
     for svg_file in glob.glob(
         os.path.join(directory, "**", "*.svg"), recursive=True
@@ -4372,40 +4424,40 @@ def _downgrade_svg2_for_batik(directory):
             if href and use.get(xhref) is None:
                 use.set(xhref, href); del use.attrib["href"]; changed = True
 
-        # a marker placed at a "marker-start" needs a 180-degree twin,
-        # since SVG 1.1 "auto" cannot express the reversal "auto-start-reverse"
-        start_references = set(
-            element.get("marker-start")
-            for element in root.iter()
-            if element.get("marker-start")
-        )
-        reversed_twin = {}
-        for marker in list(root.iter(tag("marker"))):
-            if marker.get("orient") != "auto-start-reverse":
-                continue
-            marker.set("orient", "auto")
-            changed = True
-            marker_id = marker.get("id")
-            reference = "url(#{})".format(marker_id) if marker_id else None
-            if reference and reference in start_references:
-                twin = copy.deepcopy(marker)
-                twin.set("id", "{}-start".format(marker_id))
-                rotation = ET.Element(tag("g"))
-                rotation.set(
-                    "transform",
-                    "rotate(180 {} {})".format(twin.get("refX", "0"), twin.get("refY", "0")),
-                )
-                for child in list(twin):
-                    twin.remove(child)
-                    rotation.append(child)
-                twin.append(rotation)
-                marker.getparent().append(twin)
-                reversed_twin[reference] = "url(#{}-start)".format(marker_id)
+        bad = {el.get("id"): el for el in root.iter(tag("marker"))
+               if el.get("id") and is_svg2_marker(el)}
+        if bad:
+            defs = root.find(tag("defs"))
+            if defs is None:
+                defs = ET.SubElement(root, tag("defs"))
+            key_map  = {}   # (orig_id, stroke, fill, rotate) → new_id
+            new_mkrs = {}   # new_id → marker element
+            used_ids = set()
 
-        for element in root.iter():
-            replacement = reversed_twin.get(element.get("marker-start"))
-            if replacement is not None:
-                element.set("marker-start", replacement)
+            for el in root.iter():
+                for pos in POSITIONS:
+                    mid = get_marker_ref(el, pos)
+                    if not mid or mid not in bad: continue
+                    stroke = get_prop(el, "stroke") or "black"
+                    fill   = get_prop(el, "fill")   or "black"
+                    rotate = (pos == "marker-start" and
+                              bad[mid].get("orient") == "auto-start-reverse")
+                    key = (mid, stroke, fill, rotate)
+                    if key not in key_map:
+                        suffix = "start" if rotate else "end"
+                        base   = f"{mid}-{suffix}"
+                        nid    = base
+                        n      = 0
+                        while nid in used_ids: n += 1; nid = f"{base}-{n}"
+                        used_ids.add(nid)
+                        key_map[key] = nid
+                        new_mkrs[nid] = make_marker(bad[mid], nid, stroke, fill, rotate)
+                    set_marker_ref(el, pos, f"url(#{key_map[key]})")
+
+            for m in new_mkrs.values(): defs.append(m)
+            for m in bad.values():
+                if m.getparent() is not None: defs.remove(m)
+            changed = True
 
         if changed:
             tree.write(svg_file)

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4334,21 +4334,27 @@ def _downgrade_svg2_for_batik(directory):
       the marker as marker-start get a rotated (180°) copy (id suffix
       "-start").
     * Plain href on <use>: migrated to xlink:href.
+    * fill="transparent" → fill="none"; hsl()/rgb() colour functions and
+      CSS filter functions in <style> blocks rewritten to values Batik
+      accepts.
     """
     # TODO (2026-07-03) This function may modify SVG 1.1 files coming
     # from PreFigure that are known to be good for Batik to ingest.
     # With access to source, we can determine filenames to avoid.
 
-    import glob, copy, re
+    import glob, copy, re, colorsys
     import lxml.etree as ET
 
-    SVG       = "http://www.w3.org/2000/svg"
-    XLINK     = "http://www.w3.org/1999/xlink"
+    SVG           = "http://www.w3.org/2000/svg"
+    XLINK         = "http://www.w3.org/1999/xlink"
     ET.register_namespace("xlink", XLINK)
-    tag       = lambda t: f"{{{SVG}}}{t}"
-    xhref     = f"{{{XLINK}}}href"
-    POSITIONS = ("marker-start", "marker-end", "marker-mid")
-    _URL_RE   = re.compile(r"^url\(#([^)]+)\)$")
+    tag           = lambda t: f"{{{SVG}}}{t}"
+    xhref         = f"{{{XLINK}}}href"
+    POSITIONS     = ("marker-start", "marker-end", "marker-mid")
+    _URL_RE       = re.compile(r"^url\(#([^)]+)\)$")
+    _HSL_RE       = re.compile(r"hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)")
+    _RGB_RE       = re.compile(r"rgb\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)")
+    _FILTER_FN_RE = re.compile(r"(filter\s*:)\s*([^;{}]+)")
 
     def parse_style(el):
         d = {}
@@ -4361,6 +4367,22 @@ def _downgrade_svg2_for_batik(directory):
 
     def get_prop(el, prop):
         return parse_style(el).get(prop) or el.get(prop)
+
+    def _hsl_to_hex(m):
+        h, s, l = float(m.group(1))/360, float(m.group(2))/100, float(m.group(3))/100
+        r, g, b = colorsys.hls_to_rgb(h, l, s)
+        return "#{:02x}{:02x}{:02x}".format(round(r*255), round(g*255), round(b*255))
+
+    def _rgb_to_hex(m):
+        return "#{:02x}{:02x}{:02x}".format(
+            round(float(m.group(1))), round(float(m.group(2))), round(float(m.group(3)))
+        )
+
+    def _strip_filter_fn(m):
+        val = m.group(2).strip()
+        if "(" in val and not val.startswith("url("):
+            return m.group(1) + "none"
+        return m.group(0)
 
     def has_context_paint(marker):
         return any(
@@ -4423,6 +4445,27 @@ def _downgrade_svg2_for_batik(directory):
             href = use.get("href")
             if href and use.get(xhref) is None:
                 use.set(xhref, href); del use.attrib["href"]; changed = True
+
+        # "transparent" is a CSS3 colour keyword, not SVG 1.1;
+        # hsl()/rgb() in presentation attributes are also rewritten here.
+        for el in root.iter():
+            if el.get("fill") == "transparent":
+                el.set("fill", "none"); changed = True
+            for attr in ("fill", "stroke"):
+                v = el.get(attr)
+                if v:
+                    nv = _HSL_RE.sub(_hsl_to_hex, v)
+                    nv = _RGB_RE.sub(_rgb_to_hex, nv)
+                    if nv != v:
+                        el.set(attr, nv); changed = True
+        for el in root.iter(tag("style")):
+            if not el.text: continue
+            t = el.text.replace("transparent", "none")
+            t = _HSL_RE.sub(_hsl_to_hex, t)
+            t = _RGB_RE.sub(_rgb_to_hex, t)
+            t = _FILTER_FN_RE.sub(_strip_filter_fn, t)
+            if t != el.text:
+                el.text = t; changed = True
 
         bad = {el.get("id"): el for el in root.iter(tag("marker"))
                if el.get("id") and is_svg2_marker(el)}


### PR DESCRIPTION
## Summary

Apache FOP renders SVG images via Apache Batik, an SVG 1.1 implementation. When a PreTeXt document includes mermaid diagrams (sequence, git, class), the SVGs mermaid generates use several SVG 2 and CSS3 features that cause Batik to abort rendering entirely, producing blank or broken images in PDF output. This PR extends the existing `_downgrade_svg2_for_batik()` function — which already handled `href`→`xlink:href` and `orient="auto-start-reverse"` — with five additional fixes.

## Changes

The commits are organized so each adds one independent fix:

1. **Preamble refactor** — Introduces shared helpers (`parse_style`, `emit_style`, `get_prop`, `tag()`) and compact namespace constants to reduce boilerplate in subsequent fixes. No behavior change.

2. **`context-stroke`/`context-fill` in marker content** — Replaces the previous simple twin-marker approach with a full context-paint resolver. For each marker using `context-stroke` or `context-fill`, a concrete copy is created per referencing element's stroke/fill color. Copies with the same color and orientation are deduplicated. The `orient="auto-start-reverse"` handling (rotate-180 twin) is subsumed here.

3. **Color and CSS property normalization** — Batik rejects `fill="transparent"` (a CSS3 keyword), `hsl()`/`rgb()` color functions, and CSS filter functions such as `drop-shadow()`. These are rewritten to SVG 1.1-compatible values: `none`, hex colors, and `filter:none` respectively.

4. **`dominant-baseline`/`alignment-baseline` on `<text>`** — Batik does not reliably support `dominant-baseline` on `<text>` elements, and `alignment-baseline` is not valid in SVG 1.1. For centering values (`central`, `middle`), the intended visual center is computed from the element's `y` + `dy` (with em→px conversion), a 0.35em alphabetic-baseline offset is added, and the result is written as a plain numeric `y`. All `dy` attributes are then removed from the `<text>` and its `<tspan>` children to avoid Batik's inconsistent dy/tspan handling.

5. **Mermaid git branch label placement** — Mermaid git diagrams render branch labels as `<text><tspan dy="1em">…</tspan></text>` with no `y` on the `<text>` element. Batik ignores a tspan's `dy` when the parent `<text>` has no `y`, placing text at `y=0` in the enclosing group's coordinate space (typically off the top of the diagram). The first tspan's `dy` is promoted to an explicit `y` on the `<text>`.

6. **`<foreignObject>` → SVG `<text>` for mermaid class diagrams** — Mermaid class diagrams render all text (class titles, attributes, methods) as `<foreignObject>` containing XHTML `<div>`/`<span>` elements. Batik cannot render `<foreignObject>`, so all class diagram text was invisible. Each `foreignObject` is replaced by an SVG `<text>` element whose position is derived from the element's `translate()` transform and `width`/`height` attributes. `classTitle` elements are centre-anchored; all others are left-aligned.

## Testing

Tested against the `examples/sample-article` document in this repository, which includes mermaid sequence, git, class, and ELK-layout class diagrams. All four diagrams render correctly in PDF output after this fix.

## Caveats

- The 0.35em centering offset in fix 4 is a heuristic for Latin text at typical font sizes; it may not be pixel-perfect for all fonts.
- The function currently processes all SVGs in the FOP staging directory, including PreFigure SVGs (which are already SVG 1.1-compliant). A future improvement could skip known-clean files.