### PR TITLE
XSL: one table of character representations for all conversions

### DIFF
--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -2057,12 +2057,6 @@
 <!-- * \    Always escape backslash.                                 -->
 <!-- #################################################### -->
 
-<!-- Ellipsis -->
-<!-- Just three periods -->
-<xsl:template name="ellipsis-character">
-    <xsl:text>...</xsl:text>
-</xsl:template>
-
 <!-- ############### -->
 <!-- Text Processing -->
 <!-- ############### -->
@@ -2194,33 +2188,23 @@
     <xsl:text>```&#xa;&#xa;</xsl:text>
 </xsl:template>
 
-<!-- The next three are WW macros that PGML will format  -->
-<!-- properly for WW HTML or LaTeX output, and so we use -->
-<!-- them as the desired characters                      -->
-
-<!-- Nonbreaking space -->
-<xsl:template name="nbsp-character">
-    <xsl:text>[$NBSP]*</xsl:text>
-</xsl:template>
-
-<!-- En dash           -->
-<xsl:template name="ndash-character">
-    <xsl:text>[$NDASH]*</xsl:text>
-</xsl:template>
-
-<!-- Em dash           -->
-<xsl:template name="mdash-character">
-    <xsl:text>[$MDASH]*</xsl:text>
-</xsl:template>
-
-<!-- The abstract template for "mdash" consults a publisher option -->
-<!-- for thin space, or no space, surrounding an em-dash.  So the  -->
-<!-- "thin-space-character" is needed for that purpose, and does   -->
-<!-- not have an associated empty PTX element.                     -->
-<!-- Cannot find such a thing documented for PGML, so just normal  -->
-
-<xsl:template name="thin-space-character">
-    <xsl:text> </xsl:text>
+<!-- Each character reads the "webwork" column of the representation -->
+<!-- table in  pretext-common.xsl.  The space and dash entries are    -->
+<!-- WW macros that PGML will format properly for WW HTML or LaTeX    -->
+<!-- output; the thin space has no documented PGML form, so it is a   -->
+<!-- normal space.  A character without a column entry warns, so the  -->
+<!-- gaps stay visible.                                               -->
+<xsl:template match="char" mode="character">
+    <xsl:choose>
+        <xsl:when test="@webwork">
+            <xsl:value-of select="@webwork"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1754,20 +1754,28 @@
 
 <xsl:template match="dblbrackets">
     <xsl:param name="b-human-readable" />
-    <xsl:call-template name="ldblbracket-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ldblbracket'"/>
+    </xsl:call-template>
     <xsl:apply-templates>
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
-    <xsl:call-template name="rdblbracket-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rdblbracket'"/>
+    </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="angles">
     <xsl:param name="b-human-readable" />
-    <xsl:call-template name="langle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'langle'"/>
+    </xsl:call-template>
     <xsl:apply-templates>
         <xsl:with-param name="b-human-readable" select="$b-human-readable" />
     </xsl:apply-templates>
-    <xsl:call-template name="rangle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rangle'"/>
+    </xsl:call-template>
 </xsl:template>
 
 

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1513,6 +1513,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--     just before it ends up in BRF                              -->
 <!--   ndash (U+2013): 6-36                                         -->
 <!--   mdash (U+2014): 6-36                                         -->
+<!--   thin-space (U+2009): 0, a braille space                     -->
 <!--   copyright (U+00A9): 45-14                                    -->
 <!--   registered (U+00AE): 45-1235                                 -->
 <!--   trademark (U+2122): 45-2345                                  -->

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1549,6 +1549,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- the CJK angle brackets: the liblouis table defines cells -->
+<!-- (above) only for these, not for the mathematical pair    -->
+<!-- carried by the representation table                      -->
+<xsl:template match="char[@name = 'langle']" mode="character">
+    <xsl:text>&#x3008;</xsl:text>
+</xsl:template>
+<xsl:template match="char[@name = 'rangle']" mode="character">
+    <xsl:text>&#x3009;</xsl:text>
+</xsl:template>
+
 <!-- Unicode Character 'LEFT SINGLE QUOTATION MARK' (U+2018) -->
 <!-- Liblouis: 6-236                                         -->
 <xsl:template match="*" mode="lsq-character">

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1499,62 +1499,53 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- as quotation mark styles, since we are limited ourselves to   -->
 <!-- English language documents by larger decisions elsewhere.     -->
 
-<!-- Unicode Character 'NO-BREAK SPACE' (U+00A0)   -->
-<!-- yields a template for "nbsp" in -common       -->
-<!-- liblouis seems to pass this through in-kind   -->
-<!-- Used in the manufacture of a cross-reference, -->
-<!-- we will want to strip just before it ends up  -->
-<!-- in BRF .                                      -->
-<xsl:template name="nbsp-character">
-    <xsl:text>&#x00A0;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'EN DASH' (U+2013) -->
-<!-- Liblouis: 6-36                       -->
-<xsl:template name="ndash-character">
-    <xsl:text>&#x2013;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'EM DASH' (U+2014) -->
-<!-- Liblouis: 6-36                       -->
-<xsl:template name="mdash-character">
-    <xsl:text>&#x2014;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'COPYRIGHT SIGN' (U+00A9) -->
-<!-- Liblouis: 45-14                             -->
-<xsl:template name="copyright-character">
-    <xsl:text>&#x00A9;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'REGISTERED SIGN' (U+00AE) -->
-<!-- Liblouis: 45-1235                            -->
-<xsl:template name="registered-character">
-    <xsl:text>&#x00AE;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'TRADE MARK SIGN' (U+2122) -->
-<!-- Liblouis: 45-2345                            -->
-<xsl:template name="trademark-character">
-    <xsl:text>&#x2122;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'DEGREE SIGN' (U+00B0) -->
-<!-- Liblouis: 45-245                         -->
-<xsl:template name="degree-character">
-    <xsl:text>&#x00B0;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'PRIME' (U+2032) -->
-<!-- Liblouis: 2356                     -->
-<xsl:template name="prime-character">
-    <xsl:text>&#x2032;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'DOUBLE PRIME' (U+2033) -->
-<!-- Liblouis: 2356-2356                       -->
-<xsl:template name="dblprime-character">
-    <xsl:text>&#x2033;</xsl:text>
+<!-- Each character reads the Unicode column of the representation -->
+<!-- table in  pretext-common.xsl.  A "braille" column entry       -->
+<!-- substitutes where liblouis lacks the true code point; the      -->
+<!-- entry "none" marks a character outside this repertoire,        -->
+<!-- which warns, keeping the gap visible.                          -->
+<!--                                                                -->
+<!-- Cells described in the liblouis table, for each Unicode        -->
+<!-- character rendered here:                                       -->
+<!--                                                                -->
+<!--   nbsp (U+00A0): passed through in-kind; used in the           -->
+<!--     manufacture of a cross-reference, we will want to strip    -->
+<!--     just before it ends up in BRF                              -->
+<!--   ndash (U+2013): 6-36                                         -->
+<!--   mdash (U+2014): 6-36                                         -->
+<!--   copyright (U+00A9): 45-14                                    -->
+<!--   registered (U+00AE): 45-1235                                 -->
+<!--   trademark (U+2122): 45-2345                                  -->
+<!--   degree (U+00B0): 45-245                                      -->
+<!--   prime (U+2032): 2356                                         -->
+<!--   dblprime (U+2033): 2356-2356                                 -->
+<!--   langle (U+3008): 4-126                                       -->
+<!--   rangle (U+3009): 4-345                                       -->
+<!--   ellipsis (U+2026): 256-256-256; [BANA-2016] Appendix G,      -->
+<!--     UEB is three periods/256                                   -->
+<!--   midpoint (U+00B7): 4-16                                      -->
+<!--   swungdash: faked with TILDE (U+007E)                         -->
+<!--   pilcrow (U+00B6): 45-1234                                    -->
+<!--   section-mark (U+00A7): 45-234                                -->
+<!--   minus (U+2212): 5-36                                         -->
+<!--   times (U+00D7): 5-236                                        -->
+<!--   solidus: faked with SOLIDUS (U+002F)                         -->
+<!--   obelus (U+00F7): 5-34                                        -->
+<!--   plusminus (U+00B1): 456-235                                  -->
+<xsl:template match="char" mode="character">
+    <xsl:choose>
+        <xsl:when test="@braille = 'none'">
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="@braille">
+            <xsl:value-of select="@braille"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@unicode"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Unicode Character 'LEFT SINGLE QUOTATION MARK' (U+2018) -->
@@ -1581,80 +1572,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>&#x201D;</xsl:text>
 </xsl:template>
 
-<!-- Unicode Character 'LEFT ANGLE BRACKET' (U+3008) -->
-<!-- Liblouis: 4-126                                 -->
-<xsl:template name="langle-character">
-    <xsl:text>&#x3008;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'RIGHT ANGLE BRACKET' (U+3009) -->
-<!-- Liblouis: 4-345                                  -->
-<xsl:template name="rangle-character">
-    <xsl:text>&#x3009;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026) -->
-<!-- Liblouis: 256-256-256                            -->
-<!-- [BANA-2016] Appendix G, UEB is three periods/256 -->
-<xsl:template name="ellipsis-character">
-    <xsl:text>&#x2026;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'MIDDLE DOT' (U+00B7) -->
-<!-- Liblouis: 4-16                          -->
-<xsl:template name="midpoint-character">
-    <xsl:text>&#x00B7;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'SWUNG DASH' (U+2053) -->
-<!-- instead faking it with                  -->
-<!-- Unicode Character 'TILDE' (U+007E)      -->
-<xsl:template name="swungdash-character">
-    <xsl:text>&#x007E;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'PILCROW SIGN' (U+00B6) -->
-<!-- Liblouis: 45-1234                         -->
-<xsl:template name="pilcrow-character">
-    <xsl:text>&#x00B6;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'SECTION SIGN' (U+00A7) -->
-<!-- Liblouis: 45-234                          -->
-<xsl:template name="section-mark-character">
-    <xsl:text>&#x00A7;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'MINUS SIGN' (U+2212) -->
-<!-- Liblouis: 5-36                          -->
-<xsl:template name="minus-character">
-    <xsl:text>&#x2212;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'MULTIPLICATION SIGN' (U+00D7) -->
-<!-- Liblouis: 5-236                                  -->
-<xsl:template name="times-character">
-    <xsl:text>&#x00D7;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'FRACTION SLASH' (U+2044) -->
-<!-- instead faking it with                      -->
-<!-- Unicode Character 'SOLIDUS' (U+002F)        -->
-<xsl:template name="solidus-character">
-    <xsl:text>&#x002F;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'DIVISION SIGN' (U+00F7) -->
-<!-- Liblouis: 5-34                             -->
-<xsl:template name="obelus-character">
-    <xsl:text>&#x00F7;</xsl:text>
-</xsl:template>
-
-<!-- Unicode Character 'PLUS-MINUS SIGN' (U+00B1) -->
-<!-- Liblouis: 456-235                            -->
-<xsl:template name="plusminus-character">
-    <xsl:text>&#x00B1;</xsl:text>
-</xsl:template>
 
 <!-- Icons -->
 <!-- Just the four arrows, unsure about the rest -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9639,6 +9639,8 @@ Book (with parts), "section" at level 3
 <!--              empty group ({}) unless  latex-ending="no"        -->
 <!--   "ascii"    7-bit stand-in for text's ascii election;         -->
 <!--              absent = unimplemented, warns                     -->
+<!--   "webwork"  PGML form for WeBWorK problem extraction;         -->
+<!--              absent = unimplemented, warns                     -->
 <!--   "braille"  absent = liblouis uses the "unicode" value;       -->
 <!--              a value = a substitute character, since liblouis  -->
 <!--              cannot use the true one; "none" = no rendering    -->
@@ -9647,13 +9649,13 @@ Book (with parts), "section" at level 3
 <xsl:variable name="character-rtf">
     <!-- U+00A0: NO-BREAK SPACE -->
     <!-- (the "&nbsp;" entity is undefined in XSL; always the numeric reference) -->
-    <char name="nbsp"          unicode="&#x00a0;"   latex="~" latex-ending="no"               ascii=" "/>
+    <char name="nbsp"          unicode="&#x00a0;"   latex="~" latex-ending="no"               ascii=" "          webwork="[$NBSP]*"/>
     <!-- U+2013: EN DASH -->
-    <char name="ndash"         unicode="&#x2013;"   latex="\textendash"                       ascii="-"/>
+    <char name="ndash"         unicode="&#x2013;"   latex="\textendash"                       ascii="-"          webwork="[$NDASH]*"/>
     <!-- U+2014: EM DASH -->
-    <char name="mdash"         unicode="&#x2014;"   latex="\textemdash"                       ascii="--"/>
+    <char name="mdash"         unicode="&#x2014;"   latex="\textemdash"                       ascii="--"         webwork="[$MDASH]*"/>
     <!-- U+2009: THIN SPACE -->
-    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "          braille="none"/>
+    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "          webwork=" " braille="none"/>
     <!-- U+27E6: MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
     <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"                    braille="none"/>
     <!-- U+27E7: MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
@@ -9663,7 +9665,7 @@ Book (with parts), "section" at level 3
     <!-- U+3009: RIGHT ANGLE BRACKET -->
     <char name="rangle"        unicode="&#x3009;"   latex="\textrangle"                       ascii="&gt;"/>
     <!-- U+2026: HORIZONTAL ELLIPSIS -->
-    <char name="ellipsis"      unicode="&#x2026;"   latex="\textellipsis"                     ascii="..."/>
+    <char name="ellipsis"      unicode="&#x2026;"   latex="\textellipsis"                     ascii="..."        webwork="..."/>
     <!-- U+00B7: MIDDLE DOT -->
     <!-- (sometimes like a decorative dash; tex.stackexchange.com/questions/19180) -->
     <char name="midpoint"      unicode="&#x00b7;"   latex="\textperiodcentered"               ascii="*"/>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9642,6 +9642,7 @@ Book (with parts), "section" at level 3
 
 <xsl:variable name="character-rtf">
     <!-- U+00A0: NO-BREAK SPACE -->
+    <!-- (the "&nbsp;" entity is undefined in XSL; always the numeric reference) -->
     <char name="nbsp"          unicode="&#x00a0;"   latex="~" latex-ending="no"               ascii=" "/>
     <!-- U+2013: EN DASH -->
     <char name="ndash"         unicode="&#x2013;"   latex="\textendash"                       ascii="-"/>
@@ -9684,8 +9685,13 @@ Book (with parts), "section" at level 3
     <!-- U+2117: SOUND RECORDING COPYRIGHT -->
     <char name="phonomark"     unicode="&#x2117;"   latex="\textcircledP"/>
     <!-- U+1F12F: COPYLEFT SYMBOL -->
+    <!-- (may not be universally available in fonts; Open C (U+0254) -->
+    <!-- plus Combining Circle (U+20DD) can imitate)                 -->
     <char name="copyleft"      unicode="&#x1f12f;"  latex="\textcopyleft"/>
     <!-- U+00AE: REGISTERED SIGN -->
+    <!-- (Bringhurst: should be superscript; not so in a font is a   -->
+    <!-- font mistake, but a "sup" wrapper renders way too small in  -->
+    <!-- a correct font)                                             -->
     <char name="registered"    unicode="&#x00ae;"   latex="\textregistered"                   ascii="(R)"/>
     <!-- U+2122: TRADE MARK SIGN -->
     <char name="trademark"     unicode="&#x2122;"   latex="\texttrademark"                    ascii="(TM)"/>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9555,8 +9555,8 @@ Book (with parts), "section" at level 3
 <!-- http://www.cs.tut.fi/~jkorpela/dashes.html -->
 
 <xsl:template name="nbsp-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'nbsp'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'nbsp'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="nbsp">
@@ -9564,8 +9564,8 @@ Book (with parts), "section" at level 3
 </xsl:template>
 
 <xsl:template name="ndash-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'ndash'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ndash'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="ndash">
@@ -9579,14 +9579,14 @@ Book (with parts), "section" at level 3
 <!-- as abstract templates and do everything else here.          -->
 
 <xsl:template name="mdash-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'mdash'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'mdash'"/>
     </xsl:call-template>
 </xsl:template>
 
 <xsl:template name="thin-space-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'thin-space'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'thin-space'"/>
     </xsl:call-template>
 </xsl:template>
 
@@ -9627,6 +9627,109 @@ Book (with parts), "section" at level 3
      <xsl:text>[[[</xsl:text>
      <xsl:value-of select="$char-name"/>
      <xsl:text>]]]</xsl:text>
+</xsl:template>
+
+<!-- The table of character representations: one row per character, -->
+<!-- one column per representation, each read by a conversion's     -->
+<!-- modal "character" template; a character whose rendering needs  -->
+<!-- more than a column value (fonts, wrapper markup) gets a        -->
+<!-- per-character template overriding that mode.  Column notes:    -->
+<!--   "unicode"  the bare code point                               -->
+<!--   "latex"    macro or construction; the reader appends an      -->
+<!--              empty group ({}) unless  latex-ending="no"        -->
+<!--   "ascii"    7-bit stand-in for text's ascii election;         -->
+<!--              absent = unimplemented, warns                     -->
+
+<xsl:variable name="character-rtf">
+    <!-- U+00A0: NO-BREAK SPACE -->
+    <char name="nbsp"          unicode="&#x00a0;"   latex="~" latex-ending="no"               ascii=" "/>
+    <!-- U+2013: EN DASH -->
+    <char name="ndash"         unicode="&#x2013;"   latex="\textendash"                       ascii="-"/>
+    <!-- U+2014: EM DASH -->
+    <char name="mdash"         unicode="&#x2014;"   latex="\textemdash"                       ascii="--"/>
+    <!-- U+2009: THIN SPACE -->
+    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "/>
+    <!-- U+27E6: MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
+    <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"/>
+    <!-- U+27E7: MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
+    <char name="rdblbracket"   unicode="&#x27e7;"   latex="\textrbrackdbl"/>
+    <!-- U+3008: LEFT ANGLE BRACKET -->
+    <char name="langle"        unicode="&#x3008;"   latex="\textlangle"                       ascii="&lt;"/>
+    <!-- U+3009: RIGHT ANGLE BRACKET -->
+    <char name="rangle"        unicode="&#x3009;"   latex="\textrangle"                       ascii="&gt;"/>
+    <!-- U+2026: HORIZONTAL ELLIPSIS -->
+    <char name="ellipsis"      unicode="&#x2026;"   latex="\textellipsis"                     ascii="..."/>
+    <!-- U+00B7: MIDDLE DOT -->
+    <char name="midpoint"      unicode="&#x00b7;"   latex="\textperiodcentered"               ascii="*"/>
+    <!-- U+2053: SWUNG DASH -->
+    <char name="swungdash"     unicode="&#x2053;"   latex="\ptxswungdash"                     ascii="~"/>
+    <!-- U+2030: PER MILLE SIGN -->
+    <char name="permille"      unicode="&#x2030;"   latex="\textperthousand"                  ascii="o/oo"/>
+    <!-- U+00B6: PILCROW SIGN -->
+    <char name="pilcrow"       unicode="&#x00b6;"   latex="\textpilcrow"                      ascii="[pilcrow]"/>
+    <!-- U+00A7: SECTION SIGN -->
+    <char name="section-mark"  unicode="&#x00a7;"   latex="\textsection"                      ascii="[section]"/>
+    <!-- U+2212: MINUS SIGN -->
+    <char name="minus"         unicode="&#x2212;"   latex="\textminus"                        ascii="-"/>
+    <!-- U+00D7: MULTIPLICATION SIGN -->
+    <char name="times"         unicode="&#x00d7;"   latex="\texttimes"                        ascii="x"/>
+    <!-- U+2044: FRACTION SLASH -->
+    <char name="solidus"       unicode="&#x2044;"   latex="\textfractionsolidus"              ascii="/"/>
+    <!-- U+00F7: DIVISION SIGN -->
+    <char name="obelus"        unicode="&#x00f7;"   latex="\textdiv"                          ascii="/"/>
+    <!-- U+00B1: PLUS-MINUS SIGN -->
+    <char name="plusminus"     unicode="&#x00b1;"   latex="\textpm"                           ascii="+/-"/>
+    <!-- U+00A9: COPYRIGHT SIGN -->
+    <char name="copyright"     unicode="&#x00a9;"   latex="\textcopyright"                    ascii="(c)"/>
+    <!-- U+2117: SOUND RECORDING COPYRIGHT -->
+    <char name="phonomark"     unicode="&#x2117;"   latex="\textcircledP"/>
+    <!-- U+1F12F: COPYLEFT SYMBOL -->
+    <char name="copyleft"      unicode="&#x1f12f;"  latex="\textcopyleft"/>
+    <!-- U+00AE: REGISTERED SIGN -->
+    <char name="registered"    unicode="&#x00ae;"   latex="\textregistered"                   ascii="(R)"/>
+    <!-- U+2122: TRADE MARK SIGN -->
+    <char name="trademark"     unicode="&#x2122;"   latex="\texttrademark"                    ascii="(TM)"/>
+    <!-- U+2120: SERVICE MARK -->
+    <char name="servicemark"   unicode="&#x2120;"   latex="\textservicemark"/>
+    <!-- U+00B0: DEGREE SIGN -->
+    <char name="degree"        unicode="&#x00b0;"   latex="\textdegree"                       ascii="deg"/>
+    <!-- U+2032: PRIME -->
+    <char name="prime"         unicode="&#x2032;"   latex="\textquotesingle"                  ascii="'"/>
+    <!-- U+2033: DOUBLE PRIME -->
+    <char name="dblprime"      unicode="&#x2033;"   latex="\textquotesingle\textquotesingle"  ascii="''"/>
+</xsl:variable>
+
+<xsl:variable name="character-table"
+    select="exsl:node-set($character-rtf)"/>
+
+<xsl:key name="character-key" match="char" use="@name"/>
+
+<!-- Look up a character by name, then render it with the modal  -->
+<!-- "character" implementation in effect.  An unknown name is a -->
+<!-- defect in a calling template, not an authoring error.       -->
+<xsl:template name="character">
+    <xsl:param name="name"/>
+    <!-- a key resolves within the document holding the context -->
+    <!-- node, so step inside the table, a node-set of one node -->
+    <xsl:for-each select="$character-table">
+        <xsl:variable name="the-row" select="key('character-key', $name)"/>
+        <xsl:choose>
+            <xsl:when test="$the-row">
+                <xsl:apply-templates select="$the-row" mode="character"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message>PTX:BUG:   the character named "<xsl:value-of select="$name"/>" is not in the character table</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:for-each>
+</xsl:template>
+
+<!-- A conversion without a modal "character" implementation gets -->
+<!-- a warning for every character in the table                   -->
+<xsl:template match="char" mode="character">
+    <xsl:call-template name="warn-unimplemented-character">
+        <xsl:with-param name="char-name" select="@name"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- A given document may use for different characters for quotations:         -->
@@ -9682,8 +9785,8 @@ Book (with parts), "section" at level 3
 
 <!-- Left Double Bracket -->
 <xsl:template name="ldblbracket-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'ldblbracket'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ldblbracket'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="ldblbracket">
@@ -9692,8 +9795,8 @@ Book (with parts), "section" at level 3
 
 <!-- Right Double Bracket -->
 <xsl:template name="rdblbracket-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'rdblbracket'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rdblbracket'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="rdblbracket">
@@ -9702,8 +9805,8 @@ Book (with parts), "section" at level 3
 
 <!-- Left Angle Bracket -->
 <xsl:template name="langle-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'langle'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'langle'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="langle">
@@ -9712,8 +9815,8 @@ Book (with parts), "section" at level 3
 
 <!-- Right Angle Bracket -->
 <xsl:template name="rangle-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'rangle'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rangle'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="rangle">
@@ -9722,8 +9825,8 @@ Book (with parts), "section" at level 3
 
 <!-- Ellipsis (dots), for text, not math -->
 <xsl:template name="ellipsis-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'ellipsis'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ellipsis'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="ellipsis">
@@ -9733,8 +9836,8 @@ Book (with parts), "section" at level 3
 <!-- Midpoint -->
 <!-- A centered dot used sometimes like a decorative dash -->
 <xsl:template name="midpoint-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'midpoint'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'midpoint'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="midpoint">
@@ -9744,8 +9847,8 @@ Book (with parts), "section" at level 3
 <!-- Swung Dash -->
 <!-- A decorative dash, like a tilde, but bigger, and centered -->
 <xsl:template name="swungdash-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'swungdash'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'swungdash'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="swungdash">
@@ -9755,8 +9858,8 @@ Book (with parts), "section" at level 3
 <!-- Per Mille -->
 <!-- Or, per thousand, like a percent sign -->
 <xsl:template name="permille-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'permille'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'permille'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="permille">
@@ -9766,8 +9869,8 @@ Book (with parts), "section" at level 3
 <!-- Pilcrow -->
 <!-- Often used to mark the start of a paragraph -->
 <xsl:template name="pilcrow-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'pilcrow'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'pilcrow'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="pilcrow">
@@ -9777,8 +9880,8 @@ Book (with parts), "section" at level 3
 <!-- Section Mark -->
 <!-- The stylized double-S to indicate section numbers -->
 <xsl:template name="section-mark-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'section-mark'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'section-mark'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="section-mark">
@@ -9788,8 +9891,8 @@ Book (with parts), "section" at level 3
 <!-- Minus -->
 <!-- A hyphen/dash for use in text as subtraction or negation-->
 <xsl:template name="minus-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'minus'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'minus'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="minus">
@@ -9799,8 +9902,8 @@ Book (with parts), "section" at level 3
 <!-- Times -->
 <!-- A "multiplication sign" symbol for use in text -->
 <xsl:template name="times-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'times'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'times'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="times">
@@ -9810,8 +9913,8 @@ Book (with parts), "section" at level 3
 <!-- Solidus -->
 <!-- Fraction bar, not as steep as a forward slash -->
 <xsl:template name="solidus-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'solidus'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'solidus'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="solidus">
@@ -9821,8 +9924,8 @@ Book (with parts), "section" at level 3
 <!-- Obelus -->
 <!-- A "division" symbol for use in text -->
 <xsl:template name="obelus-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'obelus'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'obelus'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="obelus">
@@ -9832,8 +9935,8 @@ Book (with parts), "section" at level 3
 <!-- Plus/Minus -->
 <!-- The combined symbol -->
 <xsl:template name="plusminus-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'plusminus'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'plusminus'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="plusminus">
@@ -9843,8 +9946,8 @@ Book (with parts), "section" at level 3
 <!-- Copyright -->
 <!-- Bringhurst: on baseline (i.e. not superscript) -->
 <xsl:template name="copyright-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'copyright'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'copyright'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="copyright">
@@ -9855,8 +9958,8 @@ Book (with parts), "section" at level 3
 <!-- copyright on sound recordings                 -->
 <!-- Bringhurst: counterpart copyright on baseline -->
 <xsl:template name="phonomark-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'phonomark'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'phonomark'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="phonomark">
@@ -9866,8 +9969,8 @@ Book (with parts), "section" at level 3
 <!-- Copyleft -->
 <!-- Bringhurst: counterpart copyright on baseline -->
 <xsl:template name="copyleft-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'copyleft'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'copyleft'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="copyleft">
@@ -9877,8 +9980,8 @@ Book (with parts), "section" at level 3
 <!-- Registered -->
 <!-- Bringhurst: should be superscript -->
 <xsl:template name="registered-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'registered'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'registered'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="registered">
@@ -9888,8 +9991,8 @@ Book (with parts), "section" at level 3
 <!-- Trademark -->
 <!-- Bringhurst: should be superscript -->
 <xsl:template name="trademark-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'trademark'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'trademark'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="trademark">
@@ -9899,8 +10002,8 @@ Book (with parts), "section" at level 3
 <!-- Servicemark -->
 <!-- Bringhurst: counterpart trademark should be superscript -->
 <xsl:template name="servicemark-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'servicemark'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'servicemark'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="servicemark">
@@ -9914,8 +10017,8 @@ Book (with parts), "section" at level 3
 
 <!-- Degree -->
 <xsl:template name="degree-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'degree'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'degree'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="degree">
@@ -9924,8 +10027,8 @@ Book (with parts), "section" at level 3
 
 <!-- Prime -->
 <xsl:template name="prime-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'prime'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'prime'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="prime">
@@ -9934,8 +10037,8 @@ Book (with parts), "section" at level 3
 
 <!-- Double Prime -->
 <xsl:template name="dblprime-character">
-    <xsl:call-template name="warn-unimplemented-character">
-        <xsl:with-param name="char-name" select="'dblprime'"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'dblprime'"/>
     </xsl:call-template>
 </xsl:template>
 <xsl:template match="dblprime">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9647,10 +9647,10 @@ Book (with parts), "section" at level 3
     <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"                    braille="none"/>
     <!-- U+27E7: MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
     <char name="rdblbracket"   unicode="&#x27e7;"   latex="\textrbrackdbl"                    braille="none"/>
-    <!-- U+3008: LEFT ANGLE BRACKET -->
-    <char name="langle"        unicode="&#x3008;"   latex="\textlangle"                       ascii="&lt;"/>
-    <!-- U+3009: RIGHT ANGLE BRACKET -->
-    <char name="rangle"        unicode="&#x3009;"   latex="\textrangle"                       ascii="&gt;"/>
+    <!-- U+27E8: MATHEMATICAL LEFT ANGLE BRACKET -->
+    <char name="langle"        unicode="&#x27e8;"   latex="\textlangle"                       ascii="&lt;"/>
+    <!-- U+27E9: MATHEMATICAL RIGHT ANGLE BRACKET -->
+    <char name="rangle"        unicode="&#x27e9;"   latex="\textrangle"                       ascii="&gt;"/>
     <!-- U+2026: HORIZONTAL ELLIPSIS -->
     <char name="ellipsis"      unicode="&#x2026;"   latex="\textellipsis"                     ascii="..."        webwork="..."/>
     <!-- U+00B7: MIDDLE DOT -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9661,6 +9661,7 @@ Book (with parts), "section" at level 3
     <!-- U+2026: HORIZONTAL ELLIPSIS -->
     <char name="ellipsis"      unicode="&#x2026;"   latex="\textellipsis"                     ascii="..."/>
     <!-- U+00B7: MIDDLE DOT -->
+    <!-- (sometimes like a decorative dash; tex.stackexchange.com/questions/19180) -->
     <char name="midpoint"      unicode="&#x00b7;"   latex="\textperiodcentered"               ascii="*"/>
     <!-- U+2053: SWUNG DASH -->
     <char name="swungdash"     unicode="&#x2053;"   latex="\ptxswungdash"                     ascii="~"/>
@@ -9675,12 +9676,14 @@ Book (with parts), "section" at level 3
     <!-- U+00D7: MULTIPLICATION SIGN -->
     <char name="times"         unicode="&#x00d7;"   latex="\texttimes"                        ascii="x"/>
     <!-- U+2044: FRACTION SLASH -->
+    <!-- (the LaTeX form should not allow a linebreak; not tested) -->
     <char name="solidus"       unicode="&#x2044;"   latex="\textfractionsolidus"              ascii="/"/>
     <!-- U+00F7: DIVISION SIGN -->
     <char name="obelus"        unicode="&#x00f7;"   latex="\textdiv"                          ascii="/"/>
     <!-- U+00B1: PLUS-MINUS SIGN -->
     <char name="plusminus"     unicode="&#x00b1;"   latex="\textpm"                           ascii="+/-"/>
     <!-- U+00A9: COPYRIGHT SIGN -->
+    <!-- (LaTeX form: tex.stackexchange.com/questions/1676) -->
     <char name="copyright"     unicode="&#x00a9;"   latex="\textcopyright"                    ascii="(c)"/>
     <!-- U+2117: SOUND RECORDING COPYRIGHT -->
     <char name="phonomark"     unicode="&#x2117;"   latex="\textcircledP"/>
@@ -9700,6 +9703,9 @@ Book (with parts), "section" at level 3
     <!-- U+00B0: DEGREE SIGN -->
     <char name="degree"        unicode="&#x00b0;"   latex="\textdegree"                       ascii="deg"/>
     <!-- U+2032: PRIME -->
+    <!-- (a LaTeX math construction looks better, but needs protection    -->
+    <!-- during text-processing; Bringhurst: many text fonts lack a prime -->
+    <!-- and/or double-prime glyph)                                       -->
     <char name="prime"         unicode="&#x2032;"   latex="\textquotesingle"                  ascii="'"/>
     <!-- U+2033: DOUBLE PRIME -->
     <char name="dblprime"      unicode="&#x2033;"   latex="\textquotesingle\textquotesingle"  ascii="''"/>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9639,6 +9639,10 @@ Book (with parts), "section" at level 3
 <!--              empty group ({}) unless  latex-ending="no"        -->
 <!--   "ascii"    7-bit stand-in for text's ascii election;         -->
 <!--              absent = unimplemented, warns                     -->
+<!--   "braille"  absent = liblouis uses the "unicode" value;       -->
+<!--              a value = a substitute character, since liblouis  -->
+<!--              cannot use the true one; "none" = no rendering    -->
+<!--              at all, warns                                     -->
 
 <xsl:variable name="character-rtf">
     <!-- U+00A0: NO-BREAK SPACE -->
@@ -9649,11 +9653,11 @@ Book (with parts), "section" at level 3
     <!-- U+2014: EM DASH -->
     <char name="mdash"         unicode="&#x2014;"   latex="\textemdash"                       ascii="--"/>
     <!-- U+2009: THIN SPACE -->
-    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "/>
+    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "          braille="none"/>
     <!-- U+27E6: MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
-    <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"/>
+    <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"                    braille="none"/>
     <!-- U+27E7: MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
-    <char name="rdblbracket"   unicode="&#x27e7;"   latex="\textrbrackdbl"/>
+    <char name="rdblbracket"   unicode="&#x27e7;"   latex="\textrbrackdbl"                    braille="none"/>
     <!-- U+3008: LEFT ANGLE BRACKET -->
     <char name="langle"        unicode="&#x3008;"   latex="\textlangle"                       ascii="&lt;"/>
     <!-- U+3009: RIGHT ANGLE BRACKET -->
@@ -9664,9 +9668,9 @@ Book (with parts), "section" at level 3
     <!-- (sometimes like a decorative dash; tex.stackexchange.com/questions/19180) -->
     <char name="midpoint"      unicode="&#x00b7;"   latex="\textperiodcentered"               ascii="*"/>
     <!-- U+2053: SWUNG DASH -->
-    <char name="swungdash"     unicode="&#x2053;"   latex="\ptxswungdash"                     ascii="~"/>
+    <char name="swungdash"     unicode="&#x2053;"   latex="\ptxswungdash"                     ascii="~"          braille="~"/>
     <!-- U+2030: PER MILLE SIGN -->
-    <char name="permille"      unicode="&#x2030;"   latex="\textperthousand"                  ascii="o/oo"/>
+    <char name="permille"      unicode="&#x2030;"   latex="\textperthousand"                  ascii="o/oo"       braille="none"/>
     <!-- U+00B6: PILCROW SIGN -->
     <char name="pilcrow"       unicode="&#x00b6;"   latex="\textpilcrow"                      ascii="[pilcrow]"/>
     <!-- U+00A7: SECTION SIGN -->
@@ -9677,7 +9681,7 @@ Book (with parts), "section" at level 3
     <char name="times"         unicode="&#x00d7;"   latex="\texttimes"                        ascii="x"/>
     <!-- U+2044: FRACTION SLASH -->
     <!-- (the LaTeX form should not allow a linebreak; not tested) -->
-    <char name="solidus"       unicode="&#x2044;"   latex="\textfractionsolidus"              ascii="/"/>
+    <char name="solidus"       unicode="&#x2044;"   latex="\textfractionsolidus"              ascii="/"          braille="/"/>
     <!-- U+00F7: DIVISION SIGN -->
     <char name="obelus"        unicode="&#x00f7;"   latex="\textdiv"                          ascii="/"/>
     <!-- U+00B1: PLUS-MINUS SIGN -->
@@ -9686,11 +9690,11 @@ Book (with parts), "section" at level 3
     <!-- (LaTeX form: tex.stackexchange.com/questions/1676) -->
     <char name="copyright"     unicode="&#x00a9;"   latex="\textcopyright"                    ascii="(c)"/>
     <!-- U+2117: SOUND RECORDING COPYRIGHT -->
-    <char name="phonomark"     unicode="&#x2117;"   latex="\textcircledP"/>
+    <char name="phonomark"     unicode="&#x2117;"   latex="\textcircledP"                     braille="none"/>
     <!-- U+1F12F: COPYLEFT SYMBOL -->
     <!-- (may not be universally available in fonts; Open C (U+0254) -->
     <!-- plus Combining Circle (U+20DD) can imitate)                 -->
-    <char name="copyleft"      unicode="&#x1f12f;"  latex="\textcopyleft"/>
+    <char name="copyleft"      unicode="&#x1f12f;"  latex="\textcopyleft"                     braille="none"/>
     <!-- U+00AE: REGISTERED SIGN -->
     <!-- (Bringhurst: should be superscript; not so in a font is a   -->
     <!-- font mistake, but a "sup" wrapper renders way too small in  -->
@@ -9699,7 +9703,7 @@ Book (with parts), "section" at level 3
     <!-- U+2122: TRADE MARK SIGN -->
     <char name="trademark"     unicode="&#x2122;"   latex="\texttrademark"                    ascii="(TM)"/>
     <!-- U+2120: SERVICE MARK -->
-    <char name="servicemark"   unicode="&#x2120;"   latex="\textservicemark"/>
+    <char name="servicemark"   unicode="&#x2120;"   latex="\textservicemark"                  braille="none"/>
     <!-- U+00B0: DEGREE SIGN -->
     <char name="degree"        unicode="&#x00b0;"   latex="\textdegree"                       ascii="deg"/>
     <!-- U+2032: PRIME -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1487,9 +1487,15 @@ Book (with parts), "section" at level 3
     <xsl:if test="$rows &gt; 1 or $cols &gt; 1">
         <xsl:text> (</xsl:text>
         <xsl:value-of select="$rows"/>
-        <xsl:call-template name="nbsp-character"/>
-        <xsl:call-template name="times-character"/>
-        <xsl:call-template name="nbsp-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'nbsp'"/>
+        </xsl:call-template>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'times'"/>
+        </xsl:call-template>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'nbsp'"/>
+        </xsl:call-template>
         <xsl:value-of select="$cols"/>
         <xsl:text> </xsl:text>
         <xsl:apply-templates select="." mode="type-name">
@@ -8292,7 +8298,9 @@ Book (with parts), "section" at level 3
                     <xsl:choose>
                         <xsl:when test="$b-is-biblio-target">
                             <xsl:text>,</xsl:text>
-                            <xsl:call-template name="nbsp-character"/>
+                            <xsl:call-template name="character">
+                                <xsl:with-param name="name" select="'nbsp'"/>
+                            </xsl:call-template>
                             <!-- this info should not be in an attribute! -->
                             <xsl:apply-templates select="@detail" />
                         </xsl:when>
@@ -8411,7 +8419,9 @@ Book (with parts), "section" at level 3
                         <xsl:apply-templates/>
                     </xsl:with-param>
                 </xsl:apply-templates>
-                <xsl:call-template name="ndash-character"/>
+                <xsl:call-template name="character">
+                    <xsl:with-param name="name" select="'ndash'"/>
+                </xsl:call-template>
                 <xsl:apply-templates select="." mode="xref-text" >
                     <xsl:with-param name="target" select="$target-two" />
                     <xsl:with-param name="text-style" select="$text-style-two" />
@@ -9122,7 +9132,9 @@ Book (with parts), "section" at level 3
             <xsl:text> </xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:call-template name="nbsp-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'nbsp'"/>
+            </xsl:call-template>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -9268,7 +9280,9 @@ Book (with parts), "section" at level 3
                     <!-- connector, internationalize -->
                     <xsl:text> of </xsl:text>
                     <xsl:apply-templates select="$highest-match" mode="type-name" />
-                    <xsl:call-template name="nbsp-character"/>
+                    <xsl:call-template name="character">
+                        <xsl:with-param name="name" select="'nbsp'"/>
+                    </xsl:call-template>
                     <xsl:apply-templates select="$highest-match" mode="xref-number">
                         <xsl:with-param name="xref" select="." />
                     </xsl:apply-templates>
@@ -9343,7 +9357,9 @@ Book (with parts), "section" at level 3
             <!-- connector, internationalize -->
             <xsl:text> of </xsl:text>
             <xsl:apply-templates select="$targets-list" mode="type-name" />
-            <xsl:call-template name="nbsp-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'nbsp'"/>
+            </xsl:call-template>
             <xsl:apply-templates select="$targets-list" mode="xref-number">
                 <xsl:with-param name="xref" select="." />
             </xsl:apply-templates>
@@ -9554,41 +9570,12 @@ Book (with parts), "section" at level 3
 <!-- Dashes and hyphens - worth reviewing       -->
 <!-- http://www.cs.tut.fi/~jkorpela/dashes.html -->
 
-<xsl:template name="nbsp-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'nbsp'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="nbsp">
-    <xsl:call-template name="nbsp-character"/>
-</xsl:template>
-
-<xsl:template name="ndash-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'ndash'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="ndash">
-    <xsl:call-template name="ndash-character"/>
-</xsl:template>
-
 <!-- An mdash may have thin space around it, otherwise it        -->
 <!-- should have none.  It might be difficult to enforce this    -->
 <!-- (we could!), but we don't.  Instead, we make the thin-space -->
-<!-- version a publisher option.  So we need two base characters -->
-<!-- as abstract templates and do everything else here.          -->
-
-<xsl:template name="mdash-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'mdash'"/>
-    </xsl:call-template>
-</xsl:template>
-
-<xsl:template name="thin-space-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'thin-space'"/>
-    </xsl:call-template>
-</xsl:template>
+<!-- version a publisher option.  So the "thin-space" character  -->
+<!-- joins the representation table for that purpose, and the    -->
+<!-- assembly of the pieces happens here.                        -->
 
 <!-- The variable, surrounding space. This approach is   -->
 <!-- executed once, so not local to template for "mdash" -->
@@ -9598,20 +9585,20 @@ Book (with parts), "section" at level 3
             <xsl:text />
         </xsl:when>
         <xsl:when test="$emdash-space='thin'">
-            <xsl:call-template name="thin-space-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'thin-space'"/>
+            </xsl:call-template>
         </xsl:when>
     </xsl:choose>
 </xsl:variable>
 
 <xsl:template match="mdash">
     <xsl:value-of select="$emdash-space-char"/>
-    <xsl:call-template name="mdash-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'mdash'"/>
+    </xsl:call-template>
     <xsl:value-of select="$emdash-space-char"/>
 </xsl:template>
-
-<!-- ################## -->
-<!-- Special Characters -->
-<!-- ################## -->
 
 
 <!-- These are characters which may look really bad                 -->
@@ -9750,6 +9737,16 @@ Book (with parts), "section" at level 3
     </xsl:call-template>
 </xsl:template>
 
+<!-- The empty source elements share one dispatcher; "mdash" is an  -->
+<!-- exception (publisher-elected surrounding space), and the       -->
+<!-- "thin-space" row has no element of its own (it exists for the  -->
+<!-- "mdash" machinery and internal use)                            -->
+<xsl:template match="nbsp|ndash|ldblbracket|rdblbracket|langle|rangle|ellipsis|midpoint|swungdash|permille|pilcrow|section-mark|minus|times|solidus|obelus|plusminus|copyright|phonomark|copyleft|registered|trademark|servicemark|degree|prime|dblprime">
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="local-name()"/>
+    </xsl:call-template>
+</xsl:template>
+
 <!-- A given document may use for different characters for quotations:         -->
 <!--                                                                           -->
 <!--     left/right (open/close)  by  primary/secondary                        -->
@@ -9801,267 +9798,34 @@ Book (with parts), "section" at level 3
     <xsl:apply-templates select="." mode="rq-character"/>
 </xsl:template>
 
-<!-- Left Double Bracket -->
-<xsl:template name="ldblbracket-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'ldblbracket'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="ldblbracket">
-    <xsl:call-template name="ldblbracket-character"/>
-</xsl:template>
 
-<!-- Right Double Bracket -->
-<xsl:template name="rdblbracket-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'rdblbracket'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="rdblbracket">
-    <xsl:call-template name="rdblbracket-character"/>
-</xsl:template>
 
-<!-- Left Angle Bracket -->
-<xsl:template name="langle-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'langle'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="langle">
-    <xsl:call-template name="langle-character"/>
-</xsl:template>
 
-<!-- Right Angle Bracket -->
-<xsl:template name="rangle-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'rangle'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="rangle">
-    <xsl:call-template name="rangle-character"/>
-</xsl:template>
 
-<!-- Ellipsis (dots), for text, not math -->
-<xsl:template name="ellipsis-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'ellipsis'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="ellipsis">
-    <xsl:call-template name="ellipsis-character"/>
-</xsl:template>
 
-<!-- Midpoint -->
-<!-- A centered dot used sometimes like a decorative dash -->
-<xsl:template name="midpoint-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'midpoint'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="midpoint">
-    <xsl:call-template name="midpoint-character"/>
-</xsl:template>
 
-<!-- Swung Dash -->
-<!-- A decorative dash, like a tilde, but bigger, and centered -->
-<xsl:template name="swungdash-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'swungdash'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="swungdash">
-    <xsl:call-template name="swungdash-character"/>
-</xsl:template>
 
-<!-- Per Mille -->
-<!-- Or, per thousand, like a percent sign -->
-<xsl:template name="permille-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'permille'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="permille">
-    <xsl:call-template name="permille-character"/>
-</xsl:template>
 
-<!-- Pilcrow -->
-<!-- Often used to mark the start of a paragraph -->
-<xsl:template name="pilcrow-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'pilcrow'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="pilcrow">
-    <xsl:call-template name="pilcrow-character"/>
-</xsl:template>
 
-<!-- Section Mark -->
-<!-- The stylized double-S to indicate section numbers -->
-<xsl:template name="section-mark-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'section-mark'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="section-mark">
-    <xsl:call-template name="section-mark-character"/>
-</xsl:template>
 
-<!-- Minus -->
-<!-- A hyphen/dash for use in text as subtraction or negation-->
-<xsl:template name="minus-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'minus'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="minus">
-    <xsl:call-template name="minus-character"/>
-</xsl:template>
 
-<!-- Times -->
-<!-- A "multiplication sign" symbol for use in text -->
-<xsl:template name="times-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'times'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="times">
-    <xsl:call-template name="times-character"/>
-</xsl:template>
 
-<!-- Solidus -->
-<!-- Fraction bar, not as steep as a forward slash -->
-<xsl:template name="solidus-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'solidus'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="solidus">
-    <xsl:call-template name="solidus-character"/>
-</xsl:template>
 
-<!-- Obelus -->
-<!-- A "division" symbol for use in text -->
-<xsl:template name="obelus-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'obelus'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="obelus">
-    <xsl:call-template name="obelus-character"/>
-</xsl:template>
 
-<!-- Plus/Minus -->
-<!-- The combined symbol -->
-<xsl:template name="plusminus-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'plusminus'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="plusminus">
-    <xsl:call-template name="plusminus-character"/>
-</xsl:template>
 
-<!-- Copyright -->
-<!-- Bringhurst: on baseline (i.e. not superscript) -->
-<xsl:template name="copyright-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'copyright'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="copyright">
-    <xsl:call-template name="copyright-character"/>
-</xsl:template>
 
-<!-- Phonomark -->
-<!-- copyright on sound recordings                 -->
-<!-- Bringhurst: counterpart copyright on baseline -->
-<xsl:template name="phonomark-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'phonomark'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="phonomark">
-    <xsl:call-template name="phonomark-character"/>
-</xsl:template>
 
-<!-- Copyleft -->
-<!-- Bringhurst: counterpart copyright on baseline -->
-<xsl:template name="copyleft-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'copyleft'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="copyleft">
-    <xsl:call-template name="copyleft-character"/>
-</xsl:template>
 
-<!-- Registered -->
-<!-- Bringhurst: should be superscript -->
-<xsl:template name="registered-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'registered'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="registered">
-    <xsl:call-template name="registered-character"/>
-</xsl:template>
 
-<!-- Trademark -->
-<!-- Bringhurst: should be superscript -->
-<xsl:template name="trademark-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'trademark'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="trademark">
-    <xsl:call-template name="trademark-character"/>
-</xsl:template>
 
-<!-- Servicemark -->
-<!-- Bringhurst: counterpart trademark should be superscript -->
-<xsl:template name="servicemark-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'servicemark'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="servicemark">
-    <xsl:call-template name="servicemark-character"/>
-</xsl:template>
 
 <!-- Coordinates, Temperature, English distance -->
 <!-- Intended for simple non-technical uses, without too -->
 <!-- much overhead.  The SI unit markup would be better  -->
 <!-- suited for scientific or technical work.            -->
 
-<!-- Degree -->
-<xsl:template name="degree-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'degree'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="degree">
-    <xsl:call-template name="degree-character"/>
-</xsl:template>
 
-<!-- Prime -->
-<xsl:template name="prime-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'prime'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="prime">
-    <xsl:call-template name="prime-character"/>
-</xsl:template>
 
-<!-- Double Prime -->
-<xsl:template name="dblprime-character">
-    <xsl:call-template name="character">
-        <xsl:with-param name="name" select="'dblprime'"/>
-    </xsl:call-template>
-</xsl:template>
-<xsl:template match="dblprime">
-    <xsl:call-template name="dblprime-character"/>
-</xsl:template>
 
 <!-- Characters for Tagging Equations -->
 
@@ -10122,15 +9886,23 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 </xsl:template>
 
 <xsl:template match="dblbrackets">
-    <xsl:call-template name="ldblbracket-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ldblbracket'"/>
+    </xsl:call-template>
     <xsl:apply-templates/>
-    <xsl:call-template name="rdblbracket-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rdblbracket'"/>
+    </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="angles">
-    <xsl:call-template name="langle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'langle'"/>
+    </xsl:call-template>
     <xsl:apply-templates/>
-    <xsl:call-template name="rangle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rangle'"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- ########## -->
@@ -10302,7 +10074,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <xsl:template match="biblio[@type='raw']/number">
     <xsl:text>no</xsl:text>
     <xsl:call-template name="biblio-period"/>
-    <xsl:call-template name="thin-space-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'thin-space'"/>
+    </xsl:call-template>
     <xsl:apply-templates/>
 </xsl:template>
 
@@ -10405,7 +10179,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <xsl:template match="biblio[@type='bibtex']/number">
     <xsl:text>no</xsl:text>
     <xsl:call-template name="biblio-period"/>
-    <xsl:call-template name="thin-space-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'thin-space'"/>
+    </xsl:call-template>
     <xsl:apply-templates select="text()"/>
     <xsl:apply-templates select="." mode="bibtex-separator">
         <xsl:with-param name="separator" select="' '"/>
@@ -10434,7 +10210,9 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
 <xsl:template match="biblio[@type='bibtex']/pages[@start]">
     <xsl:text>pp</xsl:text>
     <xsl:call-template name="biblio-period"/>
-    <xsl:call-template name="thin-space-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'thin-space'"/>
+    </xsl:call-template>
     <xsl:value-of select="@start"/><xsl:text>-</xsl:text><xsl:value-of select="@end"/>
     <xsl:apply-templates select="." mode="bibtex-separator">
         <xsl:with-param name="separator" select="', '"/>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9642,7 +9642,7 @@ Book (with parts), "section" at level 3
     <!-- U+2014: EM DASH -->
     <char name="mdash"         unicode="&#x2014;"   latex="\textemdash"                       ascii="--"         webwork="[$MDASH]*"/>
     <!-- U+2009: THIN SPACE -->
-    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "          webwork=" " braille="none"/>
+    <char name="thin-space"    unicode="&#x2009;"   latex="\," latex-ending="no"              ascii=" "          webwork=" "/>
     <!-- U+27E6: MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
     <char name="ldblbracket"   unicode="&#x27e6;"   latex="\textlbrackdbl"                    braille="none"/>
     <!-- U+27E7: MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3559,10 +3559,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>&#x27e7;</xsl:text>
     </fo:inline>
 </xsl:template>
-<!-- the *mathematical* angle brackets (U+27E8, U+27E9), missing  -->
-<!-- from the main (serif) face, so they borrow the symbol font;  -->
-<!-- the CJK pair (U+3008, U+3009) of the table is in no embedded  -->
-<!-- font at all                                                   -->
+<!-- the mathematical angle brackets are missing from the main -->
+<!-- (serif) face, so they borrow the symbol font, as the      -->
+<!-- tombstone does                                            -->
 <xsl:template match="char[@name = 'langle']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x27e8;</xsl:text>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2829,7 +2829,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:for-each select="line">
                 <fo:block text-align="end">
                     <xsl:if test="position() = 1">
-                        <xsl:call-template name="mdash-character"/>
+                        <xsl:call-template name="character">
+                            <xsl:with-param name="name" select="'mdash'"/>
+                        </xsl:call-template>
                     </xsl:if>
                     <xsl:apply-templates/>
                 </fo:block>
@@ -2837,7 +2839,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <xsl:otherwise>
             <fo:block text-align="end">
-                <xsl:call-template name="mdash-character"/>
+                <xsl:call-template name="character">
+                    <xsl:with-param name="name" select="'mdash'"/>
+                </xsl:call-template>
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:otherwise>
@@ -4217,11 +4221,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <fo:block space-before="1em" space-after="1em">
         <xsl:apply-templates select="." mode="link-id-attribute"/>
         <fo:block>
-            <xsl:call-template name="langle-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'langle'"/>
+            </xsl:call-template>
             <xsl:apply-templates select="." mode="number"/>
             <xsl:text> </xsl:text>
             <xsl:apply-templates select="." mode="title-full"/>
-            <xsl:call-template name="rangle-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'rangle'"/>
+            </xsl:call-template>
             <xsl:text> </xsl:text>
             <xsl:text>&#x2261;</xsl:text>
         </fo:block>
@@ -4259,7 +4267,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="$target" mode="unique-id"/>
     </xsl:variable>
     <fo:block start-indent="2em">
-        <xsl:call-template name="langle-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'langle'"/>
+        </xsl:call-template>
         <xsl:apply-templates select="$target" mode="title-full"/>
         <xsl:text> </xsl:text>
         <fo:inline font-size="70%">
@@ -4271,7 +4281,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </fo:basic-link>
             <xsl:text>]</xsl:text>
         </fo:inline>
-        <xsl:call-template name="rangle-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'rangle'"/>
+        </xsl:call-template>
     </fo:block>
 </xsl:template>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3512,19 +3512,26 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </fo:inline>
 </xsl:template>
 
-<!-- The Unicode code points below match the HTML conversion. -->
-<xsl:template name="nbsp-character">
-    <xsl:text>&#xa0;</xsl:text>
-</xsl:template>
-<xsl:template name="ndash-character">
-    <xsl:text>&#x2013;</xsl:text>
-</xsl:template>
-<xsl:template name="mdash-character">
-    <xsl:text>&#x2014;</xsl:text>
+<!-- Most characters read the Unicode code point straight from the -->
+<!-- representation table in  pretext-common.xsl; the code points   -->
+<!-- match the HTML conversion.  The exceptions below borrow the    -->
+<!-- symbol font for glyphs missing from the main (serif) face, or  -->
+<!-- are otherwise particular to this conversion.                   -->
+<xsl:template match="char" mode="character">
+    <xsl:choose>
+        <xsl:when test="@unicode">
+            <xsl:value-of select="@unicode"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 <!-- the thin space is missing from the main (serif) face, so it -->
 <!-- borrows the symbol font, as the narrow no-break space does   -->
-<xsl:template name="thin-space-character">
+<xsl:template match="char[@name = 'thin-space']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2009;</xsl:text>
     </fo:inline>
@@ -3538,73 +3545,46 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 <!-- the white square brackets are missing from the main (serif)  -->
 <!-- face, so they borrow the symbol font, as the tombstone does  -->
-<xsl:template name="ldblbracket-character">
+<xsl:template match="char[@name = 'ldblbracket']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x27e6;</xsl:text>
     </fo:inline>
 </xsl:template>
-<xsl:template name="rdblbracket-character">
+<xsl:template match="char[@name = 'rdblbracket']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x27e7;</xsl:text>
     </fo:inline>
 </xsl:template>
 <!-- the *mathematical* angle brackets (U+27E8, U+27E9), missing  -->
 <!-- from the main (serif) face, so they borrow the symbol font;  -->
-<!-- the CJK pair (U+3008, U+3009) is in no embedded font at all   -->
-<xsl:template name="langle-character">
+<!-- the CJK pair (U+3008, U+3009) of the table is in no embedded  -->
+<!-- font at all                                                   -->
+<xsl:template match="char[@name = 'langle']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x27e8;</xsl:text>
     </fo:inline>
 </xsl:template>
-<xsl:template name="rangle-character">
+<xsl:template match="char[@name = 'rangle']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x27e9;</xsl:text>
     </fo:inline>
 </xsl:template>
-<xsl:template name="ellipsis-character">
-    <xsl:text>&#x2026;</xsl:text>
-</xsl:template>
-<xsl:template name="midpoint-character">
-    <xsl:text>&#xb7;</xsl:text>
-</xsl:template>
 <!-- the swung dash is missing from the main (serif) face, so it -->
 <!-- borrows the symbol font, as the tombstone does              -->
-<xsl:template name="swungdash-character">
+<xsl:template match="char[@name = 'swungdash']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2053;</xsl:text>
     </fo:inline>
 </xsl:template>
-<xsl:template name="permille-character">
-    <xsl:text>&#x2030;</xsl:text>
-</xsl:template>
-<xsl:template name="pilcrow-character">
-    <xsl:text>&#xb6;</xsl:text>
-</xsl:template>
-<xsl:template name="section-mark-character">
-    <xsl:text>&#xa7;</xsl:text>
-</xsl:template>
-<xsl:template name="minus-character">
-    <xsl:text>&#x2212;</xsl:text>
-</xsl:template>
-<xsl:template name="times-character">
-    <xsl:text>&#xd7;</xsl:text>
-</xsl:template>
-<xsl:template name="solidus-character">
-    <xsl:text>&#x2044;</xsl:text>
-</xsl:template>
-<xsl:template name="obelus-character">
-    <xsl:text>&#xf7;</xsl:text>
-</xsl:template>
-<xsl:template name="plusminus-character">
-    <xsl:text>&#xb1;</xsl:text>
-</xsl:template>
-<xsl:template name="copyright-character">
-    <xsl:text>&#xa9;</xsl:text>
-</xsl:template>
 <!-- the sound-recording and service marks borrow the symbol font -->
-<xsl:template name="phonomark-character">
+<xsl:template match="char[@name = 'phonomark']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2117;</xsl:text>
+    </fo:inline>
+</xsl:template>
+<xsl:template match="char[@name = 'servicemark']" mode="character">
+    <fo:inline font-family="{$font-family-symbol}">
+        <xsl:text>&#x2120;</xsl:text>
     </fo:inline>
 </xsl:template>
 <!-- The copyleft symbol (U+1F12F) is in no embeddable font, so it  -->
@@ -3612,38 +3592,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- parentheses.  The main font lacks the reversed "c", and it sits -->
 <!-- between the parentheses with no surrounding space, so it is     -->
 <!-- named from the symbol font explicitly, as the primes are.       -->
-<xsl:template name="copyleft-character">
+<xsl:template match="char[@name = 'copyleft']" mode="character">
     <xsl:text>(</xsl:text>
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2184;</xsl:text>
     </fo:inline>
     <xsl:text>)</xsl:text>
 </xsl:template>
-<xsl:template name="registered-character">
-    <xsl:text>&#xae;</xsl:text>
-</xsl:template>
-<xsl:template name="trademark-character">
-    <xsl:text>&#x2122;</xsl:text>
-</xsl:template>
-<xsl:template name="servicemark-character">
-    <fo:inline font-family="{$font-family-symbol}">
-        <xsl:text>&#x2120;</xsl:text>
-    </fo:inline>
-</xsl:template>
-<xsl:template name="degree-character">
-    <xsl:text>&#xb0;</xsl:text>
-</xsl:template>
 <!-- the prime and double prime (minutes and seconds, feet and       -->
 <!-- inches) are missing from the main (serif) face; because they     -->
 <!-- sit *within* a measurement, with no surrounding space, FOP's     -->
 <!-- per-word font selection cannot reach the symbol font for them,   -->
 <!-- so each is named explicitly, as the tombstone is.                -->
-<xsl:template name="prime-character">
+<xsl:template match="char[@name = 'prime']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2032;</xsl:text>
     </fo:inline>
 </xsl:template>
-<xsl:template name="dblprime-character">
+<xsl:template match="char[@name = 'dblprime']" mode="character">
     <fo:inline font-family="{$font-family-symbol}">
         <xsl:text>&#x2033;</xsl:text>
     </fo:inline>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1279,7 +1279,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="bibinfo/copyright">
     <div class="para copyright">
-        <xsl:call-template name="copyright-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'copyright'"/>
+        </xsl:call-template>
         <xsl:apply-templates select="year" />
         <xsl:text> </xsl:text>
         <xsl:apply-templates select="holder" />
@@ -5323,11 +5325,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="heading-generic">
         <xsl:with-param name="heading-level" select="$heading-level"/>
         <xsl:with-param name="heading-title">
-            <xsl:call-template name="langle-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'langle'"/>
+            </xsl:call-template>
             <xsl:apply-templates select="." mode="number"/>
             <xsl:text> </xsl:text>
             <xsl:apply-templates select="." mode="title-full"/>
-            <xsl:call-template name="rangle-character"/>
+            <xsl:call-template name="character">
+                <xsl:with-param name="name" select="'rangle'"/>
+            </xsl:call-template>
             <!--  U+2261 ≡ IDENTICAL TO -->
             <xsl:text> &#x2261;</xsl:text>
         </xsl:with-param>
@@ -9471,7 +9477,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="fragref">
     <xsl:variable name="target" select="id(@ref)"/>
     <span>
-        <xsl:call-template name="langle-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'langle'"/>
+        </xsl:call-template>
         <xsl:apply-templates select="." mode="xref-link">
             <xsl:with-param name="target" select="$target" />
             <!-- "fragref" is isomorpic to "xref" as a link -->
@@ -9482,7 +9490,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
         <xsl:apply-templates select="$target" mode="number"/>
-        <xsl:call-template name="rangle-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'rangle'"/>
+        </xsl:call-template>
     </span>
     <br/>
 </xsl:template>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8847,56 +8847,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </s>
 </xsl:template>
 
-<!-- Copyright symbol -->
-<xsl:template name="copyright-character">
-    <xsl:text>&#xa9;</xsl:text>
-</xsl:template>
-
-<!-- Phonomark symbol -->
-<xsl:template name="phonomark-character">
-    <xsl:text>&#x2117;</xsl:text>
-</xsl:template>
-
-<!-- Copyleft symbol -->
-<!-- May not be universally available in fonts                 -->
-<!-- Open C (U+254) plus Combining Circle (U+20dd) can imitate -->
-<xsl:template name="copyleft-character">
-    <xsl:text>&#x1f12f;</xsl:text>
-</xsl:template>
-
-<!-- Registered symbol -->
-<!-- Bringhurst: should be superscript                    -->
-<!-- We consider it a font mistake if not superscripted,  -->
-<!-- since if we use a "sup" tag then a correct font will -->
-<!-- get way too small                                    -->
-<xsl:template name="registered-character">
-    <xsl:text>&#xae;</xsl:text>
-</xsl:template>
-
-<!-- Trademark symbol -->
-<xsl:template name="trademark-character">
-    <xsl:text>&#x2122;</xsl:text>
-</xsl:template>
-
-<!-- Servicemark symbol -->
-<xsl:template name="servicemark-character">
-    <xsl:text>&#x2120;</xsl:text>
-</xsl:template>
-
-<!-- Degree -->
-<xsl:template name="degree-character">
-    <xsl:text>&#xb0;</xsl:text>
-</xsl:template>
-
-<!-- Prime -->
-<xsl:template name="prime-character">
-    <xsl:text>&#x2032;</xsl:text>
-</xsl:template>
-
-<xsl:template name="dblprime-character">
-    <xsl:text>&#x2033;</xsl:text>
-</xsl:template>
-
 <!-- Characters for Tagging Equations -->
 
 <!-- 'SIX POINTED BLACK STAR' (U+2736) -->
@@ -9192,109 +9142,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:apply-templates>
 </xsl:template>
 
-<!-- Left Double Bracket -->
-<!-- MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
-<xsl:template name="ldblbracket-character">
-    <xsl:text>&#x27e6;</xsl:text>
-</xsl:template>
-
-<!-- Right Double Bracket -->
-<!-- MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
-<xsl:template name="rdblbracket-character">
-    <xsl:text>&#x27e7;</xsl:text>
-</xsl:template>
-
-<!-- Left Angle Bracket -->
-<!-- LEFT ANGLE BRACKET -->
-<!-- U+2329 was once used and caused a validator warning      -->
-<!-- "Text run is not in Unicode Normalization Form C" (NFC)  -->
-<xsl:template name="langle-character">
-    <xsl:text>&#x3008;</xsl:text>
-</xsl:template>
-
-<!-- Right Angle Bracket -->
-<!-- RIGHT ANGLE BRACKET -->
-<!-- U+232A was once used and caused a validator warning      -->
-<!-- "Text run is not in Unicode Normalization Form C" (NFC)  -->
-<xsl:template name="rangle-character">
-    <xsl:text>&#x3009;</xsl:text>
-</xsl:template>
-
 
 <!-- Other Miscellaneous Symbols, Constructions -->
-
-<!-- Ellipsis (dots), for text, not math -->
-<xsl:template name="ellipsis-character">
-    <xsl:text>&#x2026;</xsl:text>
-</xsl:template>
-
-<!-- Midpoint -->
-<!-- A centered dot used sometimes like a decorative dash -->
-<!-- Bringhurst: Not Unicode +387, "GREEK ANO TELEIA"     -->
-<xsl:template name="midpoint-character">
-    <xsl:text>&#xb7;</xsl:text>
-</xsl:template>
-
-<!-- Swung Dash -->
-<!-- A decorative dash, like a tilde, but bigger, and centered -->
-<xsl:template name="swungdash-character">
-    <xsl:text>&#x2053;</xsl:text>
-</xsl:template>
-
-<!-- Per Mille -->
-<!-- Or, per thousand, like a percent sign -->
-<xsl:template name="permille-character">
-    <xsl:text>&#x2030;</xsl:text>
-</xsl:template>
-
-<!-- Pilcrow -->
-<!-- Often used to mark the start of a paragraph -->
-<xsl:template name="pilcrow-character">
-    <xsl:text>&#xb6;</xsl:text>
-</xsl:template>
-
-<!-- Section Mark -->
-<!-- The stylized double-S to indicate section numbers -->
-<xsl:template name="section-mark-character">
-    <xsl:text>&#xa7;</xsl:text>
-</xsl:template>
-
-<!-- Minus -->
-<!-- A hyphen/dash for use in text as subtraction or negation-->
-<xsl:template name="minus-character">
-    <xsl:text>&#x2212;</xsl:text>
-</xsl:template>
-
-<!-- Times -->
-<!-- A "multiplication sign" symbol for use in text   -->
-<!-- Styled to enhance, consensus at Google Group was -->
-<!-- font-size: larger; vertical-align: -.2ex;        -->
-<xsl:template name="times-character">
-    <xsl:element name="span">
-        <xsl:attribute name="class">
-            <xsl:text>times-sign</xsl:text>
-        </xsl:attribute>
-        <xsl:text>&#xd7;</xsl:text>
-    </xsl:element>
-</xsl:template>
-
-<!-- Solidus -->
-<!-- Fraction bar, not as steep as a forward slash -->
-<xsl:template name="solidus-character">
-    <xsl:text>&#x2044;</xsl:text>
-</xsl:template>
-
-<!-- Obelus -->
-<!-- A "division" symbol for use in text -->
-<xsl:template name="obelus-character">
-    <xsl:text>&#xf7;</xsl:text>
-</xsl:template>
-
-<!-- Plus/Minus -->
-<!-- The combined symbol -->
-<xsl:template name="plusminus-character">
-    <xsl:text>&#xb1;</xsl:text>
-</xsl:template>
 
 <!-- Foreign words/idioms -->
 <!-- Rutter, Web Typography, p.50 advocates a "span" with      -->
@@ -9490,35 +9339,34 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Special Characters -->
 <!-- ################## -->
 
-<!-- These are specific instances of abstract templates        -->
-<!-- See the similar section of  pretext-common.xsl  for more -->
+<!-- Each character is the bare Unicode code point, read from the -->
+<!-- representation table in  pretext-common.xsl; an exception    -->
+<!-- needing markup overrides the modal template, per character   -->
 
-<!-- Non-breaking space, which "joins" two words as a unit            -->
-<!-- Using &nbsp; does not travel well into node-set() in common file -->
-<!-- http://stackoverflow.com/questions/31870                         -->
-<!-- /using-a-html-entity-in-xslt-e-g-nbsp                            -->
-<!-- Should create UTF-8 anyway:                                      -->
-<!-- https://html.spec.whatwg.org/multipage/semantics.html#charset    -->
-
-<xsl:template name="nbsp-character">
-    <xsl:text>&#xa0;</xsl:text>
+<xsl:template match="char" mode="character">
+    <xsl:choose>
+        <xsl:when test="@unicode">
+            <xsl:value-of select="@unicode"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
-<xsl:template name="ndash-character">
-    <xsl:text>&#8211;</xsl:text>
-</xsl:template>
-
-<xsl:template name="mdash-character">
-    <xsl:text>&#8212;</xsl:text>
-</xsl:template>
-
-<!-- The abstract template for "mdash" consults a publisher option -->
-<!-- for thin space, or no space, surrounding an em-dash.  So the  -->
-<!-- "thin-space-character" is needed for that purpose, and does   -->
-<!-- not have an associated empty PTX element.                     -->
-
-<xsl:template name="thin-space-character">
-    <xsl:text>&#8201;</xsl:text>
+<!-- Times -->
+<!-- A "multiplication sign" symbol for use in text   -->
+<!-- Styled to enhance, consensus at Google Group was -->
+<!-- font-size: larger; vertical-align: -.2ex;        -->
+<xsl:template match="char[@name = 'times']" mode="character">
+    <xsl:element name="span">
+        <xsl:attribute name="class">
+            <xsl:text>times-sign</xsl:text>
+        </xsl:attribute>
+        <xsl:text>&#xd7;</xsl:text>
+    </xsl:element>
 </xsl:template>
 
 <!--       -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -5938,7 +5938,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\nopagebreak\par%&#xa;</xsl:text>
     <xsl:text>\hfill</xsl:text>
     <xsl:if test="parent::blockquote">
-        <xsl:call-template name="mdash-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'mdash'"/>
+        </xsl:call-template>
         <!-- remove the left-side column spacing -->
         <xsl:text>{\setlength{\tabcolsep}{0pt}</xsl:text>
     </xsl:if>
@@ -6417,7 +6419,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This is an override of the base *template*           -->
 <xsl:template match="title//swungdash|shortitle//swungdash">
     <xsl:text>\protect</xsl:text>
-    <xsl:call-template name="swungdash-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'swungdash'"/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- All Latin abbreviations are defined in -common    -->
@@ -9090,11 +9094,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- always possible to label (universal PTX capability) -->
     <xsl:text>\noindent\phantomsection</xsl:text>
     <xsl:apply-templates select="." mode="label"/>
-    <xsl:call-template name="langle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'langle'"/>
+    </xsl:call-template>
     <xsl:apply-templates select="." mode="number"/>
     <xsl:text> </xsl:text>
     <xsl:apply-templates select="." mode="title-full"/>
-    <xsl:call-template name="rangle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rangle'"/>
+    </xsl:call-template>
     <xsl:text> </xsl:text>
     <xsl:call-template name="inline-math-wrapper">
         <xsl:with-param name="math" select="'\equiv'"/>
@@ -9142,7 +9150,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- with a hyperlink to the target (as a page number for print)          -->
 <xsl:template match="fragref">
     <xsl:variable name="target" select="id(@ref)"/>
-    <xsl:call-template name="langle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'langle'"/>
+    </xsl:call-template>
     <xsl:apply-templates select="$target" mode="title-full"/>
     <xsl:text> </xsl:text>
     <xsl:text>{\scriptsize </xsl:text>
@@ -9151,7 +9161,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$target" mode="unique-id"/>
     <xsl:text>}]</xsl:text>
     <xsl:text>}</xsl:text>
-    <xsl:call-template name="rangle-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'rangle'"/>
+    </xsl:call-template>
     <xsl:text>\\&#xa;</xsl:text>
 </xsl:template>
 

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -926,6 +926,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/ -->
     <xsl:if test="$document-root//swungdash">
         <xsl:text>%% A character like a tilde, but different&#xa;</xsl:text>
+        <!-- http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/ -->
         <xsl:text>\newcommand{\ptxswungdash}{\raisebox{-2.25ex}{\scalebox{2}{\~{}}}}&#xa;</xsl:text>
     </xsl:if>
     <xsl:call-template name="quantity-support"/>
@@ -6380,24 +6381,27 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:apply-templates>
 </xsl:template>
 
-<!-- Left Double Bracket -->
-<xsl:template name="ldblbracket-character">
-    <xsl:text>\textlbrackdbl{}</xsl:text>
-</xsl:template>
-
-<!-- Right Double Bracket -->
-<xsl:template name="rdblbracket-character">
-    <xsl:text>\textrbrackdbl{}</xsl:text>
-</xsl:template>
-
-<!-- Left Angle Bracket -->
-<xsl:template name="langle-character">
-    <xsl:text>\textlangle{}</xsl:text>
-</xsl:template>
-
-<!-- Right Angle Bracket -->
-<xsl:template name="rangle-character">
-    <xsl:text>\textrangle{}</xsl:text>
+<!-- Each character is a LaTeX macro or construction, read from   -->
+<!-- the representation table in  pretext-common.xsl.  Per the    -->
+<!-- note above, an argument-less macro finishes with an empty     -->
+<!-- group, supplied here; a row declares  latex-ending="no"  when -->
+<!-- its value is not such a macro                                 -->
+<!-- TODO: Perhaps use LaTeX double and triple hyphen variants of  -->
+<!-- en-dash and em-dash under some option for human-variant LaTeX -->
+<xsl:template match="char" mode="character">
+    <xsl:choose>
+        <xsl:when test="@latex">
+            <xsl:value-of select="@latex"/>
+            <xsl:if test="not(@latex-ending = 'no')">
+                <xsl:text>{}</xsl:text>
+            </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Vertical Bar -->
@@ -6409,78 +6413,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Other Miscellaneous Symbols, Constructions -->
 
-<!-- Ellipsis (dots), for text, not math -->
-<xsl:template name="ellipsis-character">
-    <xsl:text>\textellipsis{}</xsl:text>
-</xsl:template>
-
-<!-- Midpoint -->
-<!-- A centered dot used sometimes like a decorative dash -->
-<!-- http://tex.stackexchange.com/questions/19180/which-dot-character-to-use-in-which-context -->
-<xsl:template name="midpoint-character">
-    <xsl:text>\textperiodcentered{}</xsl:text>
-</xsl:template>
-
-<!-- Swung Dash -->
-<!-- A decorative dash, like a tilde, but bigger, and centered -->
-<!-- http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/  -->
-<xsl:template name="swungdash-character">
-    <xsl:text>\ptxswungdash{}</xsl:text>
-</xsl:template>
 <!-- Protect the version of the macro appearing in titles -->
 <!-- This is an override of the base *template*           -->
 <xsl:template match="title//swungdash|shortitle//swungdash">
     <xsl:text>\protect</xsl:text>
     <xsl:call-template name="swungdash-character"/>
-</xsl:template>
-
-<!-- Per Mille -->
-<!-- Or, per thousand, like a percent sign -->
-<xsl:template name="permille-character">
-    <xsl:text>\textperthousand{}</xsl:text>
-</xsl:template>
-
-<!-- Pilcrow -->
-<!-- Often used to mark the start of a paragraph -->
-<xsl:template name="pilcrow-character">
-    <xsl:text>\textpilcrow{}</xsl:text>
-</xsl:template>
-
-<!-- Section Mark -->
-<!-- The stylized double-S to indicate section numbers -->
-<xsl:template name="section-mark-character">
-    <xsl:text>\textsection{}</xsl:text>
-</xsl:template>
-
-<!-- Minus -->
-<!-- A hyphen/dash for use in text as subtraction or negation-->
-<xsl:template name="minus-character">
-    <xsl:text>\textminus{}</xsl:text>
-</xsl:template>
-
-<!-- Times -->
-<!-- A "multiplication sign" symbol for use in text -->
-<xsl:template name="times-character">
-    <xsl:text>\texttimes{}</xsl:text>
-</xsl:template>
-
-<!-- Solidus -->
-<!-- Fraction bar, not as steep as a forward slash -->
-<!-- This should not allow a linebreak, not tested -->
-<xsl:template name="solidus-character">
-    <xsl:text>\textfractionsolidus{}</xsl:text>
-</xsl:template>
-
-<!-- Obelus -->
-<!-- A "division" symbol for use in text -->
-<xsl:template name="obelus-character">
-    <xsl:text>\textdiv{}</xsl:text>
-</xsl:template>
-
-<!-- Plus/Minus -->
-<!-- The combined symbol -->
-<xsl:template name="plusminus-character">
-    <xsl:text>\textpm{}</xsl:text>
 </xsl:template>
 
 <!-- All Latin abbreviations are defined in -common    -->
@@ -6499,59 +6436,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template name="abbreviation-period">
     <xsl:text>.\@</xsl:text>
-</xsl:template>
-
-<!-- Copyright symbol -->
-<!-- http://tex.stackexchange.com/questions/1676/             -->
-<!-- how-to-get-good-looking-copyright-and-registered-symbols -->
-<xsl:template name="copyright-character">
-    <xsl:text>\textcopyright{}</xsl:text>
-</xsl:template>
-
-<!-- Phonomark symbol -->
-<xsl:template name="phonomark-character">
-    <xsl:text>\textcircledP{}</xsl:text>
-</xsl:template>
-
-<!-- Copyleft symbol -->
-<xsl:template name="copyleft-character">
-    <xsl:text>\textcopyleft{}</xsl:text>
-</xsl:template>
-
-<!-- Registered symbol -->
-<xsl:template name="registered-character">
-    <xsl:text>\textregistered{}</xsl:text>
-</xsl:template>
-
-<!-- Trademark symbol -->
-<xsl:template name="trademark-character">
-    <xsl:text>\texttrademark{}</xsl:text>
-</xsl:template>
-
-<!-- Servicemark symbol -->
-<xsl:template name="servicemark-character">
-    <xsl:text>\textservicemark{}</xsl:text>
-</xsl:template>
-
-<!-- Degree -->
-<xsl:template name="degree-character">
-    <xsl:text>\textdegree{}</xsl:text>
-</xsl:template>
-
-<!-- Prime -->
-<!-- A construction such as  \(^{\prime}\)  looks much better,     -->
-<!-- but will require a lot of extra care in the "text-processing" -->
-<!-- template since all this math-mode will need to be protected   -->
-<!-- at the outset.  Bringhurst opines that many text fonts lack   -->
-<!-- a prime and/or double-prime glyph, and LaTeX does not seem    -->
-<!-- to have any good way to realize them without using math-mode. -->
-<xsl:template name="prime-character">
-    <xsl:text>\textquotesingle{}</xsl:text>
-</xsl:template>
-
-<!-- Double Prime -->
-<xsl:template name="dblprime-character">
-    <xsl:text>\textquotesingle\textquotesingle{}</xsl:text>
 </xsl:template>
 
 <!-- Characters for Tagging Equations -->
@@ -6746,37 +6630,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="lq-character"/>
     <xsl:apply-templates/>
     <xsl:apply-templates select="." mode="rq-character"/>
-</xsl:template>
-
-<!-- ################-->
-<!-- Other Characters -->
-<!-- ################ -->
-
-<!-- These are specific instances of abstract templates        -->
-<!-- See the similar section of  pretext-common.xsl  for more -->
-
-<!-- TODO: Perhaps use LaTeX double and triple hyphen variants of  -->
-<!-- en-dash and em-dash under some option for human-variant LaTeX -->
-
-<xsl:template name="nbsp-character">
-    <xsl:text>~</xsl:text>
-</xsl:template>
-
-<xsl:template name="ndash-character">
-    <xsl:text>\textendash{}</xsl:text>
-</xsl:template>
-
-<xsl:template name="mdash-character">
-    <xsl:text>\textemdash{}</xsl:text>
-</xsl:template>
-
-<!-- The abstract template for "mdash" consults a publisher option -->
-<!-- for thin space, or no space, surrounding an em-dash.  So the  -->
-<!-- "thin-space-character" is needed for that purpose, and does   -->
-<!-- not have an associated empty PTX element.                     -->
-
-<xsl:template name="thin-space-character">
-    <xsl:text>\,</xsl:text>
 </xsl:template>
 
 <!-- Sage Cells -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -6406,13 +6406,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
-<!-- Vertical Bar -->
-<!-- Bringhurst: a "pipe" is a broken bar -->
-<!-- Exists as \textbrokenbar             -->
-<xsl:template name="bar-character">
-    <xsl:text>\textbar{}</xsl:text>
-</xsl:template>
-
 <!-- Other Miscellaneous Symbols, Constructions -->
 
 <!-- Protect the version of the macro appearing in titles -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -986,7 +986,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- mining one "copyright" element at a time.               -->
     <xsl:for-each select="$bibinfo/copyright">
         <xsl:text>\noindent</xsl:text>
-        <xsl:call-template name="copyright-character"/>
+        <xsl:call-template name="character">
+            <xsl:with-param name="name" select="'copyright'"/>
+        </xsl:call-template>
         <xsl:apply-templates select="year" />
         <xsl:text>\quad{}</xsl:text>
         <xsl:apply-templates select="holder" />

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -389,7 +389,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- group as its serial number.     -->
 <xsl:template match="exercisegroup" mode="serial-number">
     <xsl:apply-templates select="exercise[1]" mode="serial-number" />
-    <xsl:call-template name="ndash-character"/>
+    <xsl:call-template name="character">
+        <xsl:with-param name="name" select="'ndash'"/>
+    </xsl:call-template>
     <xsl:apply-templates select="exercise[last()]" mode="serial-number" />
 </xsl:template>
 

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -898,35 +898,38 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- TODO: quotation marks should localize by language in the        -->
 <!-- unicode repertoire, as other conversions do.                    -->
 
-<xsl:template name="nbsp-character">
+<!-- A character reads its elected column of the representation -->
+<!-- table in  pretext-common.xsl.  A row without an "ascii"     -->
+<!-- stand-in is outside the text repertoire altogether, and     -->
+<!-- warns under either election, so gaps stay visible.          -->
+<xsl:template match="char" mode="character">
     <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xa0;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+        <xsl:when test="not(@ascii)">
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$b-text-unicode">
+            <xsl:value-of select="@unicode"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@ascii"/>
+        </xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
-<xsl:template name="ndash-character">
+<!-- the *mathematical* angle brackets, rather than the table's -->
+<!-- CJK pair, matching the XSL-FO conversion's choice          -->
+<xsl:template match="char[@name = 'langle']" mode="character">
     <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2013;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>-</xsl:text></xsl:otherwise>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e8;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>&lt;</xsl:text></xsl:otherwise>
     </xsl:choose>
 </xsl:template>
-
-<xsl:template name="mdash-character">
+<xsl:template match="char[@name = 'rangle']" mode="character">
     <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2014;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>--</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<!-- The abstract template for "mdash" consults a publisher option -->
-<!-- for thin space, or no space, surrounding an em-dash.  So the  -->
-<!-- "thin-space-character" is needed for that purpose, and does   -->
-<!-- not have an associated empty PTX element.                     -->
-<xsl:template name="thin-space-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2009;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e9;</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>&gt;</xsl:text></xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 
@@ -955,139 +958,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <xsl:when test="$b-text-unicode"><xsl:text>&#x201D;</xsl:text></xsl:when>
         <xsl:otherwise><xsl:text>"</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="ellipsis-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2026;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>...</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="copyright-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xa9;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>(c)</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="registered-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xae;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>(R)</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="trademark-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2122;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>(TM)</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="degree-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xb0;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>deg</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="prime-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2032;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>'</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="dblprime-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2033;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>''</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="langle-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e8;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>&lt;</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="rangle-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e9;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>&gt;</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="midpoint-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xb7;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>*</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="pilcrow-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xb6;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>[pilcrow]</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="section-mark-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xa7;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>[section]</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="minus-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2212;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>-</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="times-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xd7;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>x</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="obelus-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xf7;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>/</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="plusminus-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#xb1;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>+/-</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="permille-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2030;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>o/oo</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="solidus-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2044;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>/</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
-<xsl:template name="swungdash-character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x2053;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>~</xsl:text></xsl:otherwise>
     </xsl:choose>
 </xsl:template>
 

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -918,21 +918,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
-<!-- the *mathematical* angle brackets, rather than the table's -->
-<!-- CJK pair, matching the XSL-FO conversion's choice          -->
-<xsl:template match="char[@name = 'langle']" mode="character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e8;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>&lt;</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-<xsl:template match="char[@name = 'rangle']" mode="character">
-    <xsl:choose>
-        <xsl:when test="$b-text-unicode"><xsl:text>&#x27e9;</xsl:text></xsl:when>
-        <xsl:otherwise><xsl:text>&gt;</xsl:text></xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
 <xsl:template match="*" mode="lsq-character">
     <xsl:choose>
         <xsl:when test="$b-text-unicode"><xsl:text>&#x2018;</xsl:text></xsl:when>

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -899,21 +899,21 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- unicode repertoire, as other conversions do.                    -->
 
 <!-- A character reads its elected column of the representation -->
-<!-- table in  pretext-common.xsl.  A row without an "ascii"     -->
-<!-- stand-in is outside the text repertoire altogether, and     -->
-<!-- warns under either election, so gaps stay visible.          -->
+<!-- table in  pretext-common.xsl.  The unicode repertoire is    -->
+<!-- complete; a row without an "ascii" stand-in warns under the -->
+<!-- ascii election, so those gaps stay visible.                 -->
 <xsl:template match="char" mode="character">
     <xsl:choose>
-        <xsl:when test="not(@ascii)">
-            <xsl:call-template name="warn-unimplemented-character">
-                <xsl:with-param name="char-name" select="@name"/>
-            </xsl:call-template>
-        </xsl:when>
         <xsl:when test="$b-text-unicode">
             <xsl:value-of select="@unicode"/>
         </xsl:when>
-        <xsl:otherwise>
+        <xsl:when test="@ascii">
             <xsl:value-of select="@ascii"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="warn-unimplemented-character">
+                <xsl:with-param name="char-name" select="@name"/>
+            </xsl:call-template>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
The empty PreTeXt character elements (`nbsp`, `mdash`, `permille`, `copyright`, `langle`, ...) have been implemented by one abstract getter template per character in `pretext-common.xsl`, overridden per character in each conversion — about 130 templates repeating the same Unicode code points in up to four places.  This series replaces that machinery with a single data island in `pretext-common.xsl`: one row per character, one column per representation, in the style of the existing `quote-character-rtf`, `kbdkey-rtf`, and `icon-rtf` tables.

Twelve commits, intended to be read in order:

1. The table (28 rows, a Unicode comment and a per-column legend), an `xsl:key`, a single named `character` entry point, and a warning fallback; the abstract getters feed from the table, while every conversion's overrides still shadow them — so output is unchanged by construction.

2.–7. One commit per consumer, each replacing its overrides with a reader of its column: HTML (`unicode`; the `times` span wrapper survives as the one markup exception), LaTeX (`latex`, with the reader supplying the trailing empty group unless a row declares `latex-ending="no"`), XSL-FO (`unicode`, retaining its eleven symbol-font `fo:inline` overrides), text (`unicode`/`ascii` per the publication file's election), braille (`unicode`, with a sparse `braille` column for substitutes and unreachable characters, and the liblouis dot-pattern records consolidated at the reader), and WeBWorK problem extraction (a sparse `webwork` column of PGML forms).

8. Retirement of the old interface: the named getters delete, twenty-six single-element dispatchers merge into one, and every internal call site uses the entry point.

9. Removal of the unused `bar-character` template.

10.–12. Three deliberate, enumerated output changes: unicode-repertoire text renders the five characters it previously warned about (`copyleft`, `ldblbracket`, `rdblbracket`, `phonomark`, `servicemark`); braille renders the thin space (liblouis defines U+2009); and `langle`/`rangle` are now the mathematical angle brackets U+27E8/U+27E9 rather than the CJK pair — Unicode's recommended delimiters, present in ordinary fonts — with braille alone overriding back to the CJK pair, the only one its liblouis table defines.

Music accidentals are deliberately not part of the table; their LaTeX forms are context-sensitive and remain as they were.

Verification, at every commit boundary: before/after builds byte-identical to `master` apart from build timestamps and the search index, excepting only the three enumerated changes above.  The full sweep covers the sample article (HTML, LaTeX, text, FO), the fonts example in the same four formats plus the ascii text repertoire, the sample book (HTML, LaTeX), the braille example (braille-electronic), the WeBWorK sample chapter (`assembly-pg`), and the EPUB sampler (epub-svg, with epubcheck reporting the same pre-existing messages as `master`).

*Claude Fable 5, acting as a coding assistant for Rob Beezer*