### PR TITLE
XSL: drop deprecated "jsxgraph" and "paragraphs" as "sidebyside" panels

### DIFF
--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -152,12 +152,11 @@
 <!-- Panels of a "sidebyside", and content of a "stack" panel.  The   -->
 <!-- lists mirror the schema, plus grandfathered items the code still -->
 <!-- tolerates: "audio", "video", "interactive" (precluded            -->
-<!-- 2026-07-22, may someday be removed), "jsxgraph" (deprecated      -->
-<!-- 2018-04-06), and "paragraphs" within a "sidebyside" (deprecated  -->
-<!-- 2018-04-06).  An "exercise" panel (worksheet or handout only)    -->
-<!-- and a "slate" panel (within an "interactive" only) are policed   -->
-<!-- by the validation-plus stylesheet.                               -->
-<!ENTITY SBSPANEL "p|pre|ol|ul|dl|program|console|poem|audio|video|interactive|slate|exercise|image|figure|table|listing|list|tabular|stack|jsxgraph|paragraphs">
+<!-- 2026-07-22, may someday be removed).  An "exercise" panel        -->
+<!-- (worksheet or handout only) and a "slate" panel (within an       -->
+<!-- "interactive" only) are policed by the validation-plus           -->
+<!-- stylesheet.                                                      -->
+<!ENTITY SBSPANEL "p|pre|ol|ul|dl|program|console|poem|audio|video|interactive|slate|exercise|image|figure|table|listing|list|tabular|stack">
 <!ENTITY STACKABLE "tabular|image|p|pre|ol|ul|dl|audio|video|interactive|slate|program|console">
 
 <!-- appendages of examples, exercises, tasks -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11265,11 +11265,18 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the &quot;jsxgraph&quot; element has been deprecated, but remains functional, rework with the &quot;interactive&quot; element'" />
     </xsl:call-template>
     <!--  -->
+    <!-- 2018-04-06  jsxgraph no longer a panel of a sidebyside -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//sidebyside/jsxgraph&quot;" />
+        <xsl:with-param name="date-string" select="'2018-04-06'" />
+        <xsl:with-param name="message" select="'a &quot;jsxgraph&quot; can no longer appear within a &quot;sidebyside&quot;, rework with the &quot;interactive&quot; element; as of 2026-07-22 the &quot;jsxgraph&quot; will be silently ignored'" />
+    </xsl:call-template>
+    <!--  -->
     <!-- 2018-05-02  paragraphs purely as a lightweight division -->
     <xsl:call-template name="deprecation-message">
         <xsl:with-param name="occurrences" select="&quot;$document-root//sidebyside/paragraphs&quot;" />
         <xsl:with-param name="date-string" select="'2018-04-06'" />
-        <xsl:with-param name="message" select="'a &quot;paragraphs&quot; can no longer appear within a &quot;sidebyside&quot;, replace with a &quot;stack&quot; containing multiple elements, such as &quot;p&quot;'" />
+        <xsl:with-param name="message" select="'a &quot;paragraphs&quot; can no longer appear within a &quot;sidebyside&quot;, replace with a &quot;stack&quot; containing multiple elements, such as &quot;p&quot;; as of 2026-07-22 the &quot;paragraphs&quot; and its content will be silently ignored'" />
     </xsl:call-template>
     <!-- 2018-05-18  WeBWorK refactor no longer needs setup/var elements for static representations-->
     <xsl:call-template name="deprecation-message">


### PR DESCRIPTION
## Summary

A "jsxgraph" and a "paragraphs" have been deprecated as panels of a "sidebyside" since 2018 — "jsxgraph" was absorbed into "interactive", and "paragraphs" was reserved as a lightweight division. The schema already disallows both in that position (a "paragraphs" is not a valid "sidebyside" panel, and "jsxgraph" is not permitted anywhere), yet the stylesheets still rendered them: the shared panel-content entity `SBSPANEL`, introduced with the side-by-side entity work in #3057, continued to list them.

This removes the two elements from `SBSPANEL`, so a "jsxgraph" or "paragraphs" placed directly in a "sidebyside" is no longer rendered as a panel. Because that single entity drives the panel selection in the common "sidebyside" template, the change applies uniformly to HTML, LaTeX/PDF, and PDF via FO. The deprecation warnings are updated to say so.

## Changes

- `xsl/entities.ent`: drop "jsxgraph" and "paragraphs" from `SBSPANEL`, and trim the accompanying comment. `STACKABLE` already excluded both, so a "stack" panel is unaffected.
- `xsl/pretext-common.xsl`: add a "sidebyside"-specific deprecation for "jsxgraph" (mirroring the existing "paragraphs" one), and extend both messages to note that, as of 2026-07-22, such a panel and its content are silently ignored.

## Notes

- A standalone "jsxgraph" (outside a "sidebyside") is untouched — its general deprecation message is unchanged and it continues to render.
- Verified: a "sidebyside" containing a "paragraphs" or "jsxgraph" panel now renders neither in HTML, LaTeX, or FO, while both deprecation warnings still fire. The sample article — whose "jsxgraph" and "paragraphs" are all standalone or divisions — is unchanged.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
