### PR TITLE
XSL: programming language lookup table cleanup

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -34,9 +34,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:str="http://exslt.org/strings"
     xmlns:dyn="http://exslt.org/dynamic"
     extension-element-prefixes="pi exsl date str dyn"
-    xmlns:mb="https://pretextbook.org/"
     xmlns:pf="https://prefigure.org"
-    exclude-result-prefixes="mb"
 >
 
 <!-- PreTeXt common templates                             -->
@@ -7331,12 +7329,9 @@ Book (with parts), "section" at level 3
 
 
 <!-- Programming Language Names -->
-<!-- Packages for listing and syntax highlighting             -->
-<!-- have their own ideas about the names of languages        -->
-<!-- We use keys to perform the translation                   -->
-<!-- See: https://gist.github.com/frabad/4189876              -->
-<!-- for motivation and document() syntax for standalone file -->
-<!-- Also: see contributors in FCLA work                      -->
+<!-- Packages for listing and syntax highlighting      -->
+<!-- have their own ideas about the names of languages -->
+<!-- We use keys to perform the translation            -->
 
 <!-- The data: attribute is our usage, elements belong to     -->
 <!-- other packages. Blank means not explicitly supported.    -->
@@ -7360,7 +7355,7 @@ Book (with parts), "section" at level 3
 <!-- are available.                                   -->
 
 <!-- Our strings (@ptx) are always all-lowercase, no symbols, no punctuation -->
-<mb:programming>
+<xsl:variable name="programming-language-rtf">
     <!-- Procedural -->
     <language ptx="basic"       active=""            listings="Basic"            prism="basic"/>
     <language ptx="c"           active="c"           listings="C"                prism="c"/>
@@ -7402,20 +7397,19 @@ Book (with parts), "section" at level 3
     <language ptx="tex"         active=""            listings="[plain]TeX"       prism="tex"/>
     <language ptx="xml"         active=""            listings="XML"              prism="xml"/>
     <language ptx="xslt"        active=""            listings="XSLT"             prism="xml"/>
-</mb:programming>
+</xsl:variable>
+
+<xsl:variable name="programming-language-table"
+    select="exsl:node-set($programming-language-rtf)"/>
 
 <!-- Define the key for indexing into the data list -->
 <xsl:key name="proglang" match="language" use="@ptx" />
-<!-- And make a variable with the context for key lookups useing that key -->
-<!-- doing the 'document('')/*/mb:programming' repeatedly is expensive.   -->
-<!-- (Especially in program|pf[prism-language]                            -->
-<xsl:variable name="proglang-key-context" select="exsl:node-set(document('')/*/mb:programming)"/>
 
 <!-- Define variables for default active language - will be picked up by -->
 <!-- RS manifest and can be a different string than the raw language. -->
 <xsl:variable name="default-active-programming-language">
     <xsl:if test="$version-docinfo/programs/@language">
-        <xsl:for-each select="$proglang-key-context">
+        <xsl:for-each select="$programming-language-table">
             <xsl:value-of select="key('proglang', $version-docinfo/programs/@language)/@active" />
         </xsl:for-each>
     </xsl:if>
@@ -7452,7 +7446,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="$proglang-key-context">
+    <xsl:for-each select="$programming-language-table">
         <xsl:value-of select="key('proglang', $language)/@active" />
     </xsl:for-each>
 </xsl:template>
@@ -7463,21 +7457,10 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="$proglang-key-context">
+    <xsl:for-each select="$programming-language-table">
         <xsl:value-of select="key('proglang', $language)/@listings" />
     </xsl:for-each>
 </xsl:template>
-
-<!-- This works, without keys, and could be adapted to range over actual data in text -->
-<!-- For example, this approach is used for contributors to FCLA                      -->
-<!--
-<xsl:template match="*" mode="listings-language">
-    <xsl:variable name="language">
-        <xsl:value-of select="@language"/>
-    </xsl:variable>
-    <xsl:value-of select="document('')/*/mb:programming/language[@ptx=$language]/listings"/>
-</xsl:template>
--->
 
 <!-- A whole <program> node comes in,  -->
 <!-- text of prism name comes out -->
@@ -7485,7 +7468,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="language">
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
-    <xsl:for-each select="$proglang-key-context">
+    <xsl:for-each select="$programming-language-table">
         <xsl:value-of select="key('proglang', $language)/@prism" />
     </xsl:for-each>
 </xsl:template>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -7354,63 +7354,63 @@ Book (with parts), "section" at level 3
 <!-- additional popular packages (e.g. numpy, pandas) -->
 <!-- are available.                                   -->
 
-<!-- Our strings (@ptx) are always all-lowercase, no symbols, no punctuation -->
+<!-- Our strings (@name) are always all-lowercase, no symbols, no punctuation -->
 <xsl:variable name="programming-language-rtf">
     <!-- Procedural -->
-    <language ptx="basic"       active=""            listings="Basic"            prism="basic"/>
-    <language ptx="c"           active="c"           listings="C"                prism="c"/>
-    <language ptx="cpp"         active="cpp"         listings="C++"              prism="cpp"/>
-    <language ptx="go"          active=""            listings="C"                prism="go"/>
-    <language ptx="java"        active="java"        listings="Java"             prism="java"/>
-    <language ptx="javascript"  active="javascript"  listings=""                 prism="javascript"/>
-    <language ptx="kotlin"      active="kotlin"      listings=""                 prism="kotlin"/>
-    <language ptx="lua"         active=""            listings="Lua"              prism="lua"/>
-    <language ptx="pascal"      active=""            listings="Pascal"           prism="pascal"/>
-    <language ptx="perl"        active=""            listings="Perl"             prism="perl"/>
-    <language ptx="python"      active="python"      listings="Python"           prism="py"/>
-    <language ptx="python3"     active="python3"     listings="Python"           prism="py"/>
-    <language ptx="r"           active=""            listings="R"                prism="r"/>
-    <language ptx="s"           active=""            listings="S"                prism="s"/>
-    <language ptx="sas"         active=""            listings="SAS"              prism="s"/>
-    <language ptx="sage"        active=""            listings="Python"           prism="py"/>
-    <language ptx="splus"       active=""            listings="[Plus]S"          prism="s"/>
-    <language ptx="vbasic"      active=""            listings="[Visual]Basic"    prism="visual-basic"/>
-    <language ptx="vbscript"    active=""            listings="VBscript"         prism="visual-basic"/>
+    <language name="basic"      active=""            listings="Basic"            prism="basic"/>
+    <language name="c"          active="c"           listings="C"                prism="c"/>
+    <language name="cpp"        active="cpp"         listings="C++"              prism="cpp"/>
+    <language name="go"         active=""            listings="C"                prism="go"/>
+    <language name="java"       active="java"        listings="Java"             prism="java"/>
+    <language name="javascript" active="javascript"  listings=""                 prism="javascript"/>
+    <language name="kotlin"     active="kotlin"      listings=""                 prism="kotlin"/>
+    <language name="lua"        active=""            listings="Lua"              prism="lua"/>
+    <language name="pascal"     active=""            listings="Pascal"           prism="pascal"/>
+    <language name="perl"       active=""            listings="Perl"             prism="perl"/>
+    <language name="python"     active="python"      listings="Python"           prism="py"/>
+    <language name="python3"    active="python3"     listings="Python"           prism="py"/>
+    <language name="r"          active=""            listings="R"                prism="r"/>
+    <language name="s"          active=""            listings="S"                prism="s"/>
+    <language name="sas"        active=""            listings="SAS"              prism="s"/>
+    <language name="sage"       active=""            listings="Python"           prism="py"/>
+    <language name="splus"      active=""            listings="[Plus]S"          prism="s"/>
+    <language name="vbasic"     active=""            listings="[Visual]Basic"    prism="visual-basic"/>
+    <language name="vbscript"   active=""            listings="VBscript"         prism="visual-basic"/>
     <!-- Others (esp. functional)  -->
-    <language ptx="clojure"     active=""            listings="Lisp"             prism="clojure"/>
-    <language ptx="lisp"        active=""            listings="Lisp"             prism="lisp"/>
-    <language ptx="clisp"       active=""            listings="Lisp"             prism="lisp"/>
-    <language ptx="elisp"       active=""            listings="Lisp"             prism="elisp"/>
-    <language ptx="scheme"      active=""            listings="Lisp"             prism="scheme"/>
-    <language ptx="racket"      active=""            listings="Lisp"             prism="racket"/>
-    <language ptx="sql"         active="sql"         listings="SQL"              prism="sql"/>
-    <language ptx="llvm"        active=""            listings="LLVM"             prism="llvm"/>
-    <language ptx="matlab"      active=""            listings="Matlab"           prism="matlab"/>
-    <language ptx="octave"      active="octave"      listings="Octave"           prism="matlab"/>
-    <language ptx="ml"          active=""            listings="ML"               prism=""/>
-    <language ptx="ocaml"       active=""            listings="[Objective]Caml"  prism="ocaml"/>
-    <language ptx="fsharp"      active=""            listings="ML"               prism="fsharp"/>
+    <language name="clojure"    active=""            listings="Lisp"             prism="clojure"/>
+    <language name="lisp"       active=""            listings="Lisp"             prism="lisp"/>
+    <language name="clisp"      active=""            listings="Lisp"             prism="lisp"/>
+    <language name="elisp"      active=""            listings="Lisp"             prism="elisp"/>
+    <language name="scheme"     active=""            listings="Lisp"             prism="scheme"/>
+    <language name="racket"     active=""            listings="Lisp"             prism="racket"/>
+    <language name="sql"        active="sql"         listings="SQL"              prism="sql"/>
+    <language name="llvm"       active=""            listings="LLVM"             prism="llvm"/>
+    <language name="matlab"     active=""            listings="Matlab"           prism="matlab"/>
+    <language name="octave"     active="octave"      listings="Octave"           prism="matlab"/>
+    <language name="ml"         active=""            listings="ML"               prism=""/>
+    <language name="ocaml"      active=""            listings="[Objective]Caml"  prism="ocaml"/>
+    <language name="fsharp"     active=""            listings="ML"               prism="fsharp"/>
     <!-- Text Manipulation -->
-    <language ptx="css"         active=""            listings=""                 prism="css"/>
-    <language ptx="latex"       active=""            listings="[LaTeX]TeX"       prism="latex"/>
-    <language ptx="html"        active="html"        listings="HTML"             prism="html"/>
-    <language ptx="tex"         active=""            listings="[plain]TeX"       prism="tex"/>
-    <language ptx="xml"         active=""            listings="XML"              prism="xml"/>
-    <language ptx="xslt"        active=""            listings="XSLT"             prism="xml"/>
+    <language name="css"        active=""            listings=""                 prism="css"/>
+    <language name="latex"      active=""            listings="[LaTeX]TeX"       prism="latex"/>
+    <language name="html"       active="html"        listings="HTML"             prism="html"/>
+    <language name="tex"        active=""            listings="[plain]TeX"       prism="tex"/>
+    <language name="xml"        active=""            listings="XML"              prism="xml"/>
+    <language name="xslt"       active=""            listings="XSLT"             prism="xml"/>
 </xsl:variable>
 
 <xsl:variable name="programming-language-table"
     select="exsl:node-set($programming-language-rtf)"/>
 
 <!-- Define the key for indexing into the data list -->
-<xsl:key name="proglang" match="language" use="@ptx" />
+<xsl:key name="programming-language-key" match="language" use="@name"/>
 
 <!-- Define variables for default active language - will be picked up by -->
 <!-- RS manifest and can be a different string than the raw language. -->
 <xsl:variable name="default-active-programming-language">
     <xsl:if test="$version-docinfo/programs/@language">
         <xsl:for-each select="$programming-language-table">
-            <xsl:value-of select="key('proglang', $version-docinfo/programs/@language)/@active" />
+            <xsl:value-of select="key('programming-language-key', $version-docinfo/programs/@language)/@active" />
         </xsl:for-each>
     </xsl:if>
 </xsl:variable>
@@ -7447,7 +7447,7 @@ Book (with parts), "section" at level 3
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
     <xsl:for-each select="$programming-language-table">
-        <xsl:value-of select="key('proglang', $language)/@active" />
+        <xsl:value-of select="key('programming-language-key', $language)/@active" />
     </xsl:for-each>
 </xsl:template>
 
@@ -7458,7 +7458,7 @@ Book (with parts), "section" at level 3
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
     <xsl:for-each select="$programming-language-table">
-        <xsl:value-of select="key('proglang', $language)/@listings" />
+        <xsl:value-of select="key('programming-language-key', $language)/@listings" />
     </xsl:for-each>
 </xsl:template>
 
@@ -7469,7 +7469,7 @@ Book (with parts), "section" at level 3
         <xsl:apply-templates select="." mode="get-programming-language"/>
     </xsl:variable>
     <xsl:for-each select="$programming-language-table">
-        <xsl:value-of select="key('proglang', $language)/@prism" />
+        <xsl:value-of select="key('programming-language-key', $language)/@prism" />
     </xsl:for-each>
 </xsl:template>
 


### PR DESCRIPTION
Two commits modernizing the programming-language name table in `pretext-common.xsl`.

**1. Access the table as a variable, not via `document('')`** (327b97f3). The table of language names (our name, plus the names used by ActiveCode, listings, and Prism) lived in a `<mb:programming>` element in a private namespace, read back by re-parsing the stylesheet file itself with `document('')`. The file's other embedded lookup tables (`quote-character-rtf`, `kbdkey-rtf`, `icon-rtf`) hold their data in a variable and read it through `exsl:node-set()`; this commit converts the language table to that same idiom. The `mb` namespace declaration and its `exclude-result-prefixes` entry become unnecessary and are removed, as is a commented-out template demonstrating the old keyless `document('')` access. The data rows are unchanged.

**2. Align the table's vocabulary with its siblings** (e03980ce). The other name-keyed lookup tables key on a `@name` attribute; this one used `@ptx`, and its key was the abbreviated `proglang`. Now: `@name`, and `programming-language-key`. Both names are internal to `pretext-common.xsl` — `@ptx` appears nowhere else in the repository. An extension stylesheet calling `key('proglang', ...)` in its own templates would need the new key name; the lookup modes (`active-language`, `listings-language`, `prism-language`) are unchanged, so ordinary derivative stylesheets are unaffected.

Verification: before/after builds of the sample article and the sample book (`-c doc`, HTML and LaTeX each) at `master` and at the branch tip are byte-identical apart from build-timestamp lines and the search index. The converted lookups demonstrably execute: Prism language classes appear in the HTML output and listings language names in the LaTeX output.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*