### PR TITLE
New conversions: plain text and markdown

### DIFF
--- a/doc/guide/developer/pretext-script.xml
+++ b/doc/guide/developer/pretext-script.xml
@@ -214,6 +214,11 @@ The script should be run on the entire document, even if all the images are in o
                 </li>
 
                 <li>
+                    <title>Text and Markdown</title>
+                    <p>The formats <c>text</c>, <c>markdown</c>, and <c>markdown-zip</c> produce a plain text rendering, a CommonMark rendering, and a single zip archive bundling the markdown with its image directories, respectively.  The chunking election of the publication file is honored: one file, or a file per division with navigation.  See <xref ref="text-markdown"/> for an overview.</p>
+                </li>
+
+                <li>
                     <title><latex/> Graphics</title>
                     <p><latex/> has a variety of languages for specifying images, such as xypic, pgfplots, and TikZ.  By including the necessary packages or setup commands in <c>docinfo/latex-preamble</c>, these can all be generated at once, in the manner of the example earlier.</p>
                 </li>

--- a/doc/guide/guide.xml
+++ b/doc/guide/guide.xml
@@ -58,6 +58,7 @@
             <xi:include href="publisher/braille.xml"/>
             <xi:include href="publisher/slides.xml"/>
             <xi:include href="publisher/jupyter-notebook.xml"/>
+            <xi:include href="publisher/text-markdown.xml"/>
             <xi:include href="publisher/instructor-version.xml"/>
             <xi:include href="publisher/ancillaries.xml"/>
             <xi:include href="publisher/webwork.xml"/>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1137,6 +1137,25 @@
         </subsection>
     </section>
 
+    <section xml:id="publication-file-text" label="publication-file-text">
+        <title>Text and Markdown Options</title>
+        <idx>text publisher options</idx>
+        <idx><h>publisher options</h><h>text and markdown</h></idx>
+
+        <introduction>
+            <p>These options apply to the plain text conversion, and to the markdown conversion built on top of it.  See <xref ref="text-markdown"/> for an overview of both.</p>
+        </introduction>
+
+        <subsection xml:id="text-characters-option" label="text-characters-option">
+            <title>Character Repertoire</title>
+            <idx><h>plain text</h><h>character repertoire</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/text/@characters</cline>
+            </cd>attribute elects the character repertoire.  The value <c>unicode</c> (the default) uses genuine Unicode characters, such as curly quotation marks and em-dashes; the value <c>ascii</c> restricts output to 7-bit <init>ASCII</init>, using traditional plain-text stand-ins instead.  See <xref ref="text-markdown-characters"/> for more.</p>
+        </subsection>
+    </section>
+
     <section xml:id="publication-file-source">
         <title>Source Options</title>
         <idx>source publisher options</idx>

--- a/doc/guide/publisher/text-markdown.xml
+++ b/doc/guide/publisher/text-markdown.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--   This file is part of the documentation of PreTeXt      -->
+<!--                                                          -->
+<!--      PreTeXt Author's Guide                              -->
+<!--                                                          -->
+<!-- Copyright (C) 2026  Robert A. Beezer                     -->
+<!-- See the file COPYING for copying conditions.             -->
+
+<chapter xml:id="text-markdown" label="text-markdown">
+    <title>Conversion to Text and Markdown</title>
+    <idx>markdown</idx>
+    <idx>plain text</idx>
+
+    <introduction>
+        <p>Two closely-related conversions produce the lightest-weight output <pretext/> offers: plain text, and markdown.  The markdown version is the plain text version, plus the small set of conventions that make the structure of a document recognizable to a renderer: headings, emphasis, links, code blocks.  Either way you get files a human can read with no tools at all beyond a pager or an editor, and that a program can consume without any parsing to speak of.  A whole document can be a single file, or the chunking election of the publication file will produce one file per division, each with a trailing navigation line, along with summary pages (<xref ref="common-chunking-options"/>).</p>
+
+        <p>Some uses we have in mind.  Websites that host source-code repositories will render markdown automatically, so a project can provide a browsable version of a book right alongside its source, with working cross-references, images, and mathematics, and no web server involved.  Markdown is also the native language of <init>AI</init> assistants and their tools: a compact, faithful rendering of your book<mdash/>or of one section of it, chunked<mdash/>is exactly the right thing to place in front of such a tool.  And plain text is the universal solvent: it can be searched with the simplest tools, quoted in email or a discussion forum, compared line-by-line between versions, or fed to the next program in a pipeline.</p>
+    </introduction>
+
+    <section xml:id="text-markdown-coverage" label="text-markdown-coverage">
+        <title>What to Expect</title>
+
+        <p>A surprising amount of a <pretext/> document survives the trip.  Lists nest, with their authored numbering or markers, to any depth, and the items of a <tag>task</tag> subdivision nest right along with them.  A <tag>tabular</tag> of simple cells becomes a genuine table (<xref ref="text-markdown-commonmark"/>).  Images appear, placed and sized according to your layout elections.  Cross-references are working links, within a file and across the files of a chunked build.  The index is genuine: collected, sorted, and grouped by letter, with each locator a link announcing its target (<q>Theorem 2.1</q>).  Footnotes are marked in place and collected at the end of the division owning them.  Program listings, console sessions, and Sage cells are code blocks, with input prompted by its language.  Mathematics renders (<xref ref="text-markdown-commonmark"/>).</p>
+
+        <p>Understand, though, that certain constructions <em>cannot</em> be supported, and no amount of cleverness will change this.  Text is a linear medium, so there is no side-by-side layout: the panels of a <tag>sidebyside</tag> appear in sequence, after a note announcing the arrangement.  An elaborate <tag>tabular</tag><mdash/>spanning cells, rules, alignment<mdash/>reduces to simple rows.  Interactives, video, and audio cannot function in a static text file; each is announced, with a <init>URL</init> when one is readily available.  There are no knowls, no fonts, no color.  The general principle: a construction that cannot be expressed is announced in-band by a bracketed note, in a fixed recognizable format, rather than being silently dropped.</p>
+    </section>
+
+    <section xml:id="text-markdown-commonmark" label="text-markdown-commonmark">
+        <title>CommonMark, Tables, Mathematics, Renderers</title>
+        <idx>CommonMark</idx>
+
+        <p>Markdown began as a loose collection of conventions, and renderers came to disagree about the fine points.  CommonMark is the careful specification that resolved this, and it is the contract this conversion honors: the output is valid CommonMark, and an escaping layer guarantees that punctuation you author can never be mistaken for markup.  What a particular renderer does beyond the specification is its own affair, and so everything in this section is subject to your renderer of choice.</p>
+
+        <p>Tables are the notable case.  CommonMark itself has no table syntax; the nearly-universal extension is the <term>pipe table</term>, where cells of a row are separated by vertical bars.  A <tag>tabular</tag> of simple cells is emitted in this form, and virtually every renderer<mdash/>repository-hosting websites, editors, notebook interfaces<mdash/>will display a real table.  A strict CommonMark renderer without the extension shows the same content as readable pipe-separated lines, so nothing is lost.</p>
+
+        <p>Mathematics is authored <latex/> riding between dollar signs, the convention MathJax-enabled renderers recognize.  Each page of a markdown build opens with an invisible block of macro definitions, so your macros, and <pretext/>'s, work throughout the page.  With a MathJax-capable renderer (many repository-hosting websites and editors qualify) the mathematics simply renders; anywhere else it reads as the <latex/> you wrote, which is the long-standing convention for mathematics in plain text anyway.  The plain text conversion does exactly that, and nothing more, on the same reasoning.</p>
+
+        <p>Finally, images and their layout use a small amount of raw <init>HTML</init>, as do the invisible anchors that cross-reference links land on.  Raw <init>HTML</init> is legal CommonMark, and renderers overwhelmingly accept these particular tags, but an aggressively-sanitizing renderer may strip them.</p>
+    </section>
+
+    <section xml:id="text-markdown-characters" label="text-markdown-characters">
+        <title>Character Repertoire</title>
+
+        <p>By default these conversions use genuine Unicode characters: curly quotation marks, en- and em-dashes, an ellipsis, and so on.  In the long tradition of plain text, you may elect 7-bit <init>ASCII</init> stand-ins instead (<c>--</c> for an em-dash, straight quotes, <c>(c)</c> for a copyright symbol).  The election is the <c>@characters</c> attribute of the <tag>text</tag> element of the publication file, with values <c>unicode</c> (the default) and <c>ascii</c>; see <xref ref="publication-file-text"/>.  It applies to both conversions, and the files are encoded as <init>UTF-8</init> either way.</p>
+    </section>
+
+    <section xml:id="text-markdown-processing" label="text-markdown-processing">
+        <title>Processing</title>
+
+        <p>The <c>pretext/pretext</c> script (<xref ref="pretext-script"/>) performs these conversions with the formats <c>text</c> and <c>markdown</c>, for example<cd>
+            <cline>pretext/pretext -c doc -f markdown -p publication.xml book.ptx</cline>
+        </cd>A positive chunking level in the publication file produces a file per division; otherwise the result is a single file named for your source.  A markdown build also deposits the directories of external and generated images alongside the markdown files, since the output references images at the same relative paths the <init>HTML</init> conversion uses.  A third format, <c>markdown-zip</c>, bundles the entire markdown build, image directories included, into a single zip archive named for your source<mdash/>convenient for handing a whole book to somebody (or something) else.</p>
+    </section>
+</chapter>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2383,6 +2383,18 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
         log.info("{} file deposited as {}".format(text_format, derivedname))
     else:
         log.info("{} files deposited in {}".format(text_format, dest_dir))
+    # Markdown references image files with relative paths matching the
+    # HTML conversion, so the managed directories ride along
+    if text_format == "markdown":
+        generated_abs, external_abs = common.get_managed_directories(xml, pub_file)
+        if external_abs:
+            shutil.copytree(
+                external_abs, os.path.join(dest_dir, "external"), dirs_exist_ok=True
+            )
+        if generated_abs:
+            shutil.copytree(
+                generated_abs, os.path.join(dest_dir, "generated"), dirs_exist_ok=True
+            )
 
 
 #######################

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2323,6 +2323,57 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
     log.info("MyOpenMath static problem download complete")
 
 
+####################
+# Conversion to Text
+####################
+
+
+def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
+    """
+    Convert XML source to a plain text rendering.
+
+    Args:
+        xml (str): Path to the XML source file.
+        pub_file (str or None): Path to the publisher configuration file, or None if not used.
+        stringparams (dict): Dictionary of string parameters to control the transformation.
+        out_file (str or None): Path to the output file.  If None, the file lands in dest_dir.
+        dest_dir (str): Directory for the output file when out_file is not specified.
+        text_format (str): "text", naming the stylesheet and the file extension.
+
+    Returns:
+        None
+
+    Side Effects:
+        - Generates a text file in the specified destination.
+    """
+
+    # to ensure provided stringparams aren't mutated unintentionally
+    stringparams = stringparams.copy()
+
+    # support publisher file, not subtree argument
+    if pub_file:
+        stringparams["publisher"] = pub_file
+
+    text_format_stylesheets = {
+        "text": "pretext-text.xsl",
+    }
+    text_format_extensions = {
+        "text": ".txt",
+    }
+
+    msg = "converting {} to {} format in {}"
+    log.info(msg.format(xml, text_format, dest_dir))
+
+    conversion_xslt = os.path.join(
+        common.get_ptx_xsl_path(), text_format_stylesheets[text_format]
+    )
+    derivedname = common.get_output_filename(
+        xml, out_file, dest_dir, text_format_extensions[text_format]
+    )
+    common.xsltproc(conversion_xslt, xml, derivedname, None, stringparams)
+    log.info("{} file deposited as {}".format(text_format, derivedname))
+
+
 #######################
 # Conversion to Braille
 #######################

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2338,7 +2338,9 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
         stringparams (dict): Dictionary of string parameters to control the transformation.
         out_file (str or None): Path to the output file.  If None, the file lands in dest_dir.
         dest_dir (str): Directory for the output file when out_file is not specified.
-        text_format (str): "text" or "markdown", naming the stylesheet and the file extension.
+        text_format (str): "text", "markdown", or "markdown-zip", naming the
+            stylesheet and the file extension.  The last bundles a markdown
+            rendering (with its image directories) as a single zip file.
 
     Returns:
         None
@@ -2357,10 +2359,12 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
     text_format_stylesheets = {
         "text": "pretext-text.xsl",
         "markdown": "pretext-markdown.xsl",
+        "markdown-zip": "pretext-markdown.xsl",
     }
     text_format_extensions = {
         "text": ".txt",
         "markdown": ".md",
+        "markdown-zip": ".md",
     }
 
     msg = "converting {} to {} format in {}"
@@ -2369,32 +2373,47 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
     conversion_xslt = os.path.join(
         common.get_ptx_xsl_path(), text_format_stylesheets[text_format]
     )
+    # A zip bundle is staged in a temporary directory, inside a folder
+    # named for the source, so the archive unpacks tidily
+    b_zip = text_format == "markdown-zip"
+    if b_zip:
+        basename = os.path.splitext(os.path.basename(xml))[0]
+        staging_parent = common.get_temporary_directory()
+        work_dir = os.path.join(staging_parent, basename)
+        os.mkdir(work_dir)
+    else:
+        work_dir = dest_dir
     # One transform serves both shapes of output.  A positive chunking
     # election (common/chunking/@level in the publication file) makes
-    # the stylesheet write one file per division into the destination
+    # the stylesheet write one file per division into the working
     # directory and leave the result tree empty; otherwise the result
     # tree is the entire rendering, deposited as a single file
-    result_tree = common.xsltproc(conversion_xslt, xml, None, dest_dir, stringparams)
+    result_tree = common.xsltproc(conversion_xslt, xml, None, work_dir, stringparams)
     if str(result_tree):
         derivedname = common.get_output_filename(
-            xml, out_file, dest_dir, text_format_extensions[text_format]
+            xml, None if b_zip else out_file, work_dir, text_format_extensions[text_format]
         )
         result_tree.write_output(derivedname)
         log.info("{} file deposited as {}".format(text_format, derivedname))
     else:
-        log.info("{} files deposited in {}".format(text_format, dest_dir))
+        log.info("{} files deposited in {}".format(text_format, work_dir))
     # Markdown references image files with relative paths matching the
     # HTML conversion, so the managed directories ride along
-    if text_format == "markdown":
+    if text_format in ("markdown", "markdown-zip"):
         generated_abs, external_abs = common.get_managed_directories(xml, pub_file)
         if external_abs:
             shutil.copytree(
-                external_abs, os.path.join(dest_dir, "external"), dirs_exist_ok=True
+                external_abs, os.path.join(work_dir, "external"), dirs_exist_ok=True
             )
         if generated_abs:
             shutil.copytree(
-                generated_abs, os.path.join(dest_dir, "generated"), dirs_exist_ok=True
+                generated_abs, os.path.join(work_dir, "generated"), dirs_exist_ok=True
             )
+    if b_zip:
+        zip_filename = shutil.make_archive(
+            os.path.join(dest_dir, basename), "zip", staging_parent, basename
+        )
+        log.info("markdown bundle deposited as {}".format(zip_filename))
 
 
 #######################

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2330,7 +2330,7 @@ def mom_static_problems(xml_source, pub_file, stringparams, xmlid_root, dest_dir
 
 def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
     """
-    Convert XML source to a plain text rendering.
+    Convert XML source to a plain text or markdown rendering.
 
     Args:
         xml (str): Path to the XML source file.
@@ -2338,13 +2338,13 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
         stringparams (dict): Dictionary of string parameters to control the transformation.
         out_file (str or None): Path to the output file.  If None, the file lands in dest_dir.
         dest_dir (str): Directory for the output file when out_file is not specified.
-        text_format (str): "text", naming the stylesheet and the file extension.
+        text_format (str): "text" or "markdown", naming the stylesheet and the file extension.
 
     Returns:
         None
 
     Side Effects:
-        - Generates a text file in the specified destination.
+        - Generates a text (or markdown) file in the specified destination.
     """
 
     # to ensure provided stringparams aren't mutated unintentionally
@@ -2356,9 +2356,11 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
 
     text_format_stylesheets = {
         "text": "pretext-text.xsl",
+        "markdown": "pretext-markdown.xsl",
     }
     text_format_extensions = {
         "text": ".txt",
+        "markdown": ".md",
     }
 
     msg = "converting {} to {} format in {}"

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2367,11 +2367,20 @@ def text(xml, pub_file, stringparams, out_file, dest_dir, text_format):
     conversion_xslt = os.path.join(
         common.get_ptx_xsl_path(), text_format_stylesheets[text_format]
     )
-    derivedname = common.get_output_filename(
-        xml, out_file, dest_dir, text_format_extensions[text_format]
-    )
-    common.xsltproc(conversion_xslt, xml, derivedname, None, stringparams)
-    log.info("{} file deposited as {}".format(text_format, derivedname))
+    # One transform serves both shapes of output.  A positive chunking
+    # election (common/chunking/@level in the publication file) makes
+    # the stylesheet write one file per division into the destination
+    # directory and leave the result tree empty; otherwise the result
+    # tree is the entire rendering, deposited as a single file
+    result_tree = common.xsltproc(conversion_xslt, xml, None, dest_dir, stringparams)
+    if str(result_tree):
+        derivedname = common.get_output_filename(
+            xml, out_file, dest_dir, text_format_extensions[text_format]
+        )
+        result_tree.write_output(derivedname)
+        log.info("{} file deposited as {}".format(text_format, derivedname))
+    else:
+        log.info("{} files deposited in {}".format(text_format, dest_dir))
 
 
 #######################

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -408,6 +408,7 @@ def get_cli_arguments():
         ("speech", "Speech (math elements)"),
         ("source", "Standalone source files"),
         ("text", "plain text rendering (experimental)"),
+        ("markdown", "markdown rendering (CommonMark, experimental)"),
         ("latex", "LaTeX source file (only, an intermediate format for developers)"),
         ("latex-plus", "LaTeX source file and all necessary build files"),
         ("fo", "XSL-FO source file (only, an intermediate format for developers, experimental)"),
@@ -903,14 +904,14 @@ def main():
                 out_file,
                 dest_dir,
             )
-        elif args.format == "text":
+        elif args.format in ["text", "markdown"]:
             ptx.text(
                 xml_source,
                 publication_file,
                 stringparams,
                 out_file,
                 dest_dir,
-                "text",
+                args.format,
             )
         elif args.format == "latex":
             ptx.latex(

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -407,6 +407,7 @@ def get_cli_arguments():
         ("tactile", "Tactile PreFigure diagrams with braille labels"),
         ("speech", "Speech (math elements)"),
         ("source", "Standalone source files"),
+        ("text", "plain text rendering (experimental)"),
         ("latex", "LaTeX source file (only, an intermediate format for developers)"),
         ("latex-plus", "LaTeX source file and all necessary build files"),
         ("fo", "XSL-FO source file (only, an intermediate format for developers, experimental)"),
@@ -901,6 +902,15 @@ def main():
                 stringparams,
                 out_file,
                 dest_dir,
+            )
+        elif args.format == "text":
+            ptx.text(
+                xml_source,
+                publication_file,
+                stringparams,
+                out_file,
+                dest_dir,
+                "text",
             )
         elif args.format == "latex":
             ptx.latex(

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -409,6 +409,7 @@ def get_cli_arguments():
         ("source", "Standalone source files"),
         ("text", "plain text rendering (experimental)"),
         ("markdown", "markdown rendering (CommonMark, experimental)"),
+        ("markdown-zip", "markdown rendering and image directories, bundled as a zip file"),
         ("latex", "LaTeX source file (only, an intermediate format for developers)"),
         ("latex-plus", "LaTeX source file and all necessary build files"),
         ("fo", "XSL-FO source file (only, an intermediate format for developers, experimental)"),
@@ -904,7 +905,7 @@ def main():
                 out_file,
                 dest_dir,
             )
-        elif args.format in ["text", "markdown"]:
+        elif args.format in ["text", "markdown", "markdown-zip"]:
             ptx.text(
                 xml_source,
                 publication_file,

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -15,6 +15,7 @@
                     Epub? &
                     Jupyter? &
                     Braille? &
+                    Text? &
                     Webwork?
                 }
             
@@ -422,6 +423,11 @@
                         attribute width { xsd:positiveInteger }?,
                         attribute height { xsd:positiveInteger }?
                     }
+                }
+            
+            Text =
+                element text {
+                    attribute characters { "unicode" | "ascii" }?
                 }
             
             Webwork =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -37,6 +37,9 @@
           <ref name="Braille"/>
         </optional>
         <optional>
+          <ref name="Text"/>
+        </optional>
+        <optional>
           <ref name="Webwork"/>
         </optional>
       </interleave>
@@ -1301,6 +1304,18 @@
           </attribute>
         </optional>
       </element>
+    </element>
+  </define>
+  <define name="Text">
+    <element name="text">
+      <optional>
+        <attribute name="characters">
+          <choice>
+            <value>unicode</value>
+            <value>ascii</value>
+          </choice>
+        </attribute>
+      </optional>
     </element>
   </define>
   <define name="Webwork">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -106,6 +106,7 @@
                     Epub? &amp;
                     Jupyter? &amp;
                     Braille? &amp;
+                    Text? &amp;
                     Webwork?
                 }
             </code>
@@ -664,6 +665,24 @@
 
 
     <section>
+        <title>Text Options</title>
+
+        <p>
+            These option(s) control the plain text and markdown outputs.  The character repertoire is <c>unicode</c> (the default) for genuine dashes, quotations marks, and the like, or <c>ascii</c> for stand-ins drawn from the 7-bit repertoire.
+        </p>
+
+        <fragment xml:id="text">
+            <title>Text Options</title>
+            <code>
+            Text =
+                element text {
+                    attribute characters { "unicode" | "ascii" }?
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
         <title><webwork/> Options</title>
 
         <p>
@@ -709,6 +728,7 @@
             <fragref ref="epub" />
             <fragref ref="jupyter" />
             <fragref ref="braille" />
+            <fragref ref="text" />
             <fragref ref="webwork" />
             <code>
             }

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -306,6 +306,61 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>**&#xa;&#xa;</xsl:text>
 </xsl:template>
 
+<!-- ##### -->
+<!-- Index -->
+<!-- ##### -->
+
+<!-- Each entry is a list item, nested two spaces per subentry     -->
+<!-- level, so entries do not run together as a single paragraph   -->
+<xsl:template name="present-index-heading">
+    <xsl:param name="the-index-list"/>
+    <xsl:param name="heading-group"/>
+    <xsl:param name="b-write-locators"/>
+    <xsl:param name="heading-level"/>
+    <xsl:param name="content"/>
+    <xsl:value-of select="substring('    ', 1, 2 * ($heading-level - 1))"/>
+    <xsl:text>- </xsl:text>
+    <xsl:copy-of select="$content"/>
+    <xsl:if test="$b-write-locators">
+        <xsl:call-template name="locator-list">
+            <xsl:with-param name="the-index-list" select="$the-index-list"/>
+            <xsl:with-param name="heading-group" select="$heading-group"/>
+            <xsl:with-param name="cross-reference-separator" select="', '"/>
+        </xsl:call-template>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- the "see"/"see also" words italicize -->
+<xsl:template name="present-index-italics">
+    <xsl:param name="content"/>
+    <xsl:text>*</xsl:text>
+    <xsl:copy-of select="$content"/>
+    <xsl:text>*</xsl:text>
+</xsl:template>
+
+<!-- a chunked build links each locator to the file of its enclosure -->
+<xsl:template match="index-list" mode="index-locator">
+    <xsl:param name="enclosure"/>
+    <xsl:param name="the-number"/>
+    <xsl:choose>
+        <xsl:when test="$chunk-level &gt; 0">
+            <xsl:text>[</xsl:text>
+            <xsl:apply-templates select="$enclosure" mode="type-name"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="$the-number"/>
+            <xsl:text>](</xsl:text>
+            <xsl:apply-templates select="$enclosure" mode="containing-filename"/>
+            <xsl:text>)</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="$enclosure" mode="type-name"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="$the-number"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- ######## -->
 <!-- Chunking -->
 <!-- ######## -->

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -63,7 +63,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- over-escaping is always safe, if unlovely; the set below is  -->
 <!-- the characters that can OPEN a construction mid-prose, plus  -->
 <!-- the dollar sign, which mathematics has claimed.              -->
-<xsl:variable name="markdown-escapes" select="'\`*_[]&lt;&amp;$'"/>
+<xsl:variable name="markdown-escapes" select="'\`*_[]&lt;&amp;$|'"/>
 
 <xsl:template name="text-processing">
     <xsl:param name="text"/>
@@ -258,6 +258,66 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- physical line a pipe table demands                         -->
 <xsl:template name="line-separator">
     <xsl:text>&lt;br&gt;</xsl:text>
+</xsl:template>
+
+<!-- ###### -->
+<!-- Tables -->
+<!-- ###### -->
+
+<!-- A tabular of simple cells becomes a pipe table: the authored -->
+<!-- header row when there is one (a row of empty header cells    -->
+<!-- otherwise, which renderers accept), a delimiter row, then    -->
+<!-- the body.  A tabular with structured cells (paragraphs)      -->
+<!-- keeps the plain conversion's row-per-line form.  Cell text   -->
+<!-- is safe in a cell: "|" is in the escaping set.               -->
+<xsl:template match="tabular">
+    <xsl:choose>
+        <xsl:when test="row/cell/p">
+            <xsl:apply-imports/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:choose>
+                <xsl:when test="row[1][@header = 'yes']">
+                    <xsl:apply-templates select="row[1]" mode="pipe-row"/>
+                    <xsl:apply-templates select="row[1]" mode="pipe-delimiter"/>
+                    <xsl:apply-templates select="row[position() &gt; 1]" mode="pipe-row"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="row[1]" mode="pipe-empty-header"/>
+                    <xsl:apply-templates select="row[1]" mode="pipe-delimiter"/>
+                    <xsl:apply-templates select="row" mode="pipe-row"/>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template match="row" mode="pipe-row">
+    <xsl:text>|</xsl:text>
+    <xsl:for-each select="cell">
+        <xsl:text> </xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text> |</xsl:text>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="row" mode="pipe-delimiter">
+    <xsl:text>|</xsl:text>
+    <xsl:for-each select="cell">
+        <xsl:text>---|</xsl:text>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="row" mode="pipe-empty-header">
+    <xsl:text>|</xsl:text>
+    <xsl:for-each select="cell">
+        <xsl:text>   |</xsl:text>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <!-- ###### -->

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -121,15 +121,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ######## -->
 
 <!-- ATX headings: honest levels, one octothorpe per depth, the -->
-<!-- document title at level one, divisions one deeper          -->
-<xsl:template match="book|article">
+<!-- document title at level one, divisions one deeper.  Only   -->
+<!-- the heading lines change flavor; the structure of a        -->
+<!-- division (content, collected footnotes) is inherited.      -->
+<xsl:template match="book|article" mode="heading-lines">
     <xsl:text># </xsl:text>
     <xsl:apply-templates select="." mode="title-full"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
-    <xsl:apply-templates select="*"/>
 </xsl:template>
 
-<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+<xsl:template match="*" mode="heading-lines">
     <xsl:variable name="raw-level">
         <xsl:apply-templates select="." mode="level"/>
     </xsl:variable>
@@ -146,23 +147,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
     <xsl:value-of select="substring('######', 1, $level + 1)"/>
     <xsl:text> </xsl:text>
-    <xsl:variable name="the-number">
-        <xsl:apply-templates select="." mode="number"/>
-    </xsl:variable>
-    <xsl:if test="not($the-number = '')">
-        <xsl:apply-templates select="." mode="type-name"/>
-        <xsl:text> </xsl:text>
-        <xsl:value-of select="$the-number"/>
-        <xsl:text> </xsl:text>
-    </xsl:if>
-    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:apply-templates select="." mode="heading-text"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
-    <xsl:apply-templates select="*"/>
-    <xsl:variable name="the-notes" select=".//fn[generate-id(ancestor::*[&STRUCTURAL-FILTER;][1]) = generate-id(current())]"/>
-    <xsl:if test="$the-notes">
-        <xsl:text>&#xa;</xsl:text>
-        <xsl:apply-templates select="$the-notes" mode="collected"/>
-    </xsl:if>
 </xsl:template>
 
 <!-- ######## -->
@@ -271,18 +257,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&lt;br&gt;</xsl:text>
 </xsl:template>
 
-<!-- ###### -->
-<!-- Blocks -->
-<!-- ###### -->
-
-<!-- A block's heading line, emboldened -->
-<xsl:template name="block-heading-line">
-    <xsl:param name="heading"/>
-    <xsl:text>**</xsl:text>
-    <xsl:copy-of select="$heading"/>
-    <xsl:text>**&#xa;&#xa;</xsl:text>
-</xsl:template>
-
 <!-- ##### -->
 <!-- Lists -->
 <!-- ##### -->
@@ -318,6 +292,82 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>- (</xsl:text>
     <xsl:apply-templates select="." mode="serial-number"/>
     <xsl:text>)</xsl:text>
+</xsl:template>
+
+<!-- ###### -->
+<!-- Blocks -->
+<!-- ###### -->
+
+<!-- A block's heading line, emboldened -->
+<xsl:template name="block-heading-line">
+    <xsl:param name="heading"/>
+    <xsl:text>**</xsl:text>
+    <xsl:copy-of select="$heading"/>
+    <xsl:text>**&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ######## -->
+<!-- Chunking -->
+<!-- ######## -->
+
+<!-- A summary page's line for a subsidiary file is a genuine link -->
+<xsl:template match="*" mode="summary-entry">
+    <xsl:text>- [</xsl:text>
+    <xsl:apply-templates select="." mode="heading-text"/>
+    <xsl:text>](</xsl:text>
+    <xsl:apply-templates select="." mode="containing-filename"/>
+    <xsl:text>)&#xa;</xsl:text>
+</xsl:template>
+
+<!-- The navigation line links its labels; a lone paragraph, -->
+<!-- pipe-separated like the plain-text form                 -->
+<xsl:template match="*" mode="navigation-line">
+    <xsl:variable name="the-filename">
+        <xsl:apply-templates select="." mode="containing-filename"/>
+    </xsl:variable>
+    <xsl:variable name="entry" select="$chunk-list[@filename = $the-filename]"/>
+    <xsl:variable name="previous" select="$entry/preceding-sibling::chunk[1]"/>
+    <xsl:variable name="next" select="$entry/following-sibling::chunk[1]"/>
+    <xsl:variable name="up">
+        <xsl:apply-templates select="." mode="up-filename"/>
+    </xsl:variable>
+    <xsl:if test="$previous or $next">
+        <xsl:text>&#xa;[</xsl:text>
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'toc'"/>
+        </xsl:apply-templates>
+        <xsl:text>](</xsl:text>
+        <xsl:value-of select="$contents-filename"/>
+        <xsl:text>)</xsl:text>
+        <xsl:if test="$previous">
+            <xsl:text> | [</xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'previous'"/>
+            </xsl:apply-templates>
+            <xsl:text>](</xsl:text>
+            <xsl:value-of select="$previous/@filename"/>
+            <xsl:text>)</xsl:text>
+        </xsl:if>
+        <xsl:if test="not($up = '')">
+            <xsl:text> | [</xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'up'"/>
+            </xsl:apply-templates>
+            <xsl:text>](</xsl:text>
+            <xsl:value-of select="$up"/>
+            <xsl:text>)</xsl:text>
+        </xsl:if>
+        <xsl:if test="$next">
+            <xsl:text> | [</xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'next'"/>
+            </xsl:apply-templates>
+            <xsl:text>](</xsl:text>
+            <xsl:value-of select="$next/@filename"/>
+            <xsl:text>)</xsl:text>
+        </xsl:if>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -129,6 +129,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- division (content, collected footnotes) is inherited.      -->
 <xsl:template match="book|article" mode="heading-lines">
     <xsl:text># </xsl:text>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
     <xsl:apply-templates select="." mode="title-full"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
 </xsl:template>
@@ -150,8 +151,141 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
     <xsl:value-of select="substring('######', 1, $level + 1)"/>
     <xsl:text> </xsl:text>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
     <xsl:apply-templates select="." mode="heading-text"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ##################### -->
+<!-- Anchors and Fragments -->
+<!-- ##################### -->
+
+<!-- The @xml:id of every element some "xref" points at,          -->
+<!-- delimited for exact-match testing; the enumeration mirrors   -->
+<!-- the HTML conversion's knowl manufacture (which could migrate -->
+<!-- to -common one day, and both would share it)                 -->
+<xsl:variable name="xref-target-ids-rtf">
+    <xsl:for-each select="$document-root//xref">
+        <xsl:choose>
+            <!-- just use @first, clean-up spaces -->
+            <xsl:when test="@first and @last">
+                <xid>
+                    <xsl:value-of select="normalize-space(@first)"/>
+                </xid>
+                <xid>
+                    <xsl:value-of select="normalize-space(@last)"/>
+                </xid>
+            </xsl:when>
+            <!-- a space-separated or comma-separated list -->
+            <xsl:when test="@ref and (contains(normalize-space(@ref), ' ') or contains(@ref, ','))">
+                <xsl:call-template name="split-ref-list">
+                    <xsl:with-param name="list" select="concat(normalize-space(translate(@ref, ',', ' ')), ' ')"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="@ref">
+                <xid>
+                    <xsl:value-of select="normalize-space(@ref)"/>
+                </xid>
+            </xsl:when>
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:for-each>
+</xsl:variable>
+
+<xsl:template name="split-ref-list">
+    <xsl:param name="list"/>
+    <xsl:choose>
+        <xsl:when test="$list = ''"/>
+        <xsl:otherwise>
+            <xid>
+                <xsl:value-of select="substring-before($list, ' ')"/>
+            </xid>
+            <xsl:call-template name="split-ref-list">
+                <xsl:with-param name="list" select="substring-after($list, ' ')"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:variable name="xref-target-list">
+    <xsl:text>|</xsl:text>
+    <xsl:for-each select="exsl:node-set($xref-target-ids-rtf)/xid">
+        <xsl:value-of select="."/>
+        <xsl:text>|</xsl:text>
+    </xsl:for-each>
+</xsl:variable>
+
+<!-- An invisible landing spot, as raw inline HTML (legal          -->
+<!-- CommonMark), riding inside a heading line so it never forms   -->
+<!-- an HTML block.  Emitted only where a link may land: elements  -->
+<!-- some "xref" targets, and elements containing an "idx" (the    -->
+<!-- index's locators climb to them) — so a document with no       -->
+<!-- cross-references produces markdown with no anchors at all.    -->
+<xsl:template match="*" mode="fragment-anchor">
+    <xsl:if test="(@xml:id and contains($xref-target-list, concat('|', @xml:id, '|'))) or .//idx">
+        <xsl:text>&lt;a id="</xsl:text>
+        <xsl:apply-templates select="." mode="unique-id"/>
+        <xsl:text>"&gt;&lt;/a&gt;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- The address of an element: its file when chunked (elided     -->
+<!-- within that same file), and its fragment anchor.  A fragment -->
+<!-- without an anchor still lands on the right file.             -->
+<xsl:template name="markdown-url">
+    <xsl:param name="origin"/>
+    <xsl:param name="target"/>
+    <xsl:if test="$chunk-level &gt; 0">
+        <xsl:variable name="origin-file">
+            <xsl:apply-templates select="$origin" mode="containing-filename"/>
+        </xsl:variable>
+        <xsl:variable name="target-file">
+            <xsl:apply-templates select="$target" mode="containing-filename"/>
+        </xsl:variable>
+        <xsl:if test="not($origin-file = $target-file)">
+            <xsl:value-of select="$target-file"/>
+        </xsl:if>
+    </xsl:if>
+    <xsl:text>#</xsl:text>
+    <xsl:apply-templates select="$target" mode="unique-id"/>
+</xsl:template>
+
+<!-- A cross-reference is a genuine link to its target's address -->
+<xsl:template match="xref" mode="xref-link">
+    <xsl:param name="target"/>
+    <xsl:param name="content"/>
+    <xsl:choose>
+        <!-- no target, or no text to carry a link: leave it be -->
+        <xsl:when test="not($target) or $content = ''">
+            <xsl:value-of select="$content"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>[</xsl:text>
+            <xsl:value-of select="$content"/>
+            <xsl:text>](</xsl:text>
+            <xsl:call-template name="markdown-url">
+                <xsl:with-param name="origin" select="."/>
+                <xsl:with-param name="target" select="$target"/>
+            </xsl:call-template>
+            <xsl:text>)</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- A bibliography entry carries its anchor, a frequent target.  -->
+<!-- (Not "apply-imports": XSLT 1.0 would not forward the         -->
+<!-- content parameter.)                                          -->
+<xsl:template match="biblio" mode="bibentry-wrapper">
+    <xsl:param name="content"/>
+    <xsl:if test="preceding-sibling::biblio">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>] </xsl:text>
+    <xsl:copy-of select="$content"/>
+    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <!-- ######## -->
@@ -568,9 +702,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Blocks -->
 <!-- ###### -->
 
-<!-- A block's heading line, emboldened -->
+<!-- A block's heading line, emboldened, and carrying the -->
+<!-- block's anchor -->
 <xsl:template name="block-heading-line">
     <xsl:param name="heading"/>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
     <xsl:text>**</xsl:text>
     <xsl:copy-of select="$heading"/>
     <xsl:text>**&#xa;&#xa;</xsl:text>
@@ -693,26 +829,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>*</xsl:text>
 </xsl:template>
 
-<!-- a chunked build links each locator to the file of its enclosure -->
+<!-- each locator links to its enclosure's address -->
 <xsl:template match="index-list" mode="index-locator">
     <xsl:param name="enclosure"/>
     <xsl:param name="the-number"/>
-    <xsl:choose>
-        <xsl:when test="$chunk-level &gt; 0">
-            <xsl:text>[</xsl:text>
-            <xsl:apply-templates select="$enclosure" mode="type-name"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$the-number"/>
-            <xsl:text>](</xsl:text>
-            <xsl:apply-templates select="$enclosure" mode="containing-filename"/>
-            <xsl:text>)</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:apply-templates select="$enclosure" mode="type-name"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$the-number"/>
-        </xsl:otherwise>
-    </xsl:choose>
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="$enclosure" mode="type-name"/>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$the-number"/>
+    <xsl:text>](</xsl:text>
+    <xsl:call-template name="markdown-url">
+        <xsl:with-param name="origin" select="."/>
+        <xsl:with-param name="target" select="$enclosure"/>
+    </xsl:call-template>
+    <xsl:text>)</xsl:text>
 </xsl:template>
 
 <!-- ######## -->

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -30,7 +30,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
     xmlns:exsl="http://exslt.org/common"
     xmlns:str="http://exslt.org/strings"
+    xmlns:pf="https://prefigure.org"
+    xmlns:pi="http://pretextbook.org/2020/pretext/internal"
     extension-element-prefixes="exsl str"
+    exclude-result-prefixes="pf pi"
 >
 
 <!-- The markdown conversion IS the text conversion, plus the     -->
@@ -255,6 +258,172 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- physical line a pipe table demands                         -->
 <xsl:template name="line-separator">
     <xsl:text>&lt;br&gt;</xsl:text>
+</xsl:template>
+
+<!-- ###### -->
+<!-- Images -->
+<!-- ###### -->
+
+<!-- A filename without an extension presumes a manufactured -->
+<!-- SVG, exactly as the HTML conversion does                -->
+<xsl:template name="presumed-svg">
+    <xsl:param name="filename"/>
+    <xsl:variable name="extension">
+        <xsl:call-template name="file-extension">
+            <xsl:with-param name="filename" select="$filename"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:if test="$extension = ''">
+        <xsl:text>.svg</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- The relative path of an image's file, matching both the HTML  -->
+<!-- conversion's references and the managed directories deposited -->
+<!-- alongside a markdown build; empty when there is no file to    -->
+<!-- point at (an interactive Asymptote diagram, say)              -->
+<xsl:template match="image" mode="markdown-path">
+    <xsl:choose>
+        <xsl:when test="@pi:generated">
+            <xsl:value-of select="$generated-directory"/>
+            <xsl:value-of select="@pi:generated"/>
+            <xsl:call-template name="presumed-svg">
+                <xsl:with-param name="filename" select="@pi:generated"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="@source">
+            <xsl:value-of select="$external-directory"/>
+            <xsl:value-of select="@source"/>
+            <xsl:call-template name="presumed-svg">
+                <xsl:with-param name="filename" select="@source"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="latex-image">
+            <xsl:value-of select="$generated-directory"/>
+            <xsl:text>latex-image/</xsl:text>
+            <xsl:apply-templates select="latex-image" mode="image-source-basename"/>
+            <xsl:text>.svg</xsl:text>
+        </xsl:when>
+        <xsl:when test="sageplot[not(@variant = '3d')]">
+            <xsl:value-of select="$generated-directory"/>
+            <xsl:text>sageplot/</xsl:text>
+            <xsl:apply-templates select="sageplot" mode="image-source-basename"/>
+            <xsl:text>.svg</xsl:text>
+        </xsl:when>
+        <xsl:when test="pf:prefigure">
+            <xsl:value-of select="$generated-directory"/>
+            <xsl:text>prefigure/</xsl:text>
+            <xsl:apply-templates select="pf:prefigure" mode="image-source-basename"/>
+            <xsl:text>.svg</xsl:text>
+        </xsl:when>
+        <xsl:otherwise/>
+    </xsl:choose>
+</xsl:template>
+
+<!-- An image is always a raw-HTML "img" (legal CommonMark, and    -->
+<!-- markdown's own syntax has no size or placement), so an        -->
+<!-- authored @width in percent is honored (100% is the default).  -->
+<!-- Centered by default, via an "align" wrapper that forge        -->
+<!-- sanitizers keep (they strip "style").  An *authored* margin   -->
+<!-- of 10% or less pins the image to that edge instead.  Without  -->
+<!-- a file to reference, the producer's note of the text          -->
+<!-- conversion stands.                                            -->
+<xsl:template match="image">
+    <xsl:variable name="path">
+        <xsl:apply-templates select="." mode="markdown-path"/>
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="not($path = '')">
+            <xsl:variable name="rtf-layout">
+                <xsl:apply-templates select="." mode="layout-parameters"/>
+            </xsl:variable>
+            <xsl:variable name="layout" select="exsl:node-set($rtf-layout)"/>
+            <!-- A panel of a "sidebyside" is not aligned (it sits on -->
+            <!-- the left edge, as any panel does); otherwise the     -->
+            <!-- layout reports margins as bare numbers, anything     -->
+            <!-- unresolvable is NaN, both comparisons fail, and      -->
+            <!-- centering wins                                       -->
+            <xsl:variable name="alignment">
+                <xsl:choose>
+                    <xsl:when test="ancestor::sidebyside"/>
+                    <xsl:when test="@margins and (number($layout/left-margin) &lt;= 10)">
+                        <xsl:text>left</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="@margins and (number($layout/right-margin) &lt;= 10)">
+                        <xsl:text>right</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>center</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <!-- The layouts report bare numbers; the "img" attribute -->
+            <!-- carries a percentage (a bare number would be pixels).-->
+            <!-- A panel image takes its width from the enclosing     -->
+            <!-- "sidebyside" layout, locating its panel as -common   -->
+            <!-- does (a "figure" or "stack" wrapper is the panel)    -->
+            <xsl:variable name="width">
+                <xsl:choose>
+                    <xsl:when test="ancestor::sidebyside">
+                        <xsl:variable name="rtf-sbs-layout">
+                            <xsl:apply-templates select="ancestor::sidebyside" mode="layout-parameters"/>
+                        </xsl:variable>
+                        <xsl:variable name="sbs-layout" select="exsl:node-set($rtf-sbs-layout)"/>
+                        <xsl:variable name="panel-number">
+                            <xsl:choose>
+                                <xsl:when test="parent::figure or parent::stack">
+                                    <xsl:value-of select="count(parent::*/preceding-sibling::*) + 1"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="count(preceding-sibling::*) + 1"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:variable>
+                        <!-- this layout's widths carry their percent signs -->
+                        <xsl:value-of select="translate($sbs-layout/width[number($panel-number)], '%', '')"/>
+                        <xsl:text>%</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="not($layout/width = '')">
+                        <xsl:value-of select="$layout/width"/>
+                        <xsl:text>%</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>100%</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="alternative-text">
+                <xsl:choose>
+                    <xsl:when test="shortdescription">
+                        <xsl:apply-templates select="shortdescription"/>
+                    </xsl:when>
+                    <xsl:when test="description">
+                        <xsl:value-of select="normalize-space(description)"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>image</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:text>&#xa;&lt;p</xsl:text>
+            <xsl:if test="not($alignment = '')">
+                <xsl:text> align="</xsl:text>
+                <xsl:value-of select="$alignment"/>
+                <xsl:text>"</xsl:text>
+            </xsl:if>
+            <xsl:text>&gt;&lt;img src="</xsl:text>
+            <xsl:value-of select="$path"/>
+            <xsl:text>" alt="</xsl:text>
+            <!-- a double quote in a description would end the attribute -->
+            <xsl:value-of select="translate($alternative-text, '&quot;', &quot;'&quot;)"/>
+            <xsl:text>" width="</xsl:text>
+            <xsl:value-of select="$width"/>
+            <xsl:text>"&gt;&lt;/p&gt;&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-imports/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- ##### -->

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -1,0 +1,323 @@
+<?xml version='1.0'?>
+
+<!--********************************************************************
+Copyright 2026 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "entities.ent">
+    %entities;
+]>
+
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="exsl str"
+>
+
+<!-- The markdown conversion IS the text conversion, plus the     -->
+<!-- conventions markdown makes machine-recognizable: ATX         -->
+<!-- headings, emphasis, code spans, links, and an escaping       -->
+<!-- layer so authored punctuation is never mistaken for markup.  -->
+<!-- The target is valid CommonMark.  The library lives here so   -->
+<!-- other conversions producing markdown (Jupyter notebook       -->
+<!-- cells) can import it and share single definitions.           -->
+<xsl:import href="./pretext-text.xsl"/>
+
+<xsl:output method="text"/>
+
+<!-- if chunking, this is the extension of the files produced -->
+<xsl:variable name="file-extension" select="'.md'"/>
+
+<!-- ######## -->
+<!-- Escaping -->
+<!-- ######## -->
+
+<!-- Prose flows through -common's "text()" machinery to the      -->
+<!-- "text-processing" hook: flatten authored line breaks (as the -->
+<!-- text conversion does), then backslash-escape every character -->
+<!-- that could be mistaken for markdown or HTML markup.  (Math   -->
+<!-- and verbatim content never reach this hook.)  CommonMark     -->
+<!-- honors a backslash before any ASCII punctuation, so          -->
+<!-- over-escaping is always safe, if unlovely; the set below is  -->
+<!-- the characters that can OPEN a construction mid-prose, plus  -->
+<!-- the dollar sign, which mathematics has claimed.              -->
+<xsl:variable name="markdown-escapes" select="'\`*_[]&lt;&amp;$'"/>
+
+<xsl:template name="text-processing">
+    <xsl:param name="text"/>
+    <xsl:variable name="flattened">
+        <xsl:call-template name="flatten-line-breaks">
+            <xsl:with-param name="text" select="$text"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:call-template name="escape-markdown">
+        <xsl:with-param name="text" select="$flattened"/>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- one pass per character of the escape set -->
+<xsl:template name="escape-markdown">
+    <xsl:param name="text"/>
+    <xsl:param name="position" select="1"/>
+    <xsl:choose>
+        <xsl:when test="$position &gt; string-length($markdown-escapes)">
+            <xsl:value-of select="$text"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:variable name="escaped">
+                <xsl:call-template name="escape-one-character">
+                    <xsl:with-param name="text" select="$text"/>
+                    <xsl:with-param name="character" select="substring($markdown-escapes, $position, 1)"/>
+                </xsl:call-template>
+            </xsl:variable>
+            <xsl:call-template name="escape-markdown">
+                <xsl:with-param name="text" select="$escaped"/>
+                <xsl:with-param name="position" select="$position + 1"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="escape-one-character">
+    <xsl:param name="text"/>
+    <xsl:param name="character"/>
+    <xsl:choose>
+        <xsl:when test="contains($text, $character)">
+            <xsl:value-of select="substring-before($text, $character)"/>
+            <xsl:text>\</xsl:text>
+            <xsl:value-of select="$character"/>
+            <xsl:call-template name="escape-one-character">
+                <xsl:with-param name="text" select="substring-after($text, $character)"/>
+                <xsl:with-param name="character" select="$character"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$text"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- ######## -->
+<!-- Headings -->
+<!-- ######## -->
+
+<!-- ATX headings: honest levels, one octothorpe per depth, the -->
+<!-- document title at level one, divisions one deeper          -->
+<xsl:template match="book|article">
+    <xsl:text># </xsl:text>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+    <xsl:variable name="raw-level">
+        <xsl:apply-templates select="." mode="level"/>
+    </xsl:variable>
+    <xsl:variable name="level">
+        <xsl:choose>
+            <xsl:when test="$raw-level &gt; 5">
+                <xsl:text>5</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$raw-level"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:value-of select="substring('######', 1, $level + 1)"/>
+    <xsl:text> </xsl:text>
+    <xsl:variable name="the-number">
+        <xsl:apply-templates select="." mode="number"/>
+    </xsl:variable>
+    <xsl:if test="not($the-number = '')">
+        <xsl:apply-templates select="." mode="type-name"/>
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="$the-number"/>
+        <xsl:text> </xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:apply-templates select="*"/>
+    <xsl:variable name="the-notes" select=".//fn[generate-id(ancestor::*[&STRUCTURAL-FILTER;][1]) = generate-id(current())]"/>
+    <xsl:if test="$the-notes">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates select="$the-notes" mode="collected"/>
+    </xsl:if>
+</xsl:template>
+
+<!-- ######## -->
+<!-- Emphasis -->
+<!-- ######## -->
+
+<xsl:template match="em|foreign|articletitle|pubtitle">
+    <xsl:text>*</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>*</xsl:text>
+</xsl:template>
+
+<xsl:template match="term|alert">
+    <xsl:text>**</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>**</xsl:text>
+</xsl:template>
+
+<!-- fonts demanded by -common machinery (bibliographies) -->
+<xsl:template match="*" mode="italic">
+    <xsl:text>*</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>*</xsl:text>
+</xsl:template>
+
+<xsl:template match="*" mode="bold">
+    <xsl:text>**</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>**</xsl:text>
+</xsl:template>
+
+<xsl:template match="*" mode="monospace">
+    <xsl:text>`</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>`</xsl:text>
+</xsl:template>
+
+<!-- #### -->
+<!-- Code -->
+<!-- #### -->
+
+<!-- backtick spans; content with a backtick gets double-backtick -->
+<!-- delimiters and interior space, per CommonMark                -->
+<xsl:template name="code-wrapper">
+    <xsl:param name="content"/>
+    <xsl:choose>
+        <xsl:when test="contains($content, '`')">
+            <xsl:text>`` </xsl:text>
+            <xsl:copy-of select="$content"/>
+            <xsl:text> ``</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>`</xsl:text>
+            <xsl:copy-of select="$content"/>
+            <xsl:text>`</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- #### -->
+<!-- URLs -->
+<!-- #### -->
+
+<!-- a labeled link; a bare address is already an autolink in -->
+<!-- the inherited angle-bracket form                         -->
+<xsl:template match="url[node()]">
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>](</xsl:text>
+    <xsl:value-of select="@href"/>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
+<!-- #### -->
+<!-- Math -->
+<!-- #### -->
+
+<!-- Display mathematics in dollar-fenced blocks, which GitHub    -->
+<!-- and Jupyter renderers typeset; four-space indentation would  -->
+<!-- read as a code block, so rows sit flush left                 -->
+<xsl:template match="md">
+    <xsl:text>&#xa;$$&#xa;</xsl:text>
+    <xsl:apply-templates select="mrow|intertext"/>
+    <xsl:text>$$&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="md[not(mrow)]">
+    <xsl:text>&#xa;$$&#xa;</xsl:text>
+    <xsl:value-of select="normalize-space(text())"/>
+    <xsl:apply-templates select="." mode="get-clause-punctuation-mark"/>
+    <xsl:text>&#xa;$$&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="mrow">
+    <xsl:value-of select="normalize-space(.)"/>
+    <xsl:if test="not(following-sibling::mrow)">
+        <xsl:apply-templates select="parent::md" mode="get-clause-punctuation-mark"/>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- A structured line breaks with a raw HTML break: legal      -->
+<!-- CommonMark, and it keeps a multi-line cell on the one      -->
+<!-- physical line a pipe table demands                         -->
+<xsl:template name="line-separator">
+    <xsl:text>&lt;br&gt;</xsl:text>
+</xsl:template>
+
+<!-- ###### -->
+<!-- Blocks -->
+<!-- ###### -->
+
+<!-- A block's heading line, emboldened -->
+<xsl:template name="block-heading-line">
+    <xsl:param name="heading"/>
+    <xsl:text>**</xsl:text>
+    <xsl:copy-of select="$heading"/>
+    <xsl:text>**&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ##### -->
+<!-- Lists -->
+<!-- ##### -->
+
+<!-- CommonMark ordered-list markers are digits only, so the     -->
+<!-- authored label (letters, Roman numerals, ...) rides inside  -->
+<!-- a bullet item instead, in the manner of a task: hard-coded, -->
+<!-- and every renderer shows exactly the label PreTeXt chose.   -->
+<!-- The label's dot is backslash-escaped: a digit label with a  -->
+<!-- bare dot would re-parse as an ordered list nested inside    -->
+<!-- the bullet, and renderers would renumber it.                -->
+<xsl:template match="ol/li" mode="item-marker">
+    <xsl:text>- </xsl:text>
+    <xsl:apply-templates select="." mode="item-number"/>
+    <xsl:text>\. </xsl:text>
+</xsl:template>
+
+<!-- A description-list item is a bullet with its emboldened     -->
+<!-- term; consecutive bare lines would otherwise merge into one -->
+<!-- paragraph when rendered                                     -->
+<xsl:template match="dl/li">
+    <xsl:apply-templates select="." mode="item-indent"/>
+    <xsl:text>- **</xsl:text>
+    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:text>** </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:apply-templates select="." mode="finish-item"/>
+</xsl:template>
+
+<!-- a task's serial marker rides inside a genuine list item, -->
+<!-- so renderers indent nested tasks properly                -->
+<xsl:template match="task" mode="item-marker">
+    <xsl:text>- (</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -231,10 +231,46 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Display mathematics in dollar-fenced blocks, which GitHub    -->
 <!-- and Jupyter renderers typeset; four-space indentation would  -->
-<!-- read as a code block, so rows sit flush left                 -->
-<xsl:template match="md">
+<!-- read as a code block, so rows sit flush left.  Inside the    -->
+<!-- fence the rows ride a genuine *inner* alignment environment  -->
+<!-- (aligned, gathered, alignedat) chosen by -common's analysis, -->
+<!-- since an ampersand (or "\amp") is only legal inside one, and -->
+<!-- rows separate with the "\\" a renderer requires.             -->
+<xsl:template match="md[mrow]">
+    <xsl:variable name="raw-alignment">
+        <xsl:apply-templates select="." mode="displaymath-alignment">
+            <xsl:with-param name="b-needs-tags" select="false()"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+    <xsl:variable name="environment">
+        <xsl:choose>
+            <xsl:when test="contains($raw-alignment, 'alignat')">
+                <xsl:text>alignedat</xsl:text>
+            </xsl:when>
+            <xsl:when test="contains($raw-alignment, 'align')">
+                <xsl:text>aligned</xsl:text>
+            </xsl:when>
+            <xsl:when test="contains($raw-alignment, 'gather')">
+                <xsl:text>gathered</xsl:text>
+            </xsl:when>
+            <!-- "equation": a single row, no environment needed -->
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:text>&#xa;$$&#xa;</xsl:text>
+    <xsl:if test="not($environment = '')">
+        <xsl:text>\begin{</xsl:text>
+        <xsl:value-of select="$environment"/>
+        <xsl:text>}</xsl:text>
+        <xsl:apply-templates select="." mode="alignat-columns"/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="mrow|intertext"/>
+    <xsl:if test="not($environment = '')">
+        <xsl:text>\end{</xsl:text>
+        <xsl:value-of select="$environment"/>
+        <xsl:text>}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>$$&#xa;</xsl:text>
 </xsl:template>
 
@@ -247,9 +283,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="mrow">
     <xsl:value-of select="normalize-space(.)"/>
-    <xsl:if test="not(following-sibling::mrow)">
-        <xsl:apply-templates select="parent::md" mode="get-clause-punctuation-mark"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="following-sibling::mrow">
+            <xsl:text>\\</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="parent::md" mode="get-clause-punctuation-mark"/>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
@@ -533,6 +574,90 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>**</xsl:text>
     <xsl:copy-of select="$heading"/>
     <xsl:text>**&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ############ -->
+<!-- Macro Support -->
+<!-- ############ -->
+
+<!-- Legacy fraction detection, as in the HTML conversion -->
+<xsl:variable name="b-has-sfrac" select="boolean($document-root//m[contains(text(),'sfrac')] or $document-root//mrow[contains(text(),'sfrac')])"/>
+
+<!-- The author's math packages, massaged to MathJax "\require"   -->
+<!-- form.  A duplicate of the variable in the HTML conversion    -->
+<!-- (which this stylesheet does not import); a migration to      -->
+<!-- -common would leave one definition.                          -->
+<xsl:variable name="latex-packages-mathjax">
+    <xsl:for-each select="$docinfo/math-package">
+        <!-- must be specified, but can be empty/null -->
+        <xsl:if test="not(normalize-space(@mathjax-name)) = ''">
+            <xsl:text>\require{</xsl:text>
+            <xsl:value-of select="@mathjax-name"/>
+            <xsl:apply-templates/>
+            <xsl:text>}</xsl:text>
+        </xsl:if>
+    </xsl:for-each>
+</xsl:variable>
+
+<!-- A page with mathematics opens with an invisible display-math -->
+<!-- block: MathJax package requirements, the author's macros,    -->
+<!-- and PreTeXt's own (\lt, \gt, and notably \amp).  MathJax     -->
+<!-- renders a definitions-only block as nothing at all, and the  -->
+<!-- definitions persist for every formula on the page, so each   -->
+<!-- page is self-sufficient.  (The Jupyter conversion does the   -->
+<!-- same in a notebook's first cell.  KaTeX-based renderers do   -->
+<!-- not persist definitions between zones; the block is still    -->
+<!-- invisible there, so no harm done.)                           -->
+<xsl:template match="*" mode="latex-macros">
+    <xsl:if test=".//m or .//md">
+        <xsl:variable name="definitions">
+            <xsl:value-of select="$latex-packages-mathjax"/>
+            <!-- the AMS "CD" commutative-diagram environment lives in  -->
+            <!-- a MathJax extension needing no author declaration; the -->
+            <!-- mixed-case v2 name persists as an alias in the later   -->
+            <!-- component-based loaders                                -->
+            <xsl:if test=".//m[contains(., '\begin{CD}')] or .//md[contains(., '\begin{CD}')]">
+                <xsl:text>\require{AMScd}</xsl:text>
+            </xsl:if>
+            <xsl:value-of select="$latex-macros"/>
+            <xsl:call-template name="fillin-math"/>
+            <!-- legacy built-in support for "slanted|beveled|nice" fractions -->
+            <xsl:if test="$b-has-sfrac">
+                <xsl:text>\newcommand{\sfrac}[2]{{#1}/{#2}}&#xa;</xsl:text>
+            </xsl:if>
+        </xsl:variable>
+        <!-- one physical line: every markdown engine recognizes a  -->
+        <!-- single-line "$$...$$", and spaces are nothing to TeX    -->
+        <xsl:text>&#xa;$$</xsl:text>
+        <xsl:value-of select="normalize-space(translate($definitions, '&#xa;', ' '))"/>
+        <xsl:text>$$&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- An override of the template in pretext-common.xsl, in the      -->
+<!-- manner of the Jupyter conversion: the publisher's "shade"      -->
+<!-- style needs \definecolor and \colorbox from a MathJax          -->
+<!-- extension a generic renderer does not load, and one undefined  -->
+<!-- macro poisons the whole definitions block.  So "shade"         -->
+<!-- degrades to "box", which needs nothing beyond \boxed.          -->
+<xsl:template name="fillin-math">
+    <xsl:choose>
+        <xsl:when test="$fillin-math-style = 'underline'">
+            <xsl:text>\newcommand{\fillinmath}[1]{\mathchoice</xsl:text>
+            <xsl:text>{\underline{\displaystyle     \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\textstyle        \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\scriptstyle      \phantom{\ \,#1\ \,}}}</xsl:text>
+            <xsl:text>{\underline{\scriptscriptstyle\phantom{\ \,#1\ \,}}}}&#xa;</xsl:text>
+        </xsl:when>
+        <!-- "box", and "shade" degraded to "box" -->
+        <xsl:otherwise>
+            <xsl:text>\newcommand{\fillinmath}[1]{\mathchoice</xsl:text>
+            <xsl:text>{\boxed{\displaystyle     \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\textstyle        \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\scriptstyle      \phantom{\,#1\,}}}</xsl:text>
+            <xsl:text>{\boxed{\scriptscriptstyle\phantom{\,#1\,}}}}&#xa;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- ##### -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -932,6 +932,31 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- Collapse each newline, and the horizontal space around -->
+<!-- it, to a single space: hard-wrapped, indented source   -->
+<!-- becomes one long line                                  -->
+<xsl:template name="flatten-line-breaks">
+    <xsl:param name="text"/>
+    <xsl:choose>
+        <xsl:when test="contains($text, '&#xa;')">
+            <xsl:call-template name="strip-trailing-whitespace">
+                <xsl:with-param name="text" select="substring-before($text, '&#xa;')"/>
+            </xsl:call-template>
+            <xsl:text> </xsl:text>
+            <xsl:call-template name="flatten-line-breaks">
+                <xsl:with-param name="text">
+                    <xsl:call-template name="strip-leading-whitespace">
+                        <xsl:with-param name="text" select="substring-after($text, '&#xa;')"/>
+                    </xsl:call-template>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$text"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- spurious newlines introduce whitespace on either side -->
 <!-- we split at newlines, strip consecutive whitesapce on either side, -->
 <!-- and replace newlines by spaces (could restore a single newline) -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -118,61 +118,211 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:value-of select="$content"/>
 </xsl:template>
 
+<!-- ########## -->
 <!-- Characters -->
+<!-- ########## -->
 
-<!-- Idea: variables from "choose" on $text.encoding variable      -->
-<!-- to use cheap ASCII versions (or stand-ins, like [PER-MILLE]), -->
-<!-- versus more realistic Unicode versions                        -->
+<!-- Each character element renders per the publication file's       -->
+<!-- character repertoire: a genuine Unicode character, or a 7-bit   -->
+<!-- ASCII stand-in in the long plain-text tradition.  The file is   -->
+<!-- UTF-8 either way; with the "ascii" election that fact is        -->
+<!-- invisible.  ($b-text-unicode arrives from the publication       -->
+<!-- machinery; "unicode" is the default.)                           -->
 
-<!-- N.B. Quotation marks are localized by language in other       -->
-<!-- conversions (HTML, LaTeX) and skipped in other conversions    -->
-<!-- (braille).  They would likely need to use Unicode characters  -->
-<!-- like  «, »  rather than cheap 7-bit ASCII versions, like      -->
-<!-- <<, >>.  So this would force the issue of a Unicode (8-bit    -->
-<!-- and more-than) switch and supporting that.  So as of          -->
-<!-- 2026-02-18 we are punting.                                    -->
+<!-- TODO: quotation marks should localize by language in the        -->
+<!-- unicode repertoire, as other conversions do.                    -->
 
-<!-- ASCII we just use a regular space -->
 <xsl:template name="nbsp-character">
-    <xsl:text> </xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xa0;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template name="ndash-character">
-    <xsl:text>-</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2013;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>-</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template name="mdash-character">
-    <xsl:text>-</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2014;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>--</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- The abstract template for "mdash" consults a publisher option -->
 <!-- for thin space, or no space, surrounding an em-dash.  So the  -->
 <!-- "thin-space-character" is needed for that purpose, and does   -->
 <!-- not have an associated empty PTX element.                     -->
-
-<!-- ASCII we just use a full space -->
 <xsl:template name="thin-space-character">
-    <xsl:text> </xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2009;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="*" mode="lsq-character">
-    <xsl:text>'</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2018;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>'</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="*" mode="rsq-character">
-    <xsl:text>'</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2019;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>'</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="*" mode="lq-character">
-    <xsl:text>"</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x201C;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>"</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template match="*" mode="rq-character">
-    <xsl:text>"</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x201D;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>"</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <xsl:template name="ellipsis-character">
-    <xsl:text>...</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2026;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>...</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="copyright-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xa9;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>(c)</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="registered-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xae;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>(R)</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="trademark-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2122;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>(TM)</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="degree-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xb0;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>deg</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="prime-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2032;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>'</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="dblprime-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2033;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>''</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="langle-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e8;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>&lt;</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="rangle-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e9;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>&gt;</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="midpoint-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xb7;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>*</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="pilcrow-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xb6;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>[pilcrow]</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="section-mark-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xa7;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>[section]</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="minus-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2212;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>-</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="times-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xd7;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>x</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="obelus-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xf7;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>/</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="plusminus-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#xb1;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>+/-</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="permille-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2030;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>o/oo</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="solidus-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2044;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>/</xsl:text></xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="swungdash-character">
+    <xsl:choose>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x2053;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>~</xsl:text></xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Math -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -116,6 +116,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
+<!-- Macro definitions preceding a page's mathematics: nothing -->
+<!-- in plain text (the mathematics is authored LaTeX, macros  -->
+<!-- and all), realized by the markdown flavor for renderers   -->
+<xsl:template match="*" mode="latex-macros"/>
+
 <!-- ######## -->
 <!-- Verbatim -->
 <!-- ######## -->
@@ -654,6 +659,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="book|article">
     <xsl:apply-templates select="." mode="heading-lines"/>
+    <xsl:apply-templates select="." mode="latex-macros"/>
     <xsl:apply-templates select="*"/>
 </xsl:template>
 
@@ -711,13 +717,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:variable>
 
-<!-- Realize one file: the content, then a navigation line -->
+<!-- Realize one file: macro support for its mathematics -->
+<!-- (nothing in plain text), the content, then a        -->
+<!-- navigation line                                     -->
 <xsl:template match="*" mode="file-wrap">
     <xsl:param name="content"/>
     <xsl:variable name="filename">
         <xsl:apply-templates select="." mode="containing-filename"/>
     </xsl:variable>
     <exsl:document href="{$filename}" method="text" encoding="UTF-8">
+        <xsl:apply-templates select="." mode="latex-macros"/>
         <xsl:copy-of select="$content"/>
         <xsl:apply-templates select="." mode="navigation-line"/>
     </exsl:document>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -400,6 +400,122 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- ##### -->
+<!-- Index -->
+<!-- ##### -->
+
+<!-- An "idx" element is invisible where it is authored; the index -->
+<!-- machinery of -common mines them all to manufacture the index  -->
+<!-- division, which renders through the presentation templates    -->
+<!-- below (modeled on the -fo implementations).                   -->
+<xsl:template match="idx"/>
+
+<!-- the assembled index needs no wrapper -->
+<xsl:template name="present-index">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<!-- a blank line separates letter groups -->
+<xsl:template name="present-letter-group">
+    <xsl:param name="the-index-list"/>
+    <xsl:param name="letter-group"/>
+    <xsl:param name="current-letter"/>
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- one line of the index: two spaces of indentation per level -->
+<!-- of subentry, locators trailing the deepest heading         -->
+<xsl:template name="present-index-heading">
+    <xsl:param name="the-index-list"/>
+    <xsl:param name="heading-group"/>
+    <xsl:param name="b-write-locators"/>
+    <xsl:param name="heading-level"/>
+    <xsl:param name="content"/>
+    <xsl:value-of select="str:padding(2 * ($heading-level - 1), ' ')"/>
+    <xsl:copy-of select="$content"/>
+    <xsl:if test="$b-write-locators">
+        <xsl:call-template name="locator-list">
+            <xsl:with-param name="the-index-list" select="$the-index-list"/>
+            <xsl:with-param name="heading-group" select="$heading-group"/>
+            <xsl:with-param name="cross-reference-separator" select="', '"/>
+        </xsl:call-template>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- the pieces of a locator: processed content suffices -->
+<xsl:template name="present-index-locator">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<xsl:template name="present-index-see">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<xsl:template name="present-index-see-also">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<!-- italics for a "see" word: plain text has no italics -->
+<xsl:template name="present-index-italics">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<!-- One locator: climb from the "idx" to the nearest enclosure   -->
+<!-- that is structural or a block AND has a number (the HTML     -->
+<!-- conversion's approach; there are no page numbers to cite),   -->
+<!-- then present it through the "index-locator" flavor template  -->
+<xsl:template match="index-list" mode="index-enclosure">
+    <xsl:param name="enclosure"/>
+    <xsl:variable name="structural">
+        <xsl:apply-templates select="$enclosure" mode="is-structural"/>
+    </xsl:variable>
+    <xsl:variable name="block">
+        <xsl:apply-templates select="$enclosure" mode="is-block"/>
+    </xsl:variable>
+    <xsl:variable name="the-number">
+        <xsl:if test="($structural = 'true') or ($block = 'true')">
+            <xsl:apply-templates select="$enclosure" mode="number"/>
+        </xsl:if>
+    </xsl:variable>
+    <xsl:choose>
+        <!-- climbed past the document root (an "idx" in an unnumbered  -->
+        <!-- peripheral of the root): the type of the root must suffice -->
+        <xsl:when test="not($enclosure)">
+            <xsl:apply-templates select="$document-root" mode="type-name"/>
+        </xsl:when>
+        <xsl:when test="not($the-number = '')">
+            <xsl:apply-templates select="." mode="index-locator">
+                <xsl:with-param name="enclosure" select="$enclosure"/>
+                <xsl:with-param name="the-number" select="$the-number"/>
+            </xsl:apply-templates>
+        </xsl:when>
+        <!-- climb; the "index-list" context rides along -->
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="index-enclosure">
+                <xsl:with-param name="enclosure" select="$enclosure/parent::*"/>
+            </xsl:apply-templates>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- "Theorem 2.1", "Section 3": the type announces what the -->
+<!-- number leads to; the markdown flavor adds the link      -->
+<xsl:template match="index-list" mode="index-locator">
+    <xsl:param name="enclosure"/>
+    <xsl:param name="the-number"/>
+    <xsl:apply-templates select="$enclosure" mode="type-name"/>
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$the-number"/>
+</xsl:template>
+
 <!-- Hooks for generated lists (list of figures, etc.): the  -->
 <!-- entries suffice, no surrounding apparatus               -->
 <xsl:template name="list-of-begin"/>
@@ -517,7 +633,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions|index">
     <xsl:apply-templates select="." mode="heading-lines"/>
     <!-- metadata-ish, eg "title", should be killed by default -->
     <xsl:apply-templates select="*"/>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -85,17 +85,91 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Divisions -->
 <!-- ######### -->
 
-<xsl:template match="part|chapter|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+<!-- A heading is the division's usual "Type Number Title" line,     -->
+<!-- underlined in the manner of typewritten manuscripts (and,       -->
+<!-- happily, of markdown's setext headings for the top two          -->
+<!-- levels): one underline character per depth.                     -->
+<xsl:variable name="heading-underline-characters" select="'=-~^&quot;'"/>
+
+<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+    <!-- the heading line, assembled once so it can be measured.    -->
+    <!-- Unnumbered peripheral divisions (preface, colophon, ...)   -->
+    <!-- take just their title: the default title IS the type-name, -->
+    <!-- and "Preface Preface" serves nobody.                       -->
+    <xsl:variable name="the-number">
+        <xsl:apply-templates select="." mode="number"/>
+    </xsl:variable>
+    <xsl:variable name="heading">
+        <xsl:if test="not($the-number = '')">
+            <xsl:apply-templates select="." mode="type-name"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="$the-number"/>
+            <xsl:text> </xsl:text>
+        </xsl:if>
+        <!-- Title is required (or default is supplied) -->
+        <xsl:apply-templates select="." mode="title-full"/>
+    </xsl:variable>
+    <!-- depth chooses the underline character; anything deeper  -->
+    <!-- than the repertoire reuses the last character           -->
+    <xsl:variable name="raw-level">
+        <xsl:apply-templates select="." mode="level"/>
+    </xsl:variable>
+    <xsl:variable name="level">
+        <xsl:choose>
+            <xsl:when test="$raw-level &gt; 5">
+                <xsl:text>5</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$raw-level"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
     <!-- empty line prior -->
     <xsl:text>&#xa;</xsl:text>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="number"/>
-    <!-- Title is required (or default is supplied) -->
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="title-full"/>
+    <xsl:value-of select="$heading"/>
     <xsl:text>&#xa;</xsl:text>
+    <xsl:value-of select="str:padding(string-length($heading), substring($heading-underline-characters, $level, 1))"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
     <!-- metadata-ish, eg "title", should be killed by default -->
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- The document itself: its title as the topmost heading, then  -->
+<!-- the content.  ("docinfo" is ignored by the entry template.)  -->
+<xsl:template match="book|article">
+    <xsl:variable name="heading">
+        <xsl:apply-templates select="." mode="title-full"/>
+    </xsl:variable>
+    <xsl:value-of select="$heading"/>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:value-of select="str:padding(string-length($heading), '*')"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- Whole-document containers with no heading of their own -->
+<xsl:template match="frontmatter|backmatter|mainmatter">
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- The title page is mined for a byline, rather than templates -->
+<xsl:template match="titlepage">
+    <xsl:for-each select="../../docinfo/../frontmatter/bibinfo/author/personname">
+        <xsl:apply-templates/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:for-each>
+</xsl:template>
+
+<!-- Bibliographic metadata: quiet, mined above -->
+<xsl:template match="bibinfo"/>
+
+<!-- Unstructured containers: just their content -->
+<xsl:template match="introduction|conclusion|statement|paragraphs|subexercises|exercisegroup">
+    <xsl:if test="title">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
     <xsl:apply-templates select="*"/>
 </xsl:template>
 
@@ -422,13 +496,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="*"/>
         </xsl:otherwise>
     </xsl:choose>
-</xsl:template>
-
-<!-- General-purpose container, we  -->
-<!-- do not enforce possibilities -->
-<xsl:template match="statement">
-    <!-- structured -->
-    <xsl:apply-templates select="*"/>
 </xsl:template>
 
 <!-- THEOREM-LIKE only -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -73,9 +73,18 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 
 <!-- Entry Template -->
-<!-- Kickstart the process, ignore "docinfo"  -->
+<!-- Kickstart the process, ignore "docinfo".  A positive chunk  -->
+<!-- level (the common election) writes a tree of files instead  -->
+<!-- of a single stream; see the Chunking section below.         -->
 <xsl:template match="/">
-    <xsl:apply-templates select="$document-root"/>
+    <xsl:choose>
+        <xsl:when test="$chunk-level &gt; 0">
+            <xsl:apply-templates select="$document-root" mode="chunking"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="$document-root"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- TEMPORARY: defined to stop errors, need stubs in -common -->
@@ -451,23 +460,29 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- levels): one underline character per depth.                     -->
 <xsl:variable name="heading-underline-characters" select="'=-~^&quot;'"/>
 
-<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
-    <!-- the heading line, assembled once so it can be measured.    -->
-    <!-- Unnumbered peripheral divisions (preface, colophon, ...)   -->
-    <!-- take just their title: the default title IS the type-name, -->
-    <!-- and "Preface Preface" serves nobody.                       -->
+<!-- The text of a heading: "Type Number Title".                -->
+<!-- Unnumbered peripheral divisions (preface, colophon, ...)   -->
+<!-- take just their title: the default title IS the type-name, -->
+<!-- and "Preface Preface" serves nobody.                       -->
+<xsl:template match="*" mode="heading-text">
     <xsl:variable name="the-number">
         <xsl:apply-templates select="." mode="number"/>
     </xsl:variable>
+    <xsl:if test="not($the-number = '')">
+        <xsl:apply-templates select="." mode="type-name"/>
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="$the-number"/>
+        <xsl:text> </xsl:text>
+    </xsl:if>
+    <!-- Title is required (or default is supplied) -->
+    <xsl:apply-templates select="." mode="title-full"/>
+</xsl:template>
+
+<!-- The heading and its underline, assembled once so the -->
+<!-- heading can be measured                               -->
+<xsl:template match="*" mode="heading-lines">
     <xsl:variable name="heading">
-        <xsl:if test="not($the-number = '')">
-            <xsl:apply-templates select="." mode="type-name"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$the-number"/>
-            <xsl:text> </xsl:text>
-        </xsl:if>
-        <!-- Title is required (or default is supplied) -->
-        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:apply-templates select="." mode="heading-text"/>
     </xsl:variable>
     <!-- depth chooses the underline character; anything deeper  -->
     <!-- than the repertoire reuses the last character           -->
@@ -490,10 +505,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
     <xsl:value-of select="str:padding(string-length($heading), substring($heading-underline-characters, $level, 1))"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
-    <!-- metadata-ish, eg "title", should be killed by default -->
-    <xsl:apply-templates select="*"/>
-    <!-- footnotes belonging to this division (and not to a  -->
-    <!-- deeper one) collect here, at its end                -->
+</xsl:template>
+
+<!-- Footnotes belonging to a division (and not to a deeper -->
+<!-- one) collect at its end                                -->
+<xsl:template match="*" mode="division-footnotes">
     <xsl:variable name="the-notes" select=".//fn[count(ancestor::*[&STRUCTURAL-FILTER;][1]|current()) = 1]"/>
     <xsl:if test="$the-notes">
         <xsl:text>&#xa;</xsl:text>
@@ -501,9 +517,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
+<xsl:template match="part|chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|exercises|reading-questions|worksheet|handout|glossary|references|solutions">
+    <xsl:apply-templates select="." mode="heading-lines"/>
+    <!-- metadata-ish, eg "title", should be killed by default -->
+    <xsl:apply-templates select="*"/>
+    <xsl:apply-templates select="." mode="division-footnotes"/>
+</xsl:template>
+
 <!-- The document itself: its title as the topmost heading, then  -->
 <!-- the content.  ("docinfo" is ignored by the entry template.)  -->
-<xsl:template match="book|article">
+<xsl:template match="book|article" mode="heading-lines">
     <xsl:variable name="heading">
         <xsl:apply-templates select="." mode="title-full"/>
     </xsl:variable>
@@ -511,12 +534,167 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
     <xsl:value-of select="str:padding(string-length($heading), '*')"/>
     <xsl:text>&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="book|article">
+    <xsl:apply-templates select="." mode="heading-lines"/>
     <xsl:apply-templates select="*"/>
 </xsl:template>
 
 <!-- Whole-document containers with no heading of their own -->
 <xsl:template match="frontmatter|backmatter|mainmatter">
     <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- ######## -->
+<!-- Chunking -->
+<!-- ######## -->
+
+<!-- The common election (common/chunking/@level in the publication -->
+<!-- file): a positive level writes each division at that depth as  -->
+<!-- its own file, driven by the generic chunking machinery of      -->
+<!-- -common.  No election produces the document as a single file.  -->
+<xsl:variable name="chunk-level">
+    <xsl:choose>
+        <xsl:when test="$chunk-level-entered != ''">
+            <xsl:value-of select="$chunk-level-entered"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>0</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+<!-- Every chunk of a chunked build, in reading order, each known -->
+<!-- by its (unique) filename: the basis of each file's           -->
+<!-- navigation line                                              -->
+<xsl:variable name="chunk-list-rtf">
+    <xsl:if test="$chunk-level &gt; 0">
+        <xsl:for-each select="($document-root|$document-root//*)[&STRUCTURAL-FILTER;]">
+            <xsl:variable name="is-chunk">
+                <xsl:apply-templates select="." mode="is-chunk"/>
+            </xsl:variable>
+            <xsl:if test="$is-chunk = 'true'">
+                <chunk>
+                    <xsl:attribute name="filename">
+                        <xsl:apply-templates select="." mode="containing-filename"/>
+                    </xsl:attribute>
+                </chunk>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:if>
+</xsl:variable>
+<xsl:variable name="chunk-list" select="exsl:node-set($chunk-list-rtf)/chunk"/>
+
+<!-- The file every navigation line points back to: the -->
+<!-- summary page of the document root (or the root as  -->
+<!-- one big chunk, for a shallow document)             -->
+<xsl:variable name="contents-filename">
+    <xsl:if test="$chunk-level &gt; 0">
+        <xsl:apply-templates select="$document-root" mode="containing-filename"/>
+    </xsl:if>
+</xsl:variable>
+
+<!-- Realize one file: the content, then a navigation line -->
+<xsl:template match="*" mode="file-wrap">
+    <xsl:param name="content"/>
+    <xsl:variable name="filename">
+        <xsl:apply-templates select="." mode="containing-filename"/>
+    </xsl:variable>
+    <exsl:document href="{$filename}" method="text" encoding="UTF-8">
+        <xsl:copy-of select="$content"/>
+        <xsl:apply-templates select="." mode="navigation-line"/>
+    </exsl:document>
+</xsl:template>
+
+<!-- A division above the chunk frontier becomes a summary page:  -->
+<!-- its heading, its unstructured content, and one line naming   -->
+<!-- the file of each structural child                            -->
+<xsl:template match="&STRUCTURAL;" mode="intermediate">
+    <xsl:apply-templates select="." mode="file-wrap">
+        <xsl:with-param name="content">
+            <xsl:apply-templates select="." mode="heading-lines"/>
+            <xsl:apply-templates select="introduction"/>
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:for-each select="*[&STRUCTURAL-FILTER;]">
+                <xsl:apply-templates select="." mode="summary-entry"/>
+            </xsl:for-each>
+            <xsl:apply-templates select="conclusion"/>
+            <xsl:apply-templates select="." mode="division-footnotes"/>
+        </xsl:with-param>
+    </xsl:apply-templates>
+</xsl:template>
+
+<!-- One line of a summary page, naming a subsidiary file; the -->
+<!-- markdown flavor overrides with a genuine link             -->
+<xsl:template match="*" mode="summary-entry">
+    <xsl:text>- </xsl:text>
+    <xsl:apply-templates select="." mode="heading-text"/>
+    <xsl:text> (</xsl:text>
+    <xsl:apply-templates select="." mode="containing-filename"/>
+    <xsl:text>)&#xa;</xsl:text>
+</xsl:template>
+
+<!-- The file of the division containing a chunk, when that is  -->
+<!-- neither the chunk itself nor the contents page: worthwhile -->
+<!-- in a deeply chunked document.  The document root has no    -->
+<!-- containing division, so nothing at all.                    -->
+<xsl:template match="*" mode="up-filename">
+    <xsl:if test="parent::*[&STRUCTURAL-FILTER;]">
+        <xsl:variable name="parent-filename">
+            <xsl:apply-templates select=".." mode="containing-filename"/>
+        </xsl:variable>
+        <xsl:if test="not($parent-filename = $contents-filename)">
+            <xsl:value-of select="$parent-filename"/>
+        </xsl:if>
+    </xsl:if>
+</xsl:template>
+
+<!-- The trailing navigation line of a file that has a neighbor;   -->
+<!-- labels localize, and the markdown flavor overrides with links -->
+<xsl:template match="*" mode="navigation-line">
+    <xsl:variable name="the-filename">
+        <xsl:apply-templates select="." mode="containing-filename"/>
+    </xsl:variable>
+    <xsl:variable name="entry" select="$chunk-list[@filename = $the-filename]"/>
+    <xsl:variable name="previous" select="$entry/preceding-sibling::chunk[1]"/>
+    <xsl:variable name="next" select="$entry/following-sibling::chunk[1]"/>
+    <xsl:variable name="up">
+        <xsl:apply-templates select="." mode="up-filename"/>
+    </xsl:variable>
+    <xsl:if test="$previous or $next">
+        <xsl:text>&#xa;[</xsl:text>
+        <xsl:apply-templates select="." mode="type-name">
+            <xsl:with-param name="string-id" select="'toc'"/>
+        </xsl:apply-templates>
+        <xsl:text>: </xsl:text>
+        <xsl:value-of select="$contents-filename"/>
+        <xsl:if test="$previous">
+            <xsl:text> | </xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'previous'"/>
+            </xsl:apply-templates>
+            <xsl:text>: </xsl:text>
+            <xsl:value-of select="$previous/@filename"/>
+        </xsl:if>
+        <xsl:if test="not($up = '')">
+            <xsl:text> | </xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'up'"/>
+            </xsl:apply-templates>
+            <xsl:text>: </xsl:text>
+            <xsl:value-of select="$up"/>
+        </xsl:if>
+        <xsl:if test="$next">
+            <xsl:text> | </xsl:text>
+            <xsl:apply-templates select="." mode="type-name">
+                <xsl:with-param name="string-id" select="'next'"/>
+            </xsl:apply-templates>
+            <xsl:text>: </xsl:text>
+            <xsl:value-of select="$next/@filename"/>
+        </xsl:if>
+        <xsl:text>]&#xa;</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- The title page is mined for a byline, rather than templates -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -62,6 +62,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:output method="text"/>
 
+<!-- Elect the absorption of clause-ending punctuation into      -->
+<!-- display mathematics (only), where our templates re-place it -->
+<!-- on the final row; inline mathematics keeps its punctuation  -->
+<!-- in the prose, where it reads naturally.                     -->
+<xsl:param name="math.punctuation.include" select="'display'"/>
+
 <!-- if chunking, this is the extension of the files produced -->
 <xsl:variable name="file-extension" select="'.txt'"/>
 
@@ -399,15 +405,67 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- #### -->
 <!-- Math -->
-<!-- Until we think of something better, we just -->
-<!-- bracket raw LaTeX that appears inline       -->
-<!-- This can be overridden, if necessary        -->
+<!-- #### -->
+
+<!-- Mathematics never renders in plain text: throughout this     -->
+<!-- section the output is the LaTeX an author wrote, verbatim,   -->
+<!-- with no processor in prospect.                               -->
+
+<!-- LaTeX is the lingua franca of plain-text mathematics, so     -->
+<!-- authored LaTeX rides along verbatim between dollar signs.    -->
+<!-- Two simple cases need no dressing at all: a single Latin     -->
+<!-- letter (a variable name), and an integer.  (The same         -->
+<!-- analysis the braille conversion performs.)                   -->
 <xsl:template name="inline-math-wrapper">
     <xsl:param name="math"/>
-    <xsl:text>[</xsl:text>
-    <xsl:value-of select="$math"/>
-    <xsl:text>]</xsl:text>
+    <xsl:variable name="clean" select="normalize-space($math)"/>
+    <xsl:choose>
+        <xsl:when test="(string-length($clean) = 1) and contains(&ALPHABET;, $clean)">
+            <xsl:value-of select="$clean"/>
+        </xsl:when>
+        <xsl:when test="not($clean = '') and (translate($clean, &DIGIT;, '') = '')">
+            <xsl:value-of select="$clean"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>$</xsl:text>
+            <xsl:value-of select="$clean"/>
+            <xsl:text>$</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- Display mathematics: set off by blank lines, each row       -->
+<!-- indented, LaTeX verbatim.  Alignment marks and such are     -->
+<!-- part of the mathematics and remain.                         -->
+<xsl:template match="md">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="mrow|intertext"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="md[not(mrow)]">
+    <xsl:text>&#xa;    </xsl:text>
+    <xsl:value-of select="normalize-space(text())"/>
+    <!-- clause-ending punctuation absorbed by the display, restored -->
+    <xsl:apply-templates select="." mode="get-clause-punctuation-mark"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="mrow">
+    <xsl:text>    </xsl:text>
+    <xsl:value-of select="normalize-space(.)"/>
+    <!-- the display's absorbed punctuation lands on the last row -->
+    <xsl:if test="not(following-sibling::mrow)">
+        <xsl:apply-templates select="parent::md" mode="get-clause-punctuation-mark"/>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="md/intertext">
+    <xsl:apply-templates/>
+    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <!-- ################# -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -504,23 +504,82 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Environments -->
 <!-- ############ -->
 
-<xsl:template match="&REMARK-LIKE;">
+<!-- A block's heading sits on its own line, set off from the   -->
+<!-- content by a blank line; the markdown flavor overrides to  -->
+<!-- embolden it                                                -->
+<xsl:template name="block-heading-line">
+    <xsl:param name="heading"/>
+    <xsl:copy-of select="$heading"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
+</xsl:template>
+
+<!-- The heading line of a block: type, number when there is one, -->
+<!-- a parenthesized creator for the theorem-like and axiom-like, -->
+<!-- title when there is one                                      -->
+<xsl:template match="*" mode="block-heading">
+    <xsl:call-template name="block-heading-line">
+        <xsl:with-param name="heading">
+            <xsl:apply-templates select="." mode="type-name"/>
+            <xsl:variable name="the-number">
+                <xsl:apply-templates select="." mode="number"/>
+            </xsl:variable>
+            <xsl:if test="not($the-number = '')">
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="$the-number"/>
+            </xsl:if>
+            <xsl:if test="creator and (&THEOREM-FILTER; or &AXIOM-FILTER;)">
+                <xsl:text> (</xsl:text>
+                <xsl:apply-templates select="." mode="creator-full"/>
+                <xsl:text>)</xsl:text>
+            </xsl:if>
+            <xsl:choose>
+                <xsl:when test="title">
+                    <xsl:text> </xsl:text>
+                    <xsl:apply-templates select="." mode="title-full"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>.</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="&REMARK-LIKE;|&DEFINITION-LIKE;|&COMPUTATION-LIKE;|&ASIDE-LIKE;|&GOAL-LIKE;|assemblage">
     <!-- space with a blank line if not -->
     <!-- first in a structured element  -->
     <!-- barring metadata-ish           -->
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="number"/>
-    <xsl:if test="title">
-        <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="title-full"/>
-    </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="block-heading"/>
     <!-- structured -->
     <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<xsl:template match="&PROJECT-LIKE;|&OPENPROBLEM-LIKE;">
+    <xsl:if test="preceding-sibling::*[not(self::title)]">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="block-heading"/>
+    <xsl:apply-templates select="introduction|statement|task|conclusion|&SOLUTION-LIKE;"/>
+</xsl:template>
+
+<xsl:template match="task">
+    <xsl:if test="preceding-sibling::*[not(self::title)]">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="type-name"/>
+    <xsl:text> </xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>.</xsl:text>
+    <xsl:if test="title">
+        <xsl:text> (</xsl:text>
+        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:text>)</xsl:text>
+    </xsl:if>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="*[not(self::title)]"/>
 </xsl:template>
 
 <xsl:template match="&EXAMPLE-LIKE;">
@@ -530,21 +589,14 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="number"/>
-    <xsl:if test="title">
-        <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="title-full"/>
-    </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="block-heading"/>
     <xsl:choose>
         <xsl:when test="statement">
             <xsl:apply-templates select="statement"/>
             <xsl:apply-templates select="&SOLUTION-LIKE;"/>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:apply-templates select="*[self::hint|self::answer|self::solution]"/>
+            <xsl:apply-templates select="*[not(self::title)]"/>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -556,14 +608,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="number"/>
-    <xsl:if test="title">
-        <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="title-full"/>
-    </xsl:if>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="block-heading"/>
     <xsl:choose>
         <xsl:when test="statement">
             <xsl:apply-templates select="statement"/>
@@ -577,8 +622,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- THEOREM-LIKE only -->
 <xsl:template match="&PROOF-LIKE;">
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text>.&#xa;</xsl:text>
+    <!-- set off from a preceding statement -->
+    <xsl:if test="preceding-sibling::*[not(self::title)]">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:call-template name="block-heading-line">
+        <xsl:with-param name="heading">
+            <xsl:apply-templates select="." mode="type-name"/>
+            <xsl:text>.</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
     <!-- structured -->
     <xsl:apply-templates select="*"/>
 </xsl:template>
@@ -586,6 +639,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- ######### -->
 <!-- Exercises -->
 <!-- ######### -->
+
+<!-- An inline exercise (a "Checkpoint") reads as a block, with  -->
+<!-- the full heading treatment; a divisional exercise keeps its -->
+<!-- run-in serial number below, reading as a numbered item      -->
+<xsl:template match="exercise[&INLINE-EXERCISE-FILTER;]">
+    <xsl:if test="preceding-sibling::*[not(self::title)]">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="." mode="block-heading"/>
+    <xsl:choose>
+        <xsl:when test="statement">
+            <xsl:apply-templates select="statement"/>
+            <xsl:apply-templates select="&SOLUTION-LIKE;"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="*[self::hint|self::answer|self::solution]"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
 
 <xsl:template match="exercise">
     <!-- space with a blank line if not -->
@@ -614,20 +686,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="&SOLUTION-LIKE;">
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:variable name="the-number">
-        <xsl:apply-templates select="." mode="non-singleton-number" />
-    </xsl:variable>
-    <!-- An empty value means element is a singleton -->
-    <!-- else the serial number comes through        -->
-    <xsl:if test="not($the-number = '')">
-        <xsl:text> </xsl:text>
-        <xsl:apply-templates select="." mode="serial-number" />
+    <!-- set off from a preceding statement -->
+    <xsl:if test="preceding-sibling::*[not(self::title)]">
+        <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:text>. </xsl:text>
+    <xsl:call-template name="block-heading-line">
+        <xsl:with-param name="heading">
+            <xsl:apply-templates select="." mode="type-name"/>
+            <xsl:variable name="the-number">
+                <xsl:apply-templates select="." mode="non-singleton-number" />
+            </xsl:variable>
+            <!-- An empty value means element is a singleton -->
+            <!-- else the serial number comes through        -->
+            <xsl:if test="not($the-number = '')">
+                <xsl:text> </xsl:text>
+                <xsl:apply-templates select="." mode="serial-number" />
+            </xsl:if>
+            <xsl:text>.</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
     <xsl:apply-templates select="*"/>
-    <!-- not needed if structured -->
-    <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <!-- ############### -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -371,6 +371,56 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- Hooks for generated lists (list of figures, etc.): the  -->
+<!-- entries suffice, no surrounding apparatus               -->
+<xsl:template name="list-of-begin"/>
+<xsl:template name="list-of-end"/>
+
+<!-- ############ -->
+<!-- Bibliography -->
+<!-- ############ -->
+
+<!-- Font modes required by -common's bibliography machinery.    -->
+<!-- Plain text has no fonts: content rides through unadorned.   -->
+<!-- (The markdown conversion overrides these with emphasis.)    -->
+<xsl:template match="*" mode="italic">
+    <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="*" mode="bold">
+    <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="*" mode="monospace">
+    <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template name="biblio-period">
+    <xsl:text>.</xsl:text>
+</xsl:template>
+
+<!-- Literal code phrases ("c") funnel through this wrapper;   -->
+<!-- plain text passes the content through unadorned.  (The    -->
+<!-- markdown conversion overrides with backtick spans.)       -->
+<xsl:template name="code-wrapper">
+    <xsl:param name="content"/>
+    <xsl:copy-of select="$content"/>
+</xsl:template>
+
+<!-- Every bibliography flavor funnels through this wrapper in    -->
+<!-- -common: a bracketed number, then the entry's content        -->
+<xsl:template match="biblio" mode="bibentry-wrapper">
+    <xsl:param name="content"/>
+    <xsl:if test="preceding-sibling::biblio">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>] </xsl:text>
+    <xsl:copy-of select="$content"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
 <!-- ######### -->
 <!-- Divisions -->
 <!-- ######### -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -855,6 +855,12 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <!-- within a list item or task, a paragraph indents to the -->
+    <!-- item's content, except the one leading a list item,    -->
+    <!-- which runs in right after the marker                   -->
+    <xsl:if test="(ancestor::li or ancestor::task) and not(parent::li and not(preceding-sibling::*[not(self::title)]))">
+        <xsl:apply-templates select="." mode="item-indent"/>
+    </xsl:if>
     <!-- mixed-content -->
     <xsl:apply-templates/>
     <!-- end onto a newline -->
@@ -926,18 +932,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="introduction|statement|task|conclusion|&SOLUTION-LIKE;"/>
 </xsl:template>
 
+<!-- A task is an item of a list, in the manner of "ol/li": its   -->
+<!-- serial marker indented to its depth, its content indented    -->
+<!-- one level deeper (the item-indent and paragraph machinery of -->
+<!-- the Lists section counts "task" ancestors too).  Markdown    -->
+<!-- prefixes a genuine list marker so renderers nest properly.   -->
+<xsl:template match="task" mode="item-marker">
+    <xsl:text>(</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>)</xsl:text>
+</xsl:template>
+
 <xsl:template match="task">
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="." mode="type-name"/>
-    <xsl:text> </xsl:text>
-    <xsl:apply-templates select="." mode="serial-number"/>
-    <xsl:text>.</xsl:text>
+    <xsl:apply-templates select="." mode="item-indent"/>
+    <xsl:apply-templates select="." mode="item-marker"/>
     <xsl:if test="title">
-        <xsl:text> (</xsl:text>
+        <xsl:text> </xsl:text>
         <xsl:apply-templates select="." mode="title-full"/>
-        <xsl:text>)</xsl:text>
     </xsl:if>
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="*[not(self::title)]"/>
@@ -1108,29 +1122,55 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Lists -->
 <!-- ##### -->
 
+<!-- The indentation of an item at its depth: four spaces per   -->
+<!-- level of containing item, list or task alike, which is the -->
+<!-- nesting convention markdown recognizes                     -->
+<xsl:template match="*" mode="item-indent">
+    <xsl:value-of select="str:padding(4 * (count(ancestor::li) + count(ancestor::task)), ' ')"/>
+</xsl:template>
+
 <xsl:template match="ul|ol|dl">
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="li"/>
 </xsl:template>
 
-<xsl:template match="ol/li">
-    <xsl:apply-templates select="." mode="serial-number"/>
+<!-- A structured item's blocks (paragraphs, nested lists) supply -->
+<!-- their own trailing newlines; an unstructured item needs one  -->
+<xsl:template match="li" mode="finish-item">
+    <xsl:if test="not(p or ol or ul or dl)">
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- The marker of an ordered list item is its own number in the -->
+<!-- authored format ("item-number"), not the dotted hierarchy   -->
+<!-- ("serial-number", which cross-references still use); the    -->
+<!-- nesting shows in the indentation                            -->
+<xsl:template match="ol/li" mode="item-marker">
+    <xsl:apply-templates select="." mode="item-number"/>
     <xsl:text>. </xsl:text>
+</xsl:template>
+
+<xsl:template match="ol/li">
+    <xsl:apply-templates select="." mode="item-indent"/>
+    <xsl:apply-templates select="." mode="item-marker"/>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="finish-item"/>
 </xsl:template>
 
 <xsl:template match="ul/li">
+    <xsl:apply-templates select="." mode="item-indent"/>
     <xsl:text>* </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="finish-item"/>
 </xsl:template>
 
 <xsl:template match="dl/li">
+    <xsl:apply-templates select="." mode="item-indent"/>
     <xsl:apply-templates select="." mode="title-full"/>
     <xsl:text> </xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="finish-item"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -116,6 +116,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
+<!-- A landing spot for a link with a fragment identifier: -->
+<!-- nothing in plain text, realized by the markdown flavor -->
+<xsl:template match="*" mode="fragment-anchor"/>
+
 <!-- Macro definitions preceding a page's mathematics: nothing -->
 <!-- in plain text (the mathematics is authored LaTeX, macros  -->
 <!-- and all), realized by the markdown flavor for renderers   -->
@@ -833,13 +837,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Bibliographic metadata: quiet, mined above -->
 <xsl:template match="bibinfo"/>
 
-<!-- Unstructured containers: just their content -->
+<!-- Unstructured containers: just their content; an addressable -->
+<!-- one is a landing spot, glued to its title or first content   -->
+<!-- so the anchor never sits alone on a line                     -->
 <xsl:template match="introduction|conclusion|statement|paragraphs|subexercises|exercisegroup">
-    <xsl:if test="title">
-        <xsl:text>&#xa;</xsl:text>
-        <xsl:apply-templates select="." mode="title-full"/>
-        <xsl:text>&#xa;</xsl:text>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="title">
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:if test="@xml:id">
+                <xsl:apply-templates select="." mode="fragment-anchor"/>
+            </xsl:if>
+            <xsl:apply-templates select="." mode="title-full"/>
+            <xsl:text>&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:if test="@xml:id">
+                <xsl:apply-templates select="." mode="fragment-anchor"/>
+            </xsl:if>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:apply-templates select="*"/>
 </xsl:template>
 
@@ -1344,6 +1360,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
     <xsl:apply-templates select="." mode="serial-number"/>
     <xsl:text>.</xsl:text>
     <xsl:if test="title">
@@ -1401,6 +1418,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="*[not(self::caption or self::title)]"/>
+    <xsl:apply-templates select="." mode="fragment-anchor"/>
     <xsl:apply-templates select="." mode="type-name"/>
     <xsl:text> </xsl:text>
     <xsl:apply-templates select="." mode="number"/>
@@ -1457,6 +1475,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="ol/li">
     <xsl:apply-templates select="." mode="item-indent"/>
     <xsl:apply-templates select="." mode="item-marker"/>
+    <!-- an addressable item is a landing spot -->
+    <xsl:if test="@xml:id">
+        <xsl:apply-templates select="." mode="fragment-anchor"/>
+    </xsl:if>
     <xsl:apply-templates/>
     <xsl:apply-templates select="." mode="finish-item"/>
 </xsl:template>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -303,6 +303,26 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="sidebyside"/>
 </xsl:template>
 
+<!-- ######### -->
+<!-- Footnotes -->
+<!-- ######### -->
+
+<!-- A numbered mark in place; the text collects at the end of  -->
+<!-- the division (see the division template)                   -->
+<xsl:template match="fn">
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>]</xsl:text>
+</xsl:template>
+
+<xsl:template match="fn" mode="collected">
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number"/>
+    <xsl:text>] </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
 <!-- ####### -->
 <!-- Tabular -->
 <!-- ####### -->
@@ -472,6 +492,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#xa;&#xa;</xsl:text>
     <!-- metadata-ish, eg "title", should be killed by default -->
     <xsl:apply-templates select="*"/>
+    <!-- footnotes belonging to this division (and not to a  -->
+    <!-- deeper one) collect here, at its end                -->
+    <xsl:variable name="the-notes" select=".//fn[count(ancestor::*[&STRUCTURAL-FILTER;][1]|current()) = 1]"/>
+    <xsl:if test="$the-notes">
+        <xsl:text>&#xa;</xsl:text>
+        <xsl:apply-templates select="$the-notes" mode="collected"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- The document itself: its title as the topmost heading, then  -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -410,6 +410,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>]</xsl:text>
 </xsl:template>
 
+<!-- ################# -->
+<!-- Prose Text Nodes  -->
+<!-- ################# -->
+
+<!-- Authors hard-wrap and indent their source; none of that      -->
+<!-- belongs in the output.  -common's "text()" template handles  -->
+<!-- punctuation migration and whitespace at the edges of nodes,  -->
+<!-- and offers this hook for conversion-specific processing:     -->
+<!-- every interior newline (with the indentation following it)   -->
+<!-- collapses to a single space, so a paragraph becomes one long -->
+<!-- line, ready for any pager to soft-wrap.  The workhorse,      -->
+<!-- "flatten-line-breaks", lives with the text utilities.        -->
+<xsl:template name="text-processing">
+    <xsl:param name="text"/>
+    <xsl:call-template name="flatten-line-breaks">
+        <xsl:with-param name="text" select="$text"/>
+    </xsl:call-template>
+</xsl:template>
+
 <xsl:template match="p">
     <!-- space with a blank line if not -->
     <!-- first in a structured element  -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -75,17 +75,301 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Entry Template -->
 <!-- Kickstart the process, ignore "docinfo"  -->
 <xsl:template match="/">
-    <xsl:call-template name="banner-warning">
-        <xsl:with-param name="warning">Conversion to simple text is incomplete&#xa;But importing this stylesheet could be helpful for certain purposes&#xa;Override the entry template to make this warning go away</xsl:with-param>
-    </xsl:call-template>
     <xsl:apply-templates select="$document-root"/>
 </xsl:template>
 
 <!-- TEMPORARY: defined to stop errors, need stubs in -common -->
 <xsl:template name="inline-warning"/>
 <xsl:template name="margin-warning"/>
-<xsl:template match="sage" mode="sage-active-markup"/>
-<xsl:template name="sage-display-markup"/>
+
+<!-- ################ -->
+<!-- Producer's Notes -->
+<!-- ################ -->
+
+<!-- Content that text cannot express is announced, not dropped:  -->
+<!-- a bracketed note with a localized label, a fixed convention  -->
+<!-- a reader (or a consuming program) can recognize and strip.   -->
+<xsl:template name="producer-note">
+    <xsl:param name="message"/>
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="type-name">
+        <xsl:with-param name="string-id" select="'note'"/>
+    </xsl:apply-templates>
+    <xsl:text>: </xsl:text>
+    <xsl:copy-of select="$message"/>
+    <xsl:text>]</xsl:text>
+</xsl:template>
+
+<!-- Structured lines ("department", "attribution", a "cell" of  -->
+<!-- "line") break onto new lines; -common's default is a        -->
+<!-- "[LINESEP]" marker demanding this implementation            -->
+<xsl:template name="line-separator">
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ######## -->
+<!-- Verbatim -->
+<!-- ######## -->
+
+<!-- A verbatim block: contents on their own lines, every line    -->
+<!-- indented four spaces (which is set-off in plain text, and    -->
+<!-- happens to be a code block in markdown).  A caller may       -->
+<!-- extend the indentation, say with a prompt.                   -->
+<xsl:template name="verbatim-block">
+    <xsl:param name="content"/>
+    <xsl:param name="indent" select="'    '"/>
+    <!-- the blank line preceding the block; a caller abutting -->
+    <!-- two blocks (Sage input, output) empties the second's  -->
+    <xsl:param name="lead" select="'&#xa;'"/>
+    <xsl:variable name="sanitized">
+        <xsl:call-template name="sanitize-text">
+            <xsl:with-param name="text" select="$content"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <xsl:value-of select="$lead"/>
+    <xsl:call-template name="add-indentation">
+        <xsl:with-param name="text" select="$sanitized"/>
+        <xsl:with-param name="indent" select="$indent"/>
+    </xsl:call-template>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="pre">
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content">
+            <xsl:apply-templates select="." mode="interior"/>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="cd">
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content">
+            <xsl:choose>
+                <xsl:when test="cline">
+                    <xsl:apply-templates select="cline"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="."/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="program">
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content">
+            <xsl:value-of select="code"/>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="console">
+    <xsl:apply-templates select="input|output"/>
+</xsl:template>
+
+<xsl:template match="console/input">
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content">
+            <xsl:value-of select="../@prompt"/>
+            <xsl:value-of select="."/>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="console/output">
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content">
+            <xsl:value-of select="."/>
+        </xsl:with-param>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- Input carries a prompt on every line, named for the cell's -->
+<!-- language (Sage by default) in the manner of a session, so  -->
+<!-- it reads apart from the bare output, which follows after a -->
+<!-- single blank line                                          -->
+<xsl:template match="sage" mode="sage-active-markup">
+    <xsl:param name="in"/>
+    <xsl:param name="out"/>
+    <xsl:variable name="the-language">
+        <xsl:choose>
+            <xsl:when test="@language">
+                <xsl:value-of select="@language"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>sage</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content" select="$in"/>
+        <xsl:with-param name="indent" select="concat('    ', $the-language, ': ')"/>
+    </xsl:call-template>
+    <xsl:if test="not($out = '')">
+        <xsl:call-template name="verbatim-block">
+            <xsl:with-param name="content" select="$out"/>
+            <xsl:with-param name="lead" select="''"/>
+        </xsl:call-template>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="sage-display-markup">
+    <xsl:param name="in"/>
+    <xsl:call-template name="verbatim-block">
+        <xsl:with-param name="content" select="$in"/>
+    </xsl:call-template>
+</xsl:template>
+
+<!-- ##### -->
+<!-- Media -->
+<!-- ##### -->
+
+<!-- An image is its author-provided description; failing that, a  -->
+<!-- note that an image was here                                   -->
+<xsl:template match="image">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:call-template name="producer-note">
+        <xsl:with-param name="message">
+            <xsl:choose>
+                <xsl:when test="shortdescription">
+                    <xsl:apply-templates select="shortdescription"/>
+                </xsl:when>
+                <xsl:when test="description">
+                    <xsl:apply-templates select="description"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>an image, undescribed by its author</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="shortdescription|description">
+    <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="video|audio|interactive|slate">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:call-template name="producer-note">
+        <xsl:with-param name="message">
+            <xsl:text>a </xsl:text>
+            <xsl:value-of select="local-name()"/>
+            <xsl:text> element is not realizable in this format</xsl:text>
+            <xsl:if test="@source|@href">
+                <xsl:text>; see </xsl:text>
+                <xsl:value-of select="@source|@href"/>
+            </xsl:if>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- A side-by-side is announced, its panels appear in sequence -->
+<xsl:template match="sidebyside">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:call-template name="producer-note">
+        <xsl:with-param name="message">
+            <xsl:text>the following </xsl:text>
+            <xsl:value-of select="count(*)"/>
+            <xsl:text> elements are arranged side-by-side in other formats</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="*"/>
+</xsl:template>
+
+<!-- A group announces itself, with each member's panel count -->
+<xsl:template match="sbsgroup">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:call-template name="producer-note">
+        <xsl:with-param name="message">
+            <xsl:text>the following is a group of </xsl:text>
+            <xsl:value-of select="count(sidebyside)"/>
+            <xsl:text> side-by-side with </xsl:text>
+            <xsl:for-each select="sidebyside">
+                <xsl:value-of select="count(*)"/>
+                <xsl:if test="following-sibling::sidebyside">
+                    <xsl:text>, </xsl:text>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:text> panels respectively</xsl:text>
+        </xsl:with-param>
+    </xsl:call-template>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="sidebyside"/>
+</xsl:template>
+
+<!-- ####### -->
+<!-- Tabular -->
+<!-- ####### -->
+
+<!-- Modest: each row a line, cells separated by double spaces.   -->
+<!-- No column alignment (yet), spanning cells simply run in.     -->
+<xsl:template match="tabular">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:apply-templates select="row"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="row">
+    <xsl:text>    </xsl:text>
+    <xsl:for-each select="cell">
+        <xsl:apply-templates/>
+        <xsl:if test="following-sibling::cell">
+            <xsl:text>  </xsl:text>
+        </xsl:if>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- ###### -->
+<!-- Poetry -->
+<!-- ###### -->
+
+<xsl:template match="poem">
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:if test="title">
+        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates select="stanza"/>
+</xsl:template>
+
+<xsl:template match="stanza">
+    <xsl:apply-templates select="line"/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="stanza/line">
+    <xsl:text>    </xsl:text>
+    <xsl:apply-templates/>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- #### -->
+<!-- URLs -->
+<!-- #### -->
+
+<!-- visible text (when there is some), address in angle brackets -->
+<xsl:template match="url">
+    <xsl:choose>
+        <xsl:when test="node()">
+            <xsl:apply-templates/>
+            <xsl:text> &lt;</xsl:text>
+            <xsl:value-of select="@href"/>
+            <xsl:text>&gt;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>&lt;</xsl:text>
+            <xsl:value-of select="@href"/>
+            <xsl:text>&gt;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
 
 <!-- ######### -->
 <!-- Divisions -->
@@ -712,18 +996,29 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Captioned Items -->
 <!-- ############### -->
 
-<xsl:template match="figure">
+<!-- A figure — or a table, listing, or named list — presents its -->
+<!-- content, and then a caption line: type, number, and the      -->
+<!-- caption (or the title, for the types that have titles)       -->
+<xsl:template match="&FIGURE-LIKE;">
     <!-- space with a blank line if not -->
     <!-- first in a structured element  -->
     <!-- barring metadata-ish           -->
     <xsl:if test="preceding-sibling::*[not(self::title)]">
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <xsl:apply-templates select="*[not(self::caption or self::title)]"/>
     <xsl:apply-templates select="." mode="type-name"/>
     <xsl:text> </xsl:text>
     <xsl:apply-templates select="." mode="number"/>
     <xsl:text>: </xsl:text>
-    <xsl:apply-templates select="caption"/>
+    <xsl:choose>
+        <xsl:when test="caption">
+            <xsl:apply-templates select="caption"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="title-full"/>
+        </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3061,6 +3061,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 
 
+<!-- ##################### -->
+<!-- Text-Specific Options -->
+<!-- ##################### -->
+
+<!-- The character repertoire of the plain text and markdown        -->
+<!-- conversions: genuine Unicode characters (dashes, quotation     -->
+<!-- marks, ...) or 7-bit ASCII stand-ins.                          -->
+<xsl:variable name="text-characters">
+    <xsl:apply-templates select="$publisher-attribute-options/text/pi:pub-attribute[@name='characters']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-text-unicode" select="$text-characters = 'unicode'"/>
+
+
 <!-- ######################## -->
 <!-- Braille-Specific Options -->
 <!-- ######################## -->
@@ -3795,6 +3808,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <pi:pub-attribute name="height" default="25" freeform="yes"/>
         </page>
     </braille>
+    <text>
+        <pi:pub-attribute name="characters" default="unicode" options="ascii"/>
+    </text>
     <revealjs>
         <appearance>
             <pi:pub-attribute name="theme" default="simple" freeform="yes"/>


### PR DESCRIPTION
This PR introduces two closely-related conversions, the lightest-weight output PreTeXt has offered.  Twenty-one commits, but mostly telling a linear story.

**Plain text.**  `xsl/pretext-text.xsl` has long been a skeleton with aspirations; it is now a genuine conversion, invoked with `-f text` through the `pretext/pretext` script.  Divisions take underlined headings in the typewriter tradition, authored line breaks and indentation flatten away so any pager can soft-wrap, and every family of blocks presents a proper heading.  Mathematics is the LaTeX an author wrote, riding between dollar signs.  A new publication file entry, `text/@characters`, elects genuine Unicode (the default) or pure 7-bit ASCII stand-ins.  Footnotes collect at division ends, bibliographies and a genuine index (mined from `idx` elements, sorted by `-common`'s machinery) round out the back matter.  The existing `common/chunking/@level` election is honored: one file, or a file per division with `[Contents | Previous | Up | Next]` navigation and summary pages above the chunk frontier.  A construction text cannot express — an interactive, a video, a side-by-side layout — is announced in-band by a bracketed producer's note, never silently dropped.

**Markdown.**  `xsl/pretext-markdown.xsl` imports the text conversion and overrides exactly the flavor-sensitive layer: ATX headings, emphasis, code spans and blocks, links, and a blanket escaping pass so authored punctuation can never be mistaken for markup.  The target is valid CommonMark; simple tabulars additionally become pipe tables, the nearly-universal extension.  Images are genuine `img` elements, placed and sized by PreTeXt's layout machinery, with the managed image directories deposited alongside.  Cross-references and index locators are working links, landing on invisible anchors emitted only where some `xref` actually points.  Each page opens with an invisible block of macro definitions, so authored macros (and `\lt`, `\gt`, `\amp`) render under any MathJax-capable renderer — repository-hosting websites and many editors qualify.  A third format, `-f markdown-zip`, bundles a whole build into one archive for easy hand-off, to a person or to an AI tool.

**Documentation.**  A new chapter in the publisher part of the Guide describes both conversions, their use cases, and — deliberately stressed — what cannot be supported; the publication file reference and the `pretext/pretext` capabilities list gain matching entries, cross-linked.

Verified throughout on the sample article: both flavors, chunked and monolithic, both character repertoires, with all image references and fragment links audited, and a full Guide build for the documentation.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
