### PR TITLE
JavaScript: the code-copy button omits a console prompt

### DIFF
--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1188,7 +1188,11 @@ document.addEventListener("click", (ev) => {
     const codeBox = ev.target.closest(".clipboardable");
     if (!navigator.clipboard || !codeBox) return;
     const button = ev.target.closest(".code-copy");
-    const preContent = codeBox.querySelector("pre").textContent;
+    // Copy a clone with "unselectable" content removed (e.g. a console prompt),
+    // so the copied text matches what a manual selection would capture.
+    const pre = codeBox.querySelector("pre").cloneNode(true);
+    pre.querySelectorAll(".unselectable").forEach((el) => el.remove());
+    const preContent = pre.textContent;
     navigator.clipboard.writeText(preContent);
     button.classList.toggle("copied")
     setTimeout(() => button.classList.toggle("copied"), 1000);


### PR DESCRIPTION
The code-copy button copies the full text of a code block's `<pre>` via `textContent`, which includes the `<span class="prompt unselectable">` that a `<console>` uses for its prompt. So copying a command line yielded, for example, `$ pretext deploy` instead of `pretext deploy`. The `unselectable` class already excludes the prompt from a manual selection; this makes the button behave the same way.

The handler now copies a clone of the `<pre>` with `.unselectable` content removed. Ordinary code blocks contain no `.unselectable` elements, so they are unaffected.

Source only — `js/dist` is regenerated by a maintainer at merge time.

Resolves #2650.

*Claude Opus 4.8 (1M context), acting as a coding assistant for Rob Beezer*
