### PR TITLE
Doc: align "update-sre" documentation with the MathJax 4 arrangement

### DIFF
--- a/doc/guide/appendices/offline-mathjax.xml
+++ b/doc/guide/appendices/offline-mathjax.xml
@@ -33,9 +33,9 @@
         <p>The <c>update-sre</c> script is supplied by <pretext/>.  It will create a file and a directory:<cd>
             <cline>/path/to/pretext/script/mjsre/package-lock.json</cline>
             <cline>/path/to/pretext/script/mjsre/node_modules</cline>
-        </cd>Neither will be tracked by <c>git</c>.  Since SRE changes faster than MathJax, this will replace MathJax's expectation for a version of SRE with a potentially newer version.  So do not be alarmed if it appears MathJax is missing a dependency, that is intentional.</p>
+        </cd>Neither will be tracked by <c>git</c>.  The versions of MathJax and <init>SRE</init> are pinned together, so when an update of <pretext/> adjusts either version, simply run the script again to refresh your installation.</p>
 
-        <p>Now you have copies of MathJax and SRE that can be used by the <c>pretext/pretext</c> script to process mathematics offline into useful formats for conversions to <init>EPUB</init>, Kindle, and braille.</p>
+        <p>Now you have copies of MathJax and SRE that can be used by the <c>pretext/pretext</c> script to process mathematics offline into useful formats for conversions to <init>EPUB</init>, Kindle, braille, and the <latex/>-free <init>PDF</init>.</p>
     </section>
 
 

--- a/script/mjsre/README.md
+++ b/script/mjsre/README.md
@@ -12,7 +12,9 @@ A `node` Javascript program to generate representations of
 mathematics as MathML, SVG, braille, and speech.
 
 ### `update-sre`
-bash script to manage npm installs, so SRE is not pinned to MJ.
+bash script to refresh the npm installation: discards
+`node_modules` and reinstalls the versions pinned by
+`package.json`.
 
 ### `package.json`
 Manages dependencies for npm installs.


### PR DESCRIPTION
Documentation follow-up to #2999. That upgrade removed the separate Speech Rule Engine install from `update-sre`, so SRE is now pinned in `package.json` to the version MathJax itself expects — but two descriptions still told the old story:

- `script/mjsre/README.md` said the script exists "so SRE is not pinned to MJ"; it now describes what the script actually does: discard `node_modules` and reinstall the versions pinned by `package.json`.
- The Guide's "Offline MathJax" appendix reassured authors that a seemingly mismatched SRE version is intentional; it now says the versions are pinned together, and to simply re-run the script when a PreTeXt update adjusts them. The list of consumers of the offline mathematics gains the LaTeX-free PDF.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
