### PR TITLE
Validation: message identifiers, terse reports, tidier paths

### DIFF
--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -34,9 +34,9 @@
                 <cline>pretext/pretext -V -p publication.xml aota.xml</cline>
             </cd>This deposits two files, named for your source file.  One, ending <c>-validation.txt</c>, is a consolidated report: messages from <c>jing</c> checking the <acro>RELAX-NG</acro> schema, followed by messages from the validation-plus stylesheet (<xref ref="validation-plus"/>), each batch clearly delineated, and all prefaced by an explanation of how to read the report.  The other file, ending <c>-assembled.xml</c>, is the version of your source that was examined: your modular source files knitted together (<xref ref="processing-modular"/>), <em>after</em> any version support in your publication file has been applied (so, include <c>-p</c> if you use a publication file).  In particular, an element excluded from the version being built cannot raise a message.  There is no need for any of the <c>xinclude</c> command-line gymnastics described in the following subsections<mdash/>the script has already merged your modular source files.</p>
 
-            <p>Each message locates its problem four ways.  A <c>file</c> line names the source file where the problem lies, even when your project is modularized.  A <c>path</c> line locates the problem within the assembled source, counting elements of each name, so<cd>
-                <cline>path: /pretext[1]/book[1]/chapter[7]/section[2]/p[13]/em[2]</cline>
-            </cd>is the second <tag>em</tag> within the thirteenth <tag>p</tag> of the second <tag>section</tag> of the seventh <tag>chapter</tag> of the book.  (Counts are of elements with the same name: that paragraph is the thirteenth <tag>p</tag> of its section, though other elements may precede it or intervene.)  A <c>line</c> line gives a line number, and a <c>text</c> line excerpts the offending content.  Take care: only <c>file</c> points into your own source files<mdash/>the line number is a line of the deposited assembled source, never of one of your files, since assembly shifts everything about.</p>
+            <p>Each message locates its problem four ways, and then names the check that raised it.  A <c>file</c> line names the source file where the problem lies, even when your project is modularized.  A <c>path</c> line locates the problem within the assembled source, counting elements of each name, so<cd>
+                <cline>path: /pretext/book/chapter[7]/section[2]/p[13]/em[2]</cline>
+            </cd>is the second <tag>em</tag> within the thirteenth <tag>p</tag> of the second <tag>section</tag> of the seventh <tag>chapter</tag> of the book.  (Counts are of elements with the same name: that paragraph is the thirteenth <tag>p</tag> of its section, though other elements may precede it or intervene.  An element without a count, like the <tag>book</tag> above, is the only element of that name at its location, so a count would just be clutter.)  A <c>line</c> line gives a line number, and a <c>text</c> line excerpts the offending content.  Take care: only <c>file</c> points into your own source files<mdash/>the line number is a line of the deposited assembled source, never of one of your files, since assembly shifts everything about.  Finally, a <c>check</c> line carries a short name for the check raising the message, such as <c>image-description-missing</c>; every message from <c>jing</c> is named <c>schema</c>.</p>
 
             <p>The script locates <c>jing</c> through the <c>[executables]</c> section of its configuration file (see the notes at the top of <c>pretext/pretext.cfg</c> about making a copy in <c>user/pretext.cfg</c>).  The default entry,<cd>
                 <cline>jing = jing</cline>
@@ -44,25 +44,25 @@
                 <cline>jing = java -jar /usr/share/java/jing.jar</cline>
             </cd>Anything after the executable name is passed along as options, as for other configured executables.</p>
 
-            <p>Two other methods may be elected with the <c>-M</c> switch.  <c>-M local-dev</c> is identical, but checks against the development schema (<c>pretext-dev.rng</c>), which additionally describes new and experimental parts of the vocabulary.  <c>-M server</c> bundles your source files and ships them to a validation server for processing, so no <c>jing</c> installation is necessary at all.</p>
+            <p>Three other methods may be elected with the <c>-M</c> switch.  <c>-M local-dev</c> is identical, but checks against the development schema (<c>pretext-dev.rng</c>), which additionally describes new and experimental parts of the vocabulary.  <c>-M server</c> bundles your source files and ships them to a validation server for processing, so no <c>jing</c> installation is necessary at all.  <c>-M terse</c> produces the machine-readable report described in <xref ref="validation-terse"/>.</p>
 
             <p>Incidentally, the <c>lxml</c> library the script relies on has <acro>RELAX-NG</acro> validation built in, and you might wonder why it is not employed for this purpose.  It cannot process the <c>externalRef</c> construction the schema uses (for PreFigure diagrams), and even given a reduced schema it reports only a small fraction of the problems <c>jing</c> finds, with messages that suggest an arbitrary alternative rather than describe the error.</p>
         </subsection>
 
-        <subsection xml:id="validation-agent">
+        <subsection xml:id="validation-terse">
             <title>Validation for Programs</title>
 
-            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The library function underlying the <c>-V</c> switch accepts an <c>agent</c> method for exactly this purpose: the report is one line per message, four tab-separated fields<mdash/>file, path, line, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.)  This method is deliberately not elective from the <c>pretext/pretext</c> command line; instead a driver program calls the library directly.  The following complete driver prints the report on standard output, and is simple enough to serve as a model.<listing>
+            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The <c>terse</c> method serves exactly this purpose: the report is one line per message, five tab-separated fields<mdash/>file, path, line, check, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.  Sorting on the <c>check</c> field clusters occurrences of the same problem.)  Elect it with <c>-V -M terse</c> at the command line, or call the library directly, as in the following complete driver, which prints the report on standard output and is simple enough to serve as a model.<listing>
                 <title>A driver for machine-readable validation</title>
                 <program language="python">
                     <code>
 #!/usr/bin/env python3
 # A minimal driver for PreTeXt validation with machine-readable
 # output.  Each line of the report is tab-separated:
-# file, path, line, message.
+# file, path, line, check, message.
 #
 # Usage:
-#   python3 validate-agent.py /path/to/pretext source.xml [publication.xml]
+#   python3 validate-terse.py /path/to/pretext source.xml [publication.xml]
 
 import os.path
 import sys
@@ -81,7 +81,7 @@ from lib import common
 common.set_executables({"jing": "jing"})
 
 report = "validation-report.txt"
-ptx.validate(xml_source, publication, {}, report, None, "agent")
+ptx.validate(xml_source, publication, {}, report, None, "terse")
 with open(report) as f:
     sys.stdout.write(f.read())
                     </code>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4992,8 +4992,11 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
         elt = opening[near] if near is not None else None
         filename = file_of.get(elt, main_file)
         path = _numbered_path(elt) if elt is not None else ""
+        # every schema message is one check, named "schema"
         if terse:
-            report.append("{}\t{}\t{}\t{}".format(filename, path, line_number, body))
+            report.append(
+                "{}\t{}\t{}\tschema\t{}".format(filename, path, line_number, body)
+            )
         else:
             report.append(body)
             report.append("    file: {}".format(filename))
@@ -5002,6 +5005,7 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
             excerpt = _excerpt(line_number)
             if excerpt:
                 report.append("    text: {}".format(excerpt))
+            report.append("    check: schema")
             report.append("")
     if not terse and not jing_messages:
         report.extend(["(no messages)", ""])
@@ -5009,18 +5013,27 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
     if not terse:
         report.extend([banner, "Messages: PreTeXt \"validation-plus\" stylesheet", banner, ""])
     plus_form = re.compile(r"^(PTX:[A-Z]+): (/\S+) (.*)$")
+    # the message id trails the message text, set off in brackets
+    id_form = re.compile(r"^(.*) \[([a-z0-9-]+)\]$")
     for message in plus_messages:
         match = plus_form.match(message)
         if not match:
             report.append(message)
             continue
         severity, path, body = match.group(1), match.group(2), match.group(3)
+        id_match = id_form.match(body)
+        if id_match:
+            body, check_id = id_match.group(1), id_match.group(2)
+        else:
+            check_id = "no-validation-message-id-assigned"
         elt = _element_at_path(path)
         filename = file_of.get(elt, main_file)
         line_number = elt.sourceline if elt is not None else ""
         if terse:
             report.append(
-                "{}\t{}\t{}\t{}: {}".format(filename, path, line_number, severity, body)
+                "{}\t{}\t{}\t{}\t{}: {}".format(
+                    filename, path, line_number, check_id, severity, body
+                )
             )
         else:
             report.append("{}: {}".format(severity, body))
@@ -5031,6 +5044,7 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
                 excerpt = _excerpt(elt.sourceline)
                 if excerpt:
                     report.append("    text: {}".format(excerpt))
+            report.append("    check: {}".format(check_id))
             report.append("")
     if not terse and not plus_messages:
         report.extend(["(no messages)", ""])
@@ -5074,12 +5088,15 @@ def _validation_report_preamble(schema_filename, assembled_source):
         "has been deposited at",
         "    {}".format(assembled_source),
         "",
-        "Each message locates its problem four ways:",
+        "Each message locates its problem four ways, and then names",
+        "the check that raised it:",
         "",
-        "    file:  the source file where the problem lies",
-        "    path:  the location within the assembled source",
-        "    line:  the line number within the assembled source",
-        "    text:  an excerpt of the offending content",
+        "    file:   the source file where the problem lies",
+        "    path:   the location within the assembled source",
+        "    line:   the line number within the assembled source",
+        "    text:   an excerpt of the offending content",
+        "    check:  a short name for the check (\"schema\" for any",
+        "            message from \"jing\")",
         "",
         "Only \"file\" points into your own source files.  In particular,",
         "\"line\" is a line number of the deposited assembled source named",

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4763,14 +4763,14 @@ def validate(xml_source, pub_file, stringparams, out_file, dest_dir, method):
     else:
         # "local" validates against the production schema, and
         # "local-dev" against the development schema, each with a
-        # report meant for an author.  The "agent" method is the
-        # production schema with terse output meant for a program
-        # (and so is not elective from the "pretext/pretext" script).
+        # report meant for an author.  The "terse" method is the
+        # production schema with machine-readable output, one
+        # tab-separated message per line, meant for a program.
         if method == "local-dev":
             schema_file = "pretext-dev.rng"
         else:
             schema_file = "pretext.rng"
-        terse = method == "agent"
+        terse = method == "terse"
         _validate_local(
             xml_source, pub_file, stringparams, out_file, dest_dir, schema_file, terse
         )

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4916,15 +4916,25 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
                 for sib in elt.itersiblings(preceding=True)
                 if isinstance(sib.tag, str) and ET.QName(sib).localname == name
             )
-            parts.append("{}[{}]".format(name, position))
+            # a count is only informative among like-named siblings
+            alone = position == 1 and not any(
+                isinstance(sib.tag, str) and ET.QName(sib).localname == name
+                for sib in elt.itersiblings()
+            )
+            if alone:
+                parts.append(name)
+            else:
+                parts.append("{}[{}]".format(name, position))
             elt = elt.getparent()
         return "/" + "/".join(reversed(parts))
 
     def _element_at_path(path):
-        # follow a numbered path (as validation-plus produces)
+        # follow a numbered path (as validation-plus produces); a
+        # segment without a bracketed count means the only element
+        # of that name at its location, so a count of one
         elt = tree_b.getroot()
         segments = path.strip("/").split("/")
-        segment_pattern = re.compile(r"(.*)\[(\d+)\]")
+        segment_pattern = re.compile(r"([^\[\]]+)(?:\[(\d+)\])?$")
         first = segment_pattern.match(segments[0])
         if not first or ET.QName(elt).localname != first.group(1):
             return None
@@ -4932,7 +4942,8 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
             match = segment_pattern.match(segment)
             if not match:
                 return None
-            name, position = match.group(1), int(match.group(2))
+            name = match.group(1)
+            position = int(match.group(2)) if match.group(2) else 1
             count = 0
             found = None
             for child in elt:
@@ -5076,13 +5087,15 @@ def _validation_report_preamble(schema_filename, assembled_source):
         "",
         "To read a \"path\", count elements of each name.  For example,",
         "",
-        "    /pretext[1]/book[1]/chapter[7]/section[2]/p[13]/em[2]",
+        "    /pretext/book/chapter[7]/section[2]/p[13]/em[2]",
         "",
         "is the second \"em\" within the thirteenth \"p\" (paragraph) of the",
         "second \"section\" of the seventh \"chapter\" of the book.  Counts",
         "are of elements with the same name: that paragraph is the",
         "thirteenth \"p\" of its section, though other elements may precede",
-        "it or intervene.",
+        "it or intervene.  An element without a count, like the \"book\"",
+        "above, is the only element of that name at its location, so a",
+        "count would just be clutter.",
         "",
         "",
     ]

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4893,9 +4893,10 @@ def _validate_local(xml_source, pub_file, stringparams, out_file, dest_dir, sche
     jing_messages = result.stdout.splitlines()
 
     # The "validation-plus" stylesheet performs checks the RELAX-NG
-    # schema cannot express, and provides advice besides.  Applied to
-    # the same assembled source, so locations are consistent with the
-    # schema messages.  Single-line output, one message per line.
+    # schema cannot express, and provides extra advice and explanation
+    # besides.  Applied to the same assembled source, so locations are
+    # consistent with the schema messages.  Single-line output, one
+    # message per line.
     plus_xsl = os.path.join(
         common.get_ptx_path(), "schema", "pretext-validation-plus.xsl"
     )
@@ -5076,8 +5077,8 @@ def _validation_report_preamble(schema_filename, assembled_source):
         "      (a schema can only describe parent-child relationships,",
         "      plus the attributes of each element)",
         "  (2) the PreTeXt \"validation-plus\" stylesheet made checks that",
-        "      no RELAX-NG schema could ever express, and offers advice",
-        "      besides",
+        "      no RELAX-NG schema could ever express, and offers extra",
+        "      advice and explanation besides",
         "",
         "Locations refer to the ASSEMBLED version of your source: your",
         "modular source files have been knitted together, and any version",

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -189,10 +189,10 @@ def sanitize_method(method, component, format, validate):
         if not (method):
             return "local"
         # set, but illegal
-        elif not (method in ["local", "local-dev", "server"]):
+        elif not (method in ["local", "local-dev", "server", "terse"]):
             msg = "\n".join(
                 [
-                    'the method given for validation ("{}") is not "local", "local-dev", or "server",',
+                    'the method given for validation ("{}") is not "local", "local-dev", "server", or "terse",',
                     '              so using the default method instead ("local")',
                 ]
             )
@@ -539,6 +539,7 @@ def get_cli_arguments():
         ("local", 'employs an installed "jing" program (default)'),
         ("local-dev", 'as "local", but checks against the development schema'),
         ("server", "a round-trip to a validation server"),
+        ("terse", "machine-readable, one tab-separated message per line"),
     ]
     validate_help = "validate source, methods are:\n" + "\n".join(
         ["  {} - {}".format(info[0], info[1]) for info in validate_info]

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -604,9 +604,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:for-each select="$ancestors">
         <xsl:text>/</xsl:text>
         <xsl:value-of select="local-name(.)"/>
-        <xsl:text>[</xsl:text>
-        <xsl:number/>
-        <xsl:text>]</xsl:text>
+        <!-- A count is only informative among like-named siblings; for -->
+        <!-- an element that is the only one of its name, it is clutter -->
+        <xsl:variable name="elt-name" select="local-name(.)"/>
+        <xsl:if test="preceding-sibling::*[local-name() = $elt-name] or following-sibling::*[local-name() = $elt-name]">
+            <xsl:text>[</xsl:text>
+            <xsl:number/>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
     </xsl:for-each>
 </xsl:template>
 

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -65,6 +65,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="@filebase">
     <xsl:apply-templates select="parent::*" mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'deprecated-filebase'"/>
         <xsl:with-param name="message">
             <xsl:text>The @filebase attribute is deprecated (2014-05-04) and no code&#xa;</xsl:text>
             <xsl:text>remains (2018-07-21), convert to using @xml:id for this purpose</xsl:text>
@@ -77,6 +78,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="cite">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'deprecated-cite'"/>
         <xsl:with-param name="message">
             <xsl:text>The &lt;cite&gt; element is deprecated (2014-06-25) and no&#xa;</xsl:text>
             <xsl:text>code remains (2018-07-21), convert to an &lt;xref&gt;</xsl:text>
@@ -91,6 +93,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="circum">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'deprecated-circum'"/>
         <xsl:with-param name="message">
             <xsl:text>The &lt;circum&gt; element is deprecated (2015-01-28) and no&#xa;</xsl:text>
             <xsl:text>code remains (2018-07-22), convert to a &lt;circumflex&gt;</xsl:text>
@@ -103,6 +106,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="sage[@copy]">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'deprecated-sage-copy'"/>
         <xsl:with-param name="message">
             <xsl:text>@copy on a &quot;sage&quot; element was deprecated (2017-12-21)</xsl:text>
             <xsl:text>Use the xinclude mechanism with common code in an external file</xsl:text>
@@ -115,6 +119,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="image[@copy]">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'deprecated-image-copy'"/>
         <xsl:with-param name="message">
             <xsl:text>@copy on an &quot;image&quot; element was deprecated (2017-12-21)</xsl:text>
             <xsl:text>Perhaps use the xinclude mechanism with common code in an external file</xsl:text>
@@ -136,6 +141,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(id(@ref)/self::contributor)">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'author-xref-not-contributor'"/>
             <xsl:with-param name="message">
                 <xsl:text>An &lt;xref&gt; within an &lt;author&gt; is meant to point&#xa;</xsl:text>
                 <xsl:text>to a &lt;contributor&gt;, not to a &lt;</xsl:text>
@@ -154,6 +160,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="count(parent::docinfo/latex-image-preamble[not(@syntax)]) > 1">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'latex-image-preamble-duplicate'"/>
             <xsl:with-param name="message">
                 <xsl:text>There should be at most one &lt;latex-image-preamble&gt; without a&#xa;</xsl:text>
                 <xsl:text>@syntax within the &lt;docinfo&gt; element. There are more than one,&#xa;</xsl:text>
@@ -172,6 +179,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(ancestor::worksheet) and not(ancestor::handout)">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'workspace-attribute-ignored'"/>
             <xsl:with-param name="message">
                 <xsl:text>The @workspace attribute is only respected within a worksheet&#xa;</xsl:text>
                 <xsl:text>or a handout, and will be ignored here</xsl:text>
@@ -190,6 +198,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(ancestor::worksheet) and not(ancestor::handout)">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'sidebyside-exercise-placement'"/>
             <xsl:with-param name="message">
                 <xsl:text>An &lt;exercise&gt; as a panel of a &lt;sidebyside&gt; is only supported&#xa;</xsl:text>
                 <xsl:text>within a &lt;worksheet&gt; or a &lt;handout&gt;.  Here, results&#xa;</xsl:text>
@@ -209,6 +218,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="count(*[not(&METADATA-FILTER;)]) = 1">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'sidebyside-single-panel'"/>
             <xsl:with-param name="message">
                 <xsl:text>A &lt;sidebyside&gt; normally does not have a single panel.&#xa;</xsl:text>
                 <xsl:text>If this construct is only for layout control, try moving&#xa;</xsl:text>
@@ -236,6 +246,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="$unnumbered-context">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'numbered-item-unnumbered-container'"/>
             <xsl:with-param name="message">
                 <xsl:text>A &lt;</xsl:text>
                 <xsl:value-of select="local-name(.)"/>
@@ -273,6 +284,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="row[(count(cell[not(@colspan)]) + sum(cell/@colspan)) != number($reference-count)]">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'tabular-ragged-rows'"/>
             <xsl:with-param name="message">
                 <xsl:text>The rows of this &lt;tabular&gt; do not all span the same number of columns&#xa;</xsl:text>
                 <xsl:text>(counting each cell as its @colspan, or as one column otherwise).&#xa;</xsl:text>
@@ -289,6 +301,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="parent::chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary|backmatter and not(following-sibling::shorttitle)">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'title-math-no-shorttitle'"/>
             <xsl:with-param name="message">
                 <xsl:text>You have a title containing m but no shorttitle.&#xa;</xsl:text>
                 <xsl:text>Because this title will be used many places, errors may result.&#xa;</xsl:text>
@@ -309,6 +322,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(@decorative = 'yes') and (not(shortdescription) or shortdescription = '') and (not(description) or description = '')">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'image-description-missing'"/>
             <xsl:with-param name="message">
                 <xsl:text>You have an image without any description and do not declare the image to be decorative.&#xa;</xsl:text>
                 <xsl:text>Because of this, output may not be accessible.&#xa;</xsl:text>
@@ -321,6 +335,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="@decorative = 'yes' and ((shortdescription and not(shortdescription = '')) or (description and not(description = '')))">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'image-decorative-with-description'"/>
             <xsl:with-param name="message">
                 <xsl:text>You have an image with @decorative="yes" that also has a &lt;shortdescription&gt; or &lt;description&gt;.&#xa;</xsl:text>
                 <xsl:text>These may not appear in output.&#xa;</xsl:text>
@@ -331,6 +346,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="string-length(shortdescription) > 125">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'advice'"/>
+            <xsl:with-param name="message-id" select="'image-shortdescription-length'"/>
             <xsl:with-param name="message">
                 <xsl:text>You have an image &lt;shortdescription&gt; that is more than 125 characters long.&#xa;</xsl:text>
                 <xsl:text>Some screen readers will cut off reading alt text after the 125th character.&#xa;</xsl:text>
@@ -352,6 +368,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not(block/@order)">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'blocks-randomize-no-order'"/>
             <xsl:with-param name="message">
                 <xsl:text>A &lt;blocks&gt; element with @randomize="no" has no &lt;block&gt; carrying @order.&#xa;</xsl:text>
                 <xsl:text>The fixed rendering order will just be the authored order.&#xa;</xsl:text>
@@ -376,6 +393,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="var[not(ancestor::webwork)]">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'var-outside-webwork'"/>
         <xsl:with-param name="message">
             <xsl:text>The &lt;var&gt; element is exclusive to a WeBWorK problem,&#xa;</xsl:text>
             <xsl:text>and so must only appear within a &lt;webwork&gt; element,&#xa;</xsl:text>
@@ -391,6 +409,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="webwork//tabular/col/@top">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'warn'"/>
+        <xsl:with-param name="message-id" select="'webwork-tabular-col-top'"/>
         <xsl:with-param name="message">
             <xsl:text>Column-specific top border attributes are not implemented for the&#xa;</xsl:text>
             <xsl:text>output of a WeBWorK PG table produced by WeBWorK's hardcopy production engine</xsl:text>
@@ -401,6 +420,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="webwork//tabular/cell/@bottom">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'warn'"/>
+        <xsl:with-param name="message-id" select="'webwork-tabular-cell-bottom'"/>
         <xsl:with-param name="message">
             <xsl:text>Cell-specific bottom border border attributes are not implemented for the&#xa;</xsl:text>
             <xsl:text>output of a WeBWorK PG table produced by WeBWorK's hardcopy production engine</xsl:text>
@@ -411,6 +431,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="webwork//tabular/*[@top='medium' or @bottom='medium' or @left='medium' or @right='medium' or @top='major' or @bottom='major' or @left='major' or @right='major']">
     <xsl:apply-templates select="." mode="messaging">
         <xsl:with-param name="severity" select="'warn'"/>
+        <xsl:with-param name="message-id" select="'webwork-tabular-rule-thickness'"/>
         <xsl:with-param name="message">
             <xsl:text>'medium' or 'major' table rule attributes will be handled as 'minor' in the&#xa;</xsl:text>
             <xsl:text>output of a WeBWorK PG table produced by WeBWorK's hardcopy production engine</xsl:text>
@@ -445,6 +466,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x00B0;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-degree'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for a degree symbol (U+00B0, decimal 176).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -456,6 +478,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x00D7;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-multiplication-sign'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for a multiplication sign (U+00D7, decimal 215).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -467,6 +490,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x200B;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-zero-width-space'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for zero-width character (U+200B, decimal 8203).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -478,6 +502,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x2013;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-en-dash'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for an en-dash (U+2013, decimal 8211).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -491,6 +516,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x2014;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-em-dash'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for an em-dash (U+2014, decimal 8212).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -505,6 +531,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x2018;') or contains(., '&#x2019;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-single-quotes'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains Unicode characters for single quotation marks (U+2018, decimal 8216; U+2019, decimal 8217).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
@@ -520,6 +547,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:if test="contains(., '&#x201C;') or contains(., '&#x201D;')">
             <xsl:apply-templates select="." mode="messaging">
                 <xsl:with-param name="severity" select="'warn'"/>
+                <xsl:with-param name="message-id" select="'unicode-double-quotes'"/>
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains Unicode characters for double quotation marks (U+201C, decimal 8220; U+201D, decimal 8221).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -39,6 +39,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="single.line.output" select="'no'"/>
 <xsl:variable name="b-single-line" select="$single.line.output = 'yes'"/>
 
+<!-- The stylesheet makes checks that no RELAX-NG schema could ever      -->
+<!-- express, and offers extra advice and explanation besides.  So a     -->
+<!-- check may deliberately overlap the schema, when an explanation      -->
+<!-- is more helpful than a bare schema violation.                       -->
+
 <!-- Walk the tree, so messages appear in document order, not topically.  -->
 <!-- Be sure to recurse into larger elements after interrupting to        -->
 <!-- process certain situations.  This is not necessary for templates     -->
@@ -332,6 +337,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:with-param>
         </xsl:apply-templates>
     </xsl:if>
+    <!-- The schema also forbids descriptions of a decorative image, but -->
+    <!-- a schema violation cannot explain itself; this message can.     -->
     <xsl:if test="@decorative = 'yes' and ((shortdescription and not(shortdescription = '')) or (description and not(description = '')))">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -554,9 +554,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Messaging -->
 <!-- ######### -->
 
+<!-- Every message carries a "message-id": a short kebab-case mnemonic -->
+<!-- naming its check.  The id trails the message text, becomes a      -->
+<!-- field of machine-readable reports, and so clusters occurrences    -->
+<!-- of the same check.  The default value below signals an omission   -->
+<!-- (and could warrant a bug report): a new message must always       -->
+<!-- provide an id, something to check in a review of a pull request.  -->
 <xsl:template match="*|text()" mode="messaging">
     <xsl:param name="severity"/>
     <xsl:param name="message"/>
+    <xsl:param name="message-id" select="'no-validation-message-id-assigned'"/>
 
     <!-- Separator is noise for (sortable) single-line output -->
     <xsl:if test="not($b-single-line)">
@@ -594,6 +601,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$message"/>
         </xsl:otherwise>
     </xsl:choose>
+    <!-- the message id trails, on the same line when consolidated -->
+    <xsl:choose>
+        <xsl:when test="$b-single-line">
+            <xsl:text>&#x20;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>[</xsl:text>
+    <xsl:value-of select="$message-id"/>
+    <xsl:text>]</xsl:text>
     <!-- supply final newline always -->
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -300,40 +300,42 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
-<!-- Image elements should have meaningful descriptions.   -->
-<!-- We catch any "image" that does not either declare     -->
-<!-- @decorative="yes" or have a non-empty description.    -->
-<!-- Warn if there is a description and @decorative="yes". -->
-<!-- Warn if a description length is over 125 characters.  -->
+<!-- An accessible image carries a "shortdescription" (concise, it -->
+<!-- becomes alternative text), possibly augmented by a structured -->
+<!-- "description" (a longer account), or else is declared to be   -->
+<!-- decorative.  Examined exactly as authored: a legacy text-only -->
+<!-- "description" upgraded during a build is not upgraded here.   -->
 <xsl:template match="image">
-    <xsl:if test="not(@decorative = 'yes') and (not(description) or description = '')">
+    <xsl:if test="not(@decorative = 'yes') and (not(shortdescription) or shortdescription = '') and (not(description) or description = '')">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
             <xsl:with-param name="message">
-                <xsl:text>You have an image without a description and do not declare the image to be decorative.&#xa;</xsl:text>
+                <xsl:text>You have an image without any description and do not declare the image to be decorative.&#xa;</xsl:text>
                 <xsl:text>Because of this, output may not be accessible.&#xa;</xsl:text>
                 <xsl:text>If the image does not add information that is not already present, use @decorative="yes".&#xa;</xsl:text>
-                <xsl:text>Otherwise, provide a &lt;description&gt;.</xsl:text>
+                <xsl:text>Otherwise, provide a &lt;shortdescription&gt; (concise, it becomes alternative text),&#xa;</xsl:text>
+                <xsl:text>perhaps augmented by a structured &lt;description&gt;.</xsl:text>
             </xsl:with-param>
         </xsl:apply-templates>
     </xsl:if>
-    <xsl:if test="@decorative = 'yes' and description and not(description = '')">
+    <xsl:if test="@decorative = 'yes' and ((shortdescription and not(shortdescription = '')) or (description and not(description = '')))">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'warn'"/>
             <xsl:with-param name="message">
-                <xsl:text>You have an image with @decorative="yes" that has a nonempty description.&#xa;</xsl:text>
-                <xsl:text>The description may not appear in output.&#xa;</xsl:text>
-                <xsl:text>Either remove the description, remove @decorative, or change @decorative to "no".</xsl:text>
+                <xsl:text>You have an image with @decorative="yes" that also has a &lt;shortdescription&gt; or &lt;description&gt;.&#xa;</xsl:text>
+                <xsl:text>These may not appear in output.&#xa;</xsl:text>
+                <xsl:text>Either remove them, remove @decorative, or change @decorative to "no".</xsl:text>
             </xsl:with-param>
         </xsl:apply-templates>
     </xsl:if>
-    <xsl:if test="string-length(description) > 125">
+    <xsl:if test="string-length(shortdescription) > 125">
         <xsl:apply-templates select="." mode="messaging">
             <xsl:with-param name="severity" select="'advice'"/>
             <xsl:with-param name="message">
-                <xsl:text>You have an image description that is more than 125 characters long.&#xa;</xsl:text>
+                <xsl:text>You have an image &lt;shortdescription&gt; that is more than 125 characters long.&#xa;</xsl:text>
                 <xsl:text>Some screen readers will cut off reading alt text after the 125th character.&#xa;</xsl:text>
-                <xsl:text>Rewrite the description to be 125 characters or fewer.</xsl:text>
+                <xsl:text>Rewrite the &lt;shortdescription&gt; to be 125 characters or fewer,&#xa;</xsl:text>
+                <xsl:text>perhaps moving detail into a structured &lt;description&gt;.</xsl:text>
             </xsl:with-param>
         </xsl:apply-templates>
     </xsl:if>


### PR DESCRIPTION
Refinements to the consolidated validation report of #3004, in ten commits.

**Paths.** A location like `/pretext[1]/article[1]/introduction[1]/p[2]` is now `/pretext/article/introduction/p[2]`: an element that is the only one of its name at its location appears without a count, so a count that does appear is informative. The report's how-to-read preamble and the Guide describe the convention, and the path-to-element resolver accepts both forms.

**Message identifiers.** Every validation-plus message now carries a short kebab-case identifier naming its check (`tabular-ragged-rows`, `unicode-em-dash`, …), minted as a `message-id` parameter of the messaging template. A missing id does not halt processing; it surfaces as the default `no-validation-message-id-assigned`, flagging that a new message needs an id — something to check when reviewing a pull request. The human-readable report shows the id on a fifth `check:` line (`schema` for any message from `jing`); the machine-readable report carries it as the fourth of five tab-separated fields, so `sort` clusters occurrences of the same check.

**Terse reports from the command line.** The machine-readable method, formerly the library-only "agent", is renamed "terse" and is now elective: `-V -M terse`. The Guide's driver listing remains as the model for calling the library directly.

**Image description checks.** The validation-plus image checks now recognize `shortdescription`: an image with only a `shortdescription` no longer warns, the 125-character alternative-text advice targets `shortdescription` rather than the structured long `description`, and message texts present the current options (`@decorative="yes"`, `shortdescription`, structured `description`). On the sample article this retires 19 misdirected messages; `jing` messages are unchanged.

A final commit widens the stylesheet's stated purpose: checks no RELAX-NG schema could ever express, plus extra advice and explanation — a check may deliberately overlap the schema when an explanation is more helpful than a bare violation (the decorative-image check stays on this basis).

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
