### PR TITLE
Slideshow: upgrade "reveal.js" to version 6, mathematics by MathJax 4

### DIFF
--- a/doc/guide/publisher/slides.xml
+++ b/doc/guide/publisher/slides.xml
@@ -93,7 +93,7 @@
                 To set up a Reveal.js slideshow to run locally, you need to have certain files available locally.  We describe here the exact mechanics of doing this.
             </p>
             <p>
-                Suppose you have done the <pretext/> conversion, and have created a single <c>slides.html</c> file, which you have placed in a directory named <c>talk</c>.  Now download or clone the git repository for Reveal.js (<url href="https://github.com/hakimel/reveal.js/" visual="github.com/hakimel/reveal.js"/>).  This has a <c>dist</c> directory with four files, such as <c>reveal.css</c>, and also directory of themes, named <c>theme</c>.  Copy these files and the directory to <c>talk</c>.  Another directory in the repository is named <c>plugin</c>.  Copy this directory to <c>talk</c> as well.
+                Suppose you have done the <pretext/> conversion, and have created a single <c>slides.html</c> file, which you have placed in a directory named <c>talk</c>.  Now download or clone the git repository for Reveal.js (<url href="https://github.com/hakimel/reveal.js/" visual="github.com/hakimel/reveal.js"/>).  This has a <c>dist</c> directory containing the files you need: <c>reset.css</c>, <c>reveal.css</c>, and <c>reveal.js</c>, along with a directory of themes named <c>theme</c> and a directory of single-file plugins named <c>plugin</c>.  Copy the contents of <c>dist</c> to <c>talk</c>.
             </p>
             <p>
                 This process will duplicate more files than you need.  Suppose your talk is produced to use the <c>solarized</c> theme (<xref ref="revealjs-appearance-options"/>), and includes some math.  Then as an example of how the copying should go, and as an example of the bare minimum necessary, your <c>talk</c> directory should be organized as follows.
@@ -108,9 +108,7 @@
                 theme
                     solarized.css
                 plugin
-                    math
-                        math.js
-                        plugin.js
+                    math.js
             </pre>
         </paragraphs>
     </section>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -129,13 +129,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="sagecell" />
             <xsl:call-template name="syntax-highlight"/>
 
-            <!-- load reveal.js resources; w/ v 4.1.2 -->
-            <!-- these seem to be *always* minified   -->
+            <!-- load reveal.js resources; w/ v 6.x                 -->
+            <!-- paths are relative to the distribution's "dist"    -->
+            <!-- directory, whose layout a "local" resource host    -->
+            <!-- must reproduce                                     -->
             <link href="{$reveal-root}/reset.css" rel="stylesheet"></link>
             <link href="{$reveal-root}/reveal.css" rel="stylesheet"></link>
             <link href="{$reveal-root}/theme/{$reveal-theme}.css" rel="stylesheet"></link>
             <script src="{$reveal-root}/reveal.js"></script>
-            <script src="{$reveal-root}/plugin/math/math.js"></script>
+            <script src="{$reveal-root}/plugin/math.js"></script>
 
             <link href="_static/pretext/css/pretext-reveal.css" rel="stylesheet"></link>
           <style>
@@ -214,19 +216,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- markup, since we use environments exclusively.   -->
             <!-- N.B. default HTML adds a "zero-width" space into -->
             <!-- a \( authored in a non-math context.             -->
-            <!-- N.B. This may need to be changed for MathJax 3   -->
+            <!-- The MathJax version matches the main HTML        -->
+            <!-- conversion; the "mathjax4" adapter of the math   -->
+            <!-- plugin loads it from the URL given and passes    -->
+            <!-- the "tex" object into the MathJax configuration. -->
 
-            <!-- Suggested by  https://revealjs.com/math/, 2021-09-19 -->
-            <xsl:text>  math: {&#xa;</xsl:text>
-            <xsl:text>    mathjax: 'https://cdn.jsdelivr.net/gh/mathjax/mathjax@2.7.8/MathJax.js',&#xa;</xsl:text>
-            <xsl:text>    config: 'TeX-AMS_HTML-full',&#xa;</xsl:text>
-            <xsl:text>    // other options are passed into MathJax.Hub.Config()&#xa;</xsl:text>
-            <xsl:text>    tex2jax: {&#xa;</xsl:text>
+            <!-- Suggested by  https://revealjs.com/math/, 2026-07-22 -->
+            <xsl:text>  mathjax4: {&#xa;</xsl:text>
+            <xsl:text>    mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js',&#xa;</xsl:text>
+            <xsl:text>    tex: {&#xa;</xsl:text>
             <xsl:text>      inlineMath:  [['\\(','\\)']],&#xa;</xsl:text>
             <xsl:text>      displayMath: [],&#xa;</xsl:text>
             <xsl:text>    }&#xa;</xsl:text>
             <xsl:text>  },&#xa;</xsl:text>
-            <xsl:text>  plugins: [ RevealMath ]&#xa;</xsl:text>
+            <xsl:text>  plugins: [ RevealMath.MathJax4 ]&#xa;</xsl:text>
             <xsl:text>});&#xa;</xsl:text>
         </script>
     </html>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3563,8 +3563,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="reveal-root">
     <!-- CDN is used twice, so just edit here -->
     <!-- NB: deprecation is frozen -->
+    <!-- The "@6" is a semantic-version range: jsdelivr serves the    -->
+    <!-- newest 6.x release, so fixes arrive automatically while a    -->
+    <!-- breaking 7.0 cannot.  Same pattern as the MathJax "@4" URLs. -->
     <xsl:variable name="cdn-url">
-        <xsl:text>https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2</xsl:text>
+        <xsl:text>https://cdn.jsdelivr.net/npm/reveal.js@6/dist</xsl:text>
     </xsl:variable>
 
     <xsl:choose>


### PR DESCRIPTION
The Reveal.js conversion pinned version 4.1.2 of the framework and version 2.7.8 of MathJax, both long out of date (raised by Mitch Keller on pretext-dev, 2026-06-25: https://groups.google.com/d/msgid/pretext-dev/6cecf1dd-1444-41c6-ac7d-b240a40726dan%40googlegroups.com). This PR moves slideshows to the Reveal.js 6.x series and MathJax 4.

- Resources load from jsdelivr with a semantic-version range, `reveal.js@6` — the newest 6.x arrives automatically while a breaking 7.0 cannot — matching how MathJax is already loaded (`mathjax@4`). cdnjs was abandoned as the default host since its URLs are immutable, which is how the conversion sat on 4.1.2. A `local` resources host mirrors the distribution's `dist` layout, and the Guide's directions are updated to match (the 6.x distribution still ships a prebuilt `dist`, now with single-file plugins such as `plugin/math.js`).
- No `Reveal.initialize` options change: the upgrade guides for 4-to-5 and 5-to-6 list none, and testing confirms the existing option block works unchanged.
- Mathematics uses the math plugin's MathJax 4 support (new in 6.0.0), configured with the same MathJax URL and delimiter conventions as the main HTML conversion: inline `\(...\)` only, display mathematics via environments. Typesetting is asynchronous, so a first paint on a cold cache may briefly show raw LaTeX before the mathematics appears.

Verified in a browser on the sample slideshow (6.x currently resolving to 6.0.1): deck initialization, theme, and controls; inline and multi-line display mathematics; the Sage-cell slide's deliberate JavaScript-interference test (a live cell alongside heavy mathematics); and the `?print-pdf` layout of all 53 pages. Excluding timestamps, the built HTML differs from master's in exactly the five resource URLs and the math configuration block.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
