### PR TITLE
EPUB: create cover and table of contents files unconditionally

### DIFF
--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -219,11 +219,13 @@
     <xsl:call-template name="packaging-info"/>
 </xsl:template>
 
-<!-- First, we use the frontmatter element to trigger various necessary files     -->
+<!-- First, create the cover page and table of contents files, which are          -->
+<!-- necessary for every EPUB, even when the source has no "frontmatter"          -->
 <!-- We process structural nodes via chunking routine in  xsl/mathbook-common.xsl -->
 <!-- This in turn calls specific modal templates defined elsewhere in this file   -->
 <xsl:template match="/pretext">
-    <xsl:apply-templates select="$document-root//frontmatter" mode="epub" />
+    <xsl:call-template name="cover-page-file"/>
+    <xsl:call-template name="table-contents-file"/>
     <xsl:call-template name="endnotes"/>
     <xsl:apply-templates mode="chunking" />
 </xsl:template>
@@ -816,6 +818,12 @@
 <!-- Content files -->
 <!-- ############# -->
 
+<!-- The cover page and table of contents files are listed in the   -->
+<!-- manifest and spine of every EPUB, and "package-manifest" reads -->
+<!-- the table of contents file once written.  So create both       -->
+<!-- unconditionally: their content comes from the document root,   -->
+<!-- not the optional "frontmatter".                                -->
+
 <!-- "coverpage.html" comes in two flavors:                            -->
 <!--                                                                   -->
 <!-- 1.  An author provides a cover image via the publication file and -->
@@ -829,7 +837,7 @@
 <!--     here is backed out.  More immediately, we build a simple page -->
 <!--     (with CSS) having title, subtitle, and authors.               -->
 
-<xsl:template match="frontmatter" mode="epub">
+<xsl:template name="cover-page-file">
     <exsl:document href="{$content-dir}/{$xhtml-dir}/cover-page.xhtml" method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="no">
         <html>
             <xsl:call-template name="html-theme-attributes"/>
@@ -878,6 +886,9 @@
             </body>
         </html>
     </exsl:document>
+</xsl:template>
+
+<xsl:template name="table-contents-file">
     <exsl:document href="{$content-dir}/{$xhtml-dir}/table-contents.xhtml" method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="no">
         <html xmlns:epub="http://www.idpf.org/2007/ops">
             <xsl:call-template name="html-theme-attributes"/>


### PR DESCRIPTION
An EPUB build fails for source with no `frontmatter`, [reported on pretext-dev](https://groups.google.com/d/msgid/pretext-dev/400a6d52-c6a8-43b4-8e5d-953fb618d0f4n%40googlegroups.com): the cover page and table of contents files were generated by a template matching `frontmatter`, while the package manifest lists both files for every EPUB and reads the table of contents file to detect mathematics — so an article without a `frontmatter` dies with `Cannot resolve URI .../EPUB/xhtml/table-contents.xhtml`.

Neither file's content depends on `frontmatter` (only the document root and bibliographic information), so the template is now two named templates, `cover-page-file` and `table-contents-file`, called unconditionally from the entry template.

Verified: a minimal article with no `frontmatter` now builds as `epub-svg` and `epub-mml`, passing epubcheck with only its pre-existing complaints about the `epub.css` file; builds of the EPUB sampler and of the same article with an empty `frontmatter` are unchanged from master apart from run timestamps.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
