### PR TITLE
WeBWorK: overwrite prior image files when unpacking an archive

### DIFF
--- a/pretext/lib/webwork.py
+++ b/pretext/lib/webwork.py
@@ -643,16 +643,15 @@ def webwork_to_xml(
                 tgzfile = tarfile.open(destination_image_file)
                 tgzfile.extractall(os.path.join(ww_images_dir))
                 tgzfile.close()
-                # template for error message(s)
-                msg = "{} did not contain a .{} file"
                 # attempt to recover four file formats, with warnings
                 for ext in ["tex", "pdf", "svg", "png"]:
                     try:
-                        os.rename(
+                        os.replace(
                             os.path.join(ww_images_dir, "image.{}".format(ext)),
                             os.path.join(ww_images_dir, ptx_image_name + ".{}".format(ext)),
                         )
                     except:
+                        msg = "{} did not contain a .{} file"
                         log.warning(msg.format(destination_image_file, ext))
                 os.remove(os.path.join(ww_images_dir, ptx_image_filename))
 


### PR DESCRIPTION
Regenerating WeBWorK representations on Windows fails to update TikZ images, [reported on pretext-support](https://groups.google.com/d/msgid/pretext-support/3b134f4c-24c4-4085-831b-35a911d9c1c1n%40googlegroups.com): each downloaded `.tgz` image archive extracts correctly, but the subsequent `os.rename` of `image.tex`/`image.pdf`/`image.svg`/`image.png` to the problem's image name raises `FileExistsError` on Windows whenever a prior run's file is present (POSIX replaces silently). The bare `except` then reports the failure as "did not contain a ... file" — for every problem and every format — and the archive is discarded, leaving stale images. `os.replace()` has the same signature and silently overwrites the destination on all platforms, so a Linux run is unchanged and a Windows run now overwrites prior generated images, matching Linux. In passing, the warning-message template moves adjacent to its single use.

Verified on Linux with the WeBWorK sample chapter against `webwork-ptx.aimath.org`: before/after runs produce identical image inventories, byte-identical representation files and `.tex`/`.svg` images, and pixel-identical `.pdf`/`.png` images (byte differences are per-request server rendering); regenerating into an already-populated images directory completes with no warnings.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
