### PR TITLE
Schema: model dynamic fill-in exercises

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10171,7 +10171,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <de-object name="base_yint" context="number">
                             <de-evaluate>
                                 <formula><eval obj="base_cubic"/></formula>
-                                <variable name="x">0</variable>
+                                <variable name="x"><de-number>0</de-number></variable>
                             </de-evaluate>
                         </de-object>
                         <de-object name="A" context="number">
@@ -10255,7 +10255,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     <logic op="not">
                                         <mathcmp>
                                             <eval obj="composition"/>
-                                            <de-expression context="formula" mode="substitution">
+                                            <de-expression mode="substitution">
                                                 <formula><eval obj="fGiven"/></formula>
                                                 <variable name="x"><eval obj="gGiven"/></variable>
                                             </de-expression>
@@ -10263,7 +10263,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                     </logic>
                                     <mathcmp>
                                         <eval obj="composition"/>
-                                        <de-expression context="formula" mode="substitution">
+                                        <de-expression mode="substitution">
                                             <formula><eval obj="gGiven"/></formula>
                                             <variable name="x"><eval obj="fGiven"/></variable>
                                         </de-expression>
@@ -10283,7 +10283,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                                 <logic op="and">
                                     <mathcmp>
                                         <eval obj="composition"/>
-                                        <de-expression context="formula" mode="substitution">
+                                        <de-expression mode="substitution">
                                             <formula><eval obj="fGiven"/></formula>
                                             <variable name="x"><eval obj="gGiven"/></variable>
                                         </de-expression>

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -377,10 +377,10 @@
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
-                Feedback?,
                 element areas {
                   ParagraphAreas+
                 },
+                Feedback?,
                 Hint*, Answer*, Solution*
 
             # General feedback element

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -389,29 +389,129 @@
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
-            # Fill-in-the-blank exercises (new-style evaluation)
+            # Fill-in-the-blank exercises: randomized setup, then evaluation.
+            # Content model per the FITB maintainer (Brian Walton), issue #2980.
             FillInBlank =
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
-                Evaluation,
-                Hint*, Answer*, Solution*
+                (Setup? & Evaluation & Hint* & Answer* & Solution*)
+            # Problem setup: named objects defined sequentially (later ones
+            # may reference earlier ones), then optional raw-Javascript hooks.
+            # A missing @seed makes any randomization unpredictable, so the
+            # FITB machinery warns; but setup has non-randomizing uses too.
+            Setup =
+                element setup {
+                    attribute seed {text}?,
+                    DEObject*,
+                    element setupScript {text}?,
+                    element postRenderScript {text}?
+                }
+            DEObject =
+                element de-object {
+                    attribute name {text},
+                    attribute context {"number" | "formula"},
+                    (DERandom | DENumber | DEExpression | DEEvaluate)
+                }
+            # A random number; @distribution may grow beyond "discrete".
+            # @by defaults to 1; @nonzero omitted means "no".
+            DERandom =
+                element de-random {
+                    attribute distribution {"discrete"},
+                    attribute min {text},
+                    attribute max {text},
+                    attribute by {text}?,
+                    attribute nonzero {"yes"}?,
+                    empty
+                }
+            # Text parses to a formula representing a constant (no free
+            # variables).  N.B. @reduce here follows sample usage; the
+            # maintainer's description lists it only on de-expression
+            # and de-evaluate.
+            DENumber =
+                element de-number {
+                    attribute reduce {"yes"}?,
+                    text
+                }
+            # A formula; the content model follows @mode
+            DEExpression =
+                element de-expression {
+                    attribute reduce {"yes"}?,
+                    (
+                        (attribute mode {"formula"}?, text) |
+                        (attribute mode {"substitution"}, DEFormula, DEVariableValued) |
+                        (attribute mode {"derivative"}, DEFormula, DEVariableEmpty)
+                    )
+                }
+            # The evaluated (numeric) version of a formula
+            DEEvaluate =
+                element de-evaluate {
+                    attribute reduce {"yes"}?,
+                    DEFormula,
+                    DEVariableValued
+                }
+            # A reference to some other formula, from which a new one is
+            # derived.  (de-random and de-number are technically possible
+            # here but have no practical use, so are not admitted.)
+            DEFormula =
+                element formula {
+                    DEExpression | DEEvaluate | Eval
+                }
+            # The variable of a substitution or evaluation carries its
+            # value; plain-text values happen to work as raw Javascript
+            # but are deliberately NOT valid
+            DEVariableValued =
+                element variable {
+                    attribute name {text},
+                    (Eval | DENumber | DEExpression)
+                }
+            # The variable of a differentiation is name-only
+            DEVariableEmpty =
+                element variable {
+                    attribute name {text},
+                    empty
+                }
+            # An inline reference to a named setup object: within
+            # mathematics it renders as the TeX form of the object,
+            # elsewhere as its plain string form.  Admitted anywhere
+            # text or mathematics occurs (statements, solutions,
+            # feedback of dynamic exercises are where it is useful).
+            Eval =
+                element eval {
+                    attribute obj {text},
+                    empty
+                }
+            # eval joins the inline unions (development schema only)
+            TextParagraphItem |= Eval
+            MathInlineItem |= Eval
+            MathRowItem |= Eval
             Evaluation =
                 element evaluation {
                     attribute answers-coupled {"yes"|"no"}?,
                     Evaluate+
                 }
+            # An "evaluate" with @all="yes" tests correctness of ALL the
+            # blanks (optional; meaningful with several blanks).  The
+            # maintainer describes an optional trailing "feedback" here;
+            # observed usage places feedback inside "test", so both are
+            # admitted.
             Evaluate =
                 element evaluate {
                     attribute name {text}?,
                     attribute submit {text}?,
                     attribute all {"yes"|"no"}?,
-                    FITBTest+
+                    FITBTest+,
+                    Feedback?
                 }
+            # At most one test should carry @correct="yes", determining
+            # correctness of a submission (unclosed by this schema); with
+            # none, the provided answer or answer object is the default
+            # comparison.  A test holds a single numcmp or strcmp, OR any
+            # number of jscmp/mathcmp/logic combined with an implied AND.
             FITBTest =
                 element test {
                     attribute correct {"yes"|"no"}?,
-                    FITBComparison,
+                    (FITBNumcmp | FITBStrcmp | (FITBJscmp | FITBMathcmp | FITBLogic)+),
                     Feedback?
                 }
             FITBComparison =
@@ -436,20 +536,24 @@
                 element jscmp {
                     text
                 }
+            # Compare the submission to the provided answer
+            # (@use-answer), to a named setup object (@obj), or to one
+            # constructed child object; two children compare with each
+            # other instead.  Children use the same building blocks as
+            # setup does.
             FITBMathcmp =
                 element mathcmp {
-                    attribute obj {text}?,
-                    mixed {AnyElement*}
+                    (
+                        attribute use-answer {"yes"} |
+                        attribute obj {text} |
+                        ((DENumber | DEExpression | DEEvaluate | Eval),
+                         (DENumber | DEExpression | DEEvaluate | Eval)?)
+                    )?
                 }
             FITBLogic =
                 element logic {
                     attribute op {"and"|"or"|"not"},
                     (FITBComparison)+
-                }
-            AnyElement =
-                element * {
-                    attribute * {text}*,
-                    mixed {AnyElement*}
                 }
             # Extended fillin with interactive attributes (extends the inline
             # text fill-in blank; the bare "FillIn" name was orphaned)

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -886,14 +886,14 @@
       <attribute name="number"/>
     </optional>
     <ref name="StatementExercise"/>
-    <optional>
-      <ref name="Feedback"/>
-    </optional>
     <element name="areas">
       <oneOrMore>
         <ref name="ParagraphAreas"/>
       </oneOrMore>
     </element>
+    <optional>
+      <ref name="Feedback"/>
+    </optional>
     <zeroOrMore>
       <ref name="Hint"/>
     </zeroOrMore>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -913,23 +913,217 @@
       </oneOrMore>
     </element>
   </define>
-  <!-- Fill-in-the-blank exercises (new-style evaluation) -->
+  <!--
+    Fill-in-the-blank exercises: randomized setup, then evaluation.
+    Content model per the FITB maintainer (Brian Walton), issue #2980.
+  -->
   <define name="FillInBlank">
     <ref name="MetaDataTitleOptional"/>
     <optional>
       <attribute name="number"/>
     </optional>
     <ref name="StatementExercise"/>
-    <ref name="Evaluation"/>
-    <zeroOrMore>
-      <ref name="Hint"/>
-    </zeroOrMore>
-    <zeroOrMore>
-      <ref name="Answer"/>
-    </zeroOrMore>
-    <zeroOrMore>
-      <ref name="Solution"/>
-    </zeroOrMore>
+    <interleave>
+      <optional>
+        <ref name="Setup"/>
+      </optional>
+      <ref name="Evaluation"/>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <!--
+    Problem setup: named objects defined sequentially (later ones
+    may reference earlier ones), then optional raw-Javascript hooks.
+    A missing @seed makes any randomization unpredictable, so the
+    FITB machinery warns; but setup has non-randomizing uses too.
+  -->
+  <define name="Setup">
+    <element name="setup">
+      <optional>
+        <attribute name="seed"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="DEObject"/>
+      </zeroOrMore>
+      <optional>
+        <element name="setupScript">
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <element name="postRenderScript">
+          <text/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="DEObject">
+    <element name="de-object">
+      <attribute name="name"/>
+      <attribute name="context">
+        <choice>
+          <value>number</value>
+          <value>formula</value>
+        </choice>
+      </attribute>
+      <choice>
+        <ref name="DERandom"/>
+        <ref name="DENumber"/>
+        <ref name="DEExpression"/>
+        <ref name="DEEvaluate"/>
+      </choice>
+    </element>
+  </define>
+  <!--
+    A random number; @distribution may grow beyond "discrete".
+    @by defaults to 1; @nonzero omitted means "no".
+  -->
+  <define name="DERandom">
+    <element name="de-random">
+      <attribute name="distribution">
+        <value>discrete</value>
+      </attribute>
+      <attribute name="min"/>
+      <attribute name="max"/>
+      <optional>
+        <attribute name="by"/>
+      </optional>
+      <optional>
+        <attribute name="nonzero">
+          <value>yes</value>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <!--
+    Text parses to a formula representing a constant (no free
+    variables).  N.B. @reduce here follows sample usage; the
+    maintainer's description lists it only on de-expression
+    and de-evaluate.
+  -->
+  <define name="DENumber">
+    <element name="de-number">
+      <optional>
+        <attribute name="reduce">
+          <value>yes</value>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <!-- A formula; the content model follows @mode -->
+  <define name="DEExpression">
+    <element name="de-expression">
+      <optional>
+        <attribute name="reduce">
+          <value>yes</value>
+        </attribute>
+      </optional>
+      <choice>
+        <group>
+          <optional>
+            <attribute name="mode">
+              <value>formula</value>
+            </attribute>
+          </optional>
+          <text/>
+        </group>
+        <group>
+          <attribute name="mode">
+            <value>substitution</value>
+          </attribute>
+          <ref name="DEFormula"/>
+          <ref name="DEVariableValued"/>
+        </group>
+        <group>
+          <attribute name="mode">
+            <value>derivative</value>
+          </attribute>
+          <ref name="DEFormula"/>
+          <ref name="DEVariableEmpty"/>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <!-- The evaluated (numeric) version of a formula -->
+  <define name="DEEvaluate">
+    <element name="de-evaluate">
+      <optional>
+        <attribute name="reduce">
+          <value>yes</value>
+        </attribute>
+      </optional>
+      <ref name="DEFormula"/>
+      <ref name="DEVariableValued"/>
+    </element>
+  </define>
+  <!--
+    A reference to some other formula, from which a new one is
+    derived.  (de-random and de-number are technically possible
+    here but have no practical use, so are not admitted.)
+  -->
+  <define name="DEFormula">
+    <element name="formula">
+      <choice>
+        <ref name="DEExpression"/>
+        <ref name="DEEvaluate"/>
+        <ref name="Eval"/>
+      </choice>
+    </element>
+  </define>
+  <!--
+    The variable of a substitution or evaluation carries its
+    value; plain-text values happen to work as raw Javascript
+    but are deliberately NOT valid
+  -->
+  <define name="DEVariableValued">
+    <element name="variable">
+      <attribute name="name"/>
+      <choice>
+        <ref name="Eval"/>
+        <ref name="DENumber"/>
+        <ref name="DEExpression"/>
+      </choice>
+    </element>
+  </define>
+  <!-- The variable of a differentiation is name-only -->
+  <define name="DEVariableEmpty">
+    <element name="variable">
+      <attribute name="name"/>
+      <empty/>
+    </element>
+  </define>
+  <!--
+    An inline reference to a named setup object: within
+    mathematics it renders as the TeX form of the object,
+    elsewhere as its plain string form.  Admitted anywhere
+    text or mathematics occurs (statements, solutions,
+    feedback of dynamic exercises are where it is useful).
+  -->
+  <define name="Eval">
+    <element name="eval">
+      <attribute name="obj"/>
+      <empty/>
+    </element>
+  </define>
+  <!-- eval joins the inline unions (development schema only) -->
+  <define name="TextParagraphItem" combine="choice">
+    <ref name="Eval"/>
+  </define>
+  <define name="MathInlineItem" combine="choice">
+    <ref name="Eval"/>
+  </define>
+  <define name="MathRowItem" combine="choice">
+    <ref name="Eval"/>
   </define>
   <define name="Evaluation">
     <element name="evaluation">
@@ -946,6 +1140,13 @@
       </oneOrMore>
     </element>
   </define>
+  <!--
+    An "evaluate" with @all="yes" tests correctness of ALL the
+    blanks (optional; meaningful with several blanks).  The
+    maintainer describes an optional trailing "feedback" here;
+    observed usage places feedback inside "test", so both are
+    admitted.
+  -->
   <define name="Evaluate">
     <element name="evaluate">
       <optional>
@@ -965,8 +1166,18 @@
       <oneOrMore>
         <ref name="FITBTest"/>
       </oneOrMore>
+      <optional>
+        <ref name="Feedback"/>
+      </optional>
     </element>
   </define>
+  <!--
+    At most one test should carry @correct="yes", determining
+    correctness of a submission (unclosed by this schema); with
+    none, the provided answer or answer object is the default
+    comparison.  A test holds a single numcmp or strcmp, OR any
+    number of jscmp/mathcmp/logic combined with an implied AND.
+  -->
   <define name="FITBTest">
     <element name="test">
       <optional>
@@ -977,7 +1188,17 @@
           </choice>
         </attribute>
       </optional>
-      <ref name="FITBComparison"/>
+      <choice>
+        <ref name="FITBNumcmp"/>
+        <ref name="FITBStrcmp"/>
+        <oneOrMore>
+          <choice>
+            <ref name="FITBJscmp"/>
+            <ref name="FITBMathcmp"/>
+            <ref name="FITBLogic"/>
+          </choice>
+        </oneOrMore>
+      </choice>
       <optional>
         <ref name="Feedback"/>
       </optional>
@@ -1047,16 +1268,39 @@
       <text/>
     </element>
   </define>
+  <!--
+    Compare the submission to the provided answer
+    (@use-answer), to a named setup object (@obj), or to one
+    constructed child object; two children compare with each
+    other instead.  Children use the same building blocks as
+    setup does.
+  -->
   <define name="FITBMathcmp">
     <element name="mathcmp">
       <optional>
-        <attribute name="obj"/>
+        <choice>
+          <attribute name="use-answer">
+            <value>yes</value>
+          </attribute>
+          <attribute name="obj"/>
+          <group>
+            <choice>
+              <ref name="DENumber"/>
+              <ref name="DEExpression"/>
+              <ref name="DEEvaluate"/>
+              <ref name="Eval"/>
+            </choice>
+            <optional>
+              <choice>
+                <ref name="DENumber"/>
+                <ref name="DEExpression"/>
+                <ref name="DEEvaluate"/>
+                <ref name="Eval"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
       </optional>
-      <mixed>
-        <zeroOrMore>
-          <ref name="AnyElement"/>
-        </zeroOrMore>
-      </mixed>
     </element>
   </define>
   <define name="FITBLogic">
@@ -1071,21 +1315,6 @@
       <oneOrMore>
         <ref name="FITBComparison"/>
       </oneOrMore>
-    </element>
-  </define>
-  <define name="AnyElement">
-    <element>
-      <anyName/>
-      <zeroOrMore>
-        <attribute>
-          <anyName/>
-        </attribute>
-      </zeroOrMore>
-      <mixed>
-        <zeroOrMore>
-          <ref name="AnyElement"/>
-        </zeroOrMore>
-      </mixed>
     </element>
   </define>
   <!--

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1629,7 +1629,9 @@
                 Caption,
                 Index*
             
-            TextParagraph = mixed { (
+            # The union is named so extensions (e.g. the development
+            # schema) can widen it with a choice-combine ("|=")
+            TextParagraphItem =
                 Character |
                 Generator |
                 Verbatim |
@@ -1644,7 +1646,8 @@
                 List |
                 Footnote |
                 Notation |
-                Index)* }
+                Index
+            TextParagraph = mixed { TextParagraphItem* }
             Paragraph =
                 element p {
                     UniqueID?,
@@ -1760,9 +1763,11 @@
                              (attribute fill{text}?|attribute characters {xsd:integer}?),
                              empty
                          }
+            # named so extensions can widen it ("|=")
+            MathInlineItem = FillInMath | WWVariable
             MathInline =
                 element m {
-                    mixed {(FillInMath | WWVariable)*}
+                    mixed {MathInlineItem*}
                 }
             TagSymbol = "star" | "dstar" | "tstar" |
                         "dagger" | "ddagger" | "tdagger" |
@@ -1777,8 +1782,10 @@
                         attribute tag { TagSymbol }
                     )?,
                     attribute break {"yes" | "no"}?,
-                    mixed {(Xref | FillInMath | WWVariable)*}
+                    mixed {MathRowItem*}
                 }
+            # named so extensions can widen it ("|=")
+            MathRowItem = Xref | FillInMath | WWVariable
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
@@ -1796,7 +1803,7 @@
                                 attribute number {"yes" | "no"} |
                                 attribute tag { TagSymbol }
                             )?,
-                            mixed {(Xref | FillInMath | WWVariable)*}
+                            mixed {MathRowItem*}
                         ) |
                         # multi-line: "mrow" content, not itself a
                         # cross-reference target, so no @xml:id, no @label;

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -4247,26 +4247,33 @@
       <ref name="Index"/>
     </zeroOrMore>
   </define>
+  <!--
+    The union is named so extensions (e.g. the development
+    schema) can widen it with a choice-combine ("|=")
+  -->
+  <define name="TextParagraphItem">
+    <choice>
+      <ref name="Character"/>
+      <ref name="Generator"/>
+      <ref name="Verbatim"/>
+      <ref name="Group"/>
+      <ref name="WWVariable"/>
+      <ref name="MathInline"/>
+      <ref name="Music"/>
+      <ref name="Reference"/>
+      <ref name="Custom"/>
+      <ref name="CodeDisplay"/>
+      <ref name="MathDisplay"/>
+      <ref name="List"/>
+      <ref name="Footnote"/>
+      <ref name="Notation"/>
+      <ref name="Index"/>
+    </choice>
+  </define>
   <define name="TextParagraph">
     <mixed>
       <zeroOrMore>
-        <choice>
-          <ref name="Character"/>
-          <ref name="Generator"/>
-          <ref name="Verbatim"/>
-          <ref name="Group"/>
-          <ref name="WWVariable"/>
-          <ref name="MathInline"/>
-          <ref name="Music"/>
-          <ref name="Reference"/>
-          <ref name="Custom"/>
-          <ref name="CodeDisplay"/>
-          <ref name="MathDisplay"/>
-          <ref name="List"/>
-          <ref name="Footnote"/>
-          <ref name="Notation"/>
-          <ref name="Index"/>
-        </choice>
+        <ref name="TextParagraphItem"/>
       </zeroOrMore>
     </mixed>
   </define>
@@ -4504,14 +4511,18 @@
       <empty/>
     </element>
   </define>
+  <!-- named so extensions can widen it ("|=") -->
+  <define name="MathInlineItem">
+    <choice>
+      <ref name="FillInMath"/>
+      <ref name="WWVariable"/>
+    </choice>
+  </define>
   <define name="MathInline">
     <element name="m">
       <mixed>
         <zeroOrMore>
-          <choice>
-            <ref name="FillInMath"/>
-            <ref name="WWVariable"/>
-          </choice>
+          <ref name="MathInlineItem"/>
         </zeroOrMore>
       </mixed>
     </element>
@@ -4561,14 +4572,18 @@
       </optional>
       <mixed>
         <zeroOrMore>
-          <choice>
-            <ref name="Xref"/>
-            <ref name="FillInMath"/>
-            <ref name="WWVariable"/>
-          </choice>
+          <ref name="MathRowItem"/>
         </zeroOrMore>
       </mixed>
     </element>
+  </define>
+  <!-- named so extensions can widen it ("|=") -->
+  <define name="MathRowItem">
+    <choice>
+      <ref name="Xref"/>
+      <ref name="FillInMath"/>
+      <ref name="WWVariable"/>
+    </choice>
   </define>
   <define name="MathIntertext">
     <element name="intertext">
@@ -4610,11 +4625,7 @@
           </optional>
           <mixed>
             <zeroOrMore>
-              <choice>
-                <ref name="Xref"/>
-                <ref name="FillInMath"/>
-                <ref name="WWVariable"/>
-              </choice>
+              <ref name="MathRowItem"/>
             </zeroOrMore>
           </mixed>
         </group>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2525,10 +2525,10 @@
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
-                Feedback?,
                 element areas {
                   ParagraphAreas+
                 },
+                Feedback?,
                 Hint*, Answer*, Solution*
 
             # General feedback element

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -526,7 +526,9 @@
         <fragment xml:id="paragraph">
             <title>Paragraphs</title>
             <code>
-            TextParagraph = mixed { (
+            # The union is named so extensions (e.g. the development
+            # schema) can widen it with a choice-combine ("|=")
+            TextParagraphItem =
                 Character |
                 Generator |
                 Verbatim |
@@ -541,7 +543,8 @@
                 List |
                 Footnote |
                 Notation |
-                Index)* }
+                Index
+            TextParagraph = mixed { TextParagraphItem* }
             Paragraph =
                 element p {
                     UniqueID?,
@@ -905,9 +908,11 @@
                              (attribute fill{text}?|attribute characters {xsd:integer}?),
                              empty
                          }
+            # named so extensions can widen it ("|=")
+            MathInlineItem = FillInMath | WWVariable
             MathInline =
                 element m {
-                    mixed {(FillInMath | WWVariable)*}
+                    mixed {MathInlineItem*}
                 }
             TagSymbol = "star" | "dstar" | "tstar" |
                         "dagger" | "ddagger" | "tdagger" |
@@ -922,8 +927,10 @@
                         attribute tag { TagSymbol }
                     )?,
                     attribute break {"yes" | "no"}?,
-                    mixed {(Xref | FillInMath | WWVariable)*}
+                    mixed {MathRowItem*}
                 }
+            # named so extensions can widen it ("|=")
+            MathRowItem = Xref | FillInMath | WWVariable
             MathIntertext = element intertext {TextLong}
             MathDisplay =
                 element md {
@@ -941,7 +948,7 @@
                                 attribute number {"yes" | "no"} |
                                 attribute tag { TagSymbol }
                             )?,
-                            mixed {(Xref | FillInMath | WWVariable)*}
+                            mixed {MathRowItem*}
                         ) |
                         # multi-line: "mrow" content, not itself a
                         # cross-reference target, so no @xml:id, no @label;

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2537,29 +2537,129 @@
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
-            # Fill-in-the-blank exercises (new-style evaluation)
+            # Fill-in-the-blank exercises: randomized setup, then evaluation.
+            # Content model per the FITB maintainer (Brian Walton), issue #2980.
             FillInBlank =
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
-                Evaluation,
-                Hint*, Answer*, Solution*
+                (Setup? &amp; Evaluation &amp; Hint* &amp; Answer* &amp; Solution*)
+            # Problem setup: named objects defined sequentially (later ones
+            # may reference earlier ones), then optional raw-Javascript hooks.
+            # A missing @seed makes any randomization unpredictable, so the
+            # FITB machinery warns; but setup has non-randomizing uses too.
+            Setup =
+                element setup {
+                    attribute seed {text}?,
+                    DEObject*,
+                    element setupScript {text}?,
+                    element postRenderScript {text}?
+                }
+            DEObject =
+                element de-object {
+                    attribute name {text},
+                    attribute context {"number" | "formula"},
+                    (DERandom | DENumber | DEExpression | DEEvaluate)
+                }
+            # A random number; @distribution may grow beyond "discrete".
+            # @by defaults to 1; @nonzero omitted means "no".
+            DERandom =
+                element de-random {
+                    attribute distribution {"discrete"},
+                    attribute min {text},
+                    attribute max {text},
+                    attribute by {text}?,
+                    attribute nonzero {"yes"}?,
+                    empty
+                }
+            # Text parses to a formula representing a constant (no free
+            # variables).  N.B. @reduce here follows sample usage; the
+            # maintainer's description lists it only on de-expression
+            # and de-evaluate.
+            DENumber =
+                element de-number {
+                    attribute reduce {"yes"}?,
+                    text
+                }
+            # A formula; the content model follows @mode
+            DEExpression =
+                element de-expression {
+                    attribute reduce {"yes"}?,
+                    (
+                        (attribute mode {"formula"}?, text) |
+                        (attribute mode {"substitution"}, DEFormula, DEVariableValued) |
+                        (attribute mode {"derivative"}, DEFormula, DEVariableEmpty)
+                    )
+                }
+            # The evaluated (numeric) version of a formula
+            DEEvaluate =
+                element de-evaluate {
+                    attribute reduce {"yes"}?,
+                    DEFormula,
+                    DEVariableValued
+                }
+            # A reference to some other formula, from which a new one is
+            # derived.  (de-random and de-number are technically possible
+            # here but have no practical use, so are not admitted.)
+            DEFormula =
+                element formula {
+                    DEExpression | DEEvaluate | Eval
+                }
+            # The variable of a substitution or evaluation carries its
+            # value; plain-text values happen to work as raw Javascript
+            # but are deliberately NOT valid
+            DEVariableValued =
+                element variable {
+                    attribute name {text},
+                    (Eval | DENumber | DEExpression)
+                }
+            # The variable of a differentiation is name-only
+            DEVariableEmpty =
+                element variable {
+                    attribute name {text},
+                    empty
+                }
+            # An inline reference to a named setup object: within
+            # mathematics it renders as the TeX form of the object,
+            # elsewhere as its plain string form.  Admitted anywhere
+            # text or mathematics occurs (statements, solutions,
+            # feedback of dynamic exercises are where it is useful).
+            Eval =
+                element eval {
+                    attribute obj {text},
+                    empty
+                }
+            # eval joins the inline unions (development schema only)
+            TextParagraphItem |= Eval
+            MathInlineItem |= Eval
+            MathRowItem |= Eval
             Evaluation =
                 element evaluation {
                     attribute answers-coupled {"yes"|"no"}?,
                     Evaluate+
                 }
+            # An "evaluate" with @all="yes" tests correctness of ALL the
+            # blanks (optional; meaningful with several blanks).  The
+            # maintainer describes an optional trailing "feedback" here;
+            # observed usage places feedback inside "test", so both are
+            # admitted.
             Evaluate =
                 element evaluate {
                     attribute name {text}?,
                     attribute submit {text}?,
                     attribute all {"yes"|"no"}?,
-                    FITBTest+
+                    FITBTest+,
+                    Feedback?
                 }
+            # At most one test should carry @correct="yes", determining
+            # correctness of a submission (unclosed by this schema); with
+            # none, the provided answer or answer object is the default
+            # comparison.  A test holds a single numcmp or strcmp, OR any
+            # number of jscmp/mathcmp/logic combined with an implied AND.
             FITBTest =
                 element test {
                     attribute correct {"yes"|"no"}?,
-                    FITBComparison,
+                    (FITBNumcmp | FITBStrcmp | (FITBJscmp | FITBMathcmp | FITBLogic)+),
                     Feedback?
                 }
             FITBComparison =
@@ -2584,20 +2684,24 @@
                 element jscmp {
                     text
                 }
+            # Compare the submission to the provided answer
+            # (@use-answer), to a named setup object (@obj), or to one
+            # constructed child object; two children compare with each
+            # other instead.  Children use the same building blocks as
+            # setup does.
             FITBMathcmp =
                 element mathcmp {
-                    attribute obj {text}?,
-                    mixed {AnyElement*}
+                    (
+                        attribute use-answer {"yes"} |
+                        attribute obj {text} |
+                        ((DENumber | DEExpression | DEEvaluate | Eval),
+                         (DENumber | DEExpression | DEEvaluate | Eval)?)
+                    )?
                 }
             FITBLogic =
                 element logic {
                     attribute op {"and"|"or"|"not"},
                     (FITBComparison)+
-                }
-            AnyElement =
-                element * {
-                    attribute * {text}*,
-                    mixed {AnyElement*}
                 }
             # Extended fillin with interactive attributes (extends the inline
             # text fill-in blank; the bare "FillIn" name was orphaned)


### PR DESCRIPTION
This encodes the dynamic fill-in-the-blank (FITB) authoring model in the development schema, following the maintainer's specification in #2980, in four commits.

1. *Schema: inline content unions are named, so extensible.*  The base schema's inline unions (paragraph content, `m`, `mrow`/single-line `md`) become named patterns (`TextParagraphItem`, `MathInlineItem`, `MathRowItem`) so extensions can widen them with a choice-combine.  No language change: validation results are identical before and after, verified on the sample article.
2. *Schema: dynamic fill-in exercises modeled fully.*  The development schema gains `setup` (optional `@seed`; `de-object*` defined sequentially; optional `setupScript`/`postRenderScript`), the object builders `de-random`/`de-number`/`de-expression`/`de-evaluate` with their mode-dependent content, `formula` and `variable` (bare-text variable values are deliberately invalid), and `eval`, which joins the three inline unions — development schema only.  On the evaluation side, `mathcmp` loses its wildcard content model in favor of the specified attribute/children choices, and `test` admits several `jscmp`/`mathcmp`/`logic` with implied AND.  Comments record two open refinements (`de-number/@reduce`, `feedback` placement) pending maintainer confirmation.
3. *Schema: feedback of a clickable-area exercise follows the areas.*  The model placed `feedback` before `areas`; usage places it after.
4. *Sample article: "de-expression" has no "@context", a "variable" value is a "de-number".*  Source repairs aligning the sample with the confirmed model.

Measured with `pretext/pretext -V -M local-dev`: the sample article's development-schema errors drop from 26 to 17.  All errors for the current FITB model are gone; the fifteen remaining beyond two known `docinfo` items come from the deprecated old-style `var`/`condition` exercise, which the schema deliberately does not model — retiring that example is separate, forthcoming work.

Addresses #2980.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
