### PR TITLE
Schema: allow "@component" on metadata elements and "docinfo"

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2013,6 +2013,7 @@
             
             DocInfo =
                 element docinfo {
+                    Component?,
                     XMLLang?,
                     Configuration+
                 }

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -849,7 +849,7 @@
                 }
             
             Caption =
-                element caption {TextLong}
+                element caption {Component?, TextLong}
             Landscape =
                 attribute landscape {"yes" | "no"}
             Figure =
@@ -1522,6 +1522,7 @@
             
             Attribution =
                 element attribution {
+                    Component?,
                     (TextLong | LongLine+)
                 }
             
@@ -1532,19 +1533,19 @@
             Component =
                 attribute component {text}
             Title =
-                element title {TextLong}
+                element title {Component?, TextLong}
             LinedTitle =
-                element title {LongLine+}
+                element title {Component?, LongLine+}
             Subtitle =
-                element subtitle {TextLong}
+                element subtitle {Component?, TextLong}
             LinedSubtitle =
-                element subtitle {LongLine+}
+                element subtitle {Component?, LongLine+}
             ShortTitle =
-                element shorttitle {TextShort}
+                element shorttitle {Component?, TextShort}
             PlainTitle =
-                element plaintitle {text}
+                element plaintitle {Component?, text}
             Creator =
-                element creator {TextShort}
+                element creator {Component?, TextShort}
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2355,6 +2355,9 @@
   </define>
   <define name="Caption">
     <element name="caption">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <ref name="TextLong"/>
     </element>
   </define>
@@ -3959,6 +3962,9 @@
   </define>
   <define name="Attribution">
     <element name="attribution">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <choice>
         <ref name="TextLong"/>
         <oneOrMore>
@@ -3978,11 +3984,17 @@
   </define>
   <define name="Title">
     <element name="title">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <ref name="TextLong"/>
     </element>
   </define>
   <define name="LinedTitle">
     <element name="title">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <oneOrMore>
         <ref name="LongLine"/>
       </oneOrMore>
@@ -3990,11 +4002,17 @@
   </define>
   <define name="Subtitle">
     <element name="subtitle">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <ref name="TextLong"/>
     </element>
   </define>
   <define name="LinedSubtitle">
     <element name="subtitle">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <oneOrMore>
         <ref name="LongLine"/>
       </oneOrMore>
@@ -4002,16 +4020,25 @@
   </define>
   <define name="ShortTitle">
     <element name="shorttitle">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <ref name="TextShort"/>
     </element>
   </define>
   <define name="PlainTitle">
     <element name="plaintitle">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <text/>
     </element>
   </define>
   <define name="Creator">
     <element name="creator">
+      <optional>
+        <ref name="Component"/>
+      </optional>
       <ref name="TextShort"/>
     </element>
   </define>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -5230,6 +5230,9 @@
   <define name="DocInfo">
     <element name="docinfo">
       <optional>
+        <ref name="Component"/>
+      </optional>
+      <optional>
         <ref name="XMLLang"/>
       </optional>
       <oneOrMore>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1685,7 +1685,7 @@
             <title>Captioned and titled displays</title>
             <code>
             Caption =
-                element caption {TextLong}
+                element caption {Component?, TextLong}
             Landscape =
                 attribute landscape {"yes" | "no"}
             Figure =
@@ -3151,6 +3151,7 @@
             <code>
             Attribution =
                 element attribution {
+                    Component?,
                     (TextLong | LongLine+)
                 }
             </code>
@@ -3182,19 +3183,19 @@
             Component =
                 attribute component {text}
             Title =
-                element title {TextLong}
+                element title {Component?, TextLong}
             LinedTitle =
-                element title {LongLine+}
+                element title {Component?, LongLine+}
             Subtitle =
-                element subtitle {TextLong}
+                element subtitle {Component?, TextLong}
             LinedSubtitle =
-                element subtitle {LongLine+}
+                element subtitle {Component?, LongLine+}
             ShortTitle =
-                element shorttitle {TextShort}
+                element shorttitle {Component?, TextShort}
             PlainTitle =
-                element plaintitle {text}
+                element plaintitle {Component?, text}
             Creator =
-                element creator {TextShort}
+                element creator {Component?, TextShort}
             XMLLang = attribute xml:lang {text}
             MetaDataTarget =
                 UniqueID?,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3609,6 +3609,7 @@
             <code>
             DocInfo =
                 element docinfo {
+                    Component?,
                     XMLLang?,
                     Configuration+
                 }


### PR DESCRIPTION
Reported on pretext-support ([VS complaining about component in subtitle, but all works well](https://groups.google.com/d/msgid/pretext-support/8da0d01d-6498-415e-88df-4cba6e3d4f62n%40googlegroups.com)): placing `component="..."` on a `subtitle` draws a validation complaint, while processing is perfectly happy. The version machinery in assembly acts on any element carrying `@component`, and the attribute survives into the assembled tree, so the schema is the only gatekeeper — for editor validation (pretext-tools) and for `-V` alike.

Two commits extend the allowance where a version-conditional variant makes sense:

1. **Title-like metadata elements** — `title` (both forms), `subtitle` (both forms, the reported case), `shorttitle`, `plaintitle`, `creator`, `caption`, `attribution`. A caption reading "the red curve" needs a variant in a black-and-white version; a title's companions travel with it.
2. **`docinfo`** — the version mechanism's motivating example (per-version `latex-image-preamble` color palettes) is authored as two `docinfo` elements, yet `@component` was not allowed there.

Precedents: `idx` already carries the allowance, and `commentary` requires the attribute.

Verified: `@component` planted on one instance of each of the eight elements in the sample article draws exactly eight complaints from the current schema and zero from the revised schema (the total error count drops by exactly eight, nothing else moves); regenerating `.rnc`/`.rng` from unmodified source was checked clean first, so each commit pairs the literate source with its derived files.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
