### PR TITLE
Cross-reference ranges honor custom text

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10692,6 +10692,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <li><p>A system of equations, given as range from first to last: <xref first="equation-system-begin" last="equation-system-end" text="global"/></p></li>
                 <li><p>A range of sections, hand-named to be plural: Sections<nbsp/><xref first="section-sage-cells" last="section-cross-referencing" text="global"/></p></li>
                 <li><p>A range of bibliographic items: <xref first="biblio-judson-AATA" last="biblio-lay-article" text="global"/></p></li>
+                <li><p>A range with custom text, which replaces the entire range, endpoints, separator, and any brackets (compare with the previous item): <xref first="biblio-judson-AATA" last="biblio-lay-article" text="custom">a pair of consecutive references</xref></p></li>
                 <!-- <li><p>: <xref ref=""/></p></li> -->
             </ul></p>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -8398,32 +8398,50 @@ Book (with parts), "section" at level 3
             <!-- brackets and detail before link manufacture  -->
             <!-- Content passes with @first, not with @second -->
             <xsl:variable name="b-is-biblio-target" select="boolean($target-one/self::biblio)" />
-            <!-- Compose two text parts with an ndash, perhaps wrappped -->
+            <!-- Compose two text parts with an ndash, perhaps wrapped. -->
+            <!-- But custom text replaces the entire composition, so no -->
+            <!-- endpoint texts, no ndash, and no bibliography brackets -->
+            <!-- (matching their suppression for a single citation with -->
+            <!-- custom text).                                          -->
             <xsl:variable name="text">
                 <xsl:if test="parent::mrow">
                     <xsl:text>\text{</xsl:text>
                 </xsl:if>
-                <xsl:if test="$b-is-biblio-target">
-                    <xsl:text>[</xsl:text>
-                </xsl:if>
-                <xsl:apply-templates select="." mode="xref-text" >
-                    <xsl:with-param name="target" select="$target-one" />
-                    <xsl:with-param name="text-style" select="$text-style-one" />
-                    <!-- pass content as an RTF, test vs. empty string, use copy-of -->
-                    <xsl:with-param name="custom-text">
-                        <xsl:apply-templates/>
-                    </xsl:with-param>
-                </xsl:apply-templates>
-                <xsl:call-template name="character">
-                    <xsl:with-param name="name" select="'ndash'"/>
-                </xsl:call-template>
-                <xsl:apply-templates select="." mode="xref-text" >
-                    <xsl:with-param name="target" select="$target-two" />
-                    <xsl:with-param name="text-style" select="$text-style-two" />
-                </xsl:apply-templates>
-                <xsl:if test="$b-is-biblio-target">
-                    <xsl:text>]</xsl:text>
-                </xsl:if>
+                <xsl:choose>
+                    <xsl:when test="$text-style-one = 'custom'">
+                        <xsl:apply-templates select="." mode="xref-text" >
+                            <xsl:with-param name="target" select="$target-one" />
+                            <xsl:with-param name="text-style" select="$text-style-one" />
+                            <!-- pass content as an RTF, test vs. empty string, use copy-of -->
+                            <xsl:with-param name="custom-text">
+                                <xsl:apply-templates/>
+                            </xsl:with-param>
+                        </xsl:apply-templates>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:if test="$b-is-biblio-target">
+                            <xsl:text>[</xsl:text>
+                        </xsl:if>
+                        <xsl:apply-templates select="." mode="xref-text" >
+                            <xsl:with-param name="target" select="$target-one" />
+                            <xsl:with-param name="text-style" select="$text-style-one" />
+                            <!-- pass content as an RTF, test vs. empty string, use copy-of -->
+                            <xsl:with-param name="custom-text">
+                                <xsl:apply-templates/>
+                            </xsl:with-param>
+                        </xsl:apply-templates>
+                        <xsl:call-template name="character">
+                            <xsl:with-param name="name" select="'ndash'"/>
+                        </xsl:call-template>
+                        <xsl:apply-templates select="." mode="xref-text" >
+                            <xsl:with-param name="target" select="$target-two" />
+                            <xsl:with-param name="text-style" select="$text-style-two" />
+                        </xsl:apply-templates>
+                        <xsl:if test="$b-is-biblio-target">
+                            <xsl:text>]</xsl:text>
+                        </xsl:if>
+                    </xsl:otherwise>
+                </xsl:choose>
                 <xsl:if test="parent::mrow">
                     <xsl:text>}</xsl:text>
                 </xsl:if>


### PR DESCRIPTION
Resolves #1576.

A cross-reference range (`xref` with `@first` and `@last`) requesting `text="custom"` produced defective output: the custom text, then a dangling ndash and an empty second endpoint (the second endpoint has no custom content to typeset; the hard error originally reported in #1576 had already given way to this silent form). Custom text now replaces the entire composition — endpoint texts, the ndash separator, and any bibliography brackets — consistent with how a single citation with custom text already suppresses its brackets.

A second commit adds a range with custom text to the sample article's cross-reference testing, alongside the existing range styles.

Verified: builds of the unmodified sample article are unchanged apart from timestamps (LaTeX, and the full HTML page tree); a range of equations with custom text now renders as just the custom text linked to `@first`, and a bibliographic range with custom text renders without the `[...]` wrapper.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
