### PR TITLE
Sample chapter: update output from 'make sample-chapter-representations'

### DIFF
--- a/examples/webwork/sample-chapter/my-generated/webwork/pg/Integrating_WeBWorK_into_Textbooks/2-Technical_Examples/2_3-Stress_Tests/2_3_1-PreTeXt_problem_source_with_servergenerated_images.pg
+++ b/examples/webwork/sample-chapter/my-generated/webwork/pg/Integrating_WeBWorK_into_Textbooks/2-Technical_Examples/2_3-Stress_Tests/2_3_1-PreTeXt_problem_source_with_servergenerated_images.pg
@@ -1,31 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
-<webwork-reps version="2" webwork2_major_version="2" webwork2_minor_version="20" xml:id="extracted-pretext-source-with-server-images" assembly-id="pretext-source-with-server-images">
-  <static seed="82">
-    <task>
-      <statement><!-- PTX:WARNING: PGML wanted to center align here. -->
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-1.png" width="25%"/>
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-2.png" width="25%"/>
-</statement>
-      <solution><!-- PTX:WARNING: PGML wanted to center align here. -->
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-3.png" width="25%"/>
-</solution>
-    </task>
-    <task>
-      <statement><!-- PTX:WARNING: PGML wanted to center align here. -->
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-4.png" width="25%"/>
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-5.png" width="25%"/>
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-6.png" width="25%"/>
-</statement>
-      <hint><!-- PTX:WARNING: PGML wanted to center align here. -->
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-7.png" width="25%"/>
-</hint>
-      <solution><!-- PTX:WARNING: PGML wanted to center align here. -->
-<image xmlns:pi="http://pretextbook.org/2020/pretext/internal" pi:generated="webwork/images/pretext-source-with-server-images-image-8.png" width="25%"/>
-</solution>
-    </task>
-  </static>
-  <rendering-data problemSource="Integrating_WeBWorK_into_Textbooks/2-Technical_Examples/2_3-Stress_Tests/2_3_1-PreTeXt_problem_source_with_servergenerated_images.pg" origin="generated" domain="https://webwork-ptx.aimath.org" course-id="anonymous" user-id="anonymous" passwd="anonymous" language="en-US"/>
-  <pg><![CDATA[
 #############################################
 ###       Generated from PreTeXt source      
 ###                                          
@@ -155,5 +127,3 @@ Scaffold::End();
 ############################################################
 
 ENDDOCUMENT();
-]]></pg>
-</webwork-reps>

--- a/examples/webwork/sample-chapter/my-generated/webwork/pg/Integrating_WeBWorK_into_Textbooks/def/set2_3-Stress_Tests.def
+++ b/examples/webwork/sample-chapter/my-generated/webwork/pg/Integrating_WeBWorK_into_Textbooks/def/set2_3-Stress_Tests.def
@@ -6,7 +6,7 @@ screenHeaderFile  = Integrating_WeBWorK_into_Textbooks/header/2_3-Stress_Tests.p
 description       = Stress Tests
 problemListV2
 problem_start
-source_file = Integrating_WeBWorK_into_Textbooks/2-Technical_Examples/2_3-Stress_Tests/2_3_1-PTX_problem_source_with_servergenerated_images.pg
+source_file = Integrating_WeBWorK_into_Textbooks/2-Technical_Examples/2_3-Stress_Tests/2_3_1-PreTeXt_problem_source_with_servergenerated_images.pg
 problem_id = 1
 problem_end
 problem_start


### PR DESCRIPTION
This is simply the result of navigating to the `examples/webwork/` folder and running `make sample-chapter-representations`. I'm not sure what led to this, but somewhere some changes were made to XSL files or to the pretext python script, and the output from `make sample-chapter-representations` was not kept up. So now as I work on things like #3053, these changes show up in the diff even though they have nothing to do with that work.

I also get changes in the generated images in `sample-chapter/my-generated/webwork/images/`, but I assume those are due to different LaTeX versions making those images, different versions of the tools used to convert PDF to other image files, metadata in the files, etc. I'm OK with just ignoring all that.