### PR TITLE
Publisher file: add "annotation" option for Hypothes.is, deprecating "html.annotation"

### DIFF
--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -47,6 +47,14 @@
             <p>The top of page banner normally features the title, subtitle, and author. If the subtitle or author list are long, or not particularly relevant for a given work, the publisher may wish to not render them at the top of each page. Of course, this information will still always be available at least once in places equivalent to a title page in the <q>front</q> of your document.  See <xref ref="online-banner"/> for details on specifying what to display.</p>
         </subsection>
 
+        <subsection xml:id="online-html-annotation">
+            <title>Annotation</title>
+            <idx><h>Hypothes.is</h></idx>
+            <idx><h>annotation</h></idx>
+
+            <p>A publisher may enable a third-party web-annotation service, which lets readers of the <init>HTML</init> output highlight passages and attach notes.  This is a publisher decision, so it is configured in the publication file rather than in the source.  At present the only supported service is <url href="https://web.hypothes.is/" visual="hypothes.is"/>, enabled by setting the <attr>platform</attr> attribute to <c>hypothesis</c>.  See <xref ref="online-annotation"/> for the exact publication-file entry.</p>
+        </subsection>
+
         <subsection xml:id="online-embedded-calculator">
             <title>Embedded Calculator</title>
             <idx><h>calculator</h><h>embedded in <init>HTML</init></h></idx>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -568,6 +568,23 @@
             </ul>The default is <c>none</c>.  See <xref ref="online-embedded-calculator"/> for more.</p>
         </subsection>
 
+        <subsection xml:id="online-annotation">
+            <title>HTML Annotation</title>
+            <idx><h>annotation</h><h>embedded in <init>HTML</init></h></idx>
+            <idx><h>Hypothes.is</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/html/annotation</cline>
+            </cd>element has the following attribute:<ul>
+                <li>
+                    <p><attr>platform</attr>: enables a third-party web-annotation service on every page.  Possible values are:<ul>
+                        <li><c>hypothesis</c>: the <url href="https://web.hypothes.is/" visual="hypothes.is"/> annotation service.</li>
+                        <li><c>none</c></li>
+                    </ul></p>
+                </li>
+            </ul>The default is <c>none</c>.  See <xref ref="online-html-annotation"/> for more.</p>
+        </subsection>
+
         <subsection xml:id="online-favicon">
             <title>HTML Favicon</title>
             <idx>favicon</idx>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -224,6 +224,7 @@
                     attribute short-answer-responses { "graded" | "always" }?,
                     (
                         Analytics? &
+                        Annotation? &
                         Asymptote? &
                         Baseurl? &
                         Calculator? &
@@ -249,6 +250,11 @@
                     attribute google-gst { text }?,
                     attribute statcounter-project { text }?,
                     attribute statcounter-security { text }?
+                }
+
+            Annotation =
+                element annotation {
+                    attribute platform { "hypothesis" | "none" }?
                 }
 
             Baseurl =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -713,6 +713,9 @@
           <ref name="Analytics"/>
         </optional>
         <optional>
+          <ref name="Annotation"/>
+        </optional>
+        <optional>
           <ref name="Asymptote"/>
         </optional>
         <optional>
@@ -776,6 +779,18 @@
       </optional>
       <optional>
         <attribute name="statcounter-security"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Annotation">
+    <element name="annotation">
+      <optional>
+        <attribute name="platform">
+          <choice>
+            <value>hypothesis</value>
+            <value>none</value>
+          </choice>
+        </attribute>
       </optional>
     </element>
   </define>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -406,6 +406,7 @@
                     attribute short-answer-responses { "graded" | "always" }?,
                     (
                         Analytics? &amp;
+                        Annotation? &amp;
                         Asymptote? &amp;
                         Baseurl? &amp;
                         Calculator? &amp;
@@ -431,6 +432,11 @@
                     attribute google-gst { text }?,
                     attribute statcounter-project { text }?,
                     attribute statcounter-security { text }?
+                }
+
+            Annotation =
+                element annotation {
+                    attribute platform { "hypothesis" | "none" }?
                 }
 
             Baseurl =

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -143,10 +143,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
-<!-- Annotation -->
-<xsl:param name="html.annotation" select="''" />
-<xsl:variable name="b-activate-hypothesis" select="boolean($html.annotation='hypothesis')" />
-
 <!-- Should we build the SCORM manifest file? -->
 <xsl:param name="html.scorm" select="'no'" />
 <!-- b-host-scorm is true when building a SCORM package  -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2045,6 +2045,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="b-has-calculator" select="not($html-calculator = 'none')" />
 
+<!-- Third-party annotation of the HTML output.  Default is "none".  -->
+<!-- Only "hypothesis" (Hypothes.is) is supported at present.        -->
+<xsl:variable name="html-annotation">
+    <xsl:apply-templates select="$publisher-attribute-options/html/annotation/pi:pub-attribute[@name='platform']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-activate-hypothesis" select="$html-annotation = 'hypothesis'" />
+
 <!-- Scratch ActiveCode Window -->
 <!-- Pop-up a window for testing program code.  So "calculator-like" but we      -->
 <!-- reserve the word "calculator" for the hand-held type (even if more modern). -->
@@ -3718,6 +3725,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <calculator>
             <pi:pub-attribute name="model" default="none" options="geogebra-classic geogebra-graphing geogebra-geometry geogebra-3d" legacy-stringparam="html.calculator"/>
         </calculator>
+        <annotation>
+            <pi:pub-attribute name="platform" default="none" options="hypothesis"/>
+        </annotation>
         <css>
             <pi:pub-attribute name="palette" freeform="yes"/>
         </css>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3726,7 +3726,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <pi:pub-attribute name="model" default="none" options="geogebra-classic geogebra-graphing geogebra-geometry geogebra-3d" legacy-stringparam="html.calculator"/>
         </calculator>
         <annotation>
-            <pi:pub-attribute name="platform" default="none" options="hypothesis"/>
+            <pi:pub-attribute name="platform" default="none" options="hypothesis" legacy-stringparam="html.annotation"/>
         </annotation>
         <css>
             <pi:pub-attribute name="palette" freeform="yes"/>
@@ -4240,6 +4240,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Deprecated 2026-06-07, but still respected -->
 <xsl:param name="debug.project.number" select="''" />
+
+<!-- DEPRECATED: 2026-07-25  In favor of          -->
+<!-- html/annotation/@platform  in publisher file -->
+<xsl:param name="html.annotation" select="''" />
 
 <!-- ###################################### -->
 <!-- Parameter Deprecation Warning Messages -->
@@ -4897,6 +4901,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="date-string" select="'2026-06-07'" />
         <xsl:with-param name="message" select="'the  debug.project.number  parameter has been replaced by the  numbering/projects/@distinct  entry in the publisher file.  We will attempt to honor your intent.  But please switch to using the Publishers File for configuration, as documented in the PreTeXt Guide.'" />
         <xsl:with-param name="incorrect-use" select="($debug.project.number != '')" />
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2026-07-25  HTML annotation platform controlled by publisher file -->
+    <xsl:call-template name="parameter-deprecation-message">
+        <xsl:with-param name="date-string" select="'2026-07-25'" />
+        <xsl:with-param name="message" select="'the  html.annotation  parameter has been replaced by the  html/annotation/@platform  entry in the publisher file.  We will attempt to honor your selection.  But please switch to using the Publishers File for configuration, as documented in the PreTeXt Guide.'" />
+        <xsl:with-param name="incorrect-use" select="($html.annotation != '')" />
     </xsl:call-template>
     <!--  -->
 </xsl:template>


### PR DESCRIPTION
Resolves #1800.

Hypothes.is annotation is now configured in the publisher file rather than the `html.annotation` string parameter (previously hardcoded/beta). A `<html><annotation platform="hypothesis"/></html>` element enables it; `platform` accepts `hypothesis` or `none` (default `none`).

Three commits:

1. **Publisher file: add "annotation" option for Hypothes.is** — the new option via the standard `pi:pub-attribute` machinery, the `html-annotation`/`b-activate-hypothesis` variables, the publication-schema `annotation` element (with `.rnc`/`.rng` regenerated), and `pretext-html.xsl` sourcing the new variable.
2. **Deprecate: the "html.annotation" string parameter** — `legacy-stringparam="html.annotation"` so an existing string parameter is still honored (publisher file primary, string parameter as fallback) with a deprecation notice; the parameter moved to the deprecated-parameter section and a `parameter-deprecation-warnings` entry, both at the chronological end of their lists.
3. **Guide: document the HTML "annotation" publisher option** — a reference entry and a conversational note, cross-linked.

Verified: the new publisher option activates Hypothes.is; the deprecated string parameter still activates it (its value honored) and warns, pointing at `$publication/html/annotation/@platform`; a publisher-file entry overrides the string parameter; nothing by default. The Guide validates against the development schema.

*Claude Opus 4.8 (1M context), acting as a coding assistant for Rob Beezer*
