### PR TITLE
Guide: document the project landing page

### DIFF
--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -312,7 +312,7 @@
         </subsection>
 
 
-        <subsection>
+        <subsection xml:id="processing-CLI-deploy">
             <title>Hosting your project: <c>pretext deploy</c></title>
             <idx><h>hosting</h></idx>
             <idx><h>CLI</h><h><c>deploy</c></h></idx>

--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -21,6 +21,7 @@
             <title><c>index.html</c> Page</title>
             <idx><h>index page</h><h>HTML</h></idx>
             <idx><h>HTML</h><h>index page</h></idx>
+            <idx><h>landing page</h><h>versus index page</h></idx>
 
             <p>The conversion to <init>HTML</init> <em>always</em> creates a file named <c>index.html</c>.  We do this because if a reader requests the <init>URL</init><cd>
                 <cline>platypus.mammal-institute.org/aota/html</cline>
@@ -35,6 +36,8 @@
             </cd>then you can set <c>ref="birds"</c> and the page for that chapter will be the default page for the shorter <init>URL</init>.  In practice, you probably really want a page that looks like the front matter or a Table of Contents.</p>
 
             <p>The default is to first have <c>index.html</c> redirect to a page for the <tag>frontmatter</tag>, and if this is not possible, then it will redirect to a page for the top-level of your content.  If your document is short or simple, you may just have a single web page.  You could choose to not distribute the <c>index.html</c> file and then just use a concise and descriptive <attr>xml:id</attr> for your top-level element (e.g. <tag>article</tag>) to fashion an attractive URL that points to your shorter work.</p>
+
+            <p>This <c>index.html</c> page is a part of your <init>HTML</init> output; it is not the same as a project <term>landing page</term><mdash/>the home page of a website devoted to your whole project.  See <xref ref="landing-page"/> if a project landing page is what you are looking for.</p>
         </subsection>
 
         <subsection xml:id="online-banner-options">

--- a/doc/guide/publisher/production.xml
+++ b/doc/guide/publisher/production.xml
@@ -26,9 +26,20 @@
         <p>TODO</p>
     </section>
 
-    <section>
-        <title>(*) Landing Page</title>
-        <p>TODO</p>
+    <section xml:id="landing-page">
+        <title>Landing Page</title>
+        <idx><h>landing page</h></idx>
+        <idx><h>project website</h></idx>
+        <idx><h>website</h><h>for a project</h></idx>
+        <idx><h>GitHub Pages</h></idx>
+
+        <p>A single book can yield many different outputs<mdash/>an online <init>HTML</init> version, a <init>PDF</init> for the screen or for print (<xref ref="print-on-demand"/>), perhaps an <init>EPUB</init> or a packet of worksheets.  We think every project deserves one thing more: a <term>landing page</term>, the home page of a small website devoted to the project as a whole.  It is the front door<mdash/>the one stable, memorable <init>URL</init> you advertise on a syllabus, cite in a talk, or hand to a colleague<mdash/>and from it a reader can reach whichever version they prefer.</p>
+
+        <p>A landing page is <em>not</em> the <init>HTML</init> index page (<xref ref="index-page"/>).  That index page is the <c>index.html</c> file <pretext/> builds <em>inside</em> your <init>HTML</init> output so that a directory <init>URL</init> resolves to a sensible first page of the book; it belongs to a single output.  A landing page sits <em>above</em> all of your outputs and introduces the project itself: a short description, a cover image, links to the current online version and to a downloadable <init>PDF</init>, perhaps errata or news, and a way to contact you or to adopt the book.</p>
+
+        <p>Because the landing page is what endures as versions come and go, and as hosting arrangements change, it is worth situating at a domain name you own and control (<xref ref="web-hosting"/>), so the project can move without breaking the links others have already made to it.</p>
+
+        <p>The PreTeXt-CLI can assemble such a site for you.  When you deploy more than one target (<xref ref="processing-CLI-deploy"/>), you place your landing page in a <c>site</c> folder at the root of your project, and <c>pretext deploy</c> stages that page together with each target's output as a single website.  For hosting, <url href="https://pages.github.com/" visual="pages.github.com/">GitHub Pages</url> is a natural, free home (<xref ref="web-hosting"/>).  This holds even when the book itself is hosted elsewhere: a Runestone book, for instance, already lives in a GitHub repository, so GitHub Pages is immediately available to carry the project's landing page.</p>
     </section>
 
     <section>


### PR DESCRIPTION
The Production chapter's "Landing Page" section was a `TODO` stub. This fills it out, and in doing so draws a clear line between two things that are easy to conflate:

- the **HTML index page** — the `index.html` redirect PreTeXt builds *inside* a single HTML output (the `index-page` publication switch), and
- a **landing page** — the home page of a website devoted to the whole project, sitting *above* all of a book's outputs (online HTML, PDF, EPUB, …) and serving as the stable front door a reader first arrives at.

The new section describes the landing page in that second sense, notes PreTeXt's own tooling for it (a `site` folder assembled by `pretext deploy` for multi-target deploys), and suggests GitHub Pages as a natural, free home — readily available even when the book itself is hosted elsewhere, since a project already in a GitHub repository can serve its landing page from Pages.

To help anyone who arrives confused, the change cross-links both directions:
- the Landing Page section `<xref>`s the index-page docs, web hosting, print-on-demand, and the `pretext deploy` subsection;
- the `index.html` Page subsection gains a short paragraph clarifying that it is *not* a project landing page, pointing readers to the new section;
- index entries connect *landing page*, *project website*, and *versus index page*.

Supporting edits: an `xml:id` is added to the `pretext deploy` subsection so it can be a cross-reference target, and the disambiguating paragraph/index entry are added to the index-page subsection.

Validates against the development schema with no new errors.

*Claude Opus 4.8 (1M context), acting as a coding assistant for Rob Beezer*
