### PR TITLE
LaTeX: Table of Contents level for a "slideshow"

### DIFF
--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -137,6 +137,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$root/book/article">3</xsl:when>
         <xsl:when test="$root/book">2</xsl:when>
         <xsl:when test="$root/article">0</xsl:when>
+        <!-- a "slideshow" needs a value here for "latex-image" extraction -->
+        <xsl:when test="$root/slideshow">0</xsl:when>
         <xsl:when test="$root/letter">0</xsl:when>
         <xsl:when test="$root/memo">0</xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
Reported on `pretext-dev` by Oscar Levin: building a slide show produces

```
* PTX:BUG:   Table of Contents level (for LaTeX conversion) not determined
```

when the `latex-image` graphics are generated.

The `$toc-level-override` variable in `pretext-latex-common.xsl` enumerates the document types — `book`, `article`, `letter`, `memo` — and a `slideshow` matches none of them, so it falls through to the `PTX:BUG` message. `publisher-variables.xsl` has had the `slideshow` case (level `0`) since slide shows arrived; only the LaTeX override was missed.

A slide show is never converted to LaTeX for its own sake, but `extract-latex-image.xsl` imports `pretext-latex.xsl`, so extracting the images evaluates the entire LaTeX variable set, and this variable along with it. That is the only route to the message, which is why it surfaces during image generation rather than during the reveal.js or Beamer conversion.

This adds the missing case, at level `0` and in the same position as its counterpart in `publisher-variables.xsl`, plus a one-line comment recording why a slide show reaches this code at all.

Verified on `examples/sample-slideshow/`. The message no longer appears when the `latex-image` component runs, and the extracted standalone LaTeX is byte-identical to before, so the undetermined level never reached the output — the spurious message was the entire symptom. The reveal.js and Beamer conversions of the same document are free of warnings and errors. As a check against collateral damage, the LaTeX conversion of the sample article is unchanged apart from its build timestamps; the new branch of the `xsl:choose` is unreachable for any other document type.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
