### PR TITLE
Reset block numbering within worksheets and handouts

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -4092,7 +4092,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
     <xsl:param name="openproblem-nodes"/>
-    <xsl:variable name="b-terminal" select="not(part|chapter|appendix|section|subsection|subsubsection|preface)"/>
+    <!-- terminal: holds content directly, so it has no child divisions of  -->
+    <!-- any kind.  Specialized divisions ("worksheet", "handout", etc.)     -->
+    <!-- count here just like the traditional ones, else a division whose    -->
+    <!-- children are specialized divisions is wrongly deemed terminal and   -->
+    <!-- pools their blocks into one scope instead of one scope apiece.      -->
+    <xsl:variable name="b-terminal" select="not(part|chapter|appendix|section|subsection|subsubsection|preface|exercises|worksheet|handout|reading-questions|references|glossary|solutions)"/>
     <xsl:variable name="b-open-eq"          select="not($eq-nodes)          and ($b-terminal or (@level &gt;= $numbering-equations))"/>
     <xsl:variable name="b-open-fn"          select="not($fn-nodes)          and ($b-terminal or (@level &gt;= $numbering-footnotes))"/>
     <xsl:variable name="b-open-blocks"      select="not($blocks-nodes)      and ($b-terminal or (@level &gt;= $numbering-blocks))"/>


### PR DESCRIPTION
Reported on [pretext-support](https://groups.google.com/d/msgid/pretext-support/50f9c147-c15c-46e9-9ed2-eff86fc79913n%40googlegroups.com): numbered blocks (definitions, theorems, etc.) in sibling `worksheet` or `handout` divisions don't restart their numbers in HTML, even though the PDF numbers them correctly.

For example, a chapter with two handouts, ten definitions each, produces:

- **PDF:** `1.1.1`–`1.1.10`, then `1.2.1`–`1.2.10`
- **HTML:** `1.1.1`–`1.1.10`, then `1.2.11`–`1.2.20` — the third component never resets

**Cause.** The two formats number these blocks by different routes. LaTeX uses its own `block` tcolorbox counter, declared `number within=section`; since each handout is emitted as a `\section`, the counter resets per handout. HTML uses the `@serial` stamped during assembly. In the assembly `serial-stamp` pass, the `$b-terminal` test — which decides whether a division opens its own block-numbering scope — listed only the traditional subdivisions (`chapter`, `section`, …) and omitted the specialized ones. So a chapter whose children are handouts is misjudged "terminal," opens a single scope, and pools the blocks of *all* its handouts into one running count. Using `section`s in place of handouts avoids the bug precisely because `section` was in the test.

**Origin.** The `$b-terminal` predicate was introduced in #2885 (serial numbers for equations and footnotes), where the omission was already present — so equation and footnote numbering inside sibling worksheets/handouts has had the same latent flaw. It surfaced as this report once #2904 (serial numbers for blocks) routed the shared block counter through the same predicate.

**Fix.** Add the specialized divisions (`exercises`, `worksheet`, `handout`, `reading-questions`, `references`, `glossary`, `solutions`) to the `$b-terminal` test, so each opens its own scope and its blocks restart, matching the print output.

**Testing.** A synthetic two-handout document now numbers `1.2.1`–`1.2.3` in HTML, matching the PDF. A before/after build of the sample article (via its publication file) shows no numbering changes — only build timestamps differ.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
