### PR TITLE
Script: extend href→xlink:href downgrade to all SVG elements

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4741,10 +4741,10 @@ def _downgrade_svg2_for_batik(directory):
         root    = tree.getroot()
         changed = False
 
-        for use in root.iter(tag("use")):
-            href = use.get("href")
-            if href and use.get(xhref) is None:
-                use.set(xhref, href); del use.attrib["href"]; changed = True
+        for el in root.iter():
+            href = el.get("href")
+            if href and el.get(xhref) is None:
+                el.set(xhref, href); del el.attrib["href"]; changed = True
 
         # "transparent" is a CSS3 colour keyword, not SVG 1.1;
         # hsl()/rgb() in presentation attributes are also rewritten here.

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4626,7 +4626,7 @@ def _downgrade_svg2_for_batik(directory):
     * orient="auto-start-reverse": changed to "auto"; elements that use
       the marker as marker-start get a rotated (180°) copy (id suffix
       "-start").
-    * Plain href on <use>: migrated to xlink:href.
+    * Plain href on any SVG element: migrated to xlink:href.
     * fill="transparent" → fill="none"; hsl()/rgb() colour functions and
       CSS filter functions in <style> blocks rewritten to values Batik
       accepts.
@@ -4742,6 +4742,8 @@ def _downgrade_svg2_for_batik(directory):
         changed = False
 
         for el in root.iter():
+            if not (isinstance(el.tag, str) and el.tag.startswith("{" + SVG + "}")):
+                continue
             href = el.get("href")
             if href and el.get(xhref) is None:
                 el.set(xhref, href); del el.attrib["href"]; changed = True


### PR DESCRIPTION
## Summary

`_downgrade_svg2_for_batik()` currently replaces bare `href` with `xlink:href` only on `<use>` elements. SVG 1.1 requires `xlink:href` on any element that carries an `href` — and several SVG elements besides `<use>` can do so: `<image>`, `<a>`, `<textPath>`, `<pattern>`, `<linearGradient>`, `<radialGradient>`, `<feImage>`, and `<mpath>`, among others. Any of these could appear in SVGs from sources other than PreFigure that are included in a PreTeXt document.

This issue came to light while developing the PreFigure testing framework, where `<image href=…>` appeared in test SVGs and was silently dropped by Batik.

## Change

One line in `_downgrade_svg2_for_batik()`: change `root.iter(tag("use"))` to `root.iter()` so every element in the tree is checked. The guard `el.get(xhref) is None` prevents double-setting on elements that already carry `xlink:href`.

## Testing

Verified against SVGs containing `<image href=…>` elements; Batik renders the image correctly after the fix.