### PR TITLE
FITB cleanup related to Schema

### DIFF
--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -425,9 +425,7 @@
                     empty
                 }
             # Text parses to a formula representing a constant (no free
-            # variables).  N.B. @reduce here follows sample usage; the
-            # maintainer's description lists it only on de-expression
-            # and de-evaluate.
+            # variables).  @reduce determines if the internal representation is simplified or not.
             DENumber =
                 element de-number {
                     attribute reduce {"yes"}?,
@@ -458,12 +456,11 @@
                     DEExpression | DEEvaluate | Eval
                 }
             # The variable of a substitution or evaluation carries its
-            # value; plain-text values happen to work as raw Javascript
-            # but are deliberately NOT valid
+            # value; plain-text values happen to work as raw Javascript automatically wrapped in de-number
             DEVariableValued =
                 element variable {
                     attribute name {text},
-                    (Eval | DENumber | DEExpression)
+                    (Eval | DENumber | DEExpression | DEEvaluate)
                 }
             # The variable of a differentiation is name-only
             DEVariableEmpty =

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1006,9 +1006,8 @@
   </define>
   <!--
     Text parses to a formula representing a constant (no free
-    variables).  N.B. @reduce here follows sample usage; the
-    maintainer's description lists it only on de-expression
-    and de-evaluate.
+    variables).  @reduce determines if the internal
+    representation is simplified or not.
   -->
   <define name="DENumber">
     <element name="de-number">
@@ -1083,7 +1082,7 @@
   <!--
     The variable of a substitution or evaluation carries its
     value; plain-text values happen to work as raw Javascript
-    but are deliberately NOT valid
+    automatically wrapped in de-number
   -->
   <define name="DEVariableValued">
     <element name="variable">
@@ -1092,6 +1091,7 @@
         <ref name="Eval"/>
         <ref name="DENumber"/>
         <ref name="DEExpression"/>
+        <ref name="DEEvaluate"/>
       </choice>
     </element>
   </define>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2573,9 +2573,7 @@
                     empty
                 }
             # Text parses to a formula representing a constant (no free
-            # variables).  N.B. @reduce here follows sample usage; the
-            # maintainer's description lists it only on de-expression
-            # and de-evaluate.
+            # variables).  @reduce determines if the internal representation is simplified or not.
             DENumber =
                 element de-number {
                     attribute reduce {"yes"}?,
@@ -2606,12 +2604,11 @@
                     DEExpression | DEEvaluate | Eval
                 }
             # The variable of a substitution or evaluation carries its
-            # value; plain-text values happen to work as raw Javascript
-            # but are deliberately NOT valid
+            # value; plain-text values happen to work as raw Javascript automatically wrapped in de-number
             DEVariableValued =
                 element variable {
                     attribute name {text},
-                    (Eval | DENumber | DEExpression)
+                    (Eval | DENumber | DEExpression | DEEvaluate)
                 }
             # The variable of a differentiation is name-only
             DEVariableEmpty =

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -386,7 +386,10 @@
 <xsl:template match="evaluation" mode="get-multianswer-check">
     <xsl:variable name="responseTree" select="../statement//fillin" />
     <xsl:if test="count($responseTree) > 1 and evaluate[@all='yes']/test">
-        <xsl:apply-templates select="evaluate[@all='yes']/test" mode="create-test-feedback">
+        <xsl:if test="count(evaluate[@all='yes']/test) > 1">
+            <xsl:message>PTX:FALLBACK: evaluate[@all='yes'] in "<xsl:value-of select="../@visible-id"/>" has multiple test elements; only the first will be used as the correctness check.</xsl:message>
+        </xsl:if>
+        <xsl:apply-templates select="evaluate[@all='yes']/test[1]" mode="create-test-feedback">
             <xsl:with-param name="b-correct" select="'yes'"/>
             <xsl:with-param name="fillin" select="$responseTree"/>
         </xsl:apply-templates>
@@ -412,6 +415,9 @@
     <xsl:text>[</xsl:text>
     <xsl:choose>
         <xsl:when test="string-length($multiAns) > 0">
+            <xsl:if test="test[@correct='yes']">
+                <xsl:message>PTX:WARNING: evaluate element has test[@correct="yes"] that will be ignored because evaluate[@all="yes"] is active in "<xsl:value-of select="ancestor::*[@visible-id][1]/@visible-id"/>".</xsl:message>
+            </xsl:if>
             <xsl:value-of select="$multiAns"/>
         </xsl:when>
         <xsl:when test="test[@correct='yes']">
@@ -1010,8 +1016,10 @@
 <!-- will parse the expression for a number appropriately,     -->
 <!-- which could be written as an expression involving symbols -->
 <!-- or a random number                                        -->
-<xsl:template match="de-number" mode="evaluate">
+<xsl:template name="create-de-number">
     <xsl:param name="setupMode" />
+    <xsl:param name="reduce" />
+    <xsl:param name="content" />
     <xsl:variable name="prefix">
         <xsl:if test="$setupMode">
             <xsl:text>v.</xsl:text>
@@ -1024,10 +1032,21 @@
     <xsl:value-of select="$de_env"/>
     <xsl:text>.parseExpression(</xsl:text>
     <xsl:call-template name="quote-strip-string">
-        <xsl:with-param name="text" select="."/>
+        <xsl:with-param name="text" select="$content"/>
     </xsl:call-template>
     <xsl:text>, "number")</xsl:text>
-    <xsl:text>.reduce().simplifyConstants()</xsl:text>
+    <xsl:if test="$reduce='yes'">
+        <xsl:text>.reduce().simplifyConstants()</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template match="de-number" mode="evaluate">
+    <xsl:param name="setupMode" />
+    <xsl:call-template name="create-de-number">
+        <xsl:with-param name="setupMode" select="$setupMode"/>
+        <xsl:with-param name="reduce" select="@reduce"/>
+        <xsl:with-param name="content" select="."/>
+    </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="de-evaluate" mode="evaluate">
@@ -1188,13 +1207,16 @@
     </xsl:call-template>
     <xsl:text>: </xsl:text>
     <xsl:choose>
-        <xsl:when test="eval or de-number or de-expression">
-            <xsl:apply-templates select="eval|de-number|de-expression" mode="evaluate">
+        <xsl:when test="eval or de-number or de-expression or de-evaluate">
+            <xsl:apply-templates select="eval|de-number|de-expression|de-evaluate" mode="evaluate">
                 <xsl:with-param name="setupMode" select="$setupMode" />
             </xsl:apply-templates>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:value-of select="." />
+            <xsl:call-template name="create-de-number">
+                <xsl:with-param name="setupMode" select="$setupMode" />
+                <xsl:with-param name="content" select="." />
+            </xsl:call-template>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
This should resolve some of the noted discrepancies in the FITB schema.

- bare-text in `variable` is allowed in the schema and is treated internally by automatically wrapping inside `de-number`. This should preserve the old treatment while ensuring that the text content is escaped inside a string as needed and parsed in javascript.
- `de-evaluate` is now also allowed inside the `variable` (would have always worked but was never parsed) to allow for nested evaluation, such as would be used for evaluation of a substitution followed by composition.

I attempted (with Claude assistance help) to update the schema files to match this work. (separate commit)