### PR TITLE
Use asyncio.run for image generation, and make preview capture resilient

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1856,6 +1856,12 @@ def preview_images(xml_source, pub_file, stringparams, xmlid_root, dest_dir, met
         async with playwright.async_api.async_playwright() as pw:
             browser = await pw.chromium.launch()
             page = await browser.new_page()
+            # One uncooperative interactive should warn and be skipped, not
+            # abort the whole batch.  "fail_ms" bounds how long we wait on a
+            # broken interactive before abandoning it; it is separate from the
+            # fast/slow settle delay below, which paces a working interactive.
+            fail_ms = 5000
+            failures = []
             # First index contains original baseurl of hosted site (not used)
             for preview_fragment in interactives:
                 # loaded page url containing interactive
@@ -1870,17 +1876,24 @@ def preview_images(xml_source, pub_file, stringparams, xmlid_root, dest_dir, met
                 msg = 'automatic screenshot of interactive with identifier "{}" on page {} to file {}'
                 log.info(msg.format(preview_fragment, input_page, filename))
 
-                # goto page and wait for content to load
-                await page.goto(input_page, wait_until='domcontentloaded')
-                # wait again, according to the value of the timeout,
-                # for more than just splash screens, etc
-                await page.wait_for_timeout(timeout)
-                # list of locations, need first (and only) one
-                elt = page.locator(xpath)
-                await elt.screenshot(path=filename, scale="css")
-
-                # copy
-                shutil.copy2(filename, dest_dir)
+                try:
+                    # goto page and wait for content to load
+                    await page.goto(input_page, wait_until='domcontentloaded', timeout=fail_ms)
+                    # wait again, according to the value of the timeout,
+                    # for more than just splash screens, etc
+                    await page.wait_for_timeout(timeout)
+                    # list of locations, need first (and only) one
+                    elt = page.locator(xpath)
+                    await elt.screenshot(path=filename, scale="css", timeout=fail_ms)
+                    # copy
+                    shutil.copy2(filename, dest_dir)
+                except Exception as e:
+                    failures.append(preview_fragment)
+                    msg = 'could not capture a preview image for the interactive with identifier "{}" ({}); a static substitute will be used'
+                    log.error(msg.format(preview_fragment, type(e).__name__))
+            if failures:
+                msg = '{} of {} interactive preview images captured; none produced for: {}'
+                log.error(msg.format(len(interactives) - len(failures), len(interactives), ", ".join(failures)))
             await browser.close()
 
     # Start http server in a thread

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1973,10 +1973,7 @@ def preview_images(xml_source, pub_file, stringparams, xmlid_root, dest_dir, met
             log.debug("Starting event loop for playwright, after starting server")
             port, server = start_server()
             baseurl = "http://localhost:{}".format(port)
-            asyncio.get_event_loop().run_until_complete(
-                generate_previews(interactives, baseurl, dest_dir, timeout)
-            )
-            # if this blows up, search for 'asyncio.get_event_loop() warning' in this file
+            asyncio.run(generate_previews(interactives, baseurl, dest_dir, timeout))
         finally:
             # close the server
             log.info("Closing http.server thread")

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2273,17 +2273,9 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
 
                             await browser.close()
 
-                    # convert to PDF
-                    asyncio.get_event_loop().run_until_complete(write_pdf(svg_string))
-                    # asyncio.get_event_loop() warning: this code assumes we are running from an synchronous context.
-                    # If called from some asynch function, by an outside tool, this will break. As will other uses in this file.
-                    # For a possible emergency fix see:
-                    # https://github.com/RunestoneInteractive/rs/pull/723
-                    # nested_asyncio did not work for RS as there were conflicts with other libraries.
-                    # get_event_loop is deprecated, so at some point we need to replace it - a permanent fix at that point would be nice
-                    # Official advice appears to be "rewrite anything that uses async to be async all the way up"
-                    # https://discuss.python.org/t/calling-coroutines-from-sync-code-2/24093/5
-                    # this warning referenced in other places... search for 'asyncio.get_event_loop() warning'
+                    # convert to PDF; asyncio.run requires a synchronous caller
+                    # and raises if a containing tool already runs an event loop
+                    asyncio.run(write_pdf(svg_string))
 
                     # Try to read the SVG width and set PreTeXt width based on document width assumptions
                     if svg_width_parsed:


### PR DESCRIPTION
## Summary

On recent Python (3.14), generating static preview images for interactive elements fails: `asyncio.get_event_loop()` no longer creates an event loop implicitly when none is running (a long-deprecated behavior, now gone). Reported on the pretext-support group by **Kyle Monette**.

This replaces both `asyncio.get_event_loop().run_until_complete(...)` call sites with `asyncio.run(...)` — available since Python 3.7, well within the current 3.10 minimum — and makes preview generation robust to a single interactive that fails to render.

## Changes

1. **Preview images use `asyncio.run`** — the originating fix; the screenshot batch is launched with `asyncio.run(...)`.

2. **MyOpenMath image conversion uses `asyncio.run`** — the same deprecated pattern appears a second time, in the SVG→PDF/PNG conversion for static MyOpenMath problems, and would fail identically on 3.14. It gets the same fix, and the obsolete stopgap comment block is removed.

3. **Resume past a failed preview screenshot** — previously, one interactive whose iframe failed to render raised out of the capture loop and aborted the whole batch, silently losing every remaining preview. Now each interactive is attempted independently: a failure is logged as an error and skipped (its static substitute is used), and a run-ending summary reports how many were captured and which were not. A separate, modest failure timeout bounds how long a broken interactive is waited on so it fails fast; the existing fast/slow settle delay for working interactives is unchanged.

## Verification

- **Behavior preserved:** for interactives that render deterministically, `asyncio.run` yields byte-identical preview images to the previous path; an isolated test of the MyOpenMath SVG→PNG conversion on fixed input is likewise byte-identical.
- **Robustness:** a full run now captures the complete set of eligible previews instead of a variable partial set; when captures are forced to fail, the run proceeds through every interactive, logs one error per failure, prints the summary, and still exits successfully (previews are best-effort).

Credit to **Kyle Monette** for reporting the Python 3.14 failure.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
