### PR TITLE
Fix uncapped height of brandlogo when $docinfo/brandlogo/@url is not set

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -14566,7 +14566,9 @@ TODO:
                 </a>
             </xsl:when>
             <xsl:otherwise>
+                <span id="logo-link" class="logo-link">
                     <img src="{$location}" alt="Logo image"/>
+                </span>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:if>


### PR DESCRIPTION
The cap on the height of a brandlogo set at https://github.com/PreTeXtBook/pretext/blob/2f098cffab023cac9feab7b1da865d11a8cfae07/css/components/page-parts/_banner.scss#L59-L70 is not being applied when $docinfo/brandlogo/@url is not set.

This small PR adds a dummy `<span class="logo-link"/>` to apply the CSS as intended even when the brandlogo dosn't have a link.