### PR TITLE
Fix duplicate-label error for image elements inside cardsort responses and premises

### DIFF
--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -743,7 +743,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <ul>
                             <xsl:for-each select="premise">
                                 <li>
-                                    <xsl:copy-of select="."/>
+                                    <xsl:apply-templates select="." mode="cardsort-sol-copy"/>
                                 </li>
                             </xsl:for-each>
                         </ul>
@@ -777,7 +777,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                             <!-- the test for adjacency -->
                             <xsl:if test="contains($the-ref-fenced, $response-xmlid-fenced)">
                                 <li>
-                                    <xsl:copy-of select="."/>
+                                    <xsl:apply-templates select="." mode="cardsort-sol-copy"/>
                                 </li>
                             </xsl:if>
                         </xsl:for-each>


### PR DESCRIPTION
Fixes #2927.

When a \`cardsort\` response or premise contains an image element with a \`@label\` attribute (\`pf:prefigure\`, \`latex-image\`, \`asymptote\`, \`sageplot\`, or \`mermaid\`), the static conversion emits the same element — and the same label — in two places: once in the statement tabular and again in the solution list. The assembly-phase duplicate-label check fires on a clean build with the message "should be unique, but is authored multiple times."

The error appears only on a clean build. On subsequent incremental builds the generated assets are already cached, so the extraction step is skipped and the error is not surfaced — making the problem seem intermittent.

The fix changes the cardsort and matching solution templates to use \`apply-templates\` with a new \`cardsort-sol-copy\` mode instead of \`xsl:copy-of\`. An additional template in that mode rewrites the \`@label\` attribute on image-source elements by appending \`-sol\`, giving each solution copy a unique label while keeping the images visible in the rendered solution.