### PR TITLE
Resolve Runestone and bibliography lookups on the assembled tree; reinstate Runestone identifier warnings

### DIFF
--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -104,7 +104,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-c">
             <title>An C program, interactive on a <pubtitle>Runestone</pubtitle> server</title>
-            <program xml:id="c-hello-world" interactive='activecode' language="c">
+            <program xml:id="c-hello-world" label="c-hello-world" interactive='activecode' language="c">
                 <code>
                 #include &lt;stdio.h&gt;
 
@@ -120,7 +120,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-java">
             <title>A Java program, interactive on a <pubtitle>Runestone</pubtitle> server</title>
-            <program xml:id="java-hello-world" interactive='activecode' language="java">
+            <program xml:id="java-hello-world" label="java-hello-world" interactive='activecode' language="java">
                 <code>
                 public class HelloWorld {
                     public static void main(String[] args) {
@@ -135,7 +135,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-javascript">
             <title>An interactive JavaScript program, using <pubtitle>Runestone</pubtitle></title>
-            <program xml:id="javascript-hello-world" interactive='activecode' language="javascript">
+            <program xml:id="javascript-hello-world" label="javascript-hello-world" interactive='activecode' language="javascript">
                 <code>
                 document.write('Hello, world!');
                 </code>
@@ -188,7 +188,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-octave">
             <title>A simple Octave program</title>
-            <program xml:id="octave-simple" interactive='activecode' language="octave">
+            <program xml:id="octave-simple" label="octave-simple" interactive='activecode' language="octave">
                 <code>
                 x = 2 + 2
                 printf("%d\n", x)
@@ -200,7 +200,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-kotlin">
             <title>A simple Kotlin program</title>
-            <program xml:id="kotlin-hello-world" interactive='activecode' language="kotlin">
+            <program xml:id="kotlin-hello-world" label="kotlin-hello-world" interactive='activecode' language="kotlin">
                 <code>
                 fun main() {
                     println("Hello, world!!")
@@ -213,7 +213,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-mistake-pascal">
             <title>A Pascal program that cannot be interactive on Runestone</title>
-            <program xml:id="pascal-mistake" interactive='activecode' language="pascal">
+            <program xml:id="pascal-mistake" label="pascal-mistake" interactive='activecode' language="pascal">
                 <code>
                 program HelloWorld;
                 begin
@@ -306,7 +306,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <listing xml:id="program-activecode-java-flags">
             <title>A Java program, interactive on a <pubtitle>Runestone</pubtitle> server, with compiler and linker flags</title>
-            <program xml:id="java-hello-world-flags" interactive='activecode' language="java" compiler-args="-g" linker-args="-s">
+            <program xml:id="java-hello-world-flags" label="java-hello-world-flags" interactive='activecode' language="java" compiler-args="-g" linker-args="-s">
                 <code>
                 import javax.swing.JFrame;  //Importing class JFrame
                 import javax.swing.JLabel;  //Importing class JLabel
@@ -330,7 +330,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>This program also makes use of <attr>autorun</attr> to execute on page load and the <attr>codelens</attr>to disable the codelens feature.</p>
 
-        <exercise xml:id="exercise-python-including">
+        <exercise xml:id="exercise-python-including" label="exercise-python-including">
             <title>A Python program, including another</title>
             <statement>
                 <p>Compute the total amount of money loaned and store it in the variable <c>loan_total</c>.</p>
@@ -361,7 +361,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>This program also makes use of <attr>hidecode</attr> to initially keep the code hidden and <attr>download</attr> to enable a file download of the program (that includes all the included code).</p>
 
-        <exercise xml:id="exercise-python-including-two">
+        <exercise xml:id="exercise-python-including-two" label="exercise-python-including-two">
             <title>A Python program, including two others</title>
             <statement>
                 <p>Compute the total amount of money loaned and store it in the variable <c>loan_total</c>.</p>
@@ -390,7 +390,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>Here is an activecode with <attr>language</attr> set to <c>sql</c> uses the <attr>database</attr> to load a SQLite database file.</p>
 
-        <exercise xml:id="exercise-sql-using-db">
+        <exercise xml:id="exercise-sql-using-db" label="exercise-sql-using-db">
             <title>An SQL program that uses an SQLite database file</title>
             <statement>
                 <p>Select all the columns of all the rows in the <c>test</c> database table.</p>
@@ -684,7 +684,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </answer>
         </exercise>
 
-        <activity xml:id="coding-exercise-partial-two">
+        <activity xml:id="coding-exercise-partial-two" label="coding-exercise-partial-two">
             <title>Activity Coding Exercise</title>
 
             <statement>
@@ -5334,7 +5334,7 @@ TEST_CASE( "Test the add function" ) {
         <p>And a final paragraph in the section, and a chance to say there is a trailing <tag>exercise</tag> outside the <tag>exercisegroup</tag>.</p>
     </section>
 
-    <worksheet groupwork="yes" groupsize="2" xml:id="worksheet-groupwork">
+    <worksheet groupwork="yes" groupsize="2" xml:id="worksheet-groupwork" label="worksheet-groupwork">
         <title>A <q>Group Work</q> Worksheet</title>
 
         <p>This is a <tag>worksheet</tag> which has a <attr>groupwork</attr> attribute set to <c>yes</c>, along with a <attr>label</attr> attribute to assist with the Runestone database.  Note, you can also set a <attr>groupsize</attr> attribute.  When hosted on Runestone, the exercises within will be available for a group of students to submit together.</p>
@@ -5540,7 +5540,7 @@ TEST_CASE( "Test the add function" ) {
 
         <!-- 2025-11-05: Donated by Matt Boelkins from Active Calculus  -->
         <!-- where it has @xml:id "doenet-interactive-exercise-1-1-1" -->
-        <exercise>
+        <exercise xml:id="doenet-average-velocity" label="doenet-average-velocity">
             <title>Finding the average velocity of a moving object from data (dual, Doenet)</title>
             <dynamic>
                 <statement>
@@ -5701,7 +5701,7 @@ TEST_CASE( "Test the add function" ) {
             </static>
         </exercise>
 
-        <exercise>
+        <exercise xml:id="opendsa-list-insertion" label="opendsa-list-insertion">
             <title>OpenDSA List Insertion (Dual)</title>
             <dynamic>
                 <statement>

--- a/xsl/extract-biblio-csl.xsl
+++ b/xsl/extract-biblio-csl.xsl
@@ -296,8 +296,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:variable name="the-ref">
                 <xsl:value-of select="."/>
             </xsl:variable>
-            <!-- context switch so id() function works -->
-            <xsl:for-each select="$original">
+            <!-- context switch so id() function works; the assembled  -->
+            <!-- tree, so content excluded by the version in play does -->
+            <!-- not validate a citation                               -->
+            <xsl:for-each select="$root">
                 <xsl:variable name="target" select="id($the-ref)"/>
                 <!-- vet each @ref value, only backmatter is considered -->
                 <xsl:if test="$target/self::biblio/parent::references/parent::backmatter">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1076,9 +1076,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- $biblios in -common, and then mined for matches not   -->
 <!-- explicitly present?                                   -->
 <xsl:template match="backmatter/references[@source]" mode="assembly">
-    <!-- Grab the list, filename is relative to the -->
-    <!-- "document" holding "references" (original) -->
-    <xsl:variable name="biblios" select="document(@source, .)"/>
+    <!-- Grab the list.  The filename is relative to the authored -->
+    <!-- document, so the lookup anchors on $original: the context -->
+    <!-- node lives in a constructed tree, which has no base URI   -->
+    <xsl:variable name="biblios" select="document(@source, $original)"/>
     <!-- Copy the "references" element (could be literal, but maybe not in "text" output mode) -->
     <xsl:copy>
         <!-- @source attribute not needed in enhanced source -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1089,9 +1089,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:for-each select="$biblios/pretext-biblios/biblio">
             <xsl:variable name="the-id" select="@xml:id"/>
             <xsl:message>PTX:DEBUG: @xml:id of &lt;biblio&gt; in bibliography file: <xsl:value-of select="$the-id"/></xsl:message>
-            <!-- Building duplicate, so look at $original for    -->
-            <!-- "xref" pointing to the current context "biblio" -->
-            <xsl:if test="$original//xref[@ref = $the-id]">
+            <!-- Building duplicate, so look in this pass's input  -->
+            <!-- tree (the version in play) for an "xref" pointing -->
+            <!-- to the current context "biblio"                   -->
+            <xsl:if test="$original-labeled//xref[@ref = $the-id]">
                 <xsl:message>PTX:DEBUG:  Located this &lt;biblio&gt; cited in original source</xsl:message>
                 <xsl:apply-templates select="." mode="assembly"/>
             </xsl:if>
@@ -1272,17 +1273,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:variable name="first-ref">
                     <xsl:value-of select="$tokenized-refs[1]"/>
                 </xsl:variable>
-                <!-- context switch -->
-                <xsl:for-each select="$original">
-                    <xsl:choose>
-                        <xsl:when test="id($first-ref)/self::biblio/parent::references/parent::backmatter">
-                            <xsl:text>yes</xsl:text>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:text>no</xsl:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:for-each>
+                <!-- The context "xref" sits in this pass's input tree, so -->
+                <!-- id() searches exactly the version in play             -->
+                <xsl:choose>
+                    <xsl:when test="id($first-ref)/self::biblio/parent::references/parent::backmatter">
+                        <xsl:text>yes</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>no</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3787,12 +3787,14 @@ Book (with parts), "section" at level 3
     <!-- As part of backwards-compatibility, we copy old @xml:id values into     -->
     <!-- fresh @label.  But have an internal  @pi:authored-label attribute whose -->
     <!-- absence alerts us to the copying, which is now not best practice.       -->
+    <!-- These messages were disabled 2024-02-20 as unreliable.  The cause       -->
+    <!-- was a pointer to another component resolving against the authored       -->
+    <!-- source, where the @pi:authored-label stamp does not exist; that is      -->
+    <!-- repaired, so the messages return.  A plain static code listing is       -->
+    <!-- the one element reaching here that legitimately has no database         -->
+    <!-- identity and needs none, so it is exempt.                               -->
     <xsl:choose>
-         <!-- 2024-02-20: neuter thse warnings.  Somehow, it seems @pi:authored-label -->
-         <!-- is not very reliable.  Were added in commit 29a42dc689cd772a            -->
-        <!--                                                                          -->
-        <xsl:when test="true()"/>
-        <!--  -->
+        <xsl:when test="self::program and not(@interactive = 'activecode' or @interactive = 'codelens')"/>
         <xsl:when test="$b-host-runestone and not(@xml:id) and not(@pi:authored-label)">
             <xsl:message>
                 <xsl:text>PTX:ERROR:  While building for a Runestone server, a PreTeXt "</xsl:text>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -3037,7 +3037,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- frequently point to other Runestone components in the database. -->
 <!--   * Authors point in their source with @xml:id                  -->
 <!--     values in a space- or comma- separated list                 -->
-<!--   * We locate the targets in the orginal source                 -->
+<!--   * We locate the targets in the assembled tree, where a        -->
+<!--     database id (a @label) exists even when only an @xml:id     -->
+<!--     was authored (a backward-compatibility promotion)           -->
 <!--   * Compute the Runestone database id                           -->
 <!--   * Return a list (varying separator) to use in Runestone HTML. -->
 <xsl:template name="runestone-targets">
@@ -3053,7 +3055,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:value-of select="."/>
         </xsl:variable>
         <!-- context shift so  id()  functions properly -->
-        <xsl:for-each select="$original">
+        <xsl:for-each select="$root">
             <xsl:variable name="target" select="id($the-id)"/>
             <xsl:if test="not($target)">
                 <xsl:message>PTX:ERROR:   an @xml:id value "<xsl:value-of select="$the-id"/>" was used to specify a runestone component but no item with that id exists.</xsl:message>


### PR DESCRIPTION
Five commits that complete the demotion of the authored source tree (`$original`) begun in #3080, reinstate a pair of Runestone author warnings that the newly-fixed bug had made unreliable, and label the sample book's own components that those warnings correctly flag.

**Runestone component pointers — the detailed story, for Runestone developers.**

A Runestone component (an activecode `program`, an interactive `exercise`, a `datafile`, …) is known to the database by its `@label`. Older projects wrote only `@xml:id`, so for backward compatibility the assembly phase copies `@xml:id` into `@label` when no label was authored. That copy exists only on the assembled tree built in memory — the authored source is never changed.

A name is needed in two situations. First, when a component renders it asks for its own name — this always worked, because rendering walks the assembled tree, where the copy has happened. Second, one component can name another: select questions (`@questions`) and a `program`'s `@include`, `@add-files`, `@compile-also` name their targets by `@xml:id`, and we look each target up to write *its* database name into the emitted HTML (`data-include`, `data-questionlist`, …). That second lookup searched the *authored source* instead of the assembled tree — it found the target, but read a `@label` from a tree where the backward-compatibility copy never happens. If the target's author wrote only `@xml:id`, the label was blank, and the HTML came out `data-include=""` — broken wiring, no message, ever. Projects that write `@label` on every component were unaffected, which is why it went unseen. This has been so since the first `@include` (direct commit `4b77cb2f`, February 2023 — there is no PR to cite); every later attribute of the same kind inherited it. The first commit here resolves those lookups on the assembled tree.

**Citations respect the version in play.** Three bibliography-citation lookups also consulted the authored tree: the CSL extraction's citation vetting, the assembly's is-this-a-citation classifier, and the external-bibliography (`references/@source`) cited-check. Under a document version that excludes a cited `biblio` the consequences were real — generating references *crashed* (`ValueError: 'bib-gone' is not in list`, the bibliography half of the extraction respecting the version while the citation half did not), and a full conversion *silently deleted* the citation from the paragraph (the unmatched replacement copies an empty node-set). Now the extraction is coherent, an excluded citation draws the standard missing-target placeholder and its error, and an external-bibliography entry cited only from excluded content is no longer realized. Unversioned documents are byte-identical.

**`references/@source` resolves again.** Surfaced by testing the citation fix: the external bibliography was fetched with `document(@source, .)`, anchored on a node in a constructed tree that has no base URI — so any *relative* `@source` failed outright. Anchoring on the authored source document restores the documented behavior.

**Reinstating the Runestone identifier warnings.** Two author-facing messages built into the database-name routine — an error when a component has no name at all, a gentle note when it has only an old-style `@xml:id` — were disabled in February 2024 as unreliable. There were two causes, both now removed. The first was the pointer bug above: a named target was handed to the routine as an authored-tree node, which carries no assembly stamp, so it looked unlabeled even when it was not — and the warnings cried wolf. The second is that the routine is also asked, purely in case a name exists, about plain static code listings that are not interactive and need no name; an empty answer there is correct, not a mistake. The fix is a single condition: a `program` that is not `activecode` or `codelens` is a plain listing and is exempt — the one element reaching the routine that legitimately has no database identity (the schema restricts `@interactive` to `codelens`/`activecode`/`no`). The message texts are unchanged from 2024.

**Labeling the sample book.** The reinstated messages correctly flag the sample book's own interactive components authored without a `@label` — a Runestone Academy build of the book would fail on the unnamed ones. Twelve components that already carried an `@xml:id` get a `@label` copied verbatim from it, which preserves the database id exactly (rendered output byte-identical; only the assembled tree records the labels as authored). Two experimental dual/Doenet exercises that carried neither identifier get a fresh matching `@xml:id`+`@label`; these previously emitted an empty database id (`id="rs-"`, the Academy failure mode), now `id="rs-doenet-average-velocity"` and the like.

Five commits, in reading order: (1) Runestone pointers on the assembled tree; (2) citations on the version tree; (3) `references/@source` relative resolution; (4) reinstate the identifier warnings; (5) label the sample book's components.

Verification. The sample article and sample book build byte-identical to `master` (`assembly-static`, `assembly-dynamic`, `latex`, `html`) through the first four commits — none of their behavior changes is reachable by the plain samples — so each is proven on a purpose-built document: a two-`program` pointer test (empty id versus resolved label), a version-excluding CSL citation test (crash versus clean generation; vanished citation versus placeholder), and a version-excluding external-bibliography test (ghost entry realized versus dropped, with a relative `@source`); the CSL tests run the full pipeline through citeproc. The fifth commit takes the Runestone Academy build of the sample book from twenty-eight messages to zero, changes no prose (the sample-book output differs only by the labels and the two new exercises' anchors), and leaves validation exactly as on `master`.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
