### PR TITLE
Braille: re-architect the conversion — translate first, then a line/page renderer

### DIFF
--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -661,14 +661,21 @@ class BRF:
             self.write_fragment("text", sxml.text, None, s)
         children = list(sxml)
         for c in children:
+            # A child that is not a recognized typeface means the
+            # intermediate XML has structure nested inside a segment,
+            # which this renderer cannot express.  Degrade rather than
+            # halt: immediate text is rendered as plain text, and any
+            # content nested deeper is dropped from the output.
+            typeface = c.tag
+            if typeface not in ("italic", "bold", "code", "math"):
+                print('BUG: unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
+                typeface = "text"
             if c.text:
                 if 'punctuation' in c.attrib:
                     math_punctuation = c.attrib['punctuation']
                 else:
                     math_punctuation = None
-                # Following can help debug nested segments
-                # print("SUSPECT TYPEFACE", c.tag, c.text)
-                self.write_fragment(c.tag, c.text, math_punctuation, s)
+                self.write_fragment(typeface, c.text, math_punctuation, s)
             if c.tail:
                 self.write_fragment("text", c.tail, None, s)
 
@@ -880,14 +887,10 @@ class BRF:
         elif typeface == "code":
             typeforms = [BRF.trans1_bit] * len(aline)
         else:
-            print('BUG: did not recognize typeface "{}"'.format(typeface) )
-            # May be the Python error:
-            #    UnboundLocalError: local variable 'typeforms' referenced before assignment
-            # When this error message reports "segment" as the typeface,
-            # it means there are nested segments.  Search this module for
-            # "SUSPECT TYPEFACE" to find a useful debugging statement to use.
-            # Setting "typeforms = None" here can keep processing alive but is
-            # likely to lead to incorrect reesults.
+            # Callers vet typefaces, so this is a defensive fallback:
+            # translate as plain text rather than halt the conversion.
+            print('BUG: did not recognize typeface "{}"; translating as plain text'.format(typeface))
+            typeforms = None
 
         return louis.translateString(tableList, aline, typeforms, 0)
 

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -17,181 +17,41 @@
 # along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-# A routine PreTeXt package/module, so
-# natural to import at the module level
-# needs warning if not available
+# The braille renderer: the second of two passes.  The first pass
+# (braille_translate.py) made contracted UEB braille of all print
+# text, so this module knows nothing of translation; it knows cells,
+# lines, and pages.  It works in two stages:
+#
+#   * The LINE STAGE (LineComposer) forms the lines of one segment:
+#     word-wrapping, first-line indentation and runover, centering,
+#     Nemeth indicator fusing for inline mathematics.  It is
+#     position-aware -- the width of a line depends on whether it
+#     lands on the last line of an embossed page, where a page
+#     number lives -- but it writes nothing: it returns lines.
+#
+#   * The PAGE STAGE (PageComposer) pours lines onto pages: blank
+#     lines and their suppression at page tops, page-break avoidance
+#     for unbreakable material (arithmetic on line counts, computed
+#     by running the line stage as a trial), page numbers, and form
+#     feeds.
+#
+# The two stages communicate through Position objects (row on page,
+# page number), which advance deterministically, so a trial run of
+# the line stage answers "how many lines, crossing which pages?"
+# without rendering anything twice.
+
 import lxml.etree as ET
 
+# "common" holds the canonical __module_warning; we alias it here so the
+# warning below reads the same as everywhere else
+from . import common
+__module_warning = common.__module_warning
+
 # could import in a routine, but will do here in the module
-# Note: an import into the BRF class requires changes to the static method
 try:
     import louis
 except ImportError:
-    msg = 'The "louis" module, providing Python bindings for LibLouis, is required for Braille output.  See the PreTeXt Guide for instructions.'
-    raise ImportError(msg)
-
-# A  Cursor  object tracks location in a BRF file:
-# location in a line, line in a page, overall page number
-# It is initialized with the overall shape/body of a page
-# The location in a line is redundant given that it is easily
-# computable from the state of the line buffer.  But we can
-# base an assertion on a comparison of the two objects.  So
-# during active development we use both objects as a check
-# on the use of the line buffer.
-
-class Cursor:
-
-    def __init__(self, width, height, page_format):
-        # page shape, dimensions, at creation time
-        self.page_width = width
-        self.page_height = height
-        # Finally, we interpret `page_format`
-        if page_format == 'emboss':
-            self.emboss = True
-        elif page_format == 'electronic':
-            self.emboss = False
-        else:
-            print("BUG: page format not recognized, so embossing")
-            self.emboss = True
-        # we allow for variable length lines, in
-        # order to allow for insertion of page numbers
-        self.text_width = width
-        # initialize clean slate
-        # chars, lines are *remaining* room
-        # they will decrement to zero
-        self.chars_left = self.text_width
-        # Default brehavior is to form pages for embossing, which requires
-        # a lot of attention to page breaks and page numbers.  BUT, if we
-        # start with an absurd number of lines available, AND we never
-        # decrement the number of lines available then we will never think
-        # we are at the bottom of a page.  No page breaks, no adjustment of
-        # the page number, no writing out page numbers.   It is like the
-        # file is an infinitely long page.  See companion discussion
-        # at Cursor.advance_line().
-        if self.emboss:
-            self.lines_left = self.page_height
-        else:
-            self.lines_left = 2*self.page_height
-        # page_num is the page being produced
-        # increment as a new page begins
-        self.page_num = 1
-
-    # this includes the line currently under formation
-    def remaining_lines(self):
-        return self.lines_left
-
-    def remaining_characters(self):
-        return self.chars_left
-
-    def at_page_start(self):
-        return (self.chars_left == self.text_width) and (self.lines_left == self.page_height)
-
-    def page_number(self):
-        return self.page_num
-
-    def embossing(self):
-        return self.emboss
-
-    #########
-    # Actions
-    #########
-
-    def new_page(self):
-        # refresh lines remaining
-        self.lines_left = self.page_height
-        # increment page number
-        self.page_num += 1
-
-    def advance_line(self):
-        # decrement the lines available
-        # This is where we decrement the number of lines available
-        # on a page.  And it is the only place.  If not embossing,
-        # then no page, so we conspire to never change the lines
-        # available count.  It is like the file is an infinitely
-        # long page.  See companion discussion at Cursor.__init__().
-        if self.emboss:
-            self.lines_left -= 1
-        else:
-            pass
-
-        # Restore the number of available characters
-        self.chars_left = self.text_width
-
-        # falling off page end provokes new page
-        if self.lines_left == 0:
-            self.new_page()
-
-    # Note: it is possible to adjust text width
-    # while in the middle of forming a line
-    def adjust_text_width(self, adjustment):
-        self.text_width  += adjustment
-        self.chars_left  += adjustment
-
-    def advance(self, nchars):
-        # do not do this unless there is room
-        # does not provoke a new line
-        self.chars_left -= nchars
-        if self.chars_left < 0:
-            print("BUG: negative chars")
-
-# The line buffer is used to break a long line of words into
-# a sequence of lines that fit width-wise on a braille page.
-# The orignal `fragment` is assumed to have no line-breaks.
-# As we fill the line buffer, some spaces become newlines.
-# So in the usual parlance this is "text-wrapping".  However,
-# we also manage automatic page breaks once a page is full.
-
-
-class LineBuffer:
-
-    def __init__(self, width):
-        self.contents = ''
-        self.page_width = width
-        self.text_width = width
-
-    # Properties
-
-    def is_room(self, text):
-        return len(self.contents) + len(text) <= self.text_width
-
-    def is_empty(self):
-        return self.contents == ''
-
-    def remaining_chars(self):
-        return self.text_width - len(self.contents)
-
-    # Actions
-
-    def add(self, text):
-        self.contents += text
-
-    def adjust_text_width(self, adjustment):
-        self.text_width += adjustment
-
-    def flush(self, brf):
-        # Flushing the line buffer places the contents into
-        # the `out_buffer` of the BRF object provided.
-
-        # this does not write a newline character as we
-        # may want to end without provoking a new page
-        # Non-breaking spaces have done their job, and we
-        # do not want to see them in the BRF file.  Thanks,
-        # you are dismissed.
-        self.contents = self.contents.replace("\xA0", " ")
-
-        # Unlikely a non-breaking space may be at the end of a line,
-        # but we do this in a particular order just in case.
-        # Remove trailing spaces which are important for spacing off
-        # mixed content, but can end up at the end of a line where they
-        # are not needed.  This does not harm line-breaking, since if
-        # another word would fit, then the space would need to be there.
-        if not(self.contents == '') and self.contents[-1] == " ":
-            self.contents = self.contents[:-1]
-
-        # OK, the main event
-        brf.write(self.contents)
-        # Once written, reset contents
-        self.contents = ''
+    raise ImportError(__module_warning.format("louis"))
 
 
 class Segment:
@@ -199,9 +59,6 @@ class Segment:
     def __init__(self, s):
 
         self.xml = s
-
-        # For switching from indentation to runover
-        self.first_line = True
 
         # decipher, record attributes
         attrs = s.attrib
@@ -306,242 +163,162 @@ class Block:
             self.punctuation = None
 
 
-class BRF:
+class Position:
+    """Where the next line of content will land.
 
-    # spaces prior to a page number, duplicated in Cursor
+    row is 1-based: the line on the page about to be formed.  page
+    is the page number that row belongs to.  For electronic (single,
+    endless page) output, the row never advances past 1 of page 1 in
+    any meaningful way; see PageLayout.
+    """
+
+    def __init__(self, row, page):
+        self.row = row
+        self.page = page
+
+    def copy(self):
+        return Position(self.row, self.page)
+
+
+class PageLayout:
+    """The shape of a page, and what geometry implies for each line.
+
+    Embossed pages have a page number in the lower-right corner: the
+    last line of every page reserves separating space and the digits
+    of the number, so lines landing there are narrower.  Electronic
+    output is one endless page: no last lines, no numbers, no form
+    feeds.
+    """
+
+    # blank cells between content and a page number
     page_num_sep = 3
 
-    # Nemeth switch indicators, class variables for convenience
-    nemeth_open = "\u2838\u2829"
-    nemeth_close = "\u2838\u2831"
+    def __init__(self, width, height, page_format):
+        self.width = width
+        self.height = height
+        if page_format == 'emboss':
+            self.emboss = True
+        elif page_format == 'electronic':
+            self.emboss = False
+        else:
+            print("BUG: page format not recognized, so embossing")
+            self.emboss = True
 
-    def __init__(self, page_format, width, height, symbols):
-        self.out_buffer = ''
-        self.accumulator = []
-        self.toc_dict = {}
-        self.toc_mode = False
-        self.cursor = Cursor(width, height, page_format)
-        self.line_buffer = LineBuffer(width)
-        # "early": mathematics arrived as BRF ASCII symbols, so the
-        # renderer must not translate it.  "late": mathematics is
-        # Unicode braille cells, translated when written (dot-for-dot).
-        # The choice rides on the root element of the preprint.
-        self.symbols_early = (symbols == "early")
-        # True while the segments of a Nemeth display block are
-        # being written, since their content is mathematics
-        self.in_nemeth_box = False
+    def is_last_row(self, position):
+        return self.emboss and (position.row == self.height)
 
-    # Properties (boolean functions) reported
-    # by the current line buffer or default/embedded cursor
+    def text_width(self, position, reduction):
+        """Width available for content of the line at this position.
 
-    def is_room_on_line(self, text):
-        return self.line_buffer.is_room(text)
+        reduction is the caller's own reservation (centering margins,
+        table-of-contents page-number columns).
+        """
+        width = self.width - reduction
+        if self.is_last_row(position):
+            width -= (PageLayout.page_num_sep + len(braille_number(position.page)))
+        return width
+
+    def advance(self, position):
+        """The position of the line after this one."""
+        if self.emboss and (position.row == self.height):
+            return Position(1, position.page + 1)
+        else:
+            return Position(position.row + 1, position.page)
+
+    def at_page_start(self, position):
+        # The top of an embossed page.  Electronic output is never
+        # at a page start, not even at the very beginning -- so
+        # requested blank lines always appear.  (This mirrors
+        # long-standing behavior of the electronic layout.)
+        return self.emboss and (position.row == 1)
+
+
+# The UEB Grade 2 table includes Grade 1 explicitly
+_TABLES = ["en-ueb-g2.ctb"]
+
+# Nemeth switch indicators, Unicode braille cells
+NEMETH_OPEN = "⠸⠩"
+NEMETH_CLOSE = "⠸⠱"
+
+
+def translate_print(aline):
+    # Renderer-generated print (page numbers, guide dots) and
+    # Unicode braille cells (which convert dot-for-dot) become
+    # BRF ASCII symbols.  Body text never passes through here:
+    # it arrives already translated, typeforms and all, from the
+    # translation pass (braille_translate.py).
+    return louis.translateString(_TABLES, aline, None, 0)
+
+
+def contains_unicode_braille(aline):
+    # The blank cell U+2800 is excluded: alone it says nothing,
+    # since genuine mathematics always carries patterned cells
+    return any(("\u2801" <= c) and (c <= "\u28FF") for c in aline)
+
+
+# Page numbers appear on every embossed page, and every line of the
+# renderer's geometry needs their braille length, so memoize them
+_braille_numbers = {}
+
+def braille_number(number):
+    """The braille form of a page number (memoized)."""
+    if number not in _braille_numbers:
+        _braille_numbers[number] = translate_print(str(number))
+    return _braille_numbers[number]
+
+
+class LineComposer:
+    """The line stage: form the lines of one segment.
+
+    Position-aware but side-effect free: feed it the fragments of a
+    segment, collect completed lines (content only -- page numbers
+    and form feeds belong to the page stage).  Lines are accounted
+    against the layout as they complete, so widths follow the page
+    geometry, including the narrower last line of an embossed page.
+    """
+
+    def __init__(self, layout, position, seg, symbols_early, reduction):
+        self.layout = layout
+        self.position = position.copy()
+        self.seg = seg
+        self.symbols_early = symbols_early
+        # a standing reservation of cells (centering, ToC number column)
+        self.reduction = reduction
+        self.lines = []
+        self.contents = ''
+        self.first_line = True
+
+    # Properties
 
     def at_line_start(self):
-        return self.line_buffer.is_empty()
+        return self.contents == ''
 
-    # Designed for segments and blocks, to avoid poor placement
-    # near a page break.  Key is a trial/sandbox BRF object and
-    # its associated cursor.
-    #
-    #  * Trial does not provoke a page break.  Good.
-    #  * Trial provokes two page breaks.  Too bad, nothing to be done.
-    #  * Trial provokes exactly one page break.
-    #     - if content is more than a page, that's life
-    #     - see if content fits on a page, recommend a page advance
-    #
-    # Note: this is a bit disingenuous.  This allows both a segment
-    # and a block as an argument, on the assumption they have common
-    # attributes employed here.  Really they should be derived from
-    # a common object.  A switch on object type is necessary to call
-    # the two different BRF "process" methods, no matter what.
-    def needs_page_advance(self, seg):
-        import copy
+    def remaining_characters(self):
+        return self.layout.text_width(self.position, self.reduction) - len(self.contents)
 
-        # A "page" only makes sense if embossing
-        if not(self.cursor.embossing()):
-            return False
-
-        # If segment explicitly creates a new page,
-        # then the question of space is moot
-        if seg.ownpage or seg.newpage:
-            return False
-
-        # Line numbers could be actual line numbers for first and
-        # last line of content produced by the sandbox BRF.
-        # Formula would be
-        #
-        #     line-number = page-height - remaining-lines + 1
-        #
-        # We will subtract the starting line from the finishing line,
-        # so the page-heights and the "+1" will cancel out.  Thus
-        # definitions are just the negatives of the remaining lines.
-        #
-        # Segment processing always ends on a new line, so the finishing
-        # line has a "-1" to walk it back a line (and if the segment reset
-        # goes to a new page, then the remaining lines would be zero on
-        # the previous page, set to negative zero here).
-
-        orginal_cursor = self.cursor
-        start_page = orginal_cursor.page_number()
-        start_line = -orginal_cursor.remaining_lines()
-        # All changes (cursor movement, text-wrapping) occur in a
-        # throwaway renderer: empty, but positioned exactly where
-        # this one is.  Processing decisions depend only on the
-        # cursor, the line buffer, and the modes below -- never on
-        # accumulated output -- so the trial reproduces them
-        # faithfully at the cost of processing one segment.
-        page_format = 'emboss' if self.cursor.embossing() else 'electronic'
-        symbols = 'early' if self.symbols_early else 'late'
-        sandbox_brf = BRF(page_format, self.cursor.page_width, self.cursor.page_height, symbols)
-        sandbox_brf.cursor = copy.copy(self.cursor)
-        sandbox_brf.line_buffer = copy.copy(self.line_buffer)
-        sandbox_brf.toc_mode = self.toc_mode
-        sandbox_brf.toc_dict = dict(self.toc_dict)
-        sandbox_brf.in_nemeth_box = self.in_nemeth_box
-        sandbox_cursor = sandbox_brf.cursor
-        # Do the deal, in a sandbox
-        # Type will be "Block" or "Segment"
-        if type(seg) == Segment:
-            # Processing marches a segment's first_line marker
-            # forward, so a trial must restore it, else the real
-            # rendering would begin with runover indentation in
-            # place of first-line indentation.  (A block builds
-            # its interior segments afresh on every processing,
-            # so a trial of a block disturbs nothing.)
-            first_line = seg.first_line
-            sandbox_brf.process_segment(seg)
-            seg.first_line = first_line
-        else:
-            sandbox_brf.process_block(seg)
-        # Attach some lines of content, virtually
-        for i in range(seg.lines_following):
-            sandbox_cursor.advance_line()
-
-        finish_page = sandbox_cursor.page_number()
-        finish_line = -sandbox_cursor.remaining_lines() - 1
-        # Except, segment finishes ready-to-go,
-        # which could be the tip-top of the next page.
-        if sandbox_cursor.at_page_start():
-            finish_page -= 1
-            finish_line = -0
-
-        # Fine as-is, no page boundary has been broached
-        if (finish_page - start_page) == 0:
-            return False
-        # Really long, hopeless, a break doesn't help
-        elif (finish_page - start_page) > 1:
-            return False
-        # Exactly one page-break, so look to line numbers
-        # More than a page-full, since finish is later
-        elif finish_line - start_line >= 0:
-            return False
-        # There would be a break, and content would fit on the next
-        # page, so go for it and report the need for a page advance
-        else:
-            return True
-
+    def is_room(self, text):
+        return self.remaining_characters() - len(text) >= 0
 
     # Actions
 
-    def adjust_text_width(self, adjustment):
-        # Temporarily adjust the width of a page
-        # For example, to construct a centered heading,
-        # or to reserve space for a trailing page number.
-        # Argument is an adjustment to the current width
-        # (reduce with negative, then quickly restore with positive).
-        # A reduction must be while preparing a line, the ensuing
-        # expansion can (and often will) occur while mid-line.
-        if (adjustment < 0):
-            assert self.at_line_start(), "BUG: reducing text width, when not at a line start"
-        self.cursor.adjust_text_width(adjustment)
-        self.line_buffer.adjust_text_width(adjustment)
-
-    def write(self, text):
-        self.out_buffer += text
-
-    def advance_one_line(self):
-        # The last line needs a page number at its conclusion, so
-        # we need to (a) shorten the buffer going *into* forming
-        # that line, and (b) actually tack on the number. These
-        # booleans identify the line we are completing as we enter
-        # this method.
-        finish_penultimate = (self.cursor.remaining_lines() == 2)
-        finish_last = (self.cursor.remaining_lines() == 1)
-
-        # We need a braille version of the page number, for actual
-        # printing on the last line, or for adjusting the size of
-        # the line buffer for the last line prior to its formation.
-        if finish_penultimate or finish_last:
-            num = str(self.cursor.page_number())
-            braille_num = BRF.translate_print(num)
-
-        # before leaving last line, add a page number, flush right
-        if finish_last:
-            # a character (period?) here can aid debugging
-            gap = " " * (self.line_buffer.remaining_chars() + BRF.page_num_sep)
-            # this can exceed buffer, but we have no checks for that
-            self.line_buffer.add(gap + braille_num)
-
-        # flush the BRF's line buffer into its
-        # `out_buffer` while adding a newline
-        # TODO: have line_buffer return contents as
-        # a string, and .write() onto `out_buffer`
-        self.line_buffer.flush(self)
-        self.write("\n")
-
-        # Record the advance to new line.
-        # Note: this changes the number of remaining lines, which
-        # explains the two booleans above recording the situation
-        self.cursor.advance_line()
-
-        # If we flushed penultimate line, set up a reduced
-        # buffer for formation of the last line so there
-        # will be room for a page number
-        # Otherwise, restore the line buffer to its usual width
-        if finish_penultimate:
-            self.adjust_text_width( -(BRF.page_num_sep + len(braille_num)))
-        if finish_last:
-            self.adjust_text_width(  (BRF.page_num_sep + len(braille_num)))
-
-        # this can cause the cursor to move to the start of a new
-        # page if there were no more lines available on the page.
-        # So add FF (trl-L, ASCII 12, hex 0C) to the `out_buffer`
-        if self.cursor.at_page_start():
-            self.write("\x0C")
+    def break_line(self):
+        """Complete the line under formation, ready or not."""
+        # Non-breaking spaces have done their job, and we do not
+        # want to see them in the BRF file
+        contents = self.contents.replace("\xA0", " ")
+        # A trailing space is important for spacing off mixed
+        # content, but is not needed at the end of a line
+        if (contents != '') and (contents[-1] == " "):
+            contents = contents[:-1]
+        self.lines.append(contents)
+        self.contents = ''
+        self.position = self.layout.advance(self.position)
 
     def blank_line(self):
-        # We assume this method is only called when
-        # we are at the start of a fresh line, so
-        # flushing the line buffer does not produce
-        # any text (unless a page number is printed)
         assert self.at_line_start(), "BUG: creating a blank line, but not at the start of a line"
-        # `advance_one_line()` should flush an empty buffer,
-        # write a newline, and manage page number output
-        self.advance_one_line()
+        self.break_line()
 
-    def advance_page(self):
-        # It might look silly to call this complicated function when we
-        # could just drop a bunch of newlines into the `out_buffer`.
-        # But we can be sure a partial line is handled correctly and we
-        # can be sure a page number gets written properly in all cases.
-        # And the FF for the end of the page.
-
-        for i in range(self.cursor.remaining_lines()):
-            self.advance_one_line()
-        self.flush()
-        if self.cursor.embossing():
-            assert self.cursor.at_page_start(), "Page advance did not reach exactly the start of a new page"
-
-    def write_word(self, word):
-        # This assumes there is room on the current line
-        # so no adjustments are made to the cursor
-        assert self.line_buffer.remaining_chars() == self.cursor.remaining_characters(), "Cursor and LineBuffer have desynced"
-        self.cursor.advance(len(word))
-        self.line_buffer.add(word)
-
-    def write_fragment(self, typeface, aline, math_punctuation, seg):
-
+    def write_fragment(self, typeface, aline, math_punctuation):
         # Body text arrives from the translation pass as braille
         # already, so most fragments ride through untouched.  The
         # exceptions: inline mathematics ("math") gets Nemeth
@@ -554,221 +331,80 @@ class BRF:
         # After this, `aline` is a BRF string, with spaces, nbsps
         if typeface == "math":
             aline = self.massage_math(aline, math_punctuation)
-        elif self.symbols_early and self.in_nemeth_box and not(BRF.contains_unicode_braille(aline)):
+        elif self.symbols_early and (typeface == "display-math") and not(contains_unicode_braille(aline)):
             # display mathematics, already BRF ASCII symbols; blank
             # cells, arriving as no-break spaces, become the plain
             # spaces that a late election gets from liblouis
-            # (a line still holding cells has print residue, and falls
-            # through for the same translation as a late election)
             aline = aline.replace("\xA0", " ")
-        elif (typeface == "print") or BRF.contains_unicode_braille(aline):
-            aline = BRF.translate_print(aline)
+        elif (typeface == "print") or contains_unicode_braille(aline):
+            aline = translate_print(aline)
 
-        # When a word is output, it gets the space from the previous split,
-        # unless it is the first word of a line and the prior space became
-        # a newline character.
+        # When a word is output, it gets the space from the previous
+        # split, unless it is the first word of a line and the prior
+        # space became a newline character.
         prior_space = ""
 
-        # We chop down `aline` until there is nothing left.  When the first
-        # space is at the end of `aline` the split will yield an empty string
-        # as the second piece.  We do want this string to pass through the
-        # `while` again, to pick up the space we split on via `prior_space`.
-        # THEN the split yields just one piece and the while ends.  This is
-        # all a long excplnation of why we control the halting of the `while`
-        # loop rather than just testing that `aline` is empty.
-
+        # We chop down `aline` until there is nothing left.  When the
+        # first space is at the end of `aline` the split will yield an
+        # empty string as the second piece.  We do want this string to
+        # pass through the `while` again, to pick up the space we
+        # split on via `prior_space`.  THEN the split yields just one
+        # piece and the while ends.  This explains why we control the
+        # halting of the `while` loop rather than just testing that
+        # `aline` is empty.
         while aline != None:
             pieces = aline.split(" ", 1)
             word = pieces[0]
-            # if we add to current output line, how many characters would
-            # be left? A negative number is indicative of no room
-            # there *is* room for previous split and next word
             next_text = prior_space + word
 
-            # `aline` is non-empty, check if at line start
             # first line:  indent and flip switch permanently to False
             # later lines: use runover instead
             if self.at_line_start():
-                if seg.first_line:
-                    pad = seg.indentation
-                    seg.first_line = False
+                if self.first_line:
+                    pad = self.seg.indentation
+                    self.first_line = False
                 else:
-                    pad = seg.runover
+                    pad = self.seg.runover
                 next_text = (" " * pad) + next_text
 
-            if self.is_room_on_line(next_text):
-                # TODO: sanitize non-breaking space now, as it has
-                # served its purpose, but we don't want it in output
-                self.write_word(next_text)
+            if self.is_room(next_text):
+                self.contents += next_text
                 prior_space = " "
-                # update, or nullify, aline
                 if len(pieces) == 2:
                     aline = pieces[1]
                 else:
-                    # A 1-piece list after a split indicates there was no
-                    # space to split on, so `word` will have been written out.
-                    # Set `aline` to `None` as sentinel.  See above for rationale.
+                    # A 1-piece list after a split indicates there was
+                    # no space to split on, so `word` has been written
+                    # out.  Set `aline` to `None` as sentinel.
                     aline = None
             elif not(self.at_line_start()):
                 # no room, have a partial line already in place
                 # so move to a new line, i.e. "go around again"
                 # do not update  aline  as it can split again
                 prior_space = ""
-                self.advance_one_line()
+                self.break_line()
             else:
-                # this is bad - we are at the start of a new line already
-                # (on accident or by having gone around) and there is
-                # *still* not enough room
-                # So we brutally hypentate the word to just fit with a hyphen
-                whole_line = word[:(self.line_buffer.remaining_chars() - 1)] + "-"
-                # Put `aline` back together, but without the string `whole_line`.
-                # If there are more pieces we need to add back the space that
-                # disappeared in the split.  Otherwise this is the last word
-                # and it just got smaller.
-                aline = word[(self.line_buffer.remaining_chars() - 1):]
+                # at the start of a new line and there is *still* not
+                # enough room: brutally hyphenate the word to just fit
+                room = self.remaining_characters()
+                whole_line = word[:(room - 1)] + "-"
+                aline = word[(room - 1):]
                 if len(pieces) == 2:
                     aline += " " + pieces[1]
-                self.write_word(whole_line)
-
-    def center(self):
-        # Centered headings, may have blank lines
-        lines = self.out_buffer.split("\x0A")
-        nlines = len(lines)
-        # Replacing contents
-        self.out_buffer = ""
-        for i in range(nlines):
-            line = lines[i]
-            if line == "":
-                self.out_buffer += line
-            else:
-                pad = " " * ((self.line_buffer.text_width - len(line))//2)
-                self.out_buffer += pad + line
-            # Restore n-1 separators
-            if i != (nlines - 1):
-                self.out_buffer += "\x0A"
-
-    def process_segment(self, s):
-        '''For actual output, and for trial output with a disposable BRF'''
-
-        # Note: this routine will fill a buffer that is part of a BRF
-        # object.  It is independent of any file, so does not ever
-        # actually output anything.  There is a separate method for that.
-        # In this way, the method can be used in a trial fashion with a
-        # scratch/temporary BRF object to see how the Cursor behaves and
-        # thus if a segmant might cross a page boundary.
-
-        # Will always start a new segment at a fresh line
-        assert self.at_line_start(), "BUG: starting a segment, but not at the start of a line"
-
-        if s.newpage and self.cursor.embossing():
-            self.advance_page()
-
-        if s.ownpage and self.cursor.embossing():
-            self.advance_page()
-
-        # Lines before (but not if at the start of a page)
-        if not(self.cursor.at_page_start()):
-            for i in range(s.lines_before):
-                self.blank_line()
-
-        # Any page adjustments are now concluded, including a sandbox
-        # trial that may have necessitated a move to a new page.  If
-        # the segment is a heading it is about to be written on the
-        # page and the cursor knows the page number
-        if s.heading_id and self.cursor.embossing() and not(self.toc_mode):
-            self.toc_dict[s.heading_id] = self.cursor.page_number()
-
-        # Centered
-        # [BANA 2016],  4.4.2
-        # At least three blank cells must precede and follow a centered heading.
-        #
-        # So shrink line buffer to get extra space
-        if s.centered:
-            self.adjust_text_width(-6)
-
-        # If making segments/headings into ToC entries, then
-        # reserve 6 spaces to the right at all times, until
-        # just about to write the guide dots and page number
-        if self.toc_mode:
-            self.adjust_text_width(-6)
-
-        # The translation pass has already made braille of all the
-        # body text, so a segment holds braille text with "math"
-        # islands (inline mathematics awaiting Nemeth indicators
-        # and space fusing).  Anything else indicates the
-        # intermediate XML has structure this renderer cannot
-        # express.  Degrade rather than halt: immediate text is
-        # rendered as text, and content nested deeper is dropped.
-        sxml = s.xml
-        if sxml.text:
-            self.write_fragment("text", sxml.text, None, s)
-        children = list(sxml)
-        for c in children:
-            typeface = c.tag
-            if typeface != "math":
-                print('BUG: unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
-                typeface = "text"
-            if c.text:
-                if 'punctuation' in c.attrib:
-                    math_punctuation = c.attrib['punctuation']
-                else:
-                    math_punctuation = None
-                self.write_fragment(typeface, c.text, math_punctuation, s)
-            if c.tail:
-                self.write_fragment("text", c.tail, None, s)
-
-        # Release width restriction to finish ToC entry
-        if self.toc_mode:
-            self.adjust_text_width(6)
-            # Page numbers iff embossing
-            if self.cursor.embossing():
-                page_num = str(self.toc_dict[s.heading_id])
-                guide_dots = self.cursor.remaining_characters() - (1 + len(page_num))
-                guide = ['', '', '']
-                if guide_dots > 0:
-                    guide[0] = ' '
-                    guide_dots -= 1
-                if guide_dots > 0:
-                    guide[2] = ' '
-                    guide_dots -= 1
-                if guide_dots > 0:
-                    guide[1] = '\u2810' * guide_dots
-                # renderer-generated print: the page number digits
-                # (the guide dots are cells, converting dot-for-dot)
-                self.write_fragment("print", ''.join(guide) + page_num, None, s)
-
-        # finished with a segment
-        # flush buffer, move to new line, maybe a new page
-        # BUT not if we landed in this state anyway
-        if not(self.at_line_start()):
-            self.advance_one_line()
-        # Necessary to restore for subsequent centering
-        if s.centered:
-            self.adjust_text_width(6)
-        # Lines after
-        for i in range(s.lines_after):
-            self.blank_line()
-        # post-process before any use
-        if s.centered:
-            self.center()
-
-        # Dedicated page, so off we go (reqires something was written on page)
-        if s.ownpage and self.cursor.embossing():
-            self.advance_page()
-
+                self.contents += whole_line
 
     def massage_math(self, aline, punctuation):
 
         # available width will change across lines,
         # so this assumption is mildly flawed
-        width = self.line_buffer.page_width
+        width = self.layout.width
 
-        # Unicode versions of Nemeth switch indicators.
-        # We control separating spaces below as a way to
-        # influence line-breaking for inline math
-        # Local versions for convenience and manipulation
-        nemeth_open = BRF.nemeth_open
-        nemeth_close = BRF.nemeth_close
+        # Local versions of the Unicode Nemeth switch indicators,
+        # for convenience and manipulation.  We control separating
+        # spaces below as a way to influence line-breaking for
+        # inline math.
+        nemeth_open = NEMETH_OPEN
+        nemeth_close = NEMETH_CLOSE
 
         # Blank cells within the mathematics are just spaces-to-be:
         # make them spaces now, so the fusing below treats every
@@ -788,15 +424,15 @@ class BRF:
         # "early" was elected AND the preprint conversion found only
         # braille cells (mathematics with print residue rides along
         # as Unicode no matter the election, see the preprint XSL).
-        early_form = self.symbols_early and not(BRF.contains_unicode_braille(aline))
+        early_form = self.symbols_early and not(contains_unicode_braille(aline))
 
         # For the early form, the Unicode indicator chunks (with
         # punctuation attached) convert here, by the same translation
         # they would otherwise receive below, and the mathematics
         # itself rides along untouched.
         if early_form:
-            nemeth_open = louis.translateString(["en-ueb-g2.ctb"], nemeth_open, None, 0)
-            nemeth_close = louis.translateString(["en-ueb-g2.ctb"], nemeth_close, None, 0)
+            nemeth_open = translate_print(nemeth_open)
+            nemeth_close = translate_print(nemeth_close)
 
         # Actual Nemeth braille, plus 3, plus 3 for indicators, and punctuation
         math_len = len(aline) + 6 + punct_len
@@ -815,142 +451,389 @@ class BRF:
             aline = nemeth_open + "\xA0" + aline + "\xA0" + nemeth_close
 
         # Already BRF ASCII symbols throughout (early form); blank
-        # cells arrived as no-break spaces, which the line-breaking
-        # decisions above do not break on, and which become plain
-        # spaces when a completed line is written out
+        # cells became plain spaces above, with all the other blanks
         if early_form:
             return aline
 
         # Unicode characters translate, one for one, into BRF
         # characters and we assume punctuation does the same.
-        # If not, we could map a few punctuation marks to Unicode.
-        # Or perhaps set argument to do uncontracted braille.
-        return louis.translateString(["en-ueb-g2.ctb"], aline, None, 0)
+        return translate_print(aline)
 
-    def process_block(self, blk):
 
-        if blk.ownpage and self.cursor.embossing():
-            self.advance_page()
+class PageComposer:
+    """The page stage: pour lines onto pages.
 
-        # We don't want to start block material right at the bottom of
-        # the page when there are not enough lines to really get moving.
-        # Never start when there is one line left.  Most box material needs
-        # three lines, a preceding blank line, a box line, and a heading
-        # (maybe four lines? but three seems OK experimentally).
-        # Likely this needs refinement.
+    Tracks one Position; emits content lines with page numbers on
+    the last line of each embossed page and a form feed at each page
+    end; decides page-break avoidance for unbreakable material by
+    counting the lines a trial of the line stage produces.
+    """
+
+    def __init__(self, layout, symbols_early):
+        self.layout = layout
+        self.symbols_early = symbols_early
+        self.position = Position(1, 1)
+        # completed physical lines, tail-joined by newlines
+        self.output = []
+        # headings noted for the table of contents: identifier to page
+        self.toc_dict = {}
+        # producing table-of-contents entries (with a column of page
+        # numbers on the right)?
+        self.toc_mode = False
+
+    # Properties
+
+    def at_page_start(self):
+        return self.layout.at_page_start(self.position)
+
+    def remaining_lines(self):
+        # lines left on this page, including the one about to form
+        return self.layout.height - self.position.row + 1
+
+    # Actions
+
+    def emit_line(self, contents):
+        """One completed content line onto the page."""
+        if self.layout.is_last_row(self.position):
+            # right-justify the page number after the content
+            number = braille_number(self.position.page)
+            gap = " " * (self.layout.width - len(contents) - len(number))
+            contents = contents + gap + number
+        self.output.append(contents)
+        rollover = self.layout.is_last_row(self.position)
+        self.position = self.layout.advance(self.position)
+        if rollover:
+            # close the page with a form feed, on its own "line"
+            # joined to the page's last newline
+            self.output[-1] += "\n\x0C"
+        else:
+            self.output[-1] += "\n"
+
+    def blank_line(self):
+        self.emit_line('')
+
+    def advance_page(self):
+        # fill the remainder of the page with blank lines (the last
+        # of which carries the page number), ending with a form
+        # feed.  Note: from the top of a fresh page this produces an
+        # entire blank (but numbered) page, deliberately.
+        if not(self.layout.emboss):
+            return
+        for i in range(self.remaining_lines()):
+            self.blank_line()
+
+    # Rendering: each piece has a "compose" (line stage, no output)
+    # and a "write" (decide page breaks, then emit)
+
+    def compose_segment(self, seg, position):
+        """The line stage for one segment: content lines, no page furniture."""
+        # centering and table-of-contents entries reserve cells
+        reduction = 0
+        if seg.centered:
+            # [BANA 2016], 4.4.2: at least three blank cells must
+            # precede and follow a centered heading
+            reduction += 6
+        if self.toc_mode:
+            # reserve a column for guide dots and a page number,
+            # released just before they are written
+            reduction += 6
+
+        composer = LineComposer(self.layout, position, seg, self.symbols_early, reduction)
+
+        sxml = seg.xml
+        if sxml.text:
+            composer.write_fragment("text", sxml.text, None)
+        for c in sxml:
+            typeface = c.tag
+            if typeface != "math":
+                print('BUG: unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
+                typeface = "text"
+            if c.text:
+                if 'punctuation' in c.attrib:
+                    math_punctuation = c.attrib['punctuation']
+                else:
+                    math_punctuation = None
+                composer.write_fragment(typeface, c.text, math_punctuation)
+            if c.tail:
+                composer.write_fragment("text", c.tail, None)
+
+        # Finish the table-of-contents entry: release the reserved
+        # column, add guide dots and the target's page number
+        if self.toc_mode:
+            composer.reduction -= 6
+            if self.layout.emboss:
+                page_num = str(self.toc_dict[seg.heading_id])
+                guide_dots = composer.remaining_characters() - (1 + len(page_num))
+                guide = ['', '', '']
+                if guide_dots > 0:
+                    guide[0] = ' '
+                    guide_dots -= 1
+                if guide_dots > 0:
+                    guide[2] = ' '
+                    guide_dots -= 1
+                if guide_dots > 0:
+                    guide[1] = '⠐' * guide_dots
+                composer.write_fragment("print", ''.join(guide) + page_num, None)
+
+        # complete any partial line
+        if not(composer.at_line_start()):
+            composer.break_line()
+
+        lines = composer.lines
+        # center, in the full width (the reservation was symmetric)
+        if seg.centered:
+            centered = []
+            for line in lines:
+                if line == '':
+                    centered.append(line)
+                else:
+                    pad = " " * ((self.layout.width - len(line)) // 2)
+                    centered.append(pad + line)
+            lines = centered
+        return lines
+
+    def compose_display_segment(self, seg, position):
+        """The line stage for a segment of a Nemeth display block."""
+        composer = LineComposer(self.layout, position, seg, self.symbols_early, 0)
+        sxml = seg.xml
+        if sxml.text:
+            composer.write_fragment("display-math", sxml.text, None)
+        if not(composer.at_line_start()):
+            composer.break_line()
+        return composer.lines
+
+    def segment_lines(self, seg, position, in_nemeth_box):
+        if in_nemeth_box:
+            return self.compose_display_segment(seg, position)
+        else:
+            return self.compose_segment(seg, position)
+
+    def needs_page_advance(self, lines_count, lines_following):
+        """Would this content cross one page boundary it could avoid?
+
+        Content beginning at the current position, occupying
+        lines_count lines (blank lines included), keeping
+        lines_following more lines attached beyond that.
+        """
+        if not(self.layout.emboss):
+            return False
+        total = lines_count + lines_following
+        remaining = self.remaining_lines()
+        # fine as-is: no page boundary broached (landing exactly at
+        # the top of the next page does not count as broaching)
+        if total <= remaining:
+            return False
+        # hopeless: does not fit whole on a fresh page either
+        if total > self.layout.height:
+            return False
+        # would break, and would fit whole on the next page
+        return True
+
+    # The layout of blocks is written positionally below: the
+    # "lay_*" methods produce lines from a position, purely -- they
+    # serve as the trial machinery, and as the interior of blocks --
+    # while the "write_*" methods do the same work against the real
+    # position, emitting page furniture as they go.  Both make the
+    # identical decisions because both see only positions.
+
+    def lay_block(self, blk, position):
+        """Lines of a whole block laid from a position: (lines, position).
+
+        Interior segments make their own page-break-avoidance
+        decisions, positionally, just as they would at the top
+        level; interior blank-line demands are suppressed at page
+        tops; box rules follow the width of the line they land on.
+        """
+        lines = []
+        position = position.copy()
+
+        def emit(line):
+            nonlocal position
+            lines.append(line)
+            position = self.layout.advance(position)
+
+        def fill_page():
+            nonlocal position
+            if not(self.layout.emboss):
+                return
+            for i in range(self.layout.height - position.row + 1):
+                emit('')
+
+        if blk.box == "standard":
+            emit("7" * self.layout.text_width(position, 0))
+        elif blk.box == "nemeth":
+            emit(translate_print(NEMETH_OPEN))
+            emit('')
+
+        for child in blk.xml.xpath("segment|block"):
+            if child.tag == "segment":
+                seg = Segment(child)
+                if seg.newpage and self.layout.emboss:
+                    fill_page()
+                if seg.ownpage and self.layout.emboss:
+                    fill_page()
+                blanks = 0 if self.layout.at_page_start(position) else seg.lines_before
+                if not(seg.breakable) and self.layout.emboss and not(seg.ownpage or seg.newpage):
+                    trial_position = position.copy()
+                    for i in range(blanks):
+                        trial_position = self.layout.advance(trial_position)
+                    trial = self.segment_lines(seg, trial_position, blk.box == "nemeth")
+                    remaining = self.layout.height - position.row + 1
+                    total = blanks + len(trial) + seg.lines_after + seg.lines_following
+                    if (total > remaining) and (total <= self.layout.height):
+                        fill_page()
+                        blanks = 0
+                for i in range(blanks):
+                    emit('')
+                for line in self.segment_lines(seg, position, blk.box == "nemeth"):
+                    emit(line)
+                for i in range(seg.lines_after):
+                    emit('')
+                if seg.ownpage and self.layout.emboss:
+                    fill_page()
+            elif child.tag == "block":
+                inner = Block(child)
+                (inner_lines, position) = self.lay_inner_block(inner, position)
+                for line in inner_lines:
+                    lines.append(line)
+
+        if blk.box == "standard":
+            emit("g" * self.layout.text_width(position, 0))
+        elif blk.box == "nemeth":
+            emit('')
+            close_brf = NEMETH_CLOSE
+            if blk.punctuation:
+                close_brf += blk.punctuation
+            emit(translate_print(close_brf))
+
+        return (lines, position)
+
+    def lay_inner_block(self, blk, position):
+        """A block, with its surrounding decisions, laid from a position."""
+        lines = []
+        position = position.copy()
+
+        def emit(line):
+            nonlocal position
+            lines.append(line)
+            position = self.layout.advance(position)
+
+        def fill_page():
+            nonlocal position
+            if not(self.layout.emboss):
+                return
+            for i in range(self.layout.height - position.row + 1):
+                emit('')
+
+        if blk.ownpage and self.layout.emboss:
+            fill_page()
+        # avoid starting box material in the last sliver of a page
         initial_lines = 1
         if blk.box:
             initial_lines += 2
-        if (self.cursor.remaining_lines() < initial_lines) and self.cursor.embossing():
-            self.advance_page()
-
-        # Lines before (but not if at the start of a page)
-        if not(self.cursor.at_page_start()):
-            for i in range(blk.lines_before):
-                self.blank_line()
-
-        if blk.box == "standard":
-            top_line = "7" * self.line_buffer.text_width
-            self.write_word(top_line)
-            self.advance_one_line()
-        elif blk.box == "nemeth":
-            open_brf = louis.translateString(["en-ueb-g2.ctb"], BRF.nemeth_open, None, 0)
-            self.write_word(open_brf)
-            self.advance_one_line()
-            self.blank_line()
-
-        # Segments of a Nemeth display block hold mathematics, which
-        # matters when it arrived as BRF ASCII symbols ("early")
-        saved_nemeth_box = self.in_nemeth_box
-        self.in_nemeth_box = (blk.box == "nemeth")
-        inner_segments = blk.xml.xpath("segment|block")
-        for s in inner_segments:
-            if s.tag == "segment":
-                seg = Segment(s)
-                self.write_segment(seg)
-            elif s.tag == "block":
-                innerblk = Block(s)
-                self.write_block(innerblk)
-        self.in_nemeth_box = saved_nemeth_box
-
-        if blk.box == "standard":
-            bottom_line = "g" * self.line_buffer.text_width
-            self.write_word(bottom_line)
-            self.advance_one_line()
-        elif blk.box == "nemeth":
-            self.blank_line()
-            # add punctuation that was mined from trailing text
-            # node.  Note: only for Nemeth box/display math
-            close_brf = BRF.nemeth_close
-            if blk.punctuation:
-                close_brf += blk.punctuation
-            close_brf = louis.translateString(["en-ueb-g2.ctb"], close_brf, None, 0)
-            self.write_word(close_brf)
-            self.advance_one_line()
-
-        # Lines after
+        if self.layout.emboss and ((self.layout.height - position.row + 1) < initial_lines):
+            fill_page()
+        blanks = 0 if self.layout.at_page_start(position) else blk.lines_before
+        if not(blk.breakable) and self.layout.emboss and not(blk.ownpage):
+            trial_position = position.copy()
+            for i in range(blanks):
+                trial_position = self.layout.advance(trial_position)
+            (trial, _) = self.lay_block(blk, trial_position)
+            remaining = self.layout.height - position.row + 1
+            total = blanks + len(trial) + blk.lines_after + blk.lines_following
+            if (total > remaining) and (total <= self.layout.height):
+                fill_page()
+                blanks = 0
+        for i in range(blanks):
+            emit('')
+        (block_lines, position) = self.lay_block(blk, position)
+        for line in block_lines:
+            lines.append(line)
         for i in range(blk.lines_after):
-            self.blank_line()
-            self.flush()
-
-        # Dedicated page, so off we go (reqires something was written on page)
-        if blk.ownpage and self.cursor.embossing():
-            self.advance_page()
-
-
-    # The next two "write" routines simply check if a page advance
-    # is necessary/desirable for the block or segment in question,
-    # and then call the "process" versions, where the real action
-    # happens.  Then a flush.
+            emit('')
+        if blk.ownpage and self.layout.emboss:
+            fill_page()
+        return (lines, position)
 
     def write_segment(self, seg):
-        # See if a page advance will improve awkward page breaks
-        if not(seg.breakable) and self.needs_page_advance(seg):
+        if seg.newpage and self.layout.emboss:
             self.advance_page()
-        self.process_segment(seg)
-        self.flush()
+        if seg.ownpage and self.layout.emboss:
+            self.advance_page()
+
+        # blank lines before, suppressed at an embossed page top
+        blanks = 0 if self.at_page_start() else seg.lines_before
+
+        # page-break avoidance for unbreakable segments: count the
+        # lines of a trial laid from just past the blank lines
+        if not(seg.breakable) and self.layout.emboss and not(seg.ownpage or seg.newpage):
+            position = self.position.copy()
+            for i in range(blanks):
+                position = self.layout.advance(position)
+            trial = self.segment_lines(seg, position, False)
+            if self.needs_page_advance(blanks + len(trial) + seg.lines_after, seg.lines_following):
+                self.advance_page()
+                # a page top: blank lines are now suppressed
+                blanks = 0
+
+        for i in range(blanks):
+            self.blank_line()
+
+        # a heading is about to be written: record its page
+        if seg.heading_id and self.layout.emboss and not(self.toc_mode):
+            self.toc_dict[seg.heading_id] = self.position.page
+
+        for line in self.segment_lines(seg, self.position, False):
+            self.emit_line(line)
+
+        for i in range(seg.lines_after):
+            self.blank_line()
+
+        if seg.ownpage and self.layout.emboss:
+            self.advance_page()
 
     def write_block(self, blk):
-        # See if a page advance will improve awkward page breaks
-        if not(blk.breakable) and self.needs_page_advance(blk):
+        if blk.ownpage and self.layout.emboss:
             self.advance_page()
-        self.process_block(blk)
-        self.flush()
 
-    def flush(self):
-        # The `accumulator` *is* the final document, as a list of
-        # strings, so here we move the (completed) string for the
-        # segment into the list that will be concatenated.  And
-        # prepare the `out_buffer` for the next segment.
-        self.accumulator.append(self.out_buffer)
-        self.out_buffer = ''
+        # We don't want to start block material right at the bottom
+        # of the page when there are not enough lines to really get
+        # moving.  Most box material needs a blank line, a box line,
+        # and a heading.
+        initial_lines = 1
+        if blk.box:
+            initial_lines += 2
+        if self.layout.emboss and (self.remaining_lines() < initial_lines):
+            self.advance_page()
 
-    # Concatenate the strings of the `accumulator`
+        blanks = 0 if self.at_page_start() else blk.lines_before
+
+        if not(blk.breakable) and self.layout.emboss and not(blk.ownpage):
+            position = self.position.copy()
+            for i in range(blanks):
+                position = self.layout.advance(position)
+            (trial, _) = self.lay_block(blk, position)
+            if self.needs_page_advance(blanks + len(trial) + blk.lines_after, blk.lines_following):
+                self.advance_page()
+                blanks = 0
+
+        for i in range(blanks):
+            self.blank_line()
+
+        (block_lines, _) = self.lay_block(blk, self.position)
+        for line in block_lines:
+            self.emit_line(line)
+
+        for i in range(blk.lines_after):
+            self.blank_line()
+
+        if blk.ownpage and self.layout.emboss:
+            self.advance_page()
+
     def get_brf(self):
-        return ''.join(self.accumulator)
-
-    # Static methods
-
-    @staticmethod
-    def contains_unicode_braille(aline):
-        # The blank cell U+2800 is excluded: alone it says nothing,
-        # since genuine mathematics always carries patterned cells
-        return any(("\u2801" <= c) and (c <= "\u28FF") for c in aline)
-
-    @staticmethod
-    def translate_print(aline):
-        # Renderer-generated print (page numbers, guide dots) and
-        # Unicode braille cells (which convert dot-for-dot) become
-        # BRF ASCII symbols.  Body text never passes through here:
-        # it arrives already translated, typeforms and all, from the
-        # translation pass (braille_translate.py).
-        # g2 includes g1 explicitly
-        return louis.translateString(["en-ueb-g2.ctb"], aline, None, 0)
-
-    # End BRF object definition
+        return ''.join(self.output)
 
 
-# Current entry point, sort of
 def parse_segments(xml_simple, out_file, page_format):
 
     # this routine converts XML information into arguments
@@ -969,50 +852,44 @@ def parse_segments(xml_simple, out_file, page_format):
     # "late" is Unicode braille cells (the default), "early" is
     # BRF ASCII symbols (a developer convenience for debugging)
     symbols = src_tree.getroot().get("brf-symbols", "late")
+    symbols_early = (symbols == "early")
 
     # page geometry, elected in the publication file and validated
     # upstream: cells in a line, lines on an embossed page
     page_width = int(src_tree.getroot().get("page-width", "40"))
     page_height = int(src_tree.getroot().get("page-height", "25"))
 
-    # Embossed, page shape
-    brf = BRF(page_format, page_width, page_height, symbols)
+    layout = PageLayout(page_width, page_height, page_format)
 
-    top_elts = src_tree.xpath("/brf/segment|/brf/block")
-
-    for elt in top_elts:
+    # the body of the document
+    body = PageComposer(layout, symbols_early)
+    for elt in src_tree.xpath("/brf/segment|/brf/block"):
         if elt.tag == "segment":
-            seg = Segment(elt)
-            brf.write_segment(seg)
+            body.write_segment(Segment(elt))
         elif elt.tag == "block":
-            blk = Block(elt)
-            brf.write_block(blk)
-        brf.flush()
+            body.write_block(Block(elt))
 
-    # Prepare a new BRF object, but copy out ToC page numbers
-    front = BRF(page_format, page_width, page_height, symbols)
+    # The front matter (table of contents) knows the page number of
+    # each heading only after the body has been laid out, so it is
+    # rendered second, on its own pages, though it appears first in
+    # the file.
+    front = PageComposer(layout, symbols_early)
     front.toc_mode = True
-    front.toc_dict = brf.toc_dict
-
-    headings = src_tree.xpath("/brf/segment[@heading-id]")
-    for head in headings:
+    front.toc_dict = body.toc_dict
+    for head in src_tree.xpath("/brf/segment[@heading-id]"):
         seg = Segment(head)
         seg.newpage = False
         seg.ownpage = False
         seg.centered = False
         seg.breakable = False
-        # indentation, runover
         seg.lines_before = 0
         seg.lines_after = 0
         seg.lines_following = 0
         front.write_segment(seg)
-    # Fill out frontmatter final page
+    # fill out the final front-matter page
     if page_format == 'emboss':
         front.advance_page()
 
-    # We assume `out_file` has been error-checked
-    # It would be better to use a context manager
-    brf_file = open(out_file, "w")
-    brf_file.write(front.get_brf())
-    brf_file.write(brf.get_brf())
-    brf_file.close()
+    with open(out_file, "w") as brf_file:
+        brf_file.write(front.get_brf())
+        brf_file.write(body.get_brf())

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -320,13 +320,21 @@ class BRF:
     # to this variant when we translate inline code phrases
     trans1_bit = louis.getTypeformForEmphClass(["en-ueb-g2.ctb"], 'trans1')
 
-    def __init__(self, page_format, width, height):
+    def __init__(self, page_format, width, height, symbols):
         self.out_buffer = ''
         self.accumulator = []
         self.toc_dict = {}
         self.toc_mode = False
         self.cursor = Cursor(width, height, page_format)
         self.line_buffer = LineBuffer(width)
+        # "early": mathematics arrived as BRF ASCII symbols, so the
+        # renderer must not translate it.  "late": mathematics is
+        # Unicode braille cells, translated when written (dot-for-dot).
+        # The choice rides on the root element of the preprint.
+        self.symbols_early = (symbols == "early")
+        # True while the segments of a Nemeth display block are
+        # being written, since their content is mathematics
+        self.in_nemeth_box = False
 
     # Properties (boolean functions) reported
     # by the current line buffer or default/embedded cursor
@@ -525,6 +533,13 @@ class BRF:
         # After this, `aline` is a BRF string, with spaces, nbsps
         if typeface == "math":
             aline = self.massage_math(aline, math_punctuation)
+        elif self.symbols_early and self.in_nemeth_box and not(BRF.contains_unicode_braille(aline)):
+            # display mathematics, already BRF ASCII symbols; blank
+            # cells, arriving as no-break spaces, become the plain
+            # spaces that a late election gets from liblouis
+            # (a line still holding cells has print residue, and falls
+            # through for the same translation as a late election)
+            aline = aline.replace("\xA0", " ")
         else:
             aline = BRF.translate_segment(typeface, aline)
 
@@ -730,6 +745,12 @@ class BRF:
         nemeth_open = BRF.nemeth_open
         nemeth_close = BRF.nemeth_close
 
+        # Blank cells within the mathematics are just spaces-to-be:
+        # make them spaces now, so the fusing below treats every
+        # blank alike.  (Blank cells arrive as U+2800 under a late
+        # election, and as no-break spaces under an early one.)
+        aline = aline.replace("\u2800", " ").replace("\xA0", " ")
+
         # Join trailing punctuation to the closing indicator and
         # record influence on overall length for line-breaking.
         if punctuation:
@@ -737,6 +758,20 @@ class BRF:
             punct_len = len(punctuation)
         else:
             punct_len = 0
+
+        # The mathematics arrived as BRF ASCII symbols exactly when
+        # "early" was elected AND the preprint conversion found only
+        # braille cells (mathematics with print residue rides along
+        # as Unicode no matter the election, see the preprint XSL).
+        early_form = self.symbols_early and not(BRF.contains_unicode_braille(aline))
+
+        # For the early form, the Unicode indicator chunks (with
+        # punctuation attached) convert here, by the same translation
+        # they would otherwise receive below, and the mathematics
+        # itself rides along untouched.
+        if early_form:
+            nemeth_open = louis.translateString(["en-ueb-g2.ctb"], nemeth_open, None, 0)
+            nemeth_close = louis.translateString(["en-ueb-g2.ctb"], nemeth_close, None, 0)
 
         # Actual Nemeth braille, plus 3, plus 3 for indicators, and punctuation
         math_len = len(aline) + 6 + punct_len
@@ -753,6 +788,13 @@ class BRF:
         else:
             # fuse on the indicators, then break at any space
             aline = nemeth_open + "\xA0" + aline + "\xA0" + nemeth_close
+
+        # Already BRF ASCII symbols throughout (early form); blank
+        # cells arrived as no-break spaces, which the line-breaking
+        # decisions above do not break on, and which become plain
+        # spaces when a completed line is written out
+        if early_form:
+            return aline
 
         # Unicode characters translate, one for one, into BRF
         # characters and we assume punctuation does the same.
@@ -792,6 +834,10 @@ class BRF:
             self.advance_one_line()
             self.blank_line()
 
+        # Segments of a Nemeth display block hold mathematics, which
+        # matters when it arrived as BRF ASCII symbols ("early")
+        saved_nemeth_box = self.in_nemeth_box
+        self.in_nemeth_box = (blk.box == "nemeth")
         inner_segments = blk.xml.xpath("segment|block")
         for s in inner_segments:
             if s.tag == "segment":
@@ -800,6 +846,7 @@ class BRF:
             elif s.tag == "block":
                 innerblk = Block(s)
                 self.write_block(innerblk)
+        self.in_nemeth_box = saved_nemeth_box
 
         if blk.box == "standard":
             bottom_line = "g" * self.line_buffer.text_width
@@ -860,6 +907,12 @@ class BRF:
     # Static methods
 
     @staticmethod
+    def contains_unicode_braille(aline):
+        # The blank cell U+2800 is excluded: alone it says nothing,
+        # since genuine mathematics always carries patterned cells
+        return any(("\u2801" <= c) and (c <= "\u28FF") for c in aline)
+
+    @staticmethod
     def translate_segment(typeface, aline):
 
         # g2 includes g1 explicitly
@@ -900,14 +953,19 @@ class BRF:
 # Current entry point, sort of
 def parse_segments(xml_simple, out_file, page_format):
 
-    # Embossed, page shape
-    brf = BRF(page_format, 40,25)
-
     # this routine converts XML information into arguments
     # to Python routines, but not exclusively yet
 
     huge_parser = ET.XMLParser(huge_tree=True)
     src_tree = ET.parse(xml_simple, parser=huge_parser)
+
+    # how braille cells are represented in the preprint:
+    # "late" is Unicode braille cells (the default), "early" is
+    # BRF ASCII symbols (a developer convenience for debugging)
+    symbols = src_tree.getroot().get("brf-symbols", "late")
+
+    # Embossed, page shape
+    brf = BRF(page_format, 40, 25, symbols)
 
     top_elts = src_tree.xpath("/brf/segment|/brf/block")
 
@@ -921,7 +979,7 @@ def parse_segments(xml_simple, out_file, page_format):
         brf.flush()
 
     # Prepare a new BRF object, but copy out ToC page numbers
-    front = BRF(page_format, 40,25)
+    front = BRF(page_format, 40, 25, symbols)
     front.toc_mode = True
     front.toc_dict = brf.toc_dict
 

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -970,8 +970,13 @@ def parse_segments(xml_simple, out_file, page_format):
     # BRF ASCII symbols (a developer convenience for debugging)
     symbols = src_tree.getroot().get("brf-symbols", "late")
 
+    # page geometry, elected in the publication file and validated
+    # upstream: cells in a line, lines on an embossed page
+    page_width = int(src_tree.getroot().get("page-width", "40"))
+    page_height = int(src_tree.getroot().get("page-height", "25"))
+
     # Embossed, page shape
-    brf = BRF(page_format, 40, 25, symbols)
+    brf = BRF(page_format, page_width, page_height, symbols)
 
     top_elts = src_tree.xpath("/brf/segment|/brf/block")
 
@@ -985,7 +990,7 @@ def parse_segments(xml_simple, out_file, page_format):
         brf.flush()
 
     # Prepare a new BRF object, but copy out ToC page numbers
-    front = BRF(page_format, 40, 25, symbols)
+    front = BRF(page_format, page_width, page_height, symbols)
     front.toc_mode = True
     front.toc_dict = brf.toc_dict
 

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -315,11 +315,6 @@ class BRF:
     nemeth_open = "\u2838\u2829"
     nemeth_close = "\u2838\u2831"
 
-    # We need to connect the "trans1" emphasis scheme of the liblouis
-    # "en-ueb-g1.ctb" table with a typeform bit we can use to switch
-    # to this variant when we translate inline code phrases
-    trans1_bit = louis.getTypeformForEmphClass(["en-ueb-g2.ctb"], 'trans1')
-
     def __init__(self, page_format, width, height, symbols):
         self.out_buffer = ''
         self.accumulator = []
@@ -460,7 +455,7 @@ class BRF:
         # the line buffer for the last line prior to its formation.
         if finish_penultimate or finish_last:
             num = str(self.cursor.page_number())
-            braille_num = self.translate_segment('text', num)
+            braille_num = BRF.translate_print(num)
 
         # before leaving last line, add a page number, flush right
         if finish_last:
@@ -528,8 +523,15 @@ class BRF:
 
     def write_fragment(self, typeface, aline, math_punctuation, seg):
 
-        # Nemeth math needs special care, and is already braille
-        # Otherwise, have liblouis translate with correct typeface
+        # Body text arrives from the translation pass as braille
+        # already, so most fragments ride through untouched.  The
+        # exceptions: inline mathematics ("math") gets Nemeth
+        # indicators and space fusing; renderer-generated print
+        # ("print": page numbers, guide dots) translates here; and
+        # anything still holding Unicode braille cells (display
+        # mathematics under a "late" election, or print residue from
+        # Speech Rule Engine) goes through liblouis, where cells
+        # convert dot-for-dot and residue translates as print.
         # After this, `aline` is a BRF string, with spaces, nbsps
         if typeface == "math":
             aline = self.massage_math(aline, math_punctuation)
@@ -540,8 +542,8 @@ class BRF:
             # (a line still holding cells has print residue, and falls
             # through for the same translation as a late election)
             aline = aline.replace("\xA0", " ")
-        else:
-            aline = BRF.translate_segment(typeface, aline)
+        elif (typeface == "print") or BRF.contains_unicode_braille(aline):
+            aline = BRF.translate_print(aline)
 
         # When a word is output, it gets the space from the previous split,
         # unless it is the first word of a line and the prior space became
@@ -671,18 +673,20 @@ class BRF:
         if self.toc_mode:
             self.adjust_text_width(-6)
 
+        # The translation pass has already made braille of all the
+        # body text, so a segment holds braille text with "math"
+        # islands (inline mathematics awaiting Nemeth indicators
+        # and space fusing).  Anything else indicates the
+        # intermediate XML has structure this renderer cannot
+        # express.  Degrade rather than halt: immediate text is
+        # rendered as text, and content nested deeper is dropped.
         sxml = s.xml
         if sxml.text:
             self.write_fragment("text", sxml.text, None, s)
         children = list(sxml)
         for c in children:
-            # A child that is not a recognized typeface means the
-            # intermediate XML has structure nested inside a segment,
-            # which this renderer cannot express.  Degrade rather than
-            # halt: immediate text is rendered as plain text, and any
-            # content nested deeper is dropped from the output.
             typeface = c.tag
-            if typeface not in ("italic", "bold", "code", "math"):
+            if typeface != "math":
                 print('BUG: unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
                 typeface = "text"
             if c.text:
@@ -710,7 +714,9 @@ class BRF:
                     guide_dots -= 1
                 if guide_dots > 0:
                     guide[1] = '\u2810' * guide_dots
-                self.write_fragment("text", ''.join(guide) + page_num, None, s)
+                # renderer-generated print: the page number digits
+                # (the guide dots are cells, converting dot-for-dot)
+                self.write_fragment("print", ''.join(guide) + page_num, None, s)
 
         # finished with a segment
         # flush buffer, move to new line, maybe a new page
@@ -913,39 +919,14 @@ class BRF:
         return any(("\u2801" <= c) and (c <= "\u28FF") for c in aline)
 
     @staticmethod
-    def translate_segment(typeface, aline):
-
+    def translate_print(aline):
+        # Renderer-generated print (page numbers, guide dots) and
+        # Unicode braille cells (which convert dot-for-dot) become
+        # BRF ASCII symbols.  Body text never passes through here:
+        # it arrives already translated, typeforms and all, from the
+        # translation pass (braille_translate.py).
         # g2 includes g1 explicitly
-        tableList = ["en-ueb-g2.ctb"]
-
-        # Typeforms bits
-        #    from Python, which is from C header, louis.h
-        # plain_text = 0x0000
-        # emph_1 = comp_emph_1 = italic = 0x0001 = 1
-        # emph_2 = comp_emph_2 = underline = 0x0002 = 2
-        # emph_3 = comp_emph_3 = bold = 0x0004 = 4
-        # computer_braille = 0x0400 = 1024
-        # no_contract = 0x1000 = 4096
-
-        # `BRF.trans1_bit` is a class variable provided by the louis
-        # package for switching into a transcriber-defined emphasis class
-        # 2023-03-09: apparently  0x0020 = 32  for "trans1" (could change?)
-
-        if typeface == "text":
-            typeforms = None
-        elif typeface == "italic":
-            typeforms = [1] * len(aline)
-        elif typeface == "bold":
-            typeforms = [4] * len(aline)
-        elif typeface == "code":
-            typeforms = [BRF.trans1_bit] * len(aline)
-        else:
-            # Callers vet typefaces, so this is a defensive fallback:
-            # translate as plain text rather than halt the conversion.
-            print('BUG: did not recognize typeface "{}"; translating as plain text'.format(typeface))
-            typeforms = None
-
-        return louis.translateString(tableList, aline, typeforms, 0)
+        return louis.translateString(["en-ueb-g2.ctb"], aline, None, 0)
 
     # End BRF object definition
 
@@ -958,6 +939,12 @@ def parse_segments(xml_simple, out_file, page_format):
 
     huge_parser = ET.XMLParser(huge_tree=True)
     src_tree = ET.parse(xml_simple, parser=huge_parser)
+
+    # This renderer requires input whose body text is braille
+    # already; rendering print text would silently produce
+    # unreadable output, so refuse it outright.
+    if src_tree.getroot().get("translated") != "yes":
+        raise ValueError("the braille renderer requires input from the translation pass, and this file has not been through it")
 
     # how braille cells are represented in the preprint:
     # "late" is Unicode braille cells (the default), "early" is

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -403,7 +403,15 @@ class BRF:
         # Do the deal, in a sandbox
         # Type will be "Block" or "Segment"
         if type(seg) == Segment:
+            # Processing marches a segment's first_line marker
+            # forward, so a trial must restore it, else the real
+            # rendering would begin with runover indentation in
+            # place of first-line indentation.  (A block builds
+            # its interior segments afresh on every processing,
+            # so a trial of a block disturbs nothing.)
+            first_line = seg.first_line
             sandbox_brf.process_segment(seg)
+            seg.first_line = first_line
         else:
             sandbox_brf.process_block(seg)
         # Attach some lines of content, virtually

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -385,9 +385,20 @@ class BRF:
         orginal_cursor = self.cursor
         start_page = orginal_cursor.page_number()
         start_line = -orginal_cursor.remaining_lines()
-        # all changes (cursor movement, text-wrapping) will
-        # occur in the temporary/sandbox/throwaway cursor
-        sandbox_brf = copy.deepcopy(self)
+        # All changes (cursor movement, text-wrapping) occur in a
+        # throwaway renderer: empty, but positioned exactly where
+        # this one is.  Processing decisions depend only on the
+        # cursor, the line buffer, and the modes below -- never on
+        # accumulated output -- so the trial reproduces them
+        # faithfully at the cost of processing one segment.
+        page_format = 'emboss' if self.cursor.embossing() else 'electronic'
+        symbols = 'early' if self.symbols_early else 'late'
+        sandbox_brf = BRF(page_format, self.cursor.page_width, self.cursor.page_height, symbols)
+        sandbox_brf.cursor = copy.copy(self.cursor)
+        sandbox_brf.line_buffer = copy.copy(self.line_buffer)
+        sandbox_brf.toc_mode = self.toc_mode
+        sandbox_brf.toc_dict = dict(self.toc_dict)
+        sandbox_brf.in_nemeth_box = self.in_nemeth_box
         sandbox_cursor = sandbox_brf.cursor
         # Do the deal, in a sandbox
         # Type will be "Block" or "Segment"

--- a/pretext/lib/braille_translate.py
+++ b/pretext/lib/braille_translate.py
@@ -1,0 +1,158 @@
+# ********************************************************************
+# Copyright 2010-2026 Robert A. Beezer
+#
+# This file is part of PreTeXt.
+#
+# PreTeXt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 or version 3 of the
+# License (at your option).
+#
+# PreTeXt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+# The braille translation pass.  The "preprint" intermediate arrives
+# from the XSL with print text organized into segments, where font
+# changes are flat "run" elements carrying "@typeform" tokens, and
+# mathematics is already braille (in "math" elements, from Speech
+# Rule Engine).  This pass translates all print text into contracted
+# UEB braille with liblouis, one call per contiguous stretch of text,
+# so liblouis sees whole phrases and can choose correctly among
+# symbol-, word-, and passage-level emphasis indicators, and so
+# contractions are never severed at markup boundaries.
+#
+# The element skeleton survives: translated braille is written back
+# into the text and tail slots surrounding the "math" islands, the
+# "run" elements dissolve, and every attribute (identifiers for the
+# table of contents, punctuation for Nemeth indicators) rides along
+# untouched.  The renderer downstream knows only braille.
+
+import lxml.etree as ET
+
+# "common" holds the canonical __module_warning; we alias it here so the
+# warning below reads the same as everywhere else
+from . import common
+__module_warning = common.__module_warning
+
+try:
+    import louis
+except ImportError:
+    raise ImportError(__module_warning.format("louis"))
+
+# The UEB Grade 2 table includes Grade 1 explicitly
+_TABLES = ["en-ueb-g2.ctb"]
+
+# Typeform bits, from the C header louis.h:
+#     emph_1 = italic = 0x0001
+#     emph_3 = bold = 0x0004
+# "code" uses the transcriber-defined emphasis class "trans1" of the
+# liblouis table, whose bit is assigned at run time
+_TYPEFORM_BITS = {
+    "italic": 0x0001,
+    "bold": 0x0004,
+    "code": louis.getTypeformForEmphClass(_TABLES, 'trans1'),
+}
+
+
+def _typeform_bits(typeform):
+    """The composite liblouis typeform bits for space-separated tokens"""
+    bits = 0
+    for token in typeform.split():
+        if token in _TYPEFORM_BITS:
+            bits |= _TYPEFORM_BITS[token]
+        else:
+            print('BUG: the typeform token "{}" is not recognized, and is ignored'.format(token))
+    return bits
+
+
+def _translate_chunk(chunk):
+    """Translate one contiguous stretch of print text, in place.
+
+    A chunk is a list of (element, slot, bits) triples, where slot is
+    "text" or "tail", locating a string, and bits are the liblouis
+    typeform bits in effect for that string.  The whole stretch goes
+    through liblouis in one call, and the resulting braille is placed
+    in the first slot; the remaining slots are emptied.
+    """
+    pieces = []
+    typeforms = []
+    for (element, slot, bits) in chunk:
+        piece = getattr(element, slot) or ''
+        pieces.append(piece)
+        typeforms.extend([bits] * len(piece))
+    whole = ''.join(pieces)
+    if whole == '':
+        return
+    # liblouis behaves identically for all-zero bits and for no bits
+    # at all, but no bits is the honest description of plain text
+    if not any(typeforms):
+        typeforms = None
+    braille = louis.translateString(_TABLES, whole, typeforms, 0)
+    # braille into the first slot, all other slots emptied
+    (element, slot, _) = chunk[0]
+    setattr(element, slot, braille)
+    for (element, slot, _) in chunk[1:]:
+        setattr(element, slot, None)
+
+
+def _translate_segment(segment):
+    """Translate the print text of one segment, in place.
+
+    The text and tail slots of the segment and its children form an
+    in-order sequence of strings ("text nodes belong to the element
+    preceding them").  "math" elements are braille already and act as
+    islands: the stretches of print text between them translate
+    independently, each in a single liblouis call.
+    """
+    chunk = [(segment, "text", 0)]
+    for child in segment:
+        if child.tag == "math":
+            # island: finish the stretch in progress, start anew
+            _translate_chunk(chunk)
+            chunk = [(child, "tail", 0)]
+        elif child.tag == "run":
+            chunk.append((child, "text", _typeform_bits(child.get("typeform", ""))))
+            chunk.append((child, "tail", 0))
+        else:
+            # translate anything unexpected as plain print text,
+            # rather than lose content or halt a conversion
+            print('BUG: unexpected element "{}" inside a segment; its content is treated as plain text'.format(child.tag))
+            chunk.append((child, "text", 0))
+            chunk.append((child, "tail", 0))
+    _translate_chunk(chunk)
+    # "run" elements have served their purpose: their content has
+    # been absorbed (braille placed leftward, slots emptied), so
+    # they dissolve without disturbing anything else
+    for child in list(segment):
+        if child.tag == "run":
+            segment.remove(child)
+
+
+def translate_document(xml_in, xml_out):
+    """Translate a preprint file into its brailled counterpart.
+
+    Every segment's print text becomes contracted UEB braille (BRF
+    ASCII symbols); the structure, the attributes, and the "math"
+    islands are undisturbed.  The root element is stamped with
+    @translated for the renderer to verify.
+    """
+    huge_parser = ET.XMLParser(huge_tree=True)
+    tree = ET.parse(xml_in, parser=huge_parser)
+    root = tree.getroot()
+    for segment in root.iter("segment"):
+        # the segments of a Nemeth display block are lines of
+        # mathematics, braille already, and are not print text
+        in_nemeth_box = any(
+            (ancestor.tag == "block") and (ancestor.get("box") == "nemeth")
+            for ancestor in segment.iterancestors()
+        )
+        if not in_nemeth_box:
+            _translate_segment(segment)
+    root.set("translated", "yes")
+    tree.write(xml_out, xml_declaration=True, encoding="UTF-8")

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2412,7 +2412,7 @@ def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format)
     # use Python to translate all print text to contracted braille,
     # then to format the result as a real BRF
     from . import braille_translate
-    from . import braille_format as braille
+    from . import braille_format
 
     # Translate the preprint: all print text becomes UEB braille,
     # one liblouis call per stretch of text, typeforms and all
@@ -2424,7 +2424,7 @@ def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format)
     # Build a BRF in the *temporary* directory: final or chunkable
     temp_brf = os.path.join(tmp_dir, "temporary.brf")
     # Python formatting call
-    braille.parse_segments(translated, temp_brf, page_format)
+    braille_format.parse_segments(translated, temp_brf, page_format)
 
     # move out of temporary directory as final product(s)
     # chunk level is either '0' or '1' (exclusive "if" follow)

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2409,13 +2409,22 @@ def braille(xml_source, pub_file, stringparams, out_file, dest_dir, page_format)
     braille_xslt = os.path.join(common.get_ptx_xsl_path(), "pretext-braille-preprint.xsl")
     common.xsltproc(braille_xslt, xml_source, preprint, tmp_dir, stringparams)
 
-    # use Python to format simplified BRF as a real BRF
+    # use Python to translate all print text to contracted braille,
+    # then to format the result as a real BRF
+    from . import braille_translate
     from . import braille_format as braille
+
+    # Translate the preprint: all print text becomes UEB braille,
+    # one liblouis call per stretch of text, typeforms and all
+    translated = os.path.join(tmp_dir, "translated.xml")
+    msg = "translating print text of preprint ({}) into braille ({})"
+    log.debug(msg.format(preprint, translated))
+    braille_translate.translate_document(preprint, translated)
 
     # Build a BRF in the *temporary* directory: final or chunkable
     temp_brf = os.path.join(tmp_dir, "temporary.brf")
     # Python formatting call
-    braille.parse_segments(preprint, temp_brf, page_format)
+    braille.parse_segments(translated, temp_brf, page_format)
 
     # move out of temporary directory as final product(s)
     # chunk level is either '0' or '1' (exclusive "if" follow)

--- a/schema/braille-preprint.rnc
+++ b/schema/braille-preprint.rnc
@@ -1,0 +1,157 @@
+# ********************************************************************
+# Copyright 2026 Robert A. Beezer
+#
+# This file is part of PreTeXt.
+#
+# PreTeXt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 or version 3 of the
+# License (at your option).
+#
+# PreTeXt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+# The braille "preprint" vocabulary: the contract between the XSL
+# conversion (xsl/pretext-braille-preprint.xsl), the translation pass
+# (pretext/lib/braille_translate.py), and the renderer
+# (pretext/lib/braille_format.py).
+#
+# The same vocabulary describes the file at both stages:
+#
+#   * As produced by the XSL: text is print, font changes are "run"
+#     elements, mathematics is braille inside "math" elements, and
+#     the root carries @brf-symbols.
+#
+#   * As produced by the translation pass: all text is braille, the
+#     "run" elements have dissolved (typeform indicators are baked
+#     into the braille), and the root additionally carries
+#     @translated = "yes".
+#
+# Design rules, so the intermediate stays rendering-ready:
+#
+#   * A "segment" is a formatting atom: it begins on a new line and
+#     ends the line it finishes on.  It holds text and islands of
+#     mathematics -- never another segment, and never a block.
+#     When a paragraph contains block-shaped material (display
+#     mathematics, say), the XSL splits the paragraph, so the
+#     block-shaped material always arrives here as a sibling,
+#     between segments.
+#
+#   * Every layout property is expressed in whole characters (cells)
+#     and whole lines; there are no lengths, no percentages, and no
+#     document semantics (nothing knows what a "theorem" is here).
+#
+#   * Vertical space requests ("lines-before", "lines-after") do not
+#     collapse; the renderer suppresses them only at a page start.
+#
+# Validate an intermediate with, for example:
+#
+#   jing -c schema/braille-preprint.rnc <intermediate file>
+
+# One file, at either stage
+start = BrfFile
+
+# yes/no strings stand in for booleans throughout, and a missing
+# attribute always means the default noted for it
+YesNo = string "yes" | string "no"
+
+# a count of characters (cells) or lines, never negative
+Count = xsd:nonNegativeInteger
+
+BrfFile =
+    element brf {
+        # how braille cells are represented in "math" elements and
+        # in Nemeth display blocks: "late" is Unicode braille cells
+        # (U+2800 through U+283F), "early" is BRF ASCII symbols
+        # (a developer debugging convenience; final output is
+        # identical under either election)
+        attribute brf-symbols { string "early" | string "late" },
+        # present, and "yes", once the translation pass has made
+        # braille of every piece of print text; the renderer
+        # refuses a file without it
+        attribute translated { string "yes" }?,
+        (Segment | Block)*
+    }
+
+# A segment: one formatting atom.  Mixed content: text (print before
+# translation, braille after), font-change runs (before translation
+# only), and islands of mathematics.
+Segment =
+    element segment {
+        # indentation of the first line, in cells (default 0)
+        attribute indentation { Count }?,
+        # indentation of every subsequent line, in cells (default 0)
+        attribute runover { Count }?,
+        # blank lines demanded before/after (default 0); not
+        # honored at the start of a page
+        attribute lines-before { Count }?,
+        attribute lines-after { Count }?,
+        # lines that must fit on the current page after this
+        # segment's last line, else the segment moves to a new page
+        # (default 0); this is how a heading stays with its content
+        attribute lines-following { Count }?,
+        # may this segment split across a page boundary? (default yes)
+        attribute breakable { YesNo }?,
+        # centered, within margins of three blank cells (default no)
+        attribute centered { YesNo }?,
+        # force a new page to begin here (default no)
+        attribute newpage { YesNo }?,
+        # demand a page of its own (default no)
+        attribute ownpage { YesNo }?,
+        # identifier connecting a heading to its table-of-contents
+        # entry, for page-number resolution after layout
+        attribute heading-id { text }?,
+        # artifact of an absorbed run-in title (ignored downstream)
+        attribute separator { text }?,
+        mixed { (Run | Math)* }
+    }
+
+# A run of text under one or more font changes, translation-pass
+# input only; the tokens compose (nested markup arrives flattened)
+Run =
+    element run {
+        attribute typeform {
+            list { (string "italic" | string "bold" | string "code")+ }
+        },
+        text
+    }
+
+# An island of mathematics: braille cells from Speech Rule Engine
+# (per @brf-symbols), never translated, wrapped in Nemeth switch
+# indicators and space-fused by the renderer
+Math =
+    element math {
+        # clause-ending print punctuation trailing the mathematics,
+        # to be joined to the closing Nemeth indicator
+        attribute punctuation { text }?,
+        text
+    }
+
+# A block: a container of segments (or nested blocks), giving box
+# drawing, page-break protection, and vertical spacing.  A Nemeth
+# display block's segments are lines of mathematics, already braille,
+# exempt from translation.
+Block =
+    element block {
+        # may the contents split across a page boundary? (default yes)
+        attribute breakable { YesNo }?,
+        # box drawing: "standard" is a full box of line-drawing
+        # cells; "nemeth" brackets the contents with Nemeth switch
+        # indicators (display mathematics)
+        attribute box { string "standard" | string "nemeth" }?,
+        # blank lines demanded before/after (default 0)
+        attribute lines-before { Count }?,
+        attribute lines-after { Count }?,
+        # demand a page of its own (default no)
+        attribute ownpage { YesNo }?,
+        # clause-ending print punctuation trailing display
+        # mathematics, joined to the closing Nemeth indicator
+        attribute punctuation { text }?,
+        (Segment | Block)*
+    }

--- a/schema/braille-preprint.rnc
+++ b/schema/braille-preprint.rnc
@@ -76,6 +76,10 @@ BrfFile =
         # braille of every piece of print text; the renderer
         # refuses a file without it
         attribute translated { string "yes" }?,
+        # page geometry, from the publication file (or defaults):
+        # cells in a line, and lines on an embossed page
+        attribute page-width { xsd:positiveInteger },
+        attribute page-height { xsd:positiveInteger },
         (Segment | Block)*
     }
 

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -14,6 +14,7 @@
                     Revealjs? &
                     Epub? &
                     Jupyter? &
+                    Braille? &
                     Webwork?
                 }
             
@@ -413,6 +414,14 @@
             Jupyter =
                 element jupyter {
                     attribute kernel { "sagemath" | "python3" }
+                }
+            
+            Braille =
+                element braille {
+                    element page {
+                        attribute width { xsd:positiveInteger }?,
+                        attribute height { xsd:positiveInteger }?
+                    }
                 }
             
             Webwork =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -34,6 +34,9 @@
           <ref name="Jupyter"/>
         </optional>
         <optional>
+          <ref name="Braille"/>
+        </optional>
+        <optional>
           <ref name="Webwork"/>
         </optional>
       </interleave>
@@ -1282,6 +1285,22 @@
           <value>python3</value>
         </choice>
       </attribute>
+    </element>
+  </define>
+  <define name="Braille">
+    <element name="braille">
+      <element name="page">
+        <optional>
+          <attribute name="width">
+            <data type="positiveInteger"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="height">
+            <data type="positiveInteger"/>
+          </attribute>
+        </optional>
+      </element>
     </element>
   </define>
   <define name="Webwork">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -88,7 +88,7 @@
         <title>Gross Structure</title>
 
         <p>
-            A publication file always has the root element <tag>publication</tag>.  After that, all elements are optional.  Those elements include common options, and options for numbering, latex, html, reveal.js, epub, source, and <webwork/>.  These can come in any order.
+            A publication file always has the root element <tag>publication</tag>.  After that, all elements are optional.  Those elements include common options, and options for numbering, latex, html, reveal.js, epub, braille, source, and <webwork/>.  These can come in any order.
         </p>
 
         <fragment xml:id="gross-structure">
@@ -105,6 +105,7 @@
                     Revealjs? &amp;
                     Epub? &amp;
                     Jupyter? &amp;
+                    Braille? &amp;
                     Webwork?
                 }
             </code>
@@ -640,6 +641,27 @@
         </fragment>
     </section>
 
+    <section>
+        <title>Braille Options</title>
+
+        <p>
+            These option(s) control the braille output.  The page geometry describes an embossed page: the number of cells in a line, and the number of lines on a page.  The default geometry is 40 cells by 25 lines, a common size for North American embossers.
+        </p>
+
+        <fragment xml:id="braille">
+            <title>Braille Options</title>
+            <code>
+            Braille =
+                element braille {
+                    element page {
+                        attribute width { xsd:positiveInteger }?,
+                        attribute height { xsd:positiveInteger }?
+                    }
+                }
+            </code>
+        </fragment>
+    </section>
+
 
     <section>
         <title><webwork/> Options</title>
@@ -686,6 +708,7 @@
             <fragref ref="revealjs" />
             <fragref ref="epub" />
             <fragref ref="jupyter" />
+            <fragref ref="braille" />
             <fragref ref="webwork" />
             <code>
             }

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -2249,5 +2249,24 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </segment>
 </xsl:template>
 
+<!-- ############## -->
+<!-- Invalid Source -->
+<!-- ############## -->
+
+<!-- Constructions that violate the PreTeXt schema receive an error   -->
+<!-- message describing the violation, and leave a placeholder in the -->
+<!-- output, rather than being accommodated.  Generated content       -->
+<!-- (STACK static representations) is the known supplier: a "p"      -->
+<!-- within a "p", an "image" within a "p", and "div" (an HTML        -->
+<!-- element, not PreTeXt at all).                                    -->
+<!--                                                                  -->
+<!-- N.B. these templates are deliberately LAST in this stylesheet:   -->
+<!-- a nested "p" can also match the display-splitting template for   -->
+<!-- "p" at equal priority, and placement here settles the conflict   -->
+<!-- in favor of the error.                                           -->
+<xsl:template match="p/p|p/image|div">
+    <xsl:message>PTX:ERROR:   the braille conversion has encountered source that is not valid PreTeXt (a "<xsl:value-of select="local-name()"/>" element within a "<xsl:value-of select="local-name(parent::*)"/>"); a placeholder appears in the output in its place</xsl:message>
+    <xsl:text>[INVALID SOURCE]</xsl:text>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -267,10 +267,78 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- The entry template "waits" for the "$math-meld-rtf" and    -->
 <!-- "$segmented-rtf" global variables to form, then the actual -->
-<!-- output is a run of modal "meld-runin" templates as a sort  -->
-<!-- of post-processing step.                                   -->
+<!-- output comes from two post-processing passes: the modal    -->
+<!-- "meld-runin" templates absorb run-in titles into their     -->
+<!-- segments, and then the modal "flatten-runs" templates      -->
+<!-- dissolve nested font-change markup into a flat sequence    -->
+<!-- of "run" elements bearing composite "@typeform" values.    -->
 <xsl:template match="/">
-    <xsl:apply-templates select="exsl:node-set($segmented-rtf)/brf" mode="meld-runin"/>
+    <xsl:variable name="melded-runin-rtf">
+        <xsl:apply-templates select="exsl:node-set($segmented-rtf)/brf" mode="meld-runin"/>
+    </xsl:variable>
+    <xsl:apply-templates select="exsl:node-set($melded-runin-rtf)/brf" mode="flatten-runs"/>
+</xsl:template>
+
+<!-- ############################ -->
+<!-- Flatten Font Changes to Runs -->
+<!-- ############################ -->
+
+<!-- Font-change markup ("italic", "bold", "code") arrives from the -->
+<!-- earlier pass as elements, which may nest ("italic" containing  -->
+<!-- "code", say).  A formatter wants a flat sequence, so each text -->
+<!-- node becomes a "run" element whose "@typeform" records every   -->
+<!-- font change in effect, as space-separated tokens.  Text with   -->
+<!-- no font change rides along bare.  The font-change elements     -->
+<!-- themselves evaporate.  Mathematics ("math") is already braille -->
+<!-- cells and is preserved whole, its interior untouched.          -->
+
+<!-- Dissolve, children continue -->
+<xsl:template match="italic|bold|code" mode="flatten-runs">
+    <xsl:apply-templates select="node()" mode="flatten-runs"/>
+</xsl:template>
+
+<!-- Mathematics is opaque, xerox entirely -->
+<xsl:template match="math" mode="flatten-runs">
+    <xsl:copy-of select="."/>
+</xsl:template>
+
+<!-- Text nodes inside a segment (or a converted run-in title)  -->
+<!-- either ride bare (no font change) or become a "run".  The  -->
+<!-- ancestor axis sees the font-change elements because they   -->
+<!-- are still present in the tree under examination.           -->
+<xsl:template match="text()" mode="flatten-runs">
+    <xsl:variable name="typeform">
+        <xsl:if test="ancestor::italic">
+            <xsl:text>italic </xsl:text>
+        </xsl:if>
+        <xsl:if test="ancestor::bold">
+            <xsl:text>bold </xsl:text>
+        </xsl:if>
+        <xsl:if test="ancestor::code">
+            <xsl:text>code </xsl:text>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="$typeform = ''">
+            <xsl:value-of select="."/>
+        </xsl:when>
+        <xsl:otherwise>
+            <run>
+                <xsl:attribute name="typeform">
+                    <xsl:value-of select="normalize-space($typeform)"/>
+                </xsl:attribute>
+                <xsl:value-of select="."/>
+            </run>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Xerox machine.  Elements and attributes only: text nodes have -->
+<!-- their own template above, and it must win the match.          -->
+<xsl:template match="*|@*" mode="flatten-runs">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="flatten-runs"/>
+    </xsl:copy>
 </xsl:template>
 
 <!-- Process segments here, looking for run-in titles/headings -->

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -67,6 +67,60 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Not so much "include" as "manipulate"            -->
 <xsl:param name="math.punctuation.include" select="'all'"/>
 
+<!-- Developer-only.  Braille arriving from Speech Rule Engine     -->
+<!-- (mathematics) is Unicode braille cells (U+2800 through        -->
+<!-- U+283F).  With "late" (the default) those cells ride through  -->
+<!-- the preprint intermediate unchanged and become BRF ASCII      -->
+<!-- symbols in the renderer.  With "early" the conversion to BRF  -->
+<!-- ASCII symbols happens here, so the preprint file itself is    -->
+<!-- readable by anyone fluent in BRF, at no change to the final   -->
+<!-- BRF.  The root element of the preprint records the choice so  -->
+<!-- the renderer can react.                                       -->
+<xsl:param name="debug.brf.symbols" select="'late'"/>
+<xsl:variable name="brf-symbols">
+    <xsl:choose>
+        <xsl:when test="($debug.brf.symbols = 'early') or ($debug.brf.symbols = 'late')">
+            <xsl:value-of select="$debug.brf.symbols"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:WARNING: the "debug.brf.symbols" string parameter must be "early" or "late", not "<xsl:value-of select="$debug.brf.symbols"/>", using "late" instead</xsl:message>
+            <xsl:text>late</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="b-braille-symbols-early" select="$brf-symbols = 'early'"/>
+
+<!-- The 64 Unicode braille cells, in numerical order, and their   -->
+<!-- BRF ASCII equivalents, generated with liblouis, which is what -->
+<!-- the renderer employs for the identical conversion when the    -->
+<!-- cells ride through as Unicode ("late").  Exception: the blank -->
+<!-- cell U+2800 maps to a NO-BREAK SPACE, not to a plain space:   -->
+<!-- it reads as a space, but the renderer can still distinguish   -->
+<!-- a (non-breaking) blank cell from an authored space when it    -->
+<!-- makes line-breaking decisions, and it becomes a plain space   -->
+<!-- in the final output, exactly as a blank cell does.            -->
+<xsl:variable name="unicode-braille-cells" select="'&#x2800;&#x2801;&#x2802;&#x2803;&#x2804;&#x2805;&#x2806;&#x2807;&#x2808;&#x2809;&#x280A;&#x280B;&#x280C;&#x280D;&#x280E;&#x280F;&#x2810;&#x2811;&#x2812;&#x2813;&#x2814;&#x2815;&#x2816;&#x2817;&#x2818;&#x2819;&#x281A;&#x281B;&#x281C;&#x281D;&#x281E;&#x281F;&#x2820;&#x2821;&#x2822;&#x2823;&#x2824;&#x2825;&#x2826;&#x2827;&#x2828;&#x2829;&#x282A;&#x282B;&#x282C;&#x282D;&#x282E;&#x282F;&#x2830;&#x2831;&#x2832;&#x2833;&#x2834;&#x2835;&#x2836;&#x2837;&#x2838;&#x2839;&#x283A;&#x283B;&#x283C;&#x283D;&#x283E;&#x283F;'"/>
+<xsl:variable name="ascii-braille-cells">&#xA0;a1b'k2l`cif/msp"e3h9o6r~djg&gt;ntq,*5&lt;-u8v.%{$+x!&amp;;:4|0z7(_?w}#y)=</xsl:variable>
+
+<!-- Convert Unicode braille cells to BRF ASCII symbols, when      -->
+<!-- elected ("early"); the text is otherwise undisturbed.         -->
+<!-- The conversion is all-or-nothing per text: when a             -->
+<!-- construction has no braille translation, Speech Rule Engine   -->
+<!-- can leave print residue among the cells, and such a mixture   -->
+<!-- must ride along whole (cells as Unicode) so the renderer      -->
+<!-- gives it the identical late treatment under either election.  -->
+<xsl:template name="brf-symbols-filter">
+    <xsl:param name="text"/>
+    <xsl:choose>
+        <xsl:when test="$b-braille-symbols-early and (translate($text, concat($unicode-braille-cells, ' &#xa;&#x9;&#xd;&#xa0;'), '') = '')">
+            <xsl:value-of select="translate($text, $unicode-braille-cells, $ascii-braille-cells)"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$text"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- ############################## -->
 <!-- Incorporate (Meld) Mathematics -->
 <!-- ############################## -->
@@ -279,6 +333,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Need an overall container   -->
     <!-- Maybe copy a language code? -->
     <brf>
+        <!-- Record how braille cells are represented ("early" is  -->
+        <!-- BRF ASCII symbols, "late" is Unicode braille cells)   -->
+        <!-- so the renderer can react to mathematics accordingly. -->
+        <xsl:attribute name="brf-symbols">
+            <xsl:value-of select="$brf-symbols"/>
+        </xsl:attribute>
         <!-- centered heading on line 1 -->
         <segment centered="yes" lines-after="1">Transcriber Notes</segment>
         <!-- Literal text for each note, control whitespace,  -->
@@ -1558,8 +1618,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="m[not(contains(math-nemeth, '&#xa;'))]">
     <!-- Unicode braille cells from Speech Rule Engine (SRE)   -->
     <!-- Not expecting any markup, so "value-of" is everything -->
+    <!-- Possibly converted to BRF ASCII symbols ("early")     -->
     <xsl:variable name="raw-braille">
-        <xsl:value-of select="math-nemeth"/>
+        <xsl:call-template name="brf-symbols-filter">
+            <xsl:with-param name="text" select="math-nemeth"/>
+        </xsl:call-template>
     </xsl:variable>
     <!-- We investigate actual source for very simple math   -->
     <!-- such as one-letter variable names as Latin letters  -->
@@ -1618,6 +1681,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="m[contains(math-nemeth, '&#xa;')]|md">
+    <!-- Lines are trimmed, and possibly converted to BRF ASCII -->
+    <!-- symbols ("early"), one at a time, below                -->
     <xsl:variable name="nemeth">
         <xsl:value-of select="math-nemeth"/>
         <xsl:text>&#xa;</xsl:text>
@@ -1639,11 +1704,20 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <!-- done, nothing left to work on -->
         <xsl:when test="$display-math = ''"/>
         <xsl:otherwise>
-            <!-- first line into a segment -->
+            <!-- first line into a segment: trailing blank cells -->
+            <!-- trimmed first, and then a possible conversion to -->
+            <!-- BRF ASCII symbols ("early"), line by line, so a  -->
+            <!-- line of print residue rides along as Unicode     -->
+            <!-- without disqualifying its neighbors              -->
             <segment>
-                <xsl:call-template name="trim-nemeth-trailing-whitespace">
-                   <xsl:with-param name="text" select="substring-before($display-math, '&#xa;')"/>
-               </xsl:call-template>
+                <xsl:variable name="trimmed">
+                    <xsl:call-template name="trim-nemeth-trailing-whitespace">
+                        <xsl:with-param name="text" select="substring-before($display-math, '&#xa;')"/>
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:call-template name="brf-symbols-filter">
+                    <xsl:with-param name="text" select="$trimmed"/>
+                </xsl:call-template>
             </segment>
             <!-- recurse on remainder -->
             <xsl:call-template name="segmentize-display-math">

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -407,6 +407,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="brf-symbols">
             <xsl:value-of select="$brf-symbols"/>
         </xsl:attribute>
+        <!-- Page geometry, from the publication file (or the      -->
+        <!-- defaults), for the renderer: cells in a line, lines   -->
+        <!-- on an embossed page.                                  -->
+        <xsl:attribute name="page-width">
+            <xsl:value-of select="$braille-page-width"/>
+        </xsl:attribute>
+        <xsl:attribute name="page-height">
+            <xsl:value-of select="$braille-page-height"/>
+        </xsl:attribute>
         <!-- centered heading on line 1 -->
         <segment centered="yes" lines-after="1">Transcriber Notes</segment>
         <!-- Literal text for each note, control whitespace,  -->

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1193,7 +1193,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Bibliographic items in a "references" division have a      -->
 <!-- bracketed number leading each new entry, then two spaces   -->
 <!-- of indentation for the remainder .                         -->
-<!-- TODO: expand to accomodate annotations ("note"), BANA 22.3 -->
+<!-- An annotation ("note") produces a block, so it cannot live -->
+<!-- inside the entry's segment; it follows as a sibling.       -->
+<!-- TODO: format annotations per BANA 22.3, rather than        -->
+<!-- reusing the boxed rendering of a REMARK-LIKE "note".       -->
 <xsl:template match="biblio[@type='raw']">
     <runin indentation="0" separator="&#x20;">
         <xsl:text>[</xsl:text>
@@ -1201,8 +1204,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>]</xsl:text>
     </runin>
     <segment indentation="0" runover="2">
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="node()[not(self::note)]"/>
     </segment>
+    <xsl:apply-templates select="note"/>
 </xsl:template>
 
 <!-- Override usual killing of title, but perhaps a generic -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3061,6 +3061,45 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 
 
+<!-- ######################## -->
+<!-- Braille-Specific Options -->
+<!-- ######################## -->
+
+<!-- Page geometry of embossed output: cells in a line, lines on a  -->
+<!-- page.  Freeform entries, validated here to positive integers,  -->
+<!-- with the common North American embosser page as the default.   -->
+
+<xsl:variable name="braille-page-width-entered">
+    <xsl:apply-templates select="$publisher-attribute-options/braille/page/pi:pub-attribute[@name='width']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="braille-page-width">
+    <xsl:choose>
+        <xsl:when test="(number($braille-page-width-entered) = round(number($braille-page-width-entered))) and (number($braille-page-width-entered) &gt; 0)">
+            <xsl:value-of select="round(number($braille-page-width-entered))"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:WARNING: the braille page width in the publication file ("<xsl:value-of select="$braille-page-width-entered"/>") must be a positive whole number of cells, using the default, 40</xsl:message>
+            <xsl:text>40</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="braille-page-height-entered">
+    <xsl:apply-templates select="$publisher-attribute-options/braille/page/pi:pub-attribute[@name='height']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="braille-page-height">
+    <xsl:choose>
+        <xsl:when test="(number($braille-page-height-entered) = round(number($braille-page-height-entered))) and (number($braille-page-height-entered) &gt; 0)">
+            <xsl:value-of select="round(number($braille-page-height-entered))"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:WARNING: the braille page height in the publication file ("<xsl:value-of select="$braille-page-height-entered"/>") must be a positive whole number of lines, using the default, 25</xsl:message>
+            <xsl:text>25</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+
 <!-- ###################### -->
 <!-- LaTeX-Specific Options -->
 <!-- ###################### -->
@@ -3750,6 +3789,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <stack>
         <pi:pub-attribute name="server" default="https://stack-api.maths.ed.ac.uk" freeform="yes"/>
     </stack>
+    <braille>
+        <page>
+            <pi:pub-attribute name="width" default="40" freeform="yes"/>
+            <pi:pub-attribute name="height" default="25" freeform="yes"/>
+        </page>
+    </braille>
     <revealjs>
         <appearance>
             <pi:pub-attribute name="theme" default="simple" freeform="yes"/>


### PR DESCRIPTION
This is a re-architecture of the braille conversion, in eleven commits meant to be read in order.

**The shape of the change.** Translation now precedes formatting. A new pass, `pretext/lib/braille_translate.py`, converts all print text of the intermediate "preprint" file to contracted UEB with one liblouis call per contiguous stretch of text, carrying per-character typeform arrays — so liblouis sees whole phrases and chooses correctly among symbol-, word-, and passage-level emphasis indicators, and contractions are never severed at markup boundaries. Upstream of it, the preprint XSL flattens nested font changes (`em` containing `c`, say) into flat `run` elements with composable `@typeform` tokens. Downstream, `pretext/lib/braille_format.py` is rewritten in two stages: a line stage (wrapping, indentation and runover, centering, Nemeth indicator fusing) feeding a page stage (page-break avoidance by line arithmetic, page numbers, form feeds) — replacing interleaved cursor bookkeeping, a copy-everything trial for page breaks whose cost grew with the length of the book, and after-the-fact centering. The intermediate vocabulary is now a specified contract: `schema/braille-preprint.rnc` (RELAX NG) describes it at both stages.

**For publishers.** The embossed page shape moves to the publication file — `<braille><page width="32" height="27"/></braille>` — validated, defaulting to the previous fixed 40×25. The publication schema gains the `braille` element (regenerated from its literate source).

**For developers.** `-x debug.brf.symbols early` writes braille as BRF ASCII symbols throughout the intermediate files, so they can be read without knowing dot patterns; final output is identical under either election.

**Commit by commit, what changes in the output:**

1. *Renderer degrades on unexpected content, instead of halting.* A defect in the intermediate file now produces a warning and imperfect output; previously it stopped the conversion with a Python error. (The sample article was such a casualty: its conversion always ended in that error. From this commit on it converts to completion.) No change for correct documents.
2. *"biblio" annotation becomes a sibling of the entry.* Annotations on bibliography entries now appear, boxed, following their entry; previously they were lost.
3. *Source that is not valid PreTeXt yields a placeholder.* A `p` inside a `p`, an `image` inside a `p`, and HTML `div` (all present in STACK static representations) produce an error message naming the violation and leave `[INVALID SOURCE]` in the output.
4. *Developer string parameter "debug.brf.symbols".* One change: blank braille cells inside short inline mathematics now fuse with their neighbors like every other blank, so an expression such as `(0, 0)` no longer splits across a line break.
5. *All text is translated before any formatting begins.* Emphasis that ends at punctuation now carries an explicit terminator indicator; a stray space that used to appear between emphasized text and following punctuation is gone; a few contractions improve because liblouis sees complete phrases.
6. *RELAX NG schema for the preprint intermediate.* No output change.
7. *Page-break trial positions an empty renderer, not a copy of everything.* No output change; conversion is faster, especially for long books.
8. *A page-break trial no longer steals a segment's first line.* Hanging-indent material that must stay on one page (description lists in boxes, spatial displays) now begins its first line at the margin, as its markup always specified; embossed output only.
9. *Page geometry elected in the publication file.* No output change under the defaults.
10. *Renderer split into a line stage and a page stage.* Output identical except one repair: a centered heading whose text ends on the next-to-last line of a page is now centered in the full page width.
11. *Renderer module imported by its full name.* No output change.

**How this was checked.** Before the work began, the BRF outputs of two documents — the braille test book and the sample article, each embossed and electronic — were saved. After every commit both documents were rebuilt and compared byte for byte against those saved outputs, and every difference had to be one of the changes listed above; anything else was treated as a bug and fixed. The saved outputs, the stage-by-stage comparisons, and rebuild instructions are archived locally.

**Notes.** The new module `pretext/lib/braille_translate.py` will need to ship in pretext-CLI packaging (issue to follow). Graded Nemeth line-break points are not yet implemented; the new line stage is the seam they will occupy.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
