### PR TITLE
Asymptote: use offscreen rendering for pdf, png, and eps

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -475,9 +475,9 @@ def asymptote_conversion(
                 # perhaps an older version is being employed
                 asy_cli = asy_executable_cmd + ["-f", outform, "-noV"]
                 if outform in ["pdf", "eps"]:
-                    asy_cli += ["-noprc", "-iconify", "-tex", "xelatex", "-batchMask"]
+                    asy_cli += ["-noprc", "-offscreen", "-tex", "xelatex", "-batchMask"]
                 elif outform in ["svg", "png"]:
-                    asy_cli += ["-render=4", "-tex", "xelatex", "-iconify"]
+                    asy_cli += ["-render=4", "-tex", "xelatex", "-offscreen"]
             if method == "server":
                 alberta = "http://asymptote.ualberta.ca:10007?f={}".format(outform)
             # loop over .asy files, doing conversions


### PR DESCRIPTION
The flag `-iconify` is now deprecated in recent versions of Asymptote.
Most users who are building Asymptote locally have an older version that ships with their TeX distribution, so the current command still works.
However, if we want to support Asymptote builds in GitHub codespaces (in particular, builds to PDF), this change is needed.

Notes:
- Testing suggests that this change has no effect on Windows and Linux for Asymptote circa 2.87
- To take advantage of offscreen rendering using Vulkan, Asymptote 3.13 or later is needed
- Asymptote 3.12 has a bug that causes OOM errors. There still seems to be a memory leak on Windows with 3.13, but I don't think there are many projects with more than 200 3D Asymptote images