### PR TITLE
Messages and severity: an honest vocabulary, enforced end-to-end

### DIFF
--- a/doc/guide/developer/messaging.xml
+++ b/doc/guide/developer/messaging.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--        PreTeXt Developer's Guide                         -->
+<!--                                                          -->
+<!-- Copyright (C) 2026                                       -->
+<!-- Robert A. Beezer                                         -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<chapter xml:id="messaging" label="messaging">
+    <title>Messages and Severity</title>
+
+    <introduction>
+        <p>PreTeXt reports to two audiences<mdash/>the author or publisher running a conversion, and the developer maintaining PreTeXt<mdash/>through a single stream of messages.  Every message carries a <term>severity</term> that says what happened and who should act.  This chapter fixes the vocabulary, so that when you write a message you never have to wonder which one to reach for.</p>
+    </introduction>
+
+    <section xml:id="messaging-severities" label="messaging-severities">
+        <title>The Seven Severities</title>
+
+        <p>The severities, from least to most consequential, are the following.  A severity is a statement about a <em>message</em>; only the last, <c>fatal</c>, is also an <em>action</em>.</p>
+
+        <p>
+            <dl>
+                <li><title>debug</title><p>Fine-grained trace, for pinpointing a problem.  Silent unless the reader asks for maximum verbosity.  (<q>xsltproc command: <ellipsis/></q>)</p></li>
+                <li><title>info</title><p>Coarse progress, so the reader sees the conversion advancing.  (<q>converting source to HTML</q>)</p></li>
+                <li><title>fallback</title><p>Input was bad or absent, but a sensible default was substituted, so the output is still complete.  (<q>no <c>@width</c>, assuming <c>100%</c></q>)</p></li>
+                <li><title>warning</title><p>Something the author should address.  (<q>a deprecated element was used</q>)</p></li>
+                <li><title>error</title><p>There is no good default, so a localized piece of the output is broken or missing, but processing continues.  (<q>cross-reference target does not exist</q>)</p></li>
+                <li><title>bug</title><p>An internal PreTeXt defect<mdash/>not the author's fault.  Please report it.  The renderer degrades and continues.  (<q>an <tag>otherwise</tag> meant to be unreachable</q>)</p></li>
+                <li><title>fatal</title><p>Processing halts and no output is expected.  (<q>the source is not valid PreTeXt</q>)</p></li>
+            </dl>
+        </p>
+
+        <p>The distinction between the last two is the crux, and worth stating twice.  <term>Bug</term> is a <em>severity</em>: it records that PreTeXt itself is at fault, and then execution continues by degrading gracefully.  <term>Fatal</term> is a <em>severity and an action</em>: it records the message and then stops the build.</p>
+
+        <p>Reach for <c>fatal</c> only as an <term>absolute last resort</term>.  An author waiting on a build<mdash/>perhaps minutes before a class<mdash/>is far better served by degraded output they can still use than by a halt with nothing to show.  Unless PreTeXt genuinely cannot produce anything sensible, prefer <c>error</c> (or <c>bug</c>) and carry on.  Halting is for source, or conditions, so broken that continuing would be meaningless.</p>
+    </section>
+
+    <section xml:id="messaging-python" label="messaging-python">
+        <title>Emitting a Message from Python</title>
+
+        <p>The shared logger provides one method per severity.<cd>
+        log.debug     log.info     log.fallback     log.warning
+        log.error     log.bug      log.fatal
+        </cd>All but the last simply record a message and return.  <c>log.fatal</c> records the message and then raises <c>PreTeXtFatal</c>, so the build stops.  Raising is the <em>only</em> way to signal a halt, which is what guarantees that <q>fatal</q> always means <q>halt.</q></p>
+
+        <p>A defect that cannot be worked around is the rare composition of the two<mdash/>record it as a bug, then stop.<cd>
+        log.bug("an impossible case was reached")
+        log.fatal("so the build cannot continue")
+        </cd></p>
+    </section>
+
+    <section xml:id="messaging-xsl" label="messaging-xsl">
+        <title>Emitting a Message from a Stylesheet</title>
+
+        <p>An <tag>xsl:message</tag> begins with the token that names its severity: <c>PTX:DEBUG</c>, <c>PTX:INFO</c>, <c>PTX:FALLBACK</c>, <c>PTX:WARNING</c>, <c>PTX:ERROR</c>, <c>PTX:BUG</c>, or <c>PTX:FATAL</c>.  A fatal message additionally carries <c>terminate="yes"</c>.  Deprecations are the one exception: they are emitted through a shared template and carry <c>PTX:DEPRECATE</c>, which is treated as a warning.</p>
+
+        <p>The Python layer reads the leading token of each stylesheet message and re-emits it at the corresponding severity.  A message whose token is malformed<mdash/>a stray space, the wrong case<mdash/>is itself reported as a bug, so an authoring slip is surfaced rather than silently demoted.</p>
+    </section>
+
+    <section xml:id="messaging-consumers" label="messaging-consumers">
+        <title>What a Consumer Learns</title>
+
+        <p>PreTeXt is normally driven as a library by a separate command-line program, which is in turn driven by tools such as an online textbook platform.  Such a tool sees only what reaches it: the severity of each logged message, and whether the build raised <c>PreTeXtFatal</c>.  From these the command-line layer can report the two outcomes an author cares about<mdash/>the build finished but had non-fatal errors, or the build did not happen at all<mdash/>without inspecting the text of any message.  For that to work, this library's obligation is simply to log every message at an honest severity, to route <em>all</em> messages through the shared logger, and to reserve <c>fatal</c> for a genuine halt.</p>
+    </section>
+
+    <section xml:id="messaging-sync" label="messaging-sync">
+        <title>Keeping This in Sync</title>
+
+        <p>The compact form of this severity table also lives as a comment where the levels are defined in the shared logging setup of the Python library.  The two are deliberately redundant: a change to a severity in one place must be matched in the other, and each carries a note pointing at its twin.</p>
+    </section>
+</chapter>

--- a/doc/guide/guide.xml
+++ b/doc/guide/guide.xml
@@ -80,6 +80,7 @@
             <xi:include href="developer/css.xml"/>
             <xi:include href="developer/localization.xml"/>
             <xi:include href="developer/code-style.xml"/>
+            <xi:include href="developer/messaging.xml"/>
             <xi:include href="developer/debugging.xml"/>
             <xi:include href="developer/git.xml"/>
         </part>

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -46,6 +46,8 @@ import lxml.etree as ET
 # warning below reads the same as everywhere else
 from . import common
 __module_warning = common.__module_warning
+# the shared PreTeXt logger (with .bug()/.fallback()/.fatal())
+log = common.log
 
 # could import in a routine, but will do here in the module
 try:
@@ -201,7 +203,7 @@ class PageLayout:
         elif page_format == 'electronic':
             self.emboss = False
         else:
-            print("BUG: page format not recognized, so embossing")
+            log.bug("page format not recognized, so embossing")
             self.emboss = True
 
     def is_last_row(self, position):
@@ -546,7 +548,7 @@ class PageComposer:
         for c in sxml:
             typeface = c.tag
             if typeface != "math":
-                print('BUG: unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
+                log.bug('unexpected element "{}" inside a segment; its text is rendered plain and any nested content is dropped'.format(c.tag))
                 typeface = "text"
             if c.text:
                 if 'punctuation' in c.attrib:

--- a/pretext/lib/braille_translate.py
+++ b/pretext/lib/braille_translate.py
@@ -39,6 +39,8 @@ import lxml.etree as ET
 # warning below reads the same as everywhere else
 from . import common
 __module_warning = common.__module_warning
+# the shared PreTeXt logger (with .bug()/.fallback()/.fatal())
+log = common.log
 
 try:
     import louis
@@ -67,7 +69,7 @@ def _typeform_bits(typeform):
         if token in _TYPEFORM_BITS:
             bits |= _TYPEFORM_BITS[token]
         else:
-            print('BUG: the typeform token "{}" is not recognized, and is ignored'.format(token))
+            log.bug('the typeform token "{}" is not recognized, and is ignored'.format(token))
     return bits
 
 
@@ -122,7 +124,7 @@ def _translate_segment(segment):
         else:
             # translate anything unexpected as plain print text,
             # rather than lose content or halt a conversion
-            print('BUG: unexpected element "{}" inside a segment; its content is treated as plain text'.format(child.tag))
+            log.bug('unexpected element "{}" inside a segment; its content is treated as plain text'.format(child.tag))
             chunk.append((child, "text", 0))
             chunk.append((child, "tail", 0))
     _translate_chunk(chunk)

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -106,6 +106,23 @@ log.fallback = _log_fallback
 log.bug = _log_bug
 log.fatal = _log_fatal
 
+
+# The level at which to re-log a stylesheet message, by its "PTX:TOKEN".
+# The bridge only *records* a message here; a FATAL one is logged like any
+# other and does not halt (the transform's own terminating exception carries
+# the halt), so every token, fatal included, routes the same way.
+_XSL_MESSAGE_LEVELS = {
+    'FATAL':     FATAL_LEVEL,
+    'BUG':       BUG_LEVEL,
+    'ERROR':     ERROR_LEVEL,
+    'FALLBACK':  FALLBACK_LEVEL,
+    'WARNING':   WARNING_LEVEL,
+    'DEPRECATE': WARNING_LEVEL,
+    'INFO':      INFO_LEVEL,
+    'DEBUG':     DEBUG_LEVEL,
+}
+
+import re
 import traceback
 import os
 import os.path
@@ -273,16 +290,23 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
                 log.info("messages from the log for XSL processing:")
             # print out any unprinted messages from error_log
             for line in xslt.error_log[start:end]:
-                if "PTX:FATAL" in line.message:
-                    log.critical(f"* {line.message}")
-                elif "PTX:ERROR" in line.message or "PTX:BUG" in line.message:
-                    log.error(f"* {line.message}")
-                elif "PTX:WARNING" in line.message or "PTX:DEPRECATE" in line.message:
-                    log.warning(f"* {line.message}")
-                elif "PTX:DEBUG" in line.message:
-                    log.debug(f"* {line.message}")
+                message = "* {}".format(line.message)
+                token = re.match(r'\s*PTX:([\w-]+)', line.message)
+                if token:
+                    level = _XSL_MESSAGE_LEVELS.get(token.group(1).upper())
+                    if level is not None:
+                        log.log(level, message)
+                    else:
+                        # a well-formed but unknown token (e.g. a "PTX:FO-TODO"
+                        # work marker); keep it quiet rather than mis-leveling
+                        log.debug(message)
+                elif re.match(r'\s*(?i:ptx|warning|error|fatal|bug|deprecate)\b', line.message):
+                    # looks like it meant to carry a severity token but is
+                    # malformed (a stylesheet-authoring slip); flag it
+                    log.bug("a PreTeXt stylesheet message has a malformed severity token: {}".format(line.message))
                 else:
-                    log.info(f"* {line.message}")
+                    # genuinely tokenless (e.g. a continuation line)
+                    log.info(message)
             start = end
         if texc is None:
             log.info("successful application of {}".format(xsl))

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -24,7 +24,87 @@
 # one-way:  common  <-  {webwork, stack, pretext}
 
 import logging
+
+# ------------------------------------------------------------------- #
+# PreTeXt message severity                                            #
+#                                                                     #
+# Every message travels through the shared "ptxlogger" at one of      #
+# these levels.  A level is a *severity* -- what happened and who     #
+# should act.  "fatal" is unique in being a severity *and* an action: #
+# it stops the build.                                                 #
+#                                                                     #
+#   log.debug     10  fine-grained trace, for pinpointing             #
+#                     ("xsltproc command: ...")                       #
+#   log.info      20  coarse progress                                 #
+#                     ("converting source to HTML")                   #
+#   log.fallback  25  bad or absent input, but a sensible default     #
+#                     was substituted; output is complete             #
+#                     ('no @width, assuming "100%"')                  #
+#   log.warning   30  should be addressed                             #
+#                     ("a deprecated element was used")               #
+#   log.error     40  no good default; localized breakage, output     #
+#                     is degraded but processing continues            #
+#                     ("cross-reference target does not exist")       #
+#   log.bug       45  an internal PreTeXt defect, NOT the author's    #
+#                     fault; please report.  A severity only:         #
+#                     execution continues (the renderer degrades)     #
+#                     ("an 'otherwise' meant to be unreachable")      #
+#   log.fatal     50  processing halts, no output expected.  A        #
+#                     severity AND an action: it logs, then raises    #
+#                     PreTeXtFatal ("invalid source, or a severe bug") #
+#                                                                     #
+# A defect that cannot be worked around is the rare composition of    #
+# the two: log.bug(...) to record it, then log.fatal(...) to stop.    #
+#                                                                     #
+# KEEP IN SYNC: this table is mirrored, with fuller prose, in the     #
+# "Messaging" chapter of the Developer Guide.  Changing a level here  #
+# means changing it there, and vice versa.                            #
+# ------------------------------------------------------------------- #
+
+# The full severity ladder in one place.  The standard five are Python's
+# own; "fallback" and "bug" are PreTeXt additions that interleave with them.
+DEBUG_LEVEL    = logging.DEBUG      # 10
+INFO_LEVEL     = logging.INFO       # 20
+FALLBACK_LEVEL = 25
+WARNING_LEVEL  = logging.WARNING    # 30
+ERROR_LEVEL    = logging.ERROR      # 40
+BUG_LEVEL      = 45
+FATAL_LEVEL    = logging.CRITICAL   # 50
+logging.addLevelName(FALLBACK_LEVEL, 'FALLBACK')
+logging.addLevelName(BUG_LEVEL, 'BUG')
+# We prefer "fatal" to Python's "critical" for level 50; a downstream
+# consumer (such as the CLI) is free to rebrand it.
+logging.addLevelName(FATAL_LEVEL, 'FATAL')
+
+
+class PreTeXtFatal(Exception):
+    '''The build cannot continue and no output is expected.  A fatal-severity
+    message (log.fatal) raises this; the program driving PreTeXt catches it
+    and reports the halt.  It is internal: an author never sees it directly.'''
+    pass
+
+
 log = logging.getLogger('ptxlogger')
+
+
+# Convenience methods for the two new levels, plus a "fatal" that is a
+# severity *and* an action.  Attached to the shared logger instance, so
+# every module that fetches "ptxlogger" gains them.
+def _log_fallback(message, *args, **kwargs):
+    if log.isEnabledFor(FALLBACK_LEVEL):
+        log._log(FALLBACK_LEVEL, message, args, **kwargs)
+
+def _log_bug(message, *args, **kwargs):
+    if log.isEnabledFor(BUG_LEVEL):
+        log._log(BUG_LEVEL, message, args, **kwargs)
+
+def _log_fatal(message, *args, **kwargs):
+    log._log(FATAL_LEVEL, message, args, **kwargs)
+    raise PreTeXtFatal(message)
+
+log.fallback = _log_fallback
+log.bug = _log_bug
+log.fatal = _log_fatal
 
 import traceback
 import os

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -287,7 +287,7 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
             # start will be reset to non-zero, so this is
             # one-time only, and never if there are no messages
             if (start == 0) and (end > 0):
-                log.info("messages from the log for XSL processing:")
+                log.info("messages from the log for XSL processing (prefaced with a *):")
             # print out any unprinted messages from error_log
             for line in xslt.error_log[start:end]:
                 message = "* {}".format(line.message)

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -460,8 +460,7 @@ def _git_symbolic_to_hash(symbolic):
             # strip a trailing newline (OK assumption?)
             return f.readline()[:-1]
     except Exception as e:
-        log.critical(traceback.format_exc())
-        log.critical("the full PreTeXt repository may not be available, so determination of commits is not possible")
+        log.debug("the full PreTeXt repository is not available, so the source commit cannot be determined")
         return None
 
 
@@ -486,8 +485,7 @@ def get_git_head():
             # strip a trailing newline (OK assumption?)
             head = f.readline()[:-1]
     except Exception as e:
-        log.critical(traceback.format_exc())
-        log.critical("the full PreTeXt repository may not be available, so determination of commits is not possible")
+        log.debug("the full PreTeXt repository is not available, so the source commit cannot be determined")
         return (None, None)
 
     # head is normally a full symbolic reference

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2196,10 +2196,10 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
                         img = PIL.Image.open(image_path)
                         imgwidthtag = min(100, round(img.width / 6))
                         img.close()
+                        image_element.set("width", "{}%".format(imgwidthtag))
                     except Exception as e:
-                        log.error(f"Unable to read image width of {image_path}: {e}")
+                        log.error("Unable to read image width of {}: {}".format(image_path, e))
 
-                    image_element.set("width", f"{imgwidthtag}%")
                     del image_element.attrib["source"]
                     image_element.set("{http://pretextbook.org/2020/pretext/internal}generated", imageloc)
                 except requests.exceptions.RequestException as e:

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1788,15 +1788,16 @@ def mermaid_images(xml_source, pub_file, stringparams, xmlid_root, dest_dir, out
         with open(mmd_config_file, 'w') as config_file:
             json.dump(mmd_config, config_file, indent=4)
         log.debug("Mermaid configuration file: {}".format(mmd_config_file))
+        # mmdc switches output on the filename extension; there is nothing
+        # to do for a format it cannot produce.  Guard once, before the
+        # loop, so every iteration below has a valid output filename.
+        if outformat not in ["png", "svg"]:
+            log.error("cannot make Mermaid diagrams in {} file format".format(outformat))
+            return
         # loop over each diagram
         for mmddiagram in glob.glob(os.path.join(tmp_dir, "*.mmd")):
             filebase, _ = os.path.splitext(mmddiagram)
-            # file format PNG or SVG
-            # mmdc executable just switches on filename extension
-            if outformat in ["png", "svg"]:
-                mmdout = "{}.{}".format(filebase, outformat)
-            else:
-                log.error("cannot make Mermaid diagrams in {} file format".format(outformat))
+            mmdout = "{}.{}".format(filebase, outformat)
             mmd_cmd = mmd_executable_cmd + ["-i", mmddiagram, "-o", mmdout, "-s", "4", "-c", "mermaid-config.json"]
             log.debug("mermaid conversion command: {}".format(" ".join(mmd_cmd)))
             subprocess.call(mmd_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -727,13 +727,7 @@ def individual_latex_image_conversion(latex_image, outformat, dest_dir, method):
                 ]
             ).format(latex_image)
             log.error(msg)
-            print(
-                "##################################################################"
-            )
-            print(result.stdout)
-            print(
-                "##################################################################"
-            )
+            log.debug(result.stdout)
             # and raise an exception so the calling function can add the image to the list of failed images
             raise Exception("LaTeX compilation of {} failed".format(latex_image))
         else:
@@ -1023,24 +1017,24 @@ def tracer(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
                 if r.status_code == 200:
                     trace = r.text[r.text.find('{"code":') :]
             except Exception as e:
-                log.critical(traceback.format_exc())
-                log.critical(server_error_msg.format(url, visible_id))
+                log.debug(traceback.format_exc())
+                log.error(server_error_msg.format(url, visible_id))
         elif language == "java":
             try:
                 r = requests.post(url, data=dict(src=source), timeout=30)
                 if r.status_code == 200:
                     trace = r.text
             except Exception as e:
-                log.critical(traceback.format_exc())
-                log.critical(server_error_msg.format(url, visible_id))
+                log.debug(traceback.format_exc())
+                log.error(server_error_msg.format(url, visible_id))
         elif language == "python":
             try:
                 r = requests.post(url, data=dict(src=source), timeout=30)
                 if r.status_code == 200:
                     trace = r.text
             except Exception as e:
-                log.critical(traceback.format_exc())
-                log.critical(server_error_msg.format(url, visible_id))
+                log.debug(traceback.format_exc())
+                log.error(server_error_msg.format(url, visible_id))
 
         # should now have a trace, except for timing out
         # no trace, then do not even try to produce a file

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5657,6 +5657,7 @@ __xml_header = '<?xml version="1.0" encoding="UTF-8"?>\n'
 
 # Re-export helpers relocated to "common.py" so the public ptx.NAME
 # interface used by the driver script is unchanged.
+PreTeXtFatal = common.PreTeXtFatal
 build_info_message = common.build_info_message
 download_file = common.download_file
 get_executable_cmd = common.get_executable_cmd

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -3762,7 +3762,7 @@ def _build_custom_theme(xml, theme_name, theme_opts, tmp_dir):
         log.debug("Theme options:" + json.dumps(theme_opts))
         result = subprocess.run(node_exec_cmd + [script, "-t", full_name, "-o", css_dest, "-c", json.dumps(theme_opts)], capture_output=True, timeout=60)
         if result.stdout:
-            log.debug(result.stdout.decode())
+            log.debug(result.stdout.decode().rstrip())
         if result.stderr:
             error_message = result.stderr.decode()
             raise Exception("Failed to build custom theme")

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -26,6 +26,8 @@
 
 from lib import pretext as ptx
 
+import sys
+
 # Set up logging (replacing _verbose/_debug).
 # Use log.info(<string>) or log.debug(<string>).
 # Also available now are log.critical(), log.error(), and log.warning().
@@ -1006,5 +1008,11 @@ def main():
     ptx.release_temporary_directories(any_log_level=False)
 
 
-# Do it - lone top-level command
-main()
+# Do it - lone top-level command.  A fatal message halts the build by
+# raising PreTeXtFatal; it has already been logged, so we exit with an
+# error status but without a Python traceback (a traceback is for an
+# unexpected internal failure, not a deliberate, reported halt).
+try:
+    main()
+except ptx.PreTeXtFatal:
+    sys.exit(1)

--- a/script/cssbuilder/cssbuilder.mjs
+++ b/script/cssbuilder/cssbuilder.mjs
@@ -251,6 +251,6 @@ if (options['help']) {
   } else {
     await ctx.rebuild();
     await ctx.dispose();
-    console.log('CSS build complete!');
+    console.log('CSS build complete');
   }
 }

--- a/xsl/extract-biblio-csl.xsl
+++ b/xsl/extract-biblio-csl.xsl
@@ -100,7 +100,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- TODO: perhaps report content also, as a better assist, or the self/parent/ancestor biblio id -->
 <!-- TODO: refine to include un-implemented bits of "citeproc-py" (e/g static-ordering) -->
 <xsl:template match="*" mode="biblio-to-json">
-    <xsl:message>BUG: PreTeXt "biblio" markup using a "<xsl:value-of select="local-name()"/>" element is not implemented</xsl:message>
+    <xsl:message>PTX:BUG: PreTeXt "biblio" markup using a "<xsl:value-of select="local-name()"/>" element is not implemented</xsl:message>
 </xsl:template>
 
 <!-- Gross JSON array structure, duplicate an ID for the division -->

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1784,7 +1784,7 @@
     <!-- warning if there is no content -->
     <xsl:if test="not(descendant::unit) and not(descendant::per) and not(descendant::mag)">
         <xsl:message>
-        <xsl:text>PTX:WARNING: magnitude or units needed</xsl:text>
+        <xsl:text>PTX:ERROR:   magnitude or units needed</xsl:text>
         </xsl:message>
     </xsl:if>
     <!-- print magnitude if there is one -->
@@ -1865,7 +1865,7 @@
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>
-                <xsl:text>PTX:WARNING: base unit needed</xsl:text>
+                <xsl:text>PTX:ERROR:   base unit needed</xsl:text>
             </xsl:message>
         </xsl:otherwise>
     </xsl:choose>

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -2815,7 +2815,7 @@
             <xsl:text>!{\vrule width 0.11em}</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING:  left or right attribute not recognized: use none, minor, medium, major</xsl:message>
+            <xsl:message>PTX:FALLBACK:  left or right attribute not recognized: use none, minor, medium, major</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -2838,7 +2838,7 @@
             <xsl:text>3</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING:  top or bottom attribute not recognized: use none, minor, medium, major</xsl:message>
+            <xsl:message>PTX:FALLBACK:  top or bottom attribute not recognized: use none, minor, medium, major</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/extract-sageplot.xsl
+++ b/xsl/extract-sageplot.xsl
@@ -88,7 +88,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>3d</xsl:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   a "sageplot" has a @variant attribute ("<xsl:value-of select="@variant"/>") for "<xsl:value-of select="$filebase"/>" whose value is not "2d" nor "3d".  The default ("2d") is being used, which could be incorrect</xsl:message>
+                <xsl:message>PTX:FALLBACK:   a "sageplot" has a @variant attribute ("<xsl:value-of select="@variant"/>") for "<xsl:value-of select="$filebase"/>" whose value is not "2d" nor "3d".  The default ("2d") is being used, which could be incorrect</xsl:message>
                 <xsl:text>2d</xsl:text>
             </xsl:otherwise>
         </xsl:choose>

--- a/xsl/latex/pretext-latex-texstyle.xsl
+++ b/xsl/latex/pretext-latex-texstyle.xsl
@@ -623,7 +623,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:apply-templates>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING: The @authority attribute on a keyword element (in a texstyle file) is required and must be "author" or "msc".  Found "@authority="<xsl:value-of select="@authority"/>". </xsl:message>
+            <xsl:message>PTX:ERROR:   The @authority attribute on a keyword element (in a texstyle file) is required and must be "author" or "msc".  Found "@authority="<xsl:value-of select="@authority"/>". </xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -872,7 +872,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- This is an AWOL node, not empty content (which is allowed) -->
         <xsl:if test="not($the-lookup)">
             <xsl:text>[MISSING CUSTOM CONTENT HERE]</xsl:text>
-            <xsl:message>PTX:WARNING:   lookup for a "custom" element with @name set to "<xsl:value-of select="$the-ref"/>" has failed, while consulting the customization file "<xsl:value-of select="$customizations-file"/>".  Output will contain "[MISSING CUSTOM CONTENT HERE]" instead</xsl:message>
+            <xsl:message>PTX:ERROR:     lookup for a "custom" element with @name set to "<xsl:value-of select="$the-ref"/>" has failed, while consulting the customization file "<xsl:value-of select="$customizations-file"/>".  Output will contain "[MISSING CUSTOM CONTENT HERE]" instead</xsl:message>
             <xsl:apply-templates select="$the-custom" mode="location-report"/>
         </xsl:if>
         <!-- Copying the contents of "custom" via the "version" templates  -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1070,11 +1070,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Look at each "biblio" in the external file -->
         <xsl:for-each select="$biblios/pretext-biblios/biblio">
             <xsl:variable name="the-id" select="@xml:id"/>
-            <xsl:message>@xml:id of &lt;biblio&gt; in bibliography file: <xsl:value-of select="$the-id"/></xsl:message>
+            <xsl:message>PTX:DEBUG: @xml:id of &lt;biblio&gt; in bibliography file: <xsl:value-of select="$the-id"/></xsl:message>
             <!-- Building duplicate, so look at $original for    -->
             <!-- "xref" pointing to the current context "biblio" -->
             <xsl:if test="$original//xref[@ref = $the-id]">
-                <xsl:message>  Located this &lt;biblio&gt; cited in original source</xsl:message>
+                <xsl:message>PTX:DEBUG:  Located this &lt;biblio&gt; cited in original source</xsl:message>
                 <xsl:apply-templates select="." mode="assembly"/>
             </xsl:if>
         </xsl:for-each>

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -83,7 +83,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$debug.brf.symbols"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING: the "debug.brf.symbols" string parameter must be "early" or "late", not "<xsl:value-of select="$debug.brf.symbols"/>", using "late" instead</xsl:message>
+            <xsl:message>PTX:FALLBACK: the "debug.brf.symbols" string parameter must be "early" or "late", not "<xsl:value-of select="$debug.brf.symbols"/>", using "late" instead</xsl:message>
             <xsl:text>late</xsl:text>
         </xsl:otherwise>
     </xsl:choose>

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1670,7 +1670,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>&#x2193;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>WARNING:  &quot;icon&quot; with @name attribute value "<xsl:value-of select="@name"/>" does not have an implementation for braille.</xsl:message>
+            <xsl:message>PTX:WARNING: &quot;icon&quot; with @name attribute value "<xsl:value-of select="@name"/>" does not have an implementation for braille.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -257,12 +257,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- And we sneak in a warning that this conversion is underway, but not complete. -->
 <xsl:template name="warning-unimplemented">
-    <xsl:message>** Some PreTeXt elements lack full implementation in the braille conversion.</xsl:message>
-    <xsl:message>** Smaller items will simply be missing from your output.</xsl:message>
-    <xsl:message>** Larger items may have all-caps placeholders in your output.</xsl:message>
-    <xsl:message>** These will all be reported as "Overlooked" in the log.</xsl:message>
-    <xsl:message>** Please report the complete list in the PreTeXt support forum,</xsl:message>
-    <xsl:message>** so we can prioritize making the output for your project complete.</xsl:message>
+    <xsl:message>PTX:INFO: Some PreTeXt elements lack full implementation in the braille conversion.</xsl:message>
+    <xsl:message>PTX:INFO: Smaller items will simply be missing from your output.</xsl:message>
+    <xsl:message>PTX:INFO: Larger items may have all-caps placeholders in your output.</xsl:message>
+    <xsl:message>PTX:INFO: These will all be reported as "Overlooked" in the log.</xsl:message>
+    <xsl:message>PTX:INFO: Please report the complete list in the PreTeXt support forum,</xsl:message>
+    <xsl:message>PTX:INFO: so we can prioritize making the output for your project complete.</xsl:message>
 </xsl:template>
 
 <!-- The entry template "waits" for the "$math-meld-rtf" and    -->
@@ -2483,11 +2483,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="element"/>
     <xsl:param name="ntimes"/>
 
-    <xsl:message>Unimplemented: <xsl:value-of select="$element"/> (<xsl:value-of select="$ntimes"/> times)</xsl:message>
+    <xsl:message>PTX:INFO: Unimplemented: <xsl:value-of select="$element"/> (<xsl:value-of select="$ntimes"/> times)</xsl:message>
 </xsl:template>
 
 <xsl:template match="*" mode="overlooked">
-    <xsl:message>Overlooked: <xsl:value-of select="local-name()"/></xsl:message>
+    <xsl:message>PTX:INFO: Overlooked: <xsl:value-of select="local-name()"/></xsl:message>
 </xsl:template>
 
 <!-- *Every* element needs an implementation, or it ends up here being -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -5179,7 +5179,7 @@ Book (with parts), "section" at level 3
                 <xsl:when test="@marker='square'">square</xsl:when>
                 <xsl:when test="@marker=''">none</xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>ptx:ERROR: unordered list label (<xsl:value-of select="@marker" />) not recognized</xsl:message>
+                    <xsl:message>PTX:ERROR: unordered list label (<xsl:value-of select="@marker" />) not recognized</xsl:message>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -719,7 +719,7 @@ Book (with parts), "section" at level 3
         <!-- check for bare # (present but \# is not) -->
         <xsl:if test="contains($inside, '#') and not(contains($inside, '\#'))">
             <xsl:message>
-                <xsl:text>PTX:WARNING:   a bare "#" inside \text{} in math must be escaped as "\#"</xsl:text>
+                <xsl:text>PTX:ERROR:     a bare "#" inside \text{} in math must be escaped as "\#"</xsl:text>
                 <xsl:text>&#xa;</xsl:text>
                 <xsl:text>               </xsl:text>
                 <xsl:apply-templates select="." mode="location-report"/>
@@ -728,7 +728,7 @@ Book (with parts), "section" at level 3
         <!-- check for bare % -->
         <xsl:if test="contains($inside, '%') and not(contains($inside, '\%'))">
             <xsl:message>
-                <xsl:text>PTX:WARNING:   a bare "%" inside \text{} in math must be escaped as "\%"</xsl:text>
+                <xsl:text>PTX:ERROR:     a bare "%" inside \text{} in math must be escaped as "\%"</xsl:text>
                 <xsl:text>&#xa;</xsl:text>
                 <xsl:text>               </xsl:text>
                 <xsl:apply-templates select="." mode="location-report"/>
@@ -737,7 +737,7 @@ Book (with parts), "section" at level 3
         <!-- check for bare & -->
         <xsl:if test="contains($inside, '&amp;') and not(contains($inside, '\&amp;'))">
             <xsl:message>
-                <xsl:text>PTX:WARNING:   a bare "&amp;" inside \text{} in math must be escaped as "\&amp;"</xsl:text>
+                <xsl:text>PTX:ERROR:     a bare "&amp;" inside \text{} in math must be escaped as "\&amp;"</xsl:text>
                 <xsl:text>&#xa;</xsl:text>
                 <xsl:text>               </xsl:text>
                 <xsl:apply-templates select="." mode="location-report"/>
@@ -3016,7 +3016,7 @@ Book (with parts), "section" at level 3
         <!-- NaN does not equal *anything*, so tests if a number  -->
         <!-- http://stackoverflow.com/questions/6895870           -->
         <xsl:when test="not(number($the-aspect) = number($the-aspect)) or ($the-aspect &lt; 0)">
-            <xsl:message>PTX:WARNING: the @aspect attribute should be a ratio, like 4:3, or a positive number, not "<xsl:value-of select="$the-aspect" />"</xsl:message>
+            <xsl:message>PTX:ERROR:   the @aspect attribute should be a ratio, like 4:3, or a positive number, not "<xsl:value-of select="$the-aspect" />"</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
         </xsl:when>
         <!-- survives as a number -->
@@ -5073,7 +5073,7 @@ Book (with parts), "section" at level 3
 <xsl:template match="li[p|ol|ul|dl]/text()">
     <xsl:variable name="text" select="normalize-space(.)" />
     <xsl:if test="$text">
-        <xsl:message>PTX:WARNING: Unstructured content within a list item is being ignored ("<xsl:value-of select="$text" />")</xsl:message>
+        <xsl:message>PTX:ERROR:   Unstructured content within a list item is being ignored ("<xsl:value-of select="$text" />")</xsl:message>
          <xsl:apply-templates select=".." mode="location-report" />
     </xsl:if>
 </xsl:template>
@@ -5745,7 +5745,7 @@ Book (with parts), "section" at level 3
         <!-- template                                                  -->
         <xsl:variable name="scope" select="id(@scope)"/>
         <xsl:if test="not($scope)">
-            <xsl:message>PTX:WARNING: unresolved @scope ("<xsl:value-of select="@scope"/>") for a &lt;solutions&gt; division</xsl:message>
+            <xsl:message>PTX:ERROR:   unresolved @scope ("<xsl:value-of select="@scope"/>") for a &lt;solutions&gt; division</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
         </xsl:if>
         <xsl:if test="not($scope/self::book|$scope/self::article|$scope/self::chapter|$scope/self::section|$scope/self::subsection|$scope/self::subsubsection|$scope/self::exercises|$scope/self::worksheet|$scope/self::reading-questions)">
@@ -8575,7 +8575,7 @@ Book (with parts), "section" at level 3
 
 <!-- Warnings for a high-frequency mistake -->
 <xsl:template match="xref[not(@ref) and not(@first and @last) and not(@provisional)]">
-    <xsl:message>PTX:WARNING: A cross-reference (&lt;xref&gt;) must have a @ref attribute, a @first/@last attribute pair, or a @provisional attribute</xsl:message>
+    <xsl:message>PTX:ERROR:   A cross-reference (&lt;xref&gt;) must have a @ref attribute, a @first/@last attribute pair, or a @provisional attribute</xsl:message>
     <xsl:apply-templates select="." mode="location-report" />
     <xsl:call-template name="inline-warning">
         <xsl:with-param name="warning">
@@ -8845,7 +8845,7 @@ Book (with parts), "section" at level 3
             </xsl:variable>
             <xsl:if test="$the-title = ''">
                 <xsl:message>
-                    <xsl:text>PTX:WARNING:    </xsl:text>
+                    <xsl:text>PTX:ERROR:      </xsl:text>
                     <xsl:text>An &lt;xref&gt; wants to build text using a title to identify the target, but the target (which has @xml:id "</xsl:text>
                     <xsl:value-of select="@ref"/>
                     <xsl:text>") has no title, not even a default title.</xsl:text>
@@ -8856,7 +8856,7 @@ Book (with parts), "section" at level 3
         <xsl:when test="$text-style = 'custom'">
             <xsl:if test="not($b-has-content)">
                 <xsl:message>
-                    <xsl:text>PTX:WARNING:    </xsl:text>
+                    <xsl:text>PTX:ERROR:      </xsl:text>
                     <xsl:text>An &lt;xref&gt; wants to use custom text to describe the target, but no custom text was provided as the content of the "xref".</xsl:text>
                 </xsl:message>
                 <xsl:apply-templates select="." mode="location-report" />
@@ -8877,7 +8877,7 @@ Book (with parts), "section" at level 3
             </xsl:variable>
             <xsl:if test="($the-number = '') and not($b-is-contributor-target)">
                 <xsl:message>
-                    <xsl:text>PTX:WARNING:    </xsl:text>
+                    <xsl:text>PTX:ERROR:      </xsl:text>
                     <xsl:text>An &lt;xref&gt; wants to build text using a number to identify the target, but the target (which has @xml:id "</xsl:text>
                     <xsl:value-of select="@ref"/>
                     <xsl:text>") does not have a number. You could try 'text="title"' or 'text="custom"' on the "xref".</xsl:text>
@@ -9021,7 +9021,7 @@ Book (with parts), "section" at level 3
         <!-- catch this first and provide no text at all (could provide busted text?) -->
         <!-- anonymous lists live in "p", but this is an unreliable indication        -->
         <xsl:when test="($text-style = 'phrase-global' or $text-style = 'phrase-hybrid') and ($target/self::li and not($target/ancestor::list or $target/ancestor::objectives or $target/ancestor::outcomes or $target/ancestor::exercise))">
-            <xsl:message>PTX:WARNING: a cross-reference to a list item of an anonymous list ("<xsl:apply-templates select="$target" mode="serial-number" />") with 'phrase-global' and 'phrase-hybrid' styles for the xref text will yield no text at all, and possibly create unpredictable results in output</xsl:message>
+            <xsl:message>PTX:ERROR:   a cross-reference to a list item of an anonymous list ("<xsl:apply-templates select="$target" mode="serial-number" />") with 'phrase-global' and 'phrase-hybrid' styles for the xref text will yield no text at all, and possibly create unpredictable results in output</xsl:message>
         </xsl:when>
         <xsl:when test="$text-style = 'phrase-global' or $text-style = 'phrase-hybrid'">
             <!-- no content override in this case -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2012,7 +2012,7 @@ Book (with parts), "section" at level 3
             <xsl:if test="$wsdebug and not($text-processed = $middle-cleaned)">
                 <!-- DEBUGGING follows, maybe move outward later -->
                 <xsl:message>
-                    <xsl:text>****&#xa;</xsl:text>
+                    <xsl:text>PTX:DEBUG: whitespace diagnostic&#xa;</xsl:text>
                     <xsl:text>O:</xsl:text>
                     <xsl:value-of select="." />
                     <xsl:text>:O&#xa;</xsl:text>
@@ -4523,7 +4523,7 @@ Book (with parts), "section" at level 3
     <!-- count the elements destined for panels  -->
     <xsl:variable name="number-panels" select="count(*)" />
     <xsl:if test="$sbsdebug">
-        <xsl:message>N:<xsl:value-of select="$number-panels" />:N</xsl:message>
+        <xsl:message>PTX:DEBUG: N:<xsl:value-of select="$number-panels" />:N</xsl:message>
     </xsl:if>
     <!-- Add to RTF -->
     <number-panels>
@@ -4569,7 +4569,7 @@ Book (with parts), "section" at level 3
         </xsl:choose>
     </xsl:variable>
     <xsl:if test="$sbsdebug">
-        <xsl:message>VA:<xsl:value-of select="$valigns" />:VA</xsl:message>
+        <xsl:message>PTX:DEBUG: VA:<xsl:value-of select="$valigns" />:VA</xsl:message>
     </xsl:if>
     <!-- check length (author-supplied could be wrong) -->
     <xsl:variable name="nspaces-valigns" select="string-length($valigns) - string-length(translate($valigns, ' ', ''))" />
@@ -4729,7 +4729,7 @@ Book (with parts), "section" at level 3
         </xsl:choose>
     </xsl:variable>
     <xsl:if test="$sbsdebug">
-        <xsl:message>M:<xsl:value-of select="$left-margin" />:<xsl:value-of select="$right-margin" />:M</xsl:message>
+        <xsl:message>PTX:DEBUG: M:<xsl:value-of select="$left-margin" />:<xsl:value-of select="$right-margin" />:M</xsl:message>
     </xsl:if>
     <!-- error check for reasonable values -->
     <!-- When there are three values, the "left" margin still -->
@@ -4774,7 +4774,7 @@ Book (with parts), "section" at level 3
         </xsl:choose>
     </xsl:variable>
     <xsl:if test="$sbsdebug">
-        <xsl:message>W:<xsl:value-of select="$widths" />:W</xsl:message>
+        <xsl:message>PTX:DEBUG: W:<xsl:value-of select="$widths" />:W</xsl:message>
     </xsl:if>
     <!-- check length (author-supplied could be wrong) -->
     <xsl:variable name="nspaces-widths" select="string-length($widths) - string-length(translate($widths, ' ', ''))" />
@@ -4813,7 +4813,7 @@ Book (with parts), "section" at level 3
         <xsl:text>%</xsl:text>
     </xsl:variable>
     <xsl:if test="$sbsdebug">
-        <xsl:message>SW:<xsl:value-of select="$space-width" />:SW</xsl:message>
+        <xsl:message>PTX:DEBUG: SW:<xsl:value-of select="$space-width" />:SW</xsl:message>
     </xsl:if>
     <!-- overall error check on space width -->
     <xsl:choose>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -579,7 +579,7 @@ Book (with parts), "section" at level 3
         <xsl:when test="$normalized-level=3">subsection</xsl:when>
         <xsl:when test="$normalized-level=4">subsubsection</xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR: Level computation is out-of-bounds (input as <xsl:value-of select="$level" />, normalized to <xsl:value-of select="$normalized-level" />)</xsl:message>
+            <xsl:message>PTX:BUG:   Level computation is out-of-bounds (input as <xsl:value-of select="$level" />, normalized to <xsl:value-of select="$normalized-level" />)</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -3192,7 +3192,7 @@ Book (with parts), "section" at level 3
             <xsl:text>[</xsl:text>
             <xsl:value-of select="$str-id" />
             <xsl:text>]</xsl:text>
-            <xsl:message>PTX:WARNING: could not translate string with id "<xsl:value-of select="$str-id"/>" into language for code "<xsl:value-of select="$lang"/>"</xsl:message>
+            <xsl:message>PTX:BUG:     could not translate string with id "<xsl:value-of select="$str-id"/>" into language for code "<xsl:value-of select="$lang"/>"</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -5676,7 +5676,7 @@ Book (with parts), "section" at level 3
             <exercise-component-report has-hint="{$b-has-reading-hint}" has-answer="{$b-has-reading-answer}" has-solution="{$b-has-reading-solution}"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR: can't determine exercise type</xsl:message>
+            <xsl:message>PTX:BUG:   can't determine exercise type</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
         </xsl:otherwise>
     </xsl:choose>
@@ -10330,7 +10330,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <!-- Final period when no following-siblings     -->
 
 <xsl:template match="biblio[not(@type = 'raw') and not(@type = 'bibtex')]/*">
-    <xsl:message>PTX:WARNING:  a child of "biblio" (<xsl:value-of select="local-name()"/>) is not being processed.  Please report me so this can be fixed.</xsl:message>
+    <xsl:message>PTX:BUG:      a child of "biblio" (<xsl:value-of select="local-name()"/>) is not being processed.  Please report me so this can be fixed.</xsl:message>
 </xsl:template>
 
 <!-- Authors: no lead-in, names via the shared "contributor-names" -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9089,7 +9089,7 @@ Book (with parts), "section" at level 3
                 <!-- we can get here by a variety of routes.)          -->
                 <xsl:when test="$b-has-content">
                     <xsl:message>
-                        <xsl:text>PTX:WARNING:    </xsl:text>
+                        <xsl:text>PTX:DEPRECATE:  </xsl:text>
                         <xsl:text>An &lt;xref&gt; requests a 'title' as its text but also provides alternate content.  The construction is deprecated as of 2020-02-18.  Instead, specify that xref/@text should be 'custom', either globally or on a per-xref basis.</xsl:text>
                     </xsl:message>
                     <xsl:apply-templates select="." mode="location-report" />

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10598,19 +10598,33 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 
 <xsl:template name="warning-line-by-line">
     <xsl:param name="warning" />
-    <xsl:variable name="after" select="substring-before($warning,'&#xa;')"/>
+    <!-- the first line, which may be all of the text -->
+    <xsl:variable name="first-line">
+        <xsl:choose>
+            <xsl:when test="contains($warning, '&#xa;')">
+                <xsl:value-of select="substring-before($warning, '&#xa;')"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$warning"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:choose>
-        <!-- no line breaks in warning, just print it -->
-        <xsl:when test="substring-before($warning,'&#xa;') = ''">
-            <xsl:message><xsl:value-of select="$warning" /></xsl:message>
+        <!-- a message with no content is reported strangely  -->
+        <!-- by the processing library, a space displays well -->
+        <xsl:when test="$first-line = ''">
+            <xsl:message><xsl:text> </xsl:text></xsl:message>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message><xsl:value-of select="substring-before($warning,'&#xa;')" /></xsl:message>
-            <xsl:call-template name="warning-line-by-line">
-                <xsl:with-param name="warning" select="substring-after($warning,'&#xa;')" />
-            </xsl:call-template>
+            <xsl:message><xsl:value-of select="$first-line"/></xsl:message>
         </xsl:otherwise>
     </xsl:choose>
+    <!-- and the lines after the first, if any -->
+    <xsl:if test="contains($warning, '&#xa;')">
+        <xsl:call-template name="warning-line-by-line">
+            <xsl:with-param name="warning" select="substring-after($warning, '&#xa;')"/>
+        </xsl:call-template>
+    </xsl:if>
 </xsl:template>
 
 <!-- Report the location of an element or attribute, for use after a   -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3955,7 +3955,7 @@ Book (with parts), "section" at level 3
 <!-- or is defined to be a null string in a particular conversion stylesheet, in which    -->
  <!-- case no extra space is added. -->
 <xsl:template name="case-cycle-delimiter-space">
-    <xsl:message>PTX:BUG A "case" has "direction" equal to "cycle", but the conversion for this output target does not have a "delimiter space" symbol defined. The maintainer for this output target may wish to know about this (or may wish to set the "delimiter space" symbol to be a null string to suppress this warning message).</xsl:message>
+    <xsl:message>PTX:BUG: A "case" has "direction" equal to "cycle", but the conversion for this output target does not have a "delimiter space" symbol defined. The maintainer for this output target may wish to know about this (or may wish to set the "delimiter space" symbol to be a null string to suppress this warning message).</xsl:message>
     <xsl:apply-templates select="." mode="location-report"/>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4341,7 +4341,7 @@ Book (with parts), "section" at level 3
     <xsl:if test="$normalized-aspect = 0">
         <xsl:message>PTX:FATAL:   an @aspect attribute equal to zero will cause serious errors.</xsl:message>
         <xsl:apply-templates select="." mode="location-report" />
-        <xsl:message terminate="yes">Quitting...</xsl:message>
+        <xsl:message terminate="yes">PTX:FATAL:   Quitting...</xsl:message>
     </xsl:if>
 
     <!-- Perhaps save for debugging -->
@@ -4577,7 +4577,7 @@ Book (with parts), "section" at level 3
         <xsl:when test="$nspaces-valigns &lt; $number-panels">
             <xsl:message>PTX:FATAL:   a &lt;sidebyside&gt; or &lt;sbsgroup&gt; does not have enough "@valigns" (maybe you did not specify enough?)</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
-            <xsl:message terminate="yes">             That's fatal.  Sorry.  Quitting...</xsl:message>
+            <xsl:message terminate="yes">PTX:FATAL:   Quitting...</xsl:message>
         </xsl:when>
         <xsl:when test="$nspaces-valigns &gt; $number-panels">
             <xsl:message>PTX:WARNING: a &lt;sidebyside&gt; or &lt;sbsgroup&gt; has extra "@valigns" (did you confuse singular and plural attribute names?)</xsl:message>
@@ -4782,7 +4782,7 @@ Book (with parts), "section" at level 3
         <xsl:when test="$nspaces-widths &lt; $number-panels">
             <xsl:message>PTX:FATAL:   a &lt;sidebyside&gt; or &lt;sbsgroup&gt; does not have enough "@widths" (maybe you did not specify enough?)</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
-            <xsl:message terminate="yes">             That's fatal.  Sorry.  Quitting...</xsl:message>
+            <xsl:message terminate="yes">PTX:FATAL:   Quitting...</xsl:message>
         </xsl:when>
         <xsl:when test="$nspaces-widths &gt; $number-panels">
             <xsl:message>PTX:WARNING: a &lt;sidebyside&gt; or &lt;sbsgroup&gt; has extra "@widths" (did you confuse singular and plural attribute names?)</xsl:message>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -10736,7 +10736,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
                 <xsl:text>&#xa;</xsl:text>
                 <xsl:text>    1.  Code generation is functional, but does not respect indentation&#xa;</xsl:text>
                 <xsl:text>    2.  LaTeX generation is functional, could be improved, 2020-11-11&#xa;</xsl:text>
-                <xsl:text>    2.  HTML generation is functional, could be improved, 2020-11-11&#xa;</xsl:text>
+                <xsl:text>    3.  HTML generation is functional, could be improved, 2020-11-11&#xa;</xsl:text>
             </xsl:with-param>
         </xsl:call-template>
     </xsl:if>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -404,7 +404,7 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
         </xsl:when>
         <xsl:otherwise>
             <xsl:message>
-                <xsl:text>PTX:WARNING: the whitespace parameter can be 'strict' or 'flexible', not '</xsl:text>
+                <xsl:text>PTX:FALLBACK: the whitespace parameter can be 'strict' or 'flexible', not '</xsl:text>
                 <xsl:value-of select="$whitespace" />
                 <xsl:text>'.  Using the default ('flexible').</xsl:text>
             </xsl:message>
@@ -2921,7 +2921,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="normalized-width" select="normalize-space($raw-width)" />
     <xsl:choose>
         <xsl:when test="not(substring($normalized-width, string-length($normalized-width)) = '%')">
-            <xsl:message>PTX:WARNING:   a "width" attribute should be given as a percentage (such as "40%", not as "<xsl:value-of select="$normalized-width" />, using 100% instead"</xsl:message>
+            <xsl:message>PTX:FALLBACK:   a "width" attribute should be given as a percentage (such as "40%", not as "<xsl:value-of select="$normalized-width" />, using 100% instead"</xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
             <!-- replace by 100% -->
             <xsl:text>100%</xsl:text>
@@ -3810,7 +3810,7 @@ Book (with parts), "section" at level 3
         </xsl:when>
         <xsl:when test="$b-host-runestone and not(@authored-label)">
             <xsl:message>
-                <xsl:text>PTX:WARNING:  While building for a Runestone server, a PreTeXt "</xsl:text>
+                <xsl:text>PTX:FALLBACK:  While building for a Runestone server, a PreTeXt "</xsl:text>
                 <xsl:value-of select="local-name(.)"/>
                 <xsl:text>" element&#xa;</xsl:text>
                 <xsl:text>has been encountered without a @label attribute.  For reasons of backward-compatibility &#xa;</xsl:text>
@@ -5622,7 +5622,7 @@ Book (with parts), "section" at level 3
             <xsl:when test="substring($raw-workspace, string-length($raw-workspace) - 0) = '%'">
                 <xsl:variable name="approximate-inches" select="concat(substring($raw-workspace, 1, string-length($raw-workspace) - 1) div 10, 'in')"/>
                 <xsl:value-of select="$approximate-inches"/>
-                <xsl:message>PTX:WARNING:  as of 2020-03-17 worksheet exercises' workspace should be specified in 'in' or in 'cm'.  Approximating a page fraction of <xsl:value-of select="@workspace"/> by <xsl:value-of select="$approximate-inches"/>.</xsl:message>
+                <xsl:message>PTX:FALLBACK:  as of 2020-03-17 worksheet exercises' workspace should be specified in 'in' or in 'cm'.  Approximating a page fraction of <xsl:value-of select="@workspace"/> by <xsl:value-of select="$approximate-inches"/>.</xsl:message>
                 <xsl:apply-templates select="." mode="location-report"/>
             </xsl:when>
             <xsl:when test="substring($raw-workspace, string-length($raw-workspace) - 1) = 'in'">
@@ -5632,7 +5632,7 @@ Book (with parts), "section" at level 3
                 <xsl:value-of select="$raw-workspace"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:message>PTX:WARNING:  a worksheet exercises', project-likes' or tasks' workspace should be specified with units of 'in' or 'cm', and not as "<xsl:value-of select="@workspace"/>".  Using a default of "2in".</xsl:message>
+                <xsl:message>PTX:FALLBACK:  a worksheet exercises', project-likes' or tasks' workspace should be specified with units of 'in' or 'cm', and not as "<xsl:value-of select="@workspace"/>".  Using a default of "2in".</xsl:message>
                 <xsl:text>2in</xsl:text>
             </xsl:otherwise>
         </xsl:choose>
@@ -9027,7 +9027,7 @@ Book (with parts), "section" at level 3
             <!-- no content override in this case -->
             <!-- maybe we can relax this somehow? -->
             <xsl:if test="$b-has-content">
-                <xsl:message>PTX:WARNING: providing content ("<xsl:value-of select="." />") for an "xref" element is ignored for 'phrase-global' and 'phrase-hybrid' styles for xref text</xsl:message>
+                <xsl:message>PTX:FALLBACK: providing content ("<xsl:value-of select="." />") for an "xref" element is ignored for 'phrase-global' and 'phrase-hybrid' styles for xref text</xsl:message>
                 <xsl:apply-templates select="." mode="location-report" />
             </xsl:if>
             <!-- type-local first, no matter what    -->
@@ -10940,7 +10940,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         </xsl:when>
         <xsl:otherwise>
             <xsl:text>P100Y</xsl:text>
-            <xsl:message>PTX:WARNING:   "author.deprecations.all" should be "yes" or "no", not "<xsl:value-of select="$author.deprecations.all"/>", using the default value of "yes"</xsl:message>
+            <xsl:message>PTX:FALLBACK:   "author.deprecations.all" should be "yes" or "no", not "<xsl:value-of select="$author.deprecations.all"/>", using the default value of "yes"</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -1263,7 +1263,7 @@
     </xsl:variable>
     <xsl:choose>
         <xsl:when test="substring($filename, string-length($filename) - 3) = '.pdf'">
-            <xsl:message>PTX:WARNING: an image is available only as a PDF, which an EPUB reading system will not display; a placeholder appears in its place</xsl:message>
+            <xsl:message>PTX:ERROR:   an image is available only as a PDF, which an EPUB reading system will not display; a placeholder appears in its place</xsl:message>
             <xsl:apply-templates select="." mode="location-report"/>
             <p class="image-placeholder">[An image belongs here, but it is available only in PDF form, which EPUB does not display.]</p>
         </xsl:when>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -205,7 +205,7 @@
         <xsl:call-template name="banner-warning">
             <xsl:with-param name="warning">PTX:FATAL: EPUB creation is only implemented for a "book" or an "article",&#xa;not a "<xsl:value-of select="local-name($document-root)"/>", and we cannot recover</xsl:with-param>
         </xsl:call-template>
-        <xsl:message terminate="yes">Quitting...</xsl:message>
+        <xsl:message terminate="yes">PTX:FATAL:   Quitting...</xsl:message>
     </xsl:if>
     <!-- analyze authored source -->
     <xsl:apply-templates select="$original" mode="generic-warnings"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -403,7 +403,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- But first, we see if there is a coding error, due to            -->
     <!-- the critical chunk level variable being overridden              -->
     <xsl:if test="$chunk-level = ''">
-        <xsl:message>PTX:BUG     the $chunk-level variable has been left undefined&#xa;due to a change in a stylesheet that imports the HTML conversion&#xa;and the computation of an index page may fail spectacularly (infinite recursion?)"</xsl:message>
+        <xsl:message>PTX:BUG:    the $chunk-level variable has been left undefined&#xa;due to a change in a stylesheet that imports the HTML conversion&#xa;and the computation of an index page may fail spectacularly (infinite recursion?)"</xsl:message>
     </xsl:if>
     <xsl:variable name="sanitized-ref">
         <xsl:choose>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6557,7 +6557,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- failure -->
             <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   the Asymptote diagram produced in "<xsl:value-of select="$image-xml"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its width cannot be determined (which you might report as a bug).  We might be able to proceed as if the diagram is square, but results can be unpredictable.</xsl:message>
+                <xsl:message>PTX:FALLBACK:   the Asymptote diagram produced in "<xsl:value-of select="$image-xml"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its width cannot be determined (which you might report as a bug).  We might be able to proceed as if the diagram is square, but results can be unpredictable.</xsl:message>
                 <!-- reasonable guess at points/pixels -->
                 <xsl:text>400</xsl:text>
             </xsl:otherwise>
@@ -6579,7 +6579,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <!-- failure -->
             <xsl:otherwise>
-                <xsl:message>PTX:ERROR:   the Asymptote diagram produced in "<xsl:value-of select="$image-xml"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its height cannot be determined (which you might report as a bug).  We might be able to proceed as if the diagram is square, but results can be unpredictable.</xsl:message>
+                <xsl:message>PTX:FALLBACK:   the Asymptote diagram produced in "<xsl:value-of select="$image-xml"/>" needs to be available relative to the primary source file, or if available it is perhaps ill-formed and its height cannot be determined (which you might report as a bug).  We might be able to proceed as if the diagram is square, but results can be unpredictable.</xsl:message>
                 <!-- reasonable guess at points/pixels -->
                 <xsl:text>400</xsl:text>
             </xsl:otherwise>
@@ -10617,7 +10617,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>",&#xa;</xsl:text>
             </xsl:when>
             <xsl:when test="@geogebra">
-                <xsl:message>PTX Warning:  "geogebra" attribute on "slate" element is deprecated; use "material" attribute</xsl:message>
+                <xsl:message>PTX:DEPRECATE: "geogebra" attribute on "slate" element is deprecated; use "material" attribute</xsl:message>
                 <xsl:text>material_id:"</xsl:text>
                 <xsl:value-of select="@geogebra" />
                 <xsl:text>",&#xa;</xsl:text>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -424,7 +424,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                         <xsl:value-of select="$html-index-page-entered-ref"/>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:message>PTX:WARNING:   the requested HTML index page cannot be constructed since "<xsl:value-of select="$html-index-page-entered-ref"/>" is not a complete web page at the current chunking level (level <xsl:value-of select="$chunk-level"/>).  Defaults will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   the requested HTML index page cannot be constructed since "<xsl:value-of select="$html-index-page-entered-ref"/>" is not a complete web page at the current chunking level (level <xsl:value-of select="$chunk-level"/>).  Defaults will be used instead</xsl:message>
                         <xsl:text/>
                     </xsl:otherwise>
                 </xsl:choose>

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -162,7 +162,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="*" mode="pretext-heading">
-    <xsl:message>pretext-heading unmatched <xsl:value-of select="local-name(.)" /></xsl:message>
+    <xsl:message>PTX:BUG: pretext-heading unmatched <xsl:value-of select="local-name(.)" /></xsl:message>
 </xsl:template>
 
 <!-- A division companion as its own notebook: a heading cell from -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -7182,7 +7182,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <xsl:when test="$fig-placement = 'block'"/>
         <xsl:otherwise>
-            <xsl:message>PTX:BUG: figure placement not recognized, plase report me</xsl:message>
+            <xsl:message>PTX:BUG: figure placement not recognized, please report me</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
     <!-- always element name and suffix -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -140,7 +140,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$root/letter">0</xsl:when>
         <xsl:when test="$root/memo">0</xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR: Table of Contents level (for LateX conversion) not determined</xsl:message>
+            <xsl:message>PTX:BUG:   Table of Contents level (for LaTeX conversion) not determined</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -2361,7 +2361,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="*" mode="division-environment-name">
-    <xsl:message>NO DIVISION ENVIRONMENT NAME for <xsl:value-of select="local-name(.)"/></xsl:message>
+    <xsl:message>PTX:BUG:   an element ("<xsl:value-of select="local-name(.)"/>") lacks a LaTeX division environment name</xsl:message>
 </xsl:template>
 
 <!-- Possibly numberless?  When employed, we can tell if a specialized -->

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -557,7 +557,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Should not drop in here.  Ever. -->
 <xsl:template match="*" mode="serial-number">
     <xsl:text>[NUM]</xsl:text>
-    <xsl:message>PTX:ERROR:   An object (<xsl:value-of select="local-name(.)" />) lacks a serial number, search output for "[NUM]"</xsl:message>
+    <xsl:message>PTX:BUG:   An object (<xsl:value-of select="local-name(.)" />) lacks a serial number, search output for "[NUM]"</xsl:message>
     <xsl:apply-templates select="." mode="location-report" />
 </xsl:template>
 
@@ -800,7 +800,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Should not drop in here.  Ever. -->
 <xsl:template match="*" mode="structure-number">
     <xsl:text>[STRUCT]</xsl:text>
-    <xsl:message>PTX:ERROR:   An object (<xsl:value-of select="local-name(.)" />) lacks a structure number, search output for "[STRUCT]"</xsl:message>
+    <xsl:message>PTX:BUG:   An object (<xsl:value-of select="local-name(.)" />) lacks a structure number, search output for "[STRUCT]"</xsl:message>
     <xsl:apply-templates select="." mode="location-report" />
 </xsl:template>
 

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -511,11 +511,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="warning">Conversion to reveal.js presentations/slideshows is experimental&#xa;Requests for additional specific constructions welcome&#xa;Additional PreTeXt elements are subject to change</xsl:with-param>
     </xsl:call-template>
     <xsl:if test="not($theme = '')">
-        <xsl:message >PTX:WARNING: the temporary "theme" stringparam is deprecated and is being ignored by the conversion to a Reveal.js slideshow.  Please switch to using a publisher file to set this option, see documentation in The Guide.  The default theme is "simple".</xsl:message>
+        <xsl:message >PTX:DEPRECATE: the temporary "theme" stringparam is deprecated and is being ignored by the conversion to a Reveal.js slideshow.  Please switch to using a publisher file to set this option, see documentation in The Guide.  The default theme is "simple".</xsl:message>
         <xsl:text>simple</xsl:text>
     </xsl:if>
     <xsl:if test="not($local = '')">
-        <xsl:message >PTX:WARNING: the temporary "local" stringparam is deprecated and is being ignored.  Please switch to using a publisher file to set this option, see documentation in The Guide.  The default behavior is to get resources from a CDN.</xsl:message>
+        <xsl:message >PTX:DEPRECATE: the temporary "local" stringparam is deprecated and is being ignored.  Please switch to using a publisher file to set this option, see documentation in The Guide.  The default behavior is to get resources from a CDN.</xsl:message>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -890,7 +890,7 @@
                 <xsl:when test="name($curTest)='mathcmp' and $curTest/@use-answer='yes'">
                     <xsl:choose>
                         <xsl:when test="not($fillin/@ansobj)">
-                            <xsl:message>PTX:WARNING: Feedback for "<xsl:value-of select="@visible-id"/>" says to use given math answer, but @ansobj not defined. </xsl:message>
+                            <xsl:message>PTX:ERROR:   Feedback for "<xsl:value-of select="@visible-id"/>" says to use given math answer, but @ansobj not defined. </xsl:message>
                             <xsl:text>UNDEFINED</xsl:text>
                         </xsl:when>
                         <xsl:otherwise>

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -83,7 +83,7 @@
                             </xsl:when>
                             <xsl:otherwise>
                                 <!-- Report if a seed is not provided-->
-                                <xsl:message>PTX:WARNING:   Dynamic exercise "<xsl:value-of select="@visible-id"/>" is missing setup @seed for static content generation.</xsl:message>
+                                <xsl:message>PTX:FALLBACK:   Dynamic exercise "<xsl:value-of select="@visible-id"/>" is missing setup @seed for static content generation.</xsl:message>
                                 <xsl:text>1234</xsl:text>
                             </xsl:otherwise>
                         </xsl:choose>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -2413,7 +2413,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:if test="tests/iotest">
                                     <xsl:choose>
                                         <xsl:when test="not(normalize-space(tests/text()) = '')">
-                                            <xsl:message>WARNING: You can either write text based tests or use iotests, but not both. iotests ignored in <xsl:value-of select="$rsid"/>.</xsl:message>
+                                            <xsl:message>PTX:WARNING: You can either write text based tests or use iotests, but not both. iotests ignored in <xsl:value-of select="$rsid"/>.</xsl:message>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <xsl:text>===iotests===&#x0a;</xsl:text>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1154,7 +1154,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:variable name="id">
                                     <xsl:apply-templates select="." mode="unique-id"/>
                                 </xsl:variable>
-                                <xsl:message>PTX:WARNING:  Parsons problems need a @langauge that is a valid activecode language to be runnable</xsl:message>
+                                <xsl:message>PTX:WARNING:  Parsons problems need a @language that is a valid activecode language to be runnable</xsl:message>
                                 <xsl:message>              id: <xsl:value-of select="$id"></xsl:value-of></xsl:message>
                             </xsl:otherwise>
                         </xsl:choose>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -3068,7 +3068,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:apply-templates select="$target" mode="runestone-id"/>
-                    <xsl:message>PTX:ERROR:   runestone-targets template was called with an invalid @output-field value "<xsl:value-of select="$output-field"/>"</xsl:message>
+                    <xsl:message>PTX:BUG:     runestone-targets template was called with an invalid @output-field value "<xsl:value-of select="$output-field"/>"</xsl:message>
                 </xsl:otherwise>
             </xsl:choose>
             <!-- n - 1 separators, required by receiving Javascript -->

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -2413,7 +2413,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                                 <xsl:if test="tests/iotest">
                                     <xsl:choose>
                                         <xsl:when test="not(normalize-space(tests/text()) = '')">
-                                            <xsl:message>PTX:WARNING: You can either write text based tests or use iotests, but not both. iotests ignored in <xsl:value-of select="$rsid"/>.</xsl:message>
+                                            <xsl:message>PTX:FALLBACK: You can either write text based tests or use iotests, but not both. iotests ignored in <xsl:value-of select="$rsid"/>.</xsl:message>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <xsl:text>===iotests===&#x0a;</xsl:text>

--- a/xsl/pretext-sage-doctest.xsl
+++ b/xsl/pretext-sage-doctest.xsl
@@ -124,7 +124,7 @@
                         <xsl:value-of select="@tolerance" />
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:message>PTX:WARNING: '<xsl:value-of select="@doctest" /> tolerance' Sage doctest needs 'tolerance=' attribute</xsl:message>
+                        <xsl:message>PTX:ERROR:   '<xsl:value-of select="@doctest" /> tolerance' Sage doctest needs 'tolerance=' attribute</xsl:message>
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
@@ -137,7 +137,7 @@
                         <xsl:value-of select="@package" />
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:message>PTX:WARNING: 'optional' Sage doctest missing package, supply a 'package=' attribute</xsl:message>
+                        <xsl:message>PTX:ERROR:   'optional' Sage doctest missing package, supply a 'package=' attribute</xsl:message>
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -1136,7 +1136,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$characters = ''">
             <xsl:message>PTX:FATAL:   Unable to find an unused character in:&#xa;<xsl:value-of select="$string" />&#xa;using characters from: <xsl:value-of select="$charset" /></xsl:message>
             <xsl:apply-templates select="." mode="location-report" />
-            <xsl:message terminate="yes">             That's fatal.  Sorry.  Quitting...</xsl:message>
+            <xsl:message terminate="yes">PTX:FATAL:   Quitting...</xsl:message>
         </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="substring($characters, 1, 1)"/>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -125,7 +125,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$version-root/letter">0</xsl:when>
         <xsl:when test="$version-root/memo">0</xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR: Table of Contents level not determined</xsl:message>
+            <xsl:message>PTX:BUG:   Table of Contents level not determined</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -2966,7 +2966,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$version-root/letter">0</xsl:when>
         <xsl:when test="$version-root/memo">0</xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR: HTML chunk level not determined</xsl:message>
+            <xsl:message>PTX:BUG:   HTML chunk level not determined</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1384,8 +1384,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:when>
             <xsl:when test="$publication/source/@webwork-problems">
                 <xsl:value-of select="str:replace($publication/source/@webwork-problems, '&#x20;', '%20')"/>
-                <xsl:message>PTX:ERROR:   the publication file entry  source/@webwork-problems  is</xsl:message>
-                <xsl:message>             deprecated, please move to using managed directories</xsl:message>
+                <xsl:message>PTX:DEPRECATE: the publication file entry  source/@webwork-problems  is</xsl:message>
+                <xsl:message>               deprecated, please move to using managed directories</xsl:message>
             </xsl:when>
             <!-- no specification, so empty string for filename -->
             <!-- this will be noted where it is employed        -->
@@ -1975,7 +1975,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:message>PTX:WARNING: your document is not a book with parts, so the publisher file  numbering/divisions/@part-structure  entry is being ignored</xsl:message>
                 </xsl:when>
                 <xsl:when test="$version-docinfo/numbering/division/@part">
-                    <xsl:message>PTX:WARNING: your document is not a book with parts, and docinfo/numbering/division/@part is deprecated anyway and is being ignored</xsl:message>
+                    <xsl:message>PTX:DEPRECATE: your document is not a book with parts, and docinfo/numbering/division/@part is deprecated anyway and is being ignored</xsl:message>
                 </xsl:when>
             </xsl:choose>
             <!-- flag this situation -->
@@ -2583,7 +2583,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="debug.html.theme-name"  select="''" />
 
 <xsl:variable name="html-theme-name">
-    <xsl:variable name="warning-message">PTX:WARNING: The "FROMSTYLE" style requested in publication/html/css is deprecated. Your book will be built with theme="TOSTYLE". See the PreTeXt Guide for options for the newer HTML themes and their specification .</xsl:variable>
+    <xsl:variable name="warning-message">PTX:DEPRECATE: The "FROMSTYLE" style requested in publication/html/css is deprecated. Your book will be built with theme="TOSTYLE". See the PreTeXt Guide for options for the newer HTML themes and their specification .</xsl:variable>
     <xsl:choose>
         <xsl:when test="$debug.html.theme-name != ''">
             <xsl:value-of select="$debug.html.theme-name"/>
@@ -3052,7 +3052,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- through the generic machinery, which has its own warning.   -->
         <xsl:when test="not($jupyter.kernel = '') and not($jupyter.kernel = 'python3') and not($jupyter.kernel = 'sagemath') and contains('|Python3|python 3|Python 3|py|Py|python|Python|', concat('|', $jupyter.kernel, '|'))">
             <xsl:text>python3</xsl:text>
-            <xsl:message>PTX:WARNING: the stringparam "jupyter.kernel" is deprecated (2026-07-10), and your value "<xsl:value-of select="$jupyter.kernel"/>" has been interpreted as "python3".  Move to the publication file entry, jupyter/@kernel, with the value "python3".</xsl:message>
+            <xsl:message>PTX:DEPRECATE: the stringparam "jupyter.kernel" is deprecated (2026-07-10), and your value "<xsl:value-of select="$jupyter.kernel"/>" has been interpreted as "python3".  Move to the publication file entry, jupyter/@kernel, with the value "python3".</xsl:message>
         </xsl:when>
         <xsl:otherwise>
             <xsl:apply-templates select="$publisher-attribute-options/jupyter/pi:pub-attribute[@name='kernel']" mode="set-pubfile-variable"/>
@@ -3844,14 +3844,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- it is among the legal options, use it and issue warning         -->
         <xsl:when test="not($pubfile-attribute) and @legacy-stringparam and (@freeform = 'yes' or dyn:evaluate(concat('$', @legacy-stringparam)) = $all-options)">
             <xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>
-            <xsl:message>PTX:WARNING: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" will be used. However you should move to using a publisher file entry for  <xsl:value-of select="$full-path"/>  instead.</xsl:message>
+            <xsl:message>PTX:DEPRECATE: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" will be used. However you should move to using a publisher file entry for  <xsl:value-of select="$full-path"/>  instead.</xsl:message>
         </xsl:when>
         <!-- if nothing is declared in the publisher file, not even as null  -->
         <!-- and if there is an old stringparam that we still honor, and if  -->
         <!-- it is among the legacy options, use default and issue warning   -->
         <xsl:when test="not($pubfile-attribute) and @legacy-stringparam and dyn:evaluate(concat('$', @legacy-stringparam)) = $legacy-options">
             <xsl:value-of select="$the-default"/>
-            <xsl:message>PTX:WARNING: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Also your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" has been retired. You should move to using a publisher file entry  <xsl:value-of select="$full-path"/>  with possible values: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
+            <xsl:message>PTX:DEPRECATE: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Also your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" has been retired. You should move to using a publisher file entry  <xsl:value-of select="$full-path"/>  with possible values: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
         </xsl:when>
         <!-- if nothing is declared in the publisher file, not even as null  -->
         <!-- and if there is an old stringparam that we still honor, but its -->
@@ -3859,7 +3859,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- then use default and issue warning                              -->
         <xsl:when test="not($pubfile-attribute) and @legacy-stringparam and dyn:evaluate(concat('$', @legacy-stringparam)) != ''">
             <xsl:value-of select="$the-default"/>
-            <xsl:message>PTX:WARNING: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Also your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" is not a legal option. You should move to using a publisher file entry  <xsl:value-of select="$full-path"/>  with possible values: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
+            <xsl:message>PTX:DEPRECATE: the stringparam "<xsl:value-of select="@legacy-stringparam"/>" is deprecated. Also your value, "<xsl:value-of select="dyn:evaluate(concat('$', @legacy-stringparam))"/>" is not a legal option. You should move to using a publisher file entry  <xsl:value-of select="$full-path"/>  with possible values: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
         </xsl:when>
         <!-- if nothing is declared in the publisher file or it is declared  -->
         <!-- as null, use the default, which might be null                   -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3267,7 +3267,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:when test="$latex.font.size='20pt'"><xsl:value-of select="$latex.font.size" /></xsl:when>
                 <xsl:otherwise>
                     <xsl:text>10pt</xsl:text>
-                    <xsl:message>PTX:FALLBACK   the *deprecated* latex.font.size parameter must be 8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, or 20pt, not "<xsl:value-of select="$latex.font.size" />".  Using the default ("10pt")</xsl:message>
+                    <xsl:message>PTX:FALLBACK:  the *deprecated* latex.font.size parameter must be 8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, or 20pt, not "<xsl:value-of select="$latex.font.size" />".  Using the default ("10pt")</xsl:message>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -358,7 +358,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-inline/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-inline/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -378,7 +378,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.text.statement" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.inline.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.statement" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.inline.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.statement" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -394,7 +394,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-inline/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-inline/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -414,7 +414,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.text.hint" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.inline.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.hint" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.inline.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.hint" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -430,7 +430,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-inline/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-inline/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -450,7 +450,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.text.answer" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.inline.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.answer" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.inline.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.answer" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -466,7 +466,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-inline/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-inline/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-inline/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -486,7 +486,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.text.solution" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.inline.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.solution" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.inline.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.inline.solution" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -502,7 +502,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-divisional/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-divisional/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -522,7 +522,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.divisional.statement" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.divisional.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.statement" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.divisional.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.statement" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -538,7 +538,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-divisional/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-divisional/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -558,7 +558,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.divisional.hint" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.divisional.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.hint" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.divisional.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.hint" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -574,7 +574,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-divisional/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-divisional/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -594,7 +594,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.divisional.answer" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.divisional.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.answer" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.divisional.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.answer" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -610,7 +610,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-divisional/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-divisional/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-divisional/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -630,7 +630,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.divisional.solution" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.divisional.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.solution" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.divisional.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.divisional.solution" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -646,7 +646,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-worksheet/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-worksheet/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -666,7 +666,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.worksheet.statement" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.worksheet.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.statement" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.worksheet.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.statement" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -682,7 +682,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-worksheet/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-worksheet/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -702,7 +702,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.worksheet.hint" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.worksheet.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.hint" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.worksheet.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.hint" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -718,7 +718,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-worksheet/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-worksheet/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -738,7 +738,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.worksheet.answer" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.worksheet.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.answer" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.worksheet.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.answer" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -754,7 +754,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-worksheet/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-worksheet/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-worksheet/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -774,7 +774,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.worksheet.solution" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.worksheet.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.solution" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.worksheet.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.worksheet.solution" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -790,7 +790,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-reading/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-reading/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -810,7 +810,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.reading.statement" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.reading.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.statement" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.reading.statement parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.statement" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -826,7 +826,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-reading/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-reading/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -846,7 +846,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.reading.hint" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.reading.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.hint" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.reading.hint parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.hint" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -862,7 +862,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-reading/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-reading/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -882,7 +882,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.reading.answer" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.reading.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.answer" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.reading.answer parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.answer" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -898,7 +898,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-reading/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-reading/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-reading/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -918,7 +918,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$exercise.reading.solution" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: exercise.reading.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.solution" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: exercise.reading.solution parameter should be "yes" or "no", not "<xsl:value-of select="$exercise.reading.solution" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -934,7 +934,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-project/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-project/@statement in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@statement"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -949,7 +949,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$project.statement" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: project.statement parameter should be "yes" or "no", not "<xsl:value-of select="$project.statement" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: project.statement parameter should be "yes" or "no", not "<xsl:value-of select="$project.statement" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -965,7 +965,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-project/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-project/@hint in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@hint"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -985,7 +985,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$project.hint" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: project.hint parameter should be "yes" or "no", not "<xsl:value-of select="$project.hint" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: project.hint parameter should be "yes" or "no", not "<xsl:value-of select="$project.hint" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -1001,7 +1001,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-project/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-project/@answer in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@answer"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -1021,7 +1021,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$project.answer" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: project.answer parameter should be "yes" or "no", not "<xsl:value-of select="$project.answer" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: project.answer parameter should be "yes" or "no", not "<xsl:value-of select="$project.answer" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -1037,7 +1037,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING:   the exercise component visibility setting (common/exercise-project/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   the exercise component visibility setting (common/exercise-project/@solution in the publisher file) must be "yes" or "no", not "<xsl:value-of select="$publication/common/exercise-project/@solution"/>".  Proceeding with the default, which is "yes".</xsl:message>
                     <xsl:text>yes</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -1057,7 +1057,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="$project.solution" />
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message >PTX:WARNING: project.solution parameter should be "yes" or "no", not "<xsl:value-of select="$project.solution" />".  Proceeding with default value.</xsl:message>
+            <xsl:message >PTX:FALLBACK: project.solution parameter should be "yes" or "no", not "<xsl:value-of select="$project.solution" />".  Proceeding with default value.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:variable>
@@ -1157,7 +1157,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-managed-directories">
             <xsl:choose>
                 <xsl:when test="substring($raw-input, 1, 1) = '/'">
-                    <xsl:message>PTX:WARNING:   a generated-image directory (source/directories/@generated in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   a generated-image directory (source/directories/@generated in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
                     <xsl:text/>
                 </xsl:when>
                 <!-- trailing path separator is good -->
@@ -1501,7 +1501,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for divisions given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for divisions given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$max-feasible"/>
                         </xsl:when>
                     <xsl:otherwise>
@@ -1522,7 +1522,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate against upper bound, $max-feasible -->
     <xsl:choose>
         <xsl:when test="$candidate-maxlevel > $max-feasible">
-            <xsl:message>PTX:WARNING:   numbering level set for divisions ("<xsl:value-of select="$candidate-maxlevel"/>") is greater than the maximum possible ("<xsl:value-of select="$max-feasible"/>") for this document type.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for divisions ("<xsl:value-of select="$candidate-maxlevel"/>") is greater than the maximum possible ("<xsl:value-of select="$max-feasible"/>") for this document type.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$max-feasible"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1564,7 +1564,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for blocks given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for blocks given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-blocks"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1585,7 +1585,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-blocks against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-blocks > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for blocks ("<xsl:value-of select="$candidate-blocks"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for blocks ("<xsl:value-of select="$candidate-blocks"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-blocks"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1623,7 +1623,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for projects given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for projects given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-projects"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1644,7 +1644,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-projects against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-projects > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for projects ("<xsl:value-of select="$candidate-projects"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for projects ("<xsl:value-of select="$candidate-projects"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-projects"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1679,7 +1679,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for equations given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for equations given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-equations"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1700,7 +1700,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-equations against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-equations > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for equations ("<xsl:value-of select="$candidate-equations"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for equations ("<xsl:value-of select="$candidate-equations"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-equations"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1735,7 +1735,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for footnotes given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for footnotes given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-footnotes"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1756,7 +1756,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-footnotes against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-footnotes > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for footnotes ("<xsl:value-of select="$candidate-footnotes"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for footnotes ("<xsl:value-of select="$candidate-footnotes"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-footnotes"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1791,7 +1791,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for figures given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for figures given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-figures"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1812,7 +1812,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-figures against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-figures > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for figures ("<xsl:value-of select="$candidate-figures"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for figures ("<xsl:value-of select="$candidate-figures"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-figures"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1847,7 +1847,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for inline exercises given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for inline exercises given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-exercises"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1868,7 +1868,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-exercises against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-exercises > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for inline exercises ("<xsl:value-of select="$candidate-exercises"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for inline exercises ("<xsl:value-of select="$candidate-exercises"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-exercises"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1903,7 +1903,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:choose>
                     <!-- NaN does not equal *anything*, so tests if a number -->
                     <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                        <xsl:message>PTX:WARNING:   numbering level for open problems given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                        <xsl:message>PTX:FALLBACK:   numbering level for open problems given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                         <xsl:value-of select="$default-openproblems"/>
                     </xsl:when>
                     <xsl:otherwise>
@@ -1920,7 +1920,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- check $candidate-openproblems against upper bound, $numbering-maxlevel -->
     <xsl:choose>
         <xsl:when test="$candidate-openproblems > $numbering-maxlevel">
-            <xsl:message>PTX:WARNING:   numbering level set for open problems ("<xsl:value-of select="$candidate-openproblems"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   numbering level set for open problems ("<xsl:value-of select="$candidate-openproblems"/>") is greater than the maximum possible levels ("<xsl:value-of select="$numbering-maxlevel"/>") configured.  The default value will be used instead</xsl:message>
             <xsl:value-of select="$default-openproblems"/>
         </xsl:when>
         <xsl:otherwise>
@@ -1945,7 +1945,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:choose>
                 <!-- NaN does not equal *anything*, so tests if a number -->
                 <xsl:when test="not(number($the-number) = number($the-number)) or ($the-number &lt; 0)">
-                    <xsl:message>PTX:WARNING:   starting number for chapters given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
+                    <xsl:message>PTX:FALLBACK:   starting number for chapters given in the publisher file ("<xsl:value-of select="$the-number"/>") is not a number or is negative.  The default value will be used instead</xsl:message>
                     <xsl:value-of select="1"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -1972,7 +1972,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="not($version-root/book/part)">
             <xsl:choose>
                 <xsl:when test="$publication/numbering/divisions/@part-structure">
-                    <xsl:message>PTX:WARNING: your document is not a book with parts, so the publisher file  numbering/divisions/@part-structure  entry is being ignored</xsl:message>
+                    <xsl:message>PTX:FALLBACK: your document is not a book with parts, so the publisher file  numbering/divisions/@part-structure  entry is being ignored</xsl:message>
                 </xsl:when>
                 <xsl:when test="$version-docinfo/numbering/division/@part">
                     <xsl:message>PTX:DEPRECATE: your document is not a book with parts, and docinfo/numbering/division/@part is deprecated anyway and is being ignored</xsl:message>
@@ -1992,7 +1992,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>decorative</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING: the publisher file  numbering/divisions/@part-structure  entry should be "decorative" or "structural", not "<xsl:value-of select="$publication/numbering/divisions/@part-structure" />".  The default will be used instead.</xsl:message>
+                    <xsl:message>PTX:FALLBACK: the publisher file  numbering/divisions/@part-structure  entry should be "decorative" or "structural", not "<xsl:value-of select="$publication/numbering/divisions/@part-structure" />".  The default will be used instead.</xsl:message>
                     <xsl:text>decorative</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -2007,7 +2007,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>decorative</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING: the  docinfo/numbering/division/@part  entry should be "decorative" or "structural", not "<xsl:value-of select="$version-docinfo/numbering/division/@part"/>".  The default will be used instead.</xsl:message>
+                    <xsl:message>PTX:FALLBACK: the  docinfo/numbering/division/@part  entry should be "decorative" or "structural", not "<xsl:value-of select="$version-docinfo/numbering/division/@part"/>".  The default will be used instead.</xsl:message>
                     <xsl:text>decorative</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -2095,14 +2095,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </xsl:when>
                 <!-- sounds good, but no, not the right build -->
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING: HTML calculator/@activecode in publisher file requests "<xsl:value-of select="$entered-lang"/>", but this language is not supported unless the publisher file also indicates the build is meant to be hosted on a Runestone server. Proceeding with the default value for current build: "<xsl:value-of select="$activecode-default"/>"</xsl:message>
+                    <xsl:message>PTX:FALLBACK: HTML calculator/@activecode in publisher file requests "<xsl:value-of select="$entered-lang"/>", but this language is not supported unless the publisher file also indicates the build is meant to be hosted on a Runestone server. Proceeding with the default value for current build: "<xsl:value-of select="$activecode-default"/>"</xsl:message>
                     <xsl:value-of select="$activecode-default"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
         <!-- an attempt was made, but failed to be any sort of language -->
         <xsl:when test="$publication/html/calculator/@activecode">
-            <xsl:message>PTX:WARNING: HTML calculator/@activecode in publisher file should be a programming language or "none", not "<xsl:value-of select="$publication/html/calculator/@activecode"/>". Proceeding with the default value for current build: "<xsl:value-of select="$activecode-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML calculator/@activecode in publisher file should be a programming language or "none", not "<xsl:value-of select="$publication/html/calculator/@activecode"/>". Proceeding with the default value for current build: "<xsl:value-of select="$activecode-default"/>"</xsl:message>
             <xsl:value-of select="$activecode-default"/>
         </xsl:when>
         <!-- no attempt to specify build-dependent default value -->
@@ -2144,7 +2144,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- bad choice, set to empty string -->
         <xsl:when test="not(id($entered-ref))">
-            <xsl:message>PTX:WARNING:   the requested HTML index page cannot be constructed since "<xsl:value-of select="$entered-ref"/>" is not an @xml:id anywhere in the document.  Defaults will be used instead</xsl:message>
+            <xsl:message>PTX:FALLBACK:   the requested HTML index page cannot be constructed since "<xsl:value-of select="$entered-ref"/>" is not an @xml:id anywhere in the document.  Defaults will be used instead</xsl:message>
             <xsl:text/>
         </xsl:when>
         <xsl:otherwise>
@@ -2216,7 +2216,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/html/webwork/@inline">
-            <xsl:message>PTX:WARNING: HTML WeBWorK @inline setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@inline"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML WeBWorK @inline setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@inline"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
             <xsl:value-of select="$ww-default"/>
         </xsl:when>
         <!-- backwards compatibility: 'yes' indicated static,     -->
@@ -2247,7 +2247,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/html/webwork/@divisional">
-            <xsl:message>PTX:WARNING: HTML WeBWorK @divisional setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@divisional"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML WeBWorK @divisional setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@divisional"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
             <xsl:value-of select="$ww-default"/>
         </xsl:when>
         <!-- backwards compatibility: 'yes' indicated static,     -->
@@ -2278,7 +2278,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/html/webwork/@reading">
-            <xsl:message>PTX:WARNING: HTML WeBWorK @reading setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@reading"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML WeBWorK @reading setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@reading"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
             <xsl:value-of select="$ww-default"/>
         </xsl:when>
         <!-- backwards compatibility: 'yes' indicated static,     -->
@@ -2309,7 +2309,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/html/webwork/@worksheet">
-            <xsl:message>PTX:WARNING: HTML WeBWorK @worksheet setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@worksheet"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML WeBWorK @worksheet setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@worksheet"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
             <xsl:value-of select="$ww-default"/>
         </xsl:when>
         <!-- backwards compatibility: 'yes' indicated static,     -->
@@ -2340,7 +2340,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/html/webwork/@project">
-            <xsl:message>PTX:WARNING: HTML WeBWorK @project setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@project"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML WeBWorK @project setting in publisher file should be "static" or "dynamic", not "<xsl:value-of select="$publication/html/webwork/@project"/>". Proceeding with default value: "<xsl:value-of select="$ww-default"/>"</xsl:message>
             <xsl:value-of select="$ww-default"/>
         </xsl:when>
         <!-- backwards compatibility: 'yes' indicated static,     -->
@@ -2543,7 +2543,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="$publisher-attribute-options/html/tableofcontents/pi:pub-attribute[@name='preexpanded-levels']" mode="set-pubfile-variable"/>
     </xsl:variable>
     <xsl:if test="not($b-html-toc-focused) and $preexpanded-value > 0">
-        <xsl:message>PTX:WARNING:   the preexpanded-levels setting (html/tableofcontents/@preexpanded-levels in the publisher file) has no effect if the table of contents is not set to focused mode (/html/tableofcontents/@focused is "yes")."</xsl:message>
+        <xsl:message>PTX:FALLBACK:   the preexpanded-levels setting (html/tableofcontents/@preexpanded-levels in the publisher file) has no effect if the table of contents is not set to focused mode (/html/tableofcontents/@focused is "yes")."</xsl:message>
     </xsl:if>
     <xsl:value-of select="$preexpanded-value"/>
 </xsl:variable>
@@ -2882,7 +2882,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- set, but not correct, so inform and use default -->
         <xsl:when test="$publication/html/search/@variant">
-            <xsl:message>PTX:WARNING: HTML search/@variant in publisher file should be "none", "textbook", "reference" or "default", not "<xsl:value-of select="$publication/html/search/@variant"/>". Proceeding with default value: "<xsl:value-of select="$default-native-search"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML search/@variant in publisher file should be "none", "textbook", "reference" or "default", not "<xsl:value-of select="$publication/html/search/@variant"/>". Proceeding with default value: "<xsl:value-of select="$default-native-search"/>"</xsl:message>
             <xsl:value-of select="$default-native-search"/>
         </xsl:when>
         <!-- unset, so use default -->
@@ -3078,7 +3078,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="round(number($braille-page-width-entered))"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING: the braille page width in the publication file ("<xsl:value-of select="$braille-page-width-entered"/>") must be a positive whole number of cells, using the default, 40</xsl:message>
+            <xsl:message>PTX:FALLBACK: the braille page width in the publication file ("<xsl:value-of select="$braille-page-width-entered"/>") must be a positive whole number of cells, using the default, 40</xsl:message>
             <xsl:text>40</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -3093,7 +3093,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="round(number($braille-page-height-entered))"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:WARNING: the braille page height in the publication file ("<xsl:value-of select="$braille-page-height-entered"/>") must be a positive whole number of lines, using the default, 25</xsl:message>
+            <xsl:message>PTX:FALLBACK: the braille page height in the publication file ("<xsl:value-of select="$braille-page-height-entered"/>") must be a positive whole number of lines, using the default, 25</xsl:message>
             <xsl:text>25</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -3178,7 +3178,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but wrong -->
         <xsl:when test="$publication/latex/page/@right-alignment">
-            <xsl:message>PTX:WARNING: LaTeX right-alignment setting in publisher file should be "flush" or "ragged", not "<xsl:value-of select="$publication/latex/page/@right-alignment"/>". Proceeding with default value: "<xsl:value-of select="$default-align"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: LaTeX right-alignment setting in publisher file should be "flush" or "ragged", not "<xsl:value-of select="$publication/latex/page/@right-alignment"/>". Proceeding with default value: "<xsl:value-of select="$default-align"/>"</xsl:message>
             <xsl:value-of select="$default-align"/>
         </xsl:when>
         <!-- or respect deprecated stringparam in use, text.alignment -->
@@ -3248,7 +3248,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>pt</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:message>PTX:WARNING: LaTeX @font-size in publication file should be 8, 9, 10, 11, 12, 14, 17 or 20 points, not "<xsl:value-of select="$publication/latex/@font-size"/>".  Proceeding with default value: "10"</xsl:message>
+                    <xsl:message>PTX:FALLBACK: LaTeX @font-size in publication file should be 8, 9, 10, 11, 12, 14, 17 or 20 points, not "<xsl:value-of select="$publication/latex/@font-size"/>".  Proceeding with default value: "10"</xsl:message>
                     <xsl:text>10pt</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
@@ -3291,7 +3291,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- attempted to set, but not a recognized key -->
         <xsl:when test="$publication/pdf/@font">
-            <xsl:message>PTX:WARNING: PDF (XSL-FO) font setting in publisher file should be "latin-modern", not "<xsl:value-of select="$publication/pdf/@font"/>". Proceeding with default value: "<xsl:value-of select="$default-pdf-font"/>"</xsl:message>
+            <xsl:message>PTX:FALLBACK: PDF (XSL-FO) font setting in publisher file should be "latin-modern", not "<xsl:value-of select="$publication/pdf/@font"/>". Proceeding with default value: "<xsl:value-of select="$default-pdf-font"/>"</xsl:message>
             <xsl:value-of select="$default-pdf-font"/>
         </xsl:when>
         <!-- no attempt at all, so default -->
@@ -3879,13 +3879,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- if it's among the legacy options, use default and issue warning  -->
         <xsl:when test="$pubfile-attribute = $legacy-options">
             <xsl:value-of select="$the-default"/>
-            <xsl:message>PTX:WARNING: your value "<xsl:value-of select="$pubfile-attribute"/>"  for the publisher file entry  <xsl:value-of select="$path"/>  has been retired; possible values are <xsl:apply-templates select="$all-options" mode="quoted-list"/>. The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
+            <xsl:message>PTX:FALLBACK: your value "<xsl:value-of select="$pubfile-attribute"/>"  for the publisher file entry  <xsl:value-of select="$path"/>  has been retired; possible values are <xsl:apply-templates select="$all-options" mode="quoted-list"/>. The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
         </xsl:when>
         <!-- pubfile has some string that is not among legal options, and    -->
         <!-- freeform is disallowed, so give a warning and use default       -->
         <xsl:otherwise>
             <xsl:value-of select="$the-default"/>
-            <xsl:message>PTX:WARNING: the publisher file  <xsl:value-of select="$path"/>  entry should not have value "<xsl:value-of select="$pubfile-attribute"/>".  Possible values are: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
+            <xsl:message>PTX:FALLBACK: the publisher file  <xsl:value-of select="$path"/>  entry should not have value "<xsl:value-of select="$pubfile-attribute"/>".  Possible values are: <xsl:apply-templates select="$all-options" mode="quoted-list"/>.  The default, "<xsl:value-of select="$the-default"/>", will be used instead.</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1132,7 +1132,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <!-- leading path separator is an error -->
         <xsl:when test="substring($raw-input, 1, 1) = '/'">
-            <xsl:message>PTX:ERROR:   an external-image directory (source/directories/@external in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   an external-image directory (source/directories/@external in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
             <xsl:text/>
         </xsl:when>
         <!-- trailing path separator is good and -->
@@ -1201,7 +1201,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>no</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:ERROR:   the publisher file specifies one of source/directories/@external and source/directories/@generated, but not both. Proceeding as if neither was specified.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   the publisher file specifies one of source/directories/@external and source/directories/@generated, but not both. Proceeding as if neither was specified.</xsl:message>
             <xsl:text>no</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -1255,7 +1255,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <xsl:choose>
         <xsl:when test="substring($raw-input, 1, 1) = '/'">
-            <xsl:message>PTX:ERROR:   a data directory (source/directories/@data in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   a data directory (source/directories/@data in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
             <xsl:text/>
         </xsl:when>
         <!-- trailing path separator is good -->
@@ -3267,7 +3267,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:when test="$latex.font.size='20pt'"><xsl:value-of select="$latex.font.size" /></xsl:when>
                 <xsl:otherwise>
                     <xsl:text>10pt</xsl:text>
-                    <xsl:message>PTX:ERROR   the *deprecated* latex.font.size parameter must be 8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, or 20pt, not "<xsl:value-of select="$latex.font.size" />".  Using the default ("10pt")</xsl:message>
+                    <xsl:message>PTX:FALLBACK   the *deprecated* latex.font.size parameter must be 8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, or 20pt, not "<xsl:value-of select="$latex.font.size" />".  Using the default ("10pt")</xsl:message>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
@@ -3371,7 +3371,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:choose>
                 <!-- fail when no base URL is given -->
                 <xsl:when test="not($b-has-baseurl)">
-                    <xsl:message>PTX WARNING: baseurl must be set in publisher file to enable links from Asymptote images</xsl:message>
+                    <xsl:message>PTX:WARNING: baseurl must be set in publisher file to enable links from Asymptote images</xsl:message>
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
@@ -3384,7 +3384,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- set, but not correct, so inform and use default -->
         <xsl:when test="$publication/latex/asymptote/@links">
-            <xsl:message>PTX WARNING: LaTeX links to Asymptote publisher file should be "yes" (links to HTML) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
+            <xsl:message>PTX:FALLBACK: LaTeX links to Asymptote publisher file should be "yes" (links to HTML) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
             <xsl:text>no</xsl:text>
         </xsl:when>
         <!-- unset, use the default, which is "no" since -->
@@ -3406,7 +3406,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:choose>
                 <!-- fail when no base URL is given -->
                 <xsl:when test="not($b-has-baseurl)">
-                    <xsl:message>PTX WARNING: baseurl must be set in publisher file to enable links from Asymptote images</xsl:message>
+                    <xsl:message>PTX:WARNING: baseurl must be set in publisher file to enable links from Asymptote images</xsl:message>
                     <xsl:text>no</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
@@ -3419,7 +3419,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <!-- set, but not correct, so inform and use default -->
         <xsl:when test="$publication/html/asymptote/@links">
-            <xsl:message>PTX WARNING: HTML links to Asymptote publisher file should be "yes" (adds link below image) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
+            <xsl:message>PTX:FALLBACK: HTML links to Asymptote publisher file should be "yes" (adds link below image) or "no" (no links), not "<xsl:value-of select="$publication/latex/asymptote/@links"/>". Proceeding with default value: "no" (no links)</xsl:message>
             <xsl:text>no</xsl:text>
         </xsl:when>
         <!-- unset, use the default, which is "no" since -->


### PR DESCRIPTION
Every message PreTeXt emits — from the Python library or from a stylesheet — now carries one of seven severities, with a precise meaning attached to each. This PR establishes the vocabulary, makes the plumbing enforce it, and then audits every existing message against it.

**The severity ladder.** Python's five standard levels plus two PreTeXt additions that interleave with them:

- `debug` (10) — fine-grained trace, for pinpointing
- `info` (20) — coarse progress
- `fallback` (25, **new**) — bad or absent input, but a sensible default was substituted; output is complete
- `warning` (30) — something the author should address
- `error` (40) — no good default; a localized piece of the output is broken or missing, but processing continues
- `bug` (45, **new**) — an internal PreTeXt defect, not the author's fault; please report it
- `fatal` (50) — processing halts, no output expected

The crux is the last two. *Bug* is a severity only: PreTeXt is at fault, and the renderer degrades and continues. *Fatal* is a severity **and** an action: `log.fatal()` logs and then raises a dedicated `PreTeXtFatal` exception, so "fatal" structurally always means "halt" — and the developer script catches it for a clean exit status 1 with no traceback. A traceback now always means an unexpected failure. This is groundwork for downstream consumers (pretext-cli, and Runestone above it): the two outcomes an author cares about — *the build finished but had errors* versus *the build did not happen* — become mechanically distinguishable, without inspecting message text.

**Strict routing of stylesheet messages.** An `xsl:message` declares its severity with a leading token (`PTX:ERROR:`, `PTX:FALLBACK:`, …), and the Python layer re-logs it at exactly that level. Previously the routing was a partial substring match; now it is a strict match on the leading token, with two safety behaviors: an unknown-but-well-formed token routes quietly to `debug` rather than being mis-leveled, and a token that looks intended but is malformed (`PTX Warning`, bare `WARNING:`) is itself reported as a bug, so an authoring slip surfaces instead of being silently demoted.

**A full audit of every stylesheet message.** All 387 `xsl:message` sites were inventoried and judged against the ladder. The large movements: 91 messages that state and substitute a default (mostly publisher-file validation) become `fallback`; 19 messages reporting genuinely broken or lost output become `error`; 9 messages only reachable through a PreTeXt gap become `bug`; deprecation announcements consolidate on `DEPRECATE`; terminating messages carry `PTX:FATAL`; debug-flag diagnostics and the braille coverage report gain honest tokens. Messages left untokened are deliberate: continuation lines of a lead message, report-formatting machinery, and standalone utilities whose console output is their product. No fatal was demoted, and none of this changes *whether* a message displays at a given verbosity — only how it is labeled. Output documents are byte-identical throughout, verified against pre-branch builds of the sample article in HTML, PDF, EPUB, and braille.

**Author-visible fixes along the way.** Two `NameError` crashes (Mermaid in an unsupported format; an unreadable image width in MyOpenMath problems) become logged errors with graceful degradation. A handful of mis-leveled messages stop shouting: the "repository may not be available" complaint no longer appears in every quiet build, and a failed LaTeX image compile no longer dumps its full log at default verbosity. Console legibility improves: a banner containing an empty line now prints line-by-line as intended (the literate-programming notice was garbled), relayed stylesheet messages are introduced with an explanation of their `*` marker, and a few stray blemishes (a blank line, a numbering typo) are gone.

**One source of truth.** A new Developer Guide chapter, "Messages and Severity," defines the vocabulary, with a compact twin of its table as a comment where the levels are defined in `common.py` — each points at the other, so a change to one demands a change to both.

**Not here, deliberately.** The library's deliberate halt sites still raise generic exceptions; converting them to `log.fatal` is consumer-visible (pretext-cli may catch those types) and will be its own coordinated pass, alongside the pretext-cli-side work this enables (an error-tracking handler and a machine-readable build outcome).

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
