### PR TITLE
Workbooks: collections of worksheets and handouts

### DIFF
--- a/examples/workbook/ho-reference-card.xml
+++ b/examples/workbook/ho-reference-card.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--********************************************************************
+Copyright 2026 Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<handout label="handout-reference-card">
+  <title>Reference Card for Vectors</title>
+    <introduction>
+        <p>A handout is a printout without the course identification of a worksheet.  Distribute this one alongside the activities, as something to keep.</p>
+    </introduction>
+    <page>
+        <definition>
+            <title>Dot Product</title>
+            <statement>
+                <p>For vectors <m>{\vec u} = (u_1, u_2)</m> and <m>{\vec v} = (v_1, v_2)</m>, the <term>dot product</term> is
+                <md>
+                    <mrow>{\vec u}\cdot{\vec v} \amp = u_1v_1 + u_2v_2\text{.}</mrow>
+                </md></p>
+            </statement>
+        </definition>
+
+        <definition>
+            <title>Length</title>
+            <statement>
+                <p>The <term>length</term> of a vector is the square root of its dot product with itself,
+                <md>
+                    <mrow>\lVert{\vec v}\rVert \amp = \sqrt{{\vec v}\cdot{\vec v}}\text{.}</mrow>
+                </md></p>
+            </statement>
+        </definition>
+
+        <example workspace="1.5in">
+            <title>Room to Work</title>
+            <statement>
+                <p>Compute the length of <m>{\vec v} = (3, 4)</m>, using the space below.</p>
+            </statement>
+        </example>
+    </page>
+    <conclusion>
+        <p>Bring this card to every meeting.</p>
+    </conclusion>
+</handout>

--- a/examples/workbook/workbook-article-publication.xml
+++ b/examples/workbook/workbook-article-publication.xml
@@ -23,9 +23,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Common Options -->
     <common>
-        <!-- How deep to go for separate files, in HTML the -->
-        <!-- default for an article with sections is 1      -->
-        <chunking level="1"/>
         <!-- How deep to nest a Table of Contents, for an article   -->
         <!-- with subsections in HTML, the default is 2, but in the -->
         <!-- LateX conversion the default is no ToC at all.  So we  -->
@@ -49,19 +46,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>
-
-    <!-- For an "article" with "section" we can only go 3 levels    -->
-    <!-- deep (section > subsection > subsubsection) and this is    -->
-    <!-- the default for divisions' levels.  For numbers on smaller -->
-    <!-- pieces of content, the default is XX.NN, i.e. level 1.     -->
-    <!-- Read the PreTeXt Guide for more on numbering and levels.   -->
-    <numbering>
-        <divisions level="1"/>
-        <blocks    level="1"/>
-        <projects  level="1"/>
-        <equations level="1"/>
-        <footnotes level="1"/>
-    </numbering>
 
     <!-- HTML-Specific Options -->
     <html>

--- a/examples/workbook/workbook-article.xml
+++ b/examples/workbook/workbook-article.xml
@@ -161,10 +161,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             is not yet available for articles.  Send requests.
              -->
         </frontmatter>
+        <introduction xml:id="introduction-workbook" label="introduction-workbook">
+            <p>A workbook is a collection of printouts<mdash/><tag>worksheet</tag> and <tag>handout</tag><mdash/>with no traditional divisions at all.  They may come in any order, interleaved with one another, and an introduction like this one (or a concluding division) is optional.</p>
+        </introduction>
         <xi:include href="ws-geometric-prelude.xml" />
         <xi:include href="ws-networks.xml" />
+        <xi:include href="ho-reference-card.xml" />
         <xi:include href="ws-testing.xml" />
         <xi:include href="ws-dot-products.xml" />
         <xi:include href="ws-activity-with-task.xml" />
+        <conclusion xml:id="conclusion-workbook" label="conclusion-workbook">
+            <p>That is the end of the activities.</p>
+        </conclusion>
       </article>
 </pretext>

--- a/examples/workbook/workbook-book-publication.xml
+++ b/examples/workbook/workbook-book-publication.xml
@@ -23,9 +23,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Common Options -->
     <common>
-        <!-- How deep to go for separate files, in HTML the -->
-        <!-- This puts each worksheet in its own HTML file  -->
-        <chunking level="2"/>
         <!-- How deep to nest a Table of Contents, for an article   -->
         <!-- with subsections in HTML, the default is 2, but in the -->
         <!-- LateX conversion the default is no ToC at all.  So we  -->
@@ -49,19 +46,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>
-
-    <!-- For an "article" with "section" we can only go 3 levels    -->
-    <!-- deep (section > subsection > subsubsection) and this is    -->
-    <!-- the default for divisions' levels.  For numbers on smaller -->
-    <!-- pieces of content, the default is XX.NN, i.e. level 1.     -->
-    <!-- Read the PreTeXt Guide for more on numbering and levels.   -->
-    <numbering>
-        <divisions level="2"/>
-        <blocks    level="1"/>
-        <projects  level="1"/>
-        <equations level="1"/>
-        <footnotes level="1"/>
-    </numbering>
 
     <!-- HTML-Specific Options -->
     <html>

--- a/examples/workbook/workbook-book.xml
+++ b/examples/workbook/workbook-book.xml
@@ -159,10 +159,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </frontmatter>
 
         <chapter xml:id="ch-triplet">
-          <title>Four Worksheets</title>
+          <title>Worksheets and a Handout</title>
+            <introduction xml:id="introduction-ch-triplet" label="introduction-ch-triplet">
+                <p>A chapter of printouts may open with an introduction, and it may interleave <tag>worksheet</tag> and <tag>handout</tag> in any order.</p>
+            </introduction>
             <xi:include href="ws-geometric-prelude.xml" />
             <xi:include href="ws-networks.xml" />
+            <xi:include href="ho-reference-card.xml" />
             <xi:include href="ws-testing.xml" />
+            <conclusion xml:id="conclusion-ch-triplet" label="conclusion-ch-triplet">
+                <p>The next chapter has no introduction or conclusion.</p>
+            </conclusion>
           </chapter>
           <chapter xml:id="ch-duo">
             <title>Two Worksheet Chapter</title>

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -181,19 +181,6 @@
                 }
 
             
-            # Main handout definition
-            Handout =
-                element handout {
-                    PrintoutAttributes,
-                    MetaDataAltTitleOptional,
-                    (Objectives? & IntroductionDivision?),
-                    (Page+ | PrintoutBlock+),
-                    (Outcomes? & ConclusionDivision?)
-                }
-            # Add Handout to Printout options
-            Printout |=
-                Handout
-            
             Solutions |=
                 element solutions {
                     MetaDataAltTitleOptional,

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -373,41 +373,6 @@
       <ref name="Tabular"/>
     </element>
   </define>
-  <!-- Main handout definition -->
-  <define name="Handout">
-    <element name="handout">
-      <ref name="PrintoutAttributes"/>
-      <ref name="MetaDataAltTitleOptional"/>
-      <interleave>
-        <optional>
-          <ref name="Objectives"/>
-        </optional>
-        <optional>
-          <ref name="IntroductionDivision"/>
-        </optional>
-      </interleave>
-      <choice>
-        <oneOrMore>
-          <ref name="Page"/>
-        </oneOrMore>
-        <oneOrMore>
-          <ref name="PrintoutBlock"/>
-        </oneOrMore>
-      </choice>
-      <interleave>
-        <optional>
-          <ref name="Outcomes"/>
-        </optional>
-        <optional>
-          <ref name="ConclusionDivision"/>
-        </optional>
-      </interleave>
-    </element>
-  </define>
-  <!-- Add Handout to Printout options -->
-  <define name="Printout" combine="choice">
-    <ref name="Handout"/>
-  </define>
   <define name="Solutions" combine="choice">
     <element name="solutions">
       <ref name="MetaDataAltTitleOptional"/>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -19,7 +19,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? & ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -59,7 +59,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? & ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -81,7 +81,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? &ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -103,7 +103,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? & ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -123,7 +123,7 @@
                     AuthorByline*,
                     Objectives?,
                     (BlockDivision | Paragraphs)+,
-                    (Printout? & ReadingQuestions? & Exercises? &
+                    (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                      Solutions? & References? & Glossary?),
                     Outcomes?
                 }
@@ -135,7 +135,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs | NotationList)+,
-                            (Printout? & ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -157,7 +157,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs | NotationList)+,
-                            (Printout? & ReadingQuestions? & Exercises? &
+                            (Worksheet? & Handout? & ReadingQuestions? & Exercises? &
                              Solutions? & References? & Glossary?),
                             Outcomes?
                         )
@@ -441,9 +441,19 @@
                     (Outcomes? & ConclusionDivision?)
                 }
 
-            # Printout currently just means a Worksheet, but could be extended later.
+            # Main handout definition
+            Handout =
+                element handout {
+                    PrintoutAttributes,
+                    MetaDataAltTitleOptional,
+                    (Objectives? & IntroductionDivision?),
+                    (Page+ | PrintoutBlock+),
+                    (Outcomes? & ConclusionDivision?)
+                }
+
+            # A printout is a worksheet or a handout
             Printout =
-                Worksheet
+                Worksheet | Handout
             
             BlockText =
                 Paragraph | BlockQuote | Preformatted |

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -65,7 +65,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -186,7 +189,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -263,7 +269,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -340,7 +349,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -415,7 +427,10 @@
       </oneOrMore>
       <interleave>
         <optional>
-          <ref name="Printout"/>
+          <ref name="Worksheet"/>
+        </optional>
+        <optional>
+          <ref name="Handout"/>
         </optional>
         <optional>
           <ref name="ReadingQuestions"/>
@@ -458,7 +473,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -536,7 +554,10 @@
           </oneOrMore>
           <interleave>
             <optional>
-              <ref name="Printout"/>
+              <ref name="Worksheet"/>
+            </optional>
+            <optional>
+              <ref name="Handout"/>
             </optional>
             <optional>
               <ref name="ReadingQuestions"/>
@@ -1258,9 +1279,43 @@
       </interleave>
     </element>
   </define>
-  <!-- Printout currently just means a Worksheet, but could be extended later. -->
+  <!-- Main handout definition -->
+  <define name="Handout">
+    <element name="handout">
+      <ref name="PrintoutAttributes"/>
+      <ref name="MetaDataAltTitleOptional"/>
+      <interleave>
+        <optional>
+          <ref name="Objectives"/>
+        </optional>
+        <optional>
+          <ref name="IntroductionDivision"/>
+        </optional>
+      </interleave>
+      <choice>
+        <oneOrMore>
+          <ref name="Page"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="PrintoutBlock"/>
+        </oneOrMore>
+      </choice>
+      <interleave>
+        <optional>
+          <ref name="Outcomes"/>
+        </optional>
+        <optional>
+          <ref name="ConclusionDivision"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <!-- A printout is a worksheet or a handout -->
   <define name="Printout">
-    <ref name="Worksheet"/>
+    <choice>
+      <ref name="Worksheet"/>
+      <ref name="Handout"/>
+    </choice>
   </define>
   <define name="BlockText">
     <choice>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -113,7 +113,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -168,7 +168,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -190,7 +190,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? &amp;ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -212,7 +212,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs)+,
-                            (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -232,7 +232,7 @@
                     AuthorByline*,
                     Objectives?,
                     (BlockDivision | Paragraphs)+,
-                    (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                    (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                      Solutions? &amp; References? &amp; Glossary?),
                     Outcomes?
                 }
@@ -244,7 +244,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs | NotationList)+,
-                            (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -266,7 +266,7 @@
                         (
                             Objectives?,
                             (BlockDivision | Paragraphs | NotationList)+,
-                            (Printout? &amp; ReadingQuestions? &amp; Exercises? &amp;
+                            (Worksheet? &amp; Handout? &amp; ReadingQuestions? &amp; Exercises? &amp;
                              Solutions? &amp; References? &amp; Glossary?),
                             Outcomes?
                         )
@@ -407,11 +407,15 @@
     <section>
         <title>Printout Divisions</title>
 
-        <p>A printout division (currently only a <tag>worksheet</tag>) is a specialized division, allowing for some additional control of spacing and page delineation, to allow for workspace.</p>
+        <p>A printout division (a <tag>worksheet</tag> or a <tag>handout</tag>) is a specialized division, allowing for some additional control of spacing and page delineation, to allow for workspace.</p>
 
         <p>The attributes on a printout include margin information to control layout.  Inside a printout we can have either a number of <tag>page</tag> elements that hold the content or just the content itself.</p>
 
         <p>The contents of a printout can include the same blocks as a division, namely BlockDivision, plus the <tag>paragraphs</tag> division.</p>
+
+        <p>A <tag>handout</tag> is very similar to a <tag>worksheet</tag>, differing only in the absence of the course-identification attributes.  Many of the blocks a printout may contain (theorems, definitions, examples, projects, exercises, tasks, proofs) accept a <attr>workspace</attr> attribute.  It is treated as a hint: respected inside a printout, and ignored elsewhere (which the validation-plus stylesheet will point out).</p>
+
+        <p>A structured division may hold any number of printouts, in any order, interleaved with one another and with the traditional divisions<mdash/>which is how a <q>workbook</q> of printouts is authored.  An unstructured division admits at most one of each, so <c>Worksheet</c> and <c>Handout</c> appear separately there rather than through <c>Printout</c>.</p>
         <fragment xml:id="printout">
             <title>Printout</title>
             <code>
@@ -443,27 +447,6 @@
                     (Outcomes? &amp; ConclusionDivision?)
                 }
 
-            # Printout currently just means a Worksheet, but could be extended later.
-            Printout =
-                Worksheet
-            </code>
-        </fragment>
-    </section>
-
-    <section>
-        <title>Handouts (experimental)</title>
-
-        <p>A handout is a specialized division very similar to a worksheet, allowing for some additional control of spacing, to allow for workspace.</p>
-
-        <p>The attributes on a handout include margin information to control layout, just like worksheets.  Also like worksheets, a handout can contain either a number of <tag>page</tag> elements that hold the content or just the content itself.</p>
-
-        <p>The contents of a handout can include the same blocks as a division, namely BlockDivision.  Many of these blocks (theorems, definitions, examples, projects, exercises, tasks, proofs) can get a <attr>workspace</attr> attribute.  It is treated as a hint: respected inside a printout, and ignored elsewhere (which the validation-plus stylesheet will point out).</p>
-
-        <p>Note: when handouts moves to the stable schema, we will need to go to every division and for the option of an unstructured division, include Worksheet and Handout as separate elements so an unstructured division can have one of each.</p>
-
-        <fragment xml:id="handout">
-            <title>Handouts (experimental)</title>
-            <code>
             # Main handout definition
             Handout =
                 element handout {
@@ -473,9 +456,10 @@
                     (Page+ | PrintoutBlock+),
                     (Outcomes? &amp; ConclusionDivision?)
                 }
-            # Add Handout to Printout options
-            Printout |=
-                Handout
+
+            # A printout is a worksheet or a handout
+            Printout =
+                Worksheet | Handout
             </code>
         </fragment>
     </section>
@@ -3956,7 +3940,6 @@
             <fragref ref="docinfo-dev"/>
             <fragref ref="proof-like"/>
             <fragref ref="figure-dev"/>
-            <fragref ref="handout"/>
             <fragref ref="solutions-dev"/>
             <fragref ref="reference-dev"/>
             <fragref ref="exercise-dev"/>

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -37,6 +37,11 @@
 
 <!ENTITY SPECIALIZED-DIVISION "exercises|worksheet|handout|reading-questions|references|glossary|solutions">
 
+<!-- A "printout" is a specialized division whose content is laid out  -->
+<!-- for printing, with workspace for a reader to write.  A collection -->
+<!-- of nothing but printouts is a "workbook".                         -->
+<!ENTITY PRINTOUT "worksheet|handout">
+
 <!-- "Division companions" are the non-structural companions of a      -->
 <!-- structured traditional division: they may earn their own page    -->
 <!-- (and links) when their parent is realized as a summary page in   -->
@@ -51,6 +56,8 @@
 <!ENTITY TRADITIONAL-DIVISION-FILTER "self::book or self::article or self::part or self::chapter or self::section or self::subsection or self::subsubsection or self::appendix">
 
 <!ENTITY SPECIALIZED-DIVISION-FILTER "self::exercises or self::worksheet or self::handout or self::reading-questions or self::references or self::glossary or self::solutions">
+
+<!ENTITY PRINTOUT-FILTER "self::worksheet or self::handout">
 
 <!ENTITY DIVISION-COMPANION-FILTER "self::introduction or self::conclusion or self::objectives or self::outcomes">
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6410,7 +6410,7 @@ Book (with parts), "section" at level 3
 <!-- Printout Margins -->
 <!-- ################ -->
 
-<xsl:template match="worksheet|handout" mode="printout-margin">
+<xsl:template match="&PRINTOUT;" mode="printout-margin">
     <xsl:param name="author-side"/>
     <xsl:param name="publisher-side"/>
     <xsl:choose>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -188,7 +188,7 @@
 <!-- template in the entry template here, so these pages are not built (good).      -->
 <!-- But we do get little buttons to elect a printable version.  We have to kill    -->
 <!-- those buttons, since EPUB wants to go looking for the printable-version files. -->
-<xsl:template match="worksheet|handout" mode="standalone-printout-links"/>
+<xsl:template match="&PRINTOUT;" mode="standalone-printout-links"/>
 
 
 <!-- ############## -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -610,7 +610,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
     <!-- material following a formatted printout begins a fresh page; -->
     <!-- a conclusion, when present, carries that break itself         -->
-    <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted and not(conclusion)">
+    <xsl:if test="(&PRINTOUT-FILTER;) and $b-latex-worksheet-formatted and not(conclusion)">
         <fo:block break-after="page"/>
     </xsl:if>
 </xsl:template>
@@ -764,7 +764,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="@xml:id = str:tokenize($latex-pagebreaks-string)">
             <xsl:text>page</xsl:text>
         </xsl:when>
-        <xsl:when test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
+        <xsl:when test="(&PRINTOUT-FILTER;) and $b-latex-worksheet-formatted">
             <xsl:text>page</xsl:text>
         </xsl:when>
     </xsl:choose>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1009,7 +1009,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="title-full" />
     </span>
     <!-- add print preview button for printouts -->
-    <xsl:if test="(self::worksheet or self::handout)">
+    <xsl:if test="(&PRINTOUT-FILTER;)">
         <xsl:apply-templates select="." mode="standalone-printout-links"/>
     </xsl:if>
 </xsl:template>
@@ -1019,7 +1019,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- print previews.  A simple button with printer icon that reloads -->
 <!-- the page with a url parameter that tells javascript to switch   -->
 <!-- to printout css and format all the pages and workspace.         -->
-<xsl:template match="worksheet|handout" mode="standalone-printout-links">
+<xsl:template match="&PRINTOUT;" mode="standalone-printout-links">
     <xsl:variable name="printout-id">
         <xsl:apply-templates select="." mode="html-id"/>
     </xsl:variable>
@@ -14692,7 +14692,7 @@ TODO:
 <!-- We put page-margins-attributes only on printout sections -->
 <xsl:template match="*" mode="page-margins-attribute"/>
 
-<xsl:template match="worksheet|handout" mode="page-margins-attribute">
+<xsl:template match="&PRINTOUT;" mode="page-margins-attribute">
     <xsl:attribute name="data-margins">
         <!-- A space-separated list for top, right, bottom, and left margins -->
         <xsl:apply-templates select="." mode="printout-margin">
@@ -14720,7 +14720,7 @@ TODO:
 <!-- Add data-* attributes for headers and footers -->
 <xsl:template match="*" mode="page-header-footer-attributes"/>
 
-<xsl:template match="worksheet|handout" mode="page-header-footer-attributes">
+<xsl:template match="&PRINTOUT;" mode="page-header-footer-attributes">
     <xsl:if test="not($ws-header-first-left = '')">
         <xsl:attribute name="data-header-first-left">
             <xsl:value-of select="normalize-space($ws-header-first-left)"/>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -3971,7 +3971,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="b-is-specialized" select="boolean(self::exercises|self::solutions[not(parent::backmatter)]|self::reading-questions|self::glossary|self::references|self::worksheet|self::handout|self::index)"/>
 
     <!-- change geometry if worksheet or handout should be formatted -->
-    <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
+    <xsl:if test="(&PRINTOUT-FILTER;) and $b-latex-worksheet-formatted">
         <!-- \newgeometry includes a \clearpage -->
         <xsl:apply-templates select="." mode="new-geometry"/>
     </xsl:if>
@@ -4076,7 +4076,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- the four margins, in units LaTeX understands (such as -->
 <!-- cm, in, pt).  This only produces text, so could go in -->
 <!-- -common, but is also only useful for LaTeX output.    -->
-<xsl:template match="worksheet|handout" mode="new-geometry">
+<xsl:template match="&PRINTOUT;" mode="new-geometry">
     <!-- Four similar "choose" effect hierarchy/priority -->
     <!-- NB: a publisher string parameter to      -->
     <!-- *really* override (worksheet.left, etc.) -->
@@ -4117,7 +4117,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- possibly numberless -->
     <xsl:apply-templates select="." mode="division-environment-name-suffix" />
     <xsl:text>}&#xa;</xsl:text>
-    <xsl:if test="(self::worksheet or self::handout) and $b-latex-worksheet-formatted">
+    <xsl:if test="(&PRINTOUT-FILTER;) and $b-latex-worksheet-formatted">
         <!-- \restoregeometry includes a \clearpage -->
         <xsl:text>\restoregeometry&#xa;</xsl:text>
     </xsl:if>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -123,18 +123,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- the document type is the element being converted -->
 <xsl:variable name="version-doc-type" select="local-name($version-document-root)"/>
 
-<!-- N.B. consumers disagree on which section-like elements make an  -->
-<!-- article "sectioned": numbering counts "worksheet", chunking     -->
-<!-- does not, and the table of contents also counts "handout".      -->
-<!-- The facts preserve those historical memberships.                -->
-<!-- TODO: harmonize the memberships — a deliberate,                 -->
-<!-- behavior-changing design decision, deferred                     -->
+<!-- An article is "sectioned" for every structure-driven default    -->
+<!-- below when it has a "section", a "worksheet", or a "handout":   -->
+<!-- the three are peers at the same level, so a workbook of         -->
+<!-- printouts numbers and chunks as a sectioned article does.       -->
 <xsl:variable name="version-has-parts"           select="boolean($version-root/book/part)"/>
 <xsl:variable name="version-book-chapters"       select="boolean($version-root/book/part/chapter|$version-root/book/chapter)"/>
 <xsl:variable name="version-book-sections"       select="boolean($version-root/book/part/chapter/section|$version-root/book/chapter/section)"/>
 <xsl:variable name="version-article-sections"    select="boolean($version-root/article/section)"/>
-<xsl:variable name="version-article-worksheets"  select="boolean($version-root/article/worksheet)"/>
-<xsl:variable name="version-article-handouts"    select="boolean($version-root/article/handout)"/>
+<xsl:variable name="version-article-printouts"   select="boolean($version-root/article/worksheet|$version-root/article/handout)"/>
 <xsl:variable name="version-article-subsections" select="boolean($version-root/article/section/subsection)"/>
 
 <!-- A book must have a chapter              -->
@@ -151,7 +148,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$version-book-sections">2</xsl:when>
         <xsl:when test="$version-book-chapters">1</xsl:when>
         <xsl:when test="$version-article-subsections">2</xsl:when>
-        <xsl:when test="$version-article-sections or $version-article-worksheets or $version-article-handouts">1</xsl:when>
+        <xsl:when test="$version-article-sections or $version-article-printouts">1</xsl:when>
         <xsl:when test="$version-doc-type = 'article'">0</xsl:when>
         <xsl:when test="$version-doc-type = 'slideshow'">0</xsl:when>
         <xsl:when test="$version-doc-type = 'letter'">0</xsl:when>
@@ -1515,7 +1512,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:choose>
             <xsl:when test="$version-has-parts">5</xsl:when>
             <xsl:when test="$version-doc-type = 'book'">4</xsl:when>
-            <xsl:when test="$version-article-sections or $version-article-worksheets">3</xsl:when>
+            <xsl:when test="$version-article-sections or $version-article-printouts">3</xsl:when>
             <xsl:when test="$version-doc-type = 'article'">0</xsl:when>
             <xsl:when test="$version-doc-type = 'letter'">0</xsl:when>
             <xsl:when test="$version-doc-type = 'slideshow'">0</xsl:when>
@@ -1580,7 +1577,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:choose>
             <xsl:when test="$version-has-parts">3</xsl:when>
             <xsl:when test="$version-doc-type = 'book'">2</xsl:when>
-            <xsl:when test="$version-article-sections or $version-article-worksheets">1</xsl:when>
+            <xsl:when test="$version-article-sections or $version-article-printouts">1</xsl:when>
             <xsl:when test="$version-doc-type = 'article'">0</xsl:when>
             <xsl:when test="$version-doc-type = 'slideshow'">0</xsl:when>
             <xsl:when test="$version-doc-type = 'letter'">0</xsl:when>
@@ -2731,7 +2728,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:when>
         <xsl:when test="$version-has-parts">3</xsl:when>
         <xsl:when test="$version-doc-type = 'book'">2</xsl:when>
-        <xsl:when test="$version-article-sections">1</xsl:when>
+        <xsl:when test="$version-article-sections or $version-article-printouts">1</xsl:when>
         <xsl:when test="$version-doc-type = 'article'">0</xsl:when>
         <xsl:when test="$version-doc-type = 'slideshow'">0</xsl:when>
         <xsl:when test="$version-doc-type = 'letter'">0</xsl:when>


### PR DESCRIPTION
Allows a *workbook* — a document whose divisions are nothing but printouts. Both structures below now work with no publication-file settings at all:

```
article                         book
  introduction   (optional)       chapter
  worksheet                         introduction   (optional)
  handout                           worksheet
  (more, any order, interleaved)    handout
  conclusion     (optional)         (more, any order, interleaved)
                                    conclusion     (optional)
                                  chapter
                                    similar, or traditional
```

Resolves #945.

**A word on the machinery.** Four publisher variables each choose a default level by walking an `xsl:choose` from the most specific document structure down to the least, taking the first branch that fits:

```xml
<xsl:when test="$version-has-parts">3</xsl:when>
<xsl:when test="$version-doc-type = 'book'">2</xsl:when>
<xsl:when test="$version-article-sections ...">1</xsl:when>
<xsl:when test="$version-doc-type = 'article'">0</xsl:when>
```

A document falls down the rungs until one matches — hence "ladder" below, for want of a better word. The four are the table of contents depth, the maximum feasible numbering level, the default numbering level, and the HTML chunking level.

The schema already permitted both shapes above, and the book side already behaved correctly, since its ladders reach the `book` rung before any question of sections arises. The article side did not, because the four ladders disagreed about which elements make an article "sectioned": the table of contents counted `section`, `worksheet`, and `handout`; the two numbering ladders counted `worksheet` but not `handout`; and chunking counted neither. That drift is the `TODO` sitting at the version-tree facts.

Two consequences, both demonstrable. A workbook article collapsed to a single HTML page, because chunking fell past the `section` rung to the `article` default of 0. And an article of handouts alone emitted **empty numbers**: the identical handout renders "Handout 2" in an article that also has a worksheet, and "Handout" with an empty `<span class="codenumber">` in one that does not — with no way for a publisher to fix it, since the requested level was silently clamped to a maximum of 0.

Five commits:

1. **Publisher variables** — the four ladders now share one fact, `$version-article-printouts`, so `section`, `worksheet`, and `handout` are peers everywhere. The `TODO` becomes a plain statement of the membership.
2. **Schema** — `handout` moves from the development schema to the stable one, joining `worksheet` under `Printout`. Every unstructured division now lists `Worksheet?` and `Handout?` separately, so it may hold one of each, as the note in the literate source anticipated.
3. **XSL** — a `PRINTOUT` entity (and its `-FILTER` twin) for the pair, used at the eleven sites that match exactly those two elements. Sites where the pair merely appears inside a longer specialized-division list are left alone.
4. **Workbook example** — a `handout` interleaved among the worksheets, plus an introduction and conclusion, in both the article and the book.
5. **Workbook example** — the explicit `chunking` and `numbering` entries come out of both publication files, so the examples now exercise the defaults rather than masking them.

Verified: `sample-article`, `sample-book`, `minimal`, and both workbook examples build byte-identical to master apart from timestamps; the entity substitution is a no-op in HTML, LaTeX, EPUB, and XSL-FO, the last confirmed pixel-by-pixel since FOP stamps a timestamp into the PDF; dev-schema error sets across the corpus are unchanged; both target structures, and an unstructured division holding one worksheet and one handout, validate against the **stable** schema; and both workbook examples build correctly on pure defaults, the handout taking its number in sequence with the worksheets.

One behavior change worth naming: a project with a worksheets-only article that relied on the old default of a single monolithic HTML page will now chunk.

*Claude Opus 5 (1M context), acting as a coding assistant for Rob Beezer*
