### PR TITLE
Script: report Python module versions in debugging output

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5657,6 +5657,41 @@ def python_version():
     return "{}.{}".format(sys.version_info[0], sys.version_info[1])
 
 
+def python_module_versions():
+    """Report installed versions of the Python packages PreTeXt depends on"""
+
+    # Package names come from the distribution's "requirements.txt", so the
+    # report tracks the actual dependency list.  Versions come from the
+    # installed package metadata, not the version specifiers in the file, so
+    # the report shows what is really in use.  Intended for the debugging log,
+    # to aid in diagnosing an author's or publisher's setup.
+    import importlib.metadata  # version(), PackageNotFoundError
+
+    # "requirements.txt" sits alongside this module's package directory
+    requirements = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "requirements.txt"
+    )
+    try:
+        with open(requirements, "r") as requirements_file:
+            lines = requirements_file.readlines()
+    except OSError:
+        return "unable to read {}".format(requirements)
+
+    reports = []
+    for line in lines:
+        line = line.strip()
+        if (line == "") or line.startswith("#"):
+            continue
+        # a requirement is a package name followed by an optional version
+        # specifier, extras, or environment marker; keep the leading name
+        name = re.split(r"[<>=!~;\[\s]", line, maxsplit=1)[0]
+        try:
+            reports.append("{} {}".format(name, importlib.metadata.version(name)))
+        except importlib.metadata.PackageNotFoundError:
+            reports.append("{} (not installed)".format(name))
+    return ", ".join(reports)
+
+
 def check_python_version():
     """Raise an error for Python 2 (or less); warn for Python 3 before 3.10"""
 

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -610,6 +610,11 @@ def main():
         "Python version: {} (expecting 3.10 or newer)".format(ptx.python_version())
     )
 
+    # Report versions of the Python packages we depend upon
+    log.debug(
+        "Python module versions: {}".format(ptx.python_module_versions())
+    )
+
     # Check discovering directory locations as
     # realized by PreTeXt installation
     # Necessary for locating configuration files (next)


### PR DESCRIPTION
Resolves #2168.

The debug output already reports the Python version; this adds a companion line reporting the installed versions of the Python packages PreTeXt depends on — useful for diagnosing an author's or publisher's setup from a bug report.

Names are read from `pretext/requirements.txt` (so the report tracks the actual dependency list without a second hardcoded copy); versions come from the installed package metadata via `importlib.metadata.version()`, i.e. what is really installed, not the file's version specifiers. A package that can't be found reports "(not installed)"; if `requirements.txt` can't be read, a single note is emitted.

Example:
```
PTX:DEBUG   : Python module versions: coloraide 8.8.1, lxml 6.1.1, nbformat 5.10.4, pdfCropMargins 1.0.9, playwright 1.60.0, PyPDF2 2.5.0, pyMuPDF 1.27.2.3, qrcode 8.2, requests 2.34.2
```

*Claude Opus 4.8 (1M context), acting as a coding assistant for Rob Beezer*
