### PR TITLE
Litprog: trim trailing whitespace from a "code" fragment

### DIFF
--- a/schema/pf-adapter.rnc
+++ b/schema/pf-adapter.rnc
@@ -3,4 +3,3 @@
                 grammar {
                     include "pf_schema.rnc"
                 }
-            

--- a/schema/pf-preamble-adapter.rnc
+++ b/schema/pf-preamble-adapter.rnc
@@ -6,4 +6,3 @@
                             ( GraphicalElements* & GroupElements* )
                     }
                 }
-            

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -3,7 +3,7 @@
                 grammar {
 
                 include "pretext.rnc"
-            
+
             Interactive =
                 element interactive {
                     UniqueID?,
@@ -139,7 +139,7 @@
                 ),
                 ConclusionDivision?
             }
-            
+
             ShortLicense_X =
                 element shortlicense {
                     TextLong &
@@ -151,19 +151,19 @@
                 element address {text}
             }
             Website |= Website_X
-            
+
             Configuration |=
                 element blurb {
                     attribute shelf {text}?,
                     text
                 }
-            
+
             Configuration |=
                 element document-id {
                     attribute edition {text}?,
                     text
                 }
-            
+
             ProofLike =
                 MetaDataTitleOptional,
                 (BlockStatement | Case)+
@@ -173,14 +173,13 @@
                 element justification {ProofLike} |
                 element reasoning {ProofLike} |
                 element explanation {ProofLike}
-            
+
             Figure |=
                 element figure {
                     MetaDataCaption,
                     Tabular
                 }
 
-            
             Solutions |=
                 element solutions {
                     MetaDataAltTitleOptional,
@@ -194,7 +193,7 @@
                     IntroductionDivision?,
                     ConclusionDivision?
                 }
-            
+
             MyOpenMath =
                 MetaDataTitleOptional,
                 IntroductionText?,
@@ -632,6 +631,5 @@
                 FreeResponse |
                 FillInBlank |
                 Areas
-            
+
                 }
-            

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1,16 +1,16 @@
 
                     namespace pf = "https://prefigure.org"
                     grammar {
-                
+
             start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Printout | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
-            
+
             PretextRoot =
                 element pretext {
                     XMLLang?,
                     DocInfo?,
                     (Book | Article | Letter | Memorandum)
                 }
-            
+
             Article =
                 element article {
                     MetaDataLinedSubtitle,
@@ -46,7 +46,7 @@
                 element letter {empty}
             Memorandum =
                 element memo {empty}
-            
+
             Part =
                 element part {
                     MetaDataLinedTitle, Chapter+
@@ -176,7 +176,7 @@
                     MetaDataAltTitleOptional,
                     IndexList
                 }
-            
+
             ArticleFrontMatter =
                 element frontmatter {
                     MetaDataTitleOptional,
@@ -327,7 +327,7 @@
                         )
                     )
                 }
-            
+
             ArticleBackMatter =
                 element backmatter {
                     MetaDataTitleOptional,
@@ -351,7 +351,7 @@
                     MetaDataTarget,
                     (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
-            
+
             Paragraphs =
                 element paragraphs {
                     MetaDataTitle,
@@ -364,7 +364,7 @@
                     Index*,
                     BlockStatementNoNumber+
                 }
-            
+
             ReadingQuestions =
                 element reading-questions {
                     MetaDataAltTitleOptional,
@@ -412,7 +412,7 @@
                     HeadNote?,
                     GlossaryItem+
                 }
-            
+
             PrintoutAttributes =
                 attribute margin { text }?,
                 attribute top { text }?,
@@ -454,7 +454,7 @@
             # A printout is a worksheet or a handout
             Printout =
                 Worksheet | Handout
-            
+
             BlockText =
                 Paragraph | BlockQuote | Preformatted |
                 Image | Video | Audio | Program | Console | Tabular
@@ -472,7 +472,7 @@
                 Remark | Computation | Theorem | Proof | Definition |
                 Axiom | Example | Exercise | Project | OpenProblem |
                 Poem | Assemblage | ListGenerator | Fragment
-            
+
             Prelude =
                 element prelude {BlockText+}
             Postlude =
@@ -496,7 +496,7 @@
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
-            
+
             IntroductionText =
                 element introduction {BlockText+}
             ConclusionText =
@@ -531,7 +531,7 @@
                 }
             HeadNote =
                 element headnote {BlockStatementNoNumber+}
-            
+
             Objectives =
                 element objectives {
                     MetaDataTitleOptional,
@@ -546,7 +546,7 @@
                     List,
                     ConclusionText?
                 }
-            
+
             BlockQuote =
                 element blockquote {
                     MetaDataTitleOptional,
@@ -559,7 +559,7 @@
                 element line {TextShort}
             LongLine =
                 element line {TextLong}
-            
+
             CodeLine =
                 element cline {text}
             CodeDisplay =
@@ -672,7 +672,7 @@
                         )
                     )
                 }
-            
+
             ListItem = element li {
                 (
                     (MetaDataTarget, TextParagraph)
@@ -702,7 +702,7 @@
                     attribute width {"narrow" | "medium" | "wide"}?,
                     DefinitionListItem+
                 }
-            
+
             DefinitionLike =
                 attribute workspace {text}?,
                 MetaDataTitleOptional,
@@ -710,7 +710,7 @@
                 Statement
             Definition =
                 element definition {DefinitionLike}
-            
+
             Case =
                 element case {
                    MetaDataTitleOptional,
@@ -738,7 +738,7 @@
                 element algorithm {TheoremLike} |
                 element fact {TheoremLike} |
                 element identity {TheoremLike}
-            
+
             AxiomLike =
                 MetaDataTitleCreatorOptional,
                 Statement
@@ -749,7 +749,7 @@
                 element heuristic {AxiomLike} |
                 element hypothesis {AxiomLike} |
                 element assumption {AxiomLike}
-            
+
             ExampleLike =
                 attribute workspace {text}?,
                 MetaDataTitleOptional,
@@ -762,7 +762,7 @@
                 element example {ExampleLike} |
                 element question {ExampleLike} |
                 element problem {ExampleLike}
-            
+
             ProjectLike =
                 attribute workspace {text}?,
                 MetaDataTitleOptional,
@@ -794,7 +794,7 @@
                         (IntroductionStatement?, Task+, ConclusionStatement?)
                     )
                 }
-            
+
             OpenProblemLike =
                 MetaDataTitleOptional,
                 Prelude?,
@@ -824,7 +824,7 @@
             DiscussionLike =
                 MetaDataTitleOptional,
                 BlockStatement+
-            
+
             RemarkLike =
                 MetaDataTitleOptional,
                 BlockStatement+
@@ -835,7 +835,7 @@
                 element observation {RemarkLike} |
                 element warning {RemarkLike} |
                 element insight {RemarkLike}
-            
+
             ComputationLike =
                 MetaDataTitleOptional,
                 BlockStatement+
@@ -843,7 +843,7 @@
                 element computation {ComputationLike} |
                 element technology {ComputationLike} |
                 element data {ComputationLike}
-            
+
             AsideLike =
                 MetaDataTitleOptional,
                 BlockText+
@@ -851,13 +851,13 @@
                 element aside {AsideLike} |
                 element biographical {AsideLike} |
                 element historical {AsideLike}
-            
+
             Assemblage =
                 element assemblage {
                     MetaDataTitleOptional,
                     (BlockText | SideBySideNoNumber | SideBySideGroupNoNumber)+
                 }
-            
+
             Caption =
                 element caption {Component?, TextLong}
             Landscape =
@@ -895,7 +895,7 @@
                     List,
                     ConclusionText?
                 }
-            
+
             Stack =
                 element stack {
                     (
@@ -961,7 +961,7 @@
                     SidebySideAttributes,
                     SideBySideNoNumber+
                 }
-            
+
             Image = ImageRaster | ImageCode
             ImageDescription = element description {(Paragraph | Tabular)+}
             ImageShortDescription = element shortdescription {text}
@@ -1055,7 +1055,7 @@
                       )
                     )
                 }
-            
+
             BorderThickness = "none" | "minor" | "medium" | "major"
             BorderTop =
                 attribute top {BorderThickness}
@@ -1117,7 +1117,7 @@
                     TableColumn*,
                     TableRow+
                 }
-            
+
             SageOutput = element output {text}
             SageInput = element input {text}
             Sage = element sage {
@@ -1129,13 +1129,13 @@
                 attribute type {text}?,
                 (SageInput, SageOutput?)?
             }
-            
+
             MuseScore =
                 element score {
                     attribute musescoreuser {text},
                     attribute musescore {text}
                 }
-            
+
             Video =
                 element video {
                     UniqueID?,
@@ -1181,7 +1181,7 @@
                 attribute youtubeplaylist {text}
             AttributesVimeo =
                 attribute vimeo {text}
-            
+
             ExerciseOrderedList =
                 element ol {
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
@@ -1219,7 +1219,7 @@
                     Exercise+,
                     ConclusionStatementNoNumber?
                 }
-            
+
             AlignmentPoem = attribute halign {"left" | "center" | "right"}
             PoemAuthor =
                 element author {
@@ -1243,7 +1243,7 @@
                     attribute indent {xsd:integer}?,
                     TextShort
                 }
-            
+
             TextBib = mixed { (Character | MathInline)* }
             BibliographyItem =
                 element biblio {
@@ -1400,13 +1400,13 @@
                     attribute day {text}?,
                     empty
                 }
-            
+
             GlossaryItem =
                 element gi {
                     MetaDataTitle,
                     BlockStatementNoNumber+
                 }
-            
+
             Contributor =
                 element contributor {
                     MetaDataTarget,
@@ -1428,7 +1428,7 @@
                 }
             AuthorByline =
                 element author {(TextSimple|Xref)}
-            
+
             WebWork = (WebWorkAuthored | WebWorkSource)
             WebWorkSource =
                 element webwork {
@@ -1509,7 +1509,7 @@
                 element solution {
                     (BlockStatementWW)+
                 }
-            
+
             Fragment =
                 element fragment {
                     (
@@ -1528,14 +1528,14 @@
                         }
                     )+
                 }
-            
-            
+
+
             Attribution =
                 element attribution {
                     Component?,
                     (TextLong | LongLine+)
                 }
-            
+
             UniqueID =
                 attribute xml:id {text}
             LabelID =
@@ -1633,7 +1633,7 @@
                 Title?,
                 Caption,
                 Index*
-            
+
             # The union is named so extensions (e.g. the development
             # schema) can widen it with a choice-combine ("|=")
             TextParagraphItem =
@@ -1668,7 +1668,7 @@
                     Component?,
                     element line {TextShort}+
                 }
-            
+
             TextSimple = mixed {
                 Character* }
             TextShort = mixed { (
@@ -1689,13 +1689,13 @@
                 Custom |
                 WWVariable
             TextLong =  mixed { (TextLongContent)* }
-                
+
             Footnote =
                 element fn {
                     MetaDataTarget,
                     TextLong
                 }
-            
+
             IdxHeading =
                 element h {
                     attribute sortby {text}?,
@@ -1719,7 +1719,7 @@
                     )
                 }
             IndexList = element index-list {empty}
-            
+
             XrefTextStyle =
                 "local" | "global" | "hybrid" | "type-local" | "type-global" |
                 "type-hybrid" | "phrase-global" | "phrase-hybrid" |
@@ -1763,7 +1763,7 @@
                     element usage {MathInline},
                     NotationDescription
                 }
-            
+
             FillInMath = element fillin {
                              (attribute fill{text}?|attribute characters {xsd:integer}?),
                              empty
@@ -1825,7 +1825,7 @@
                         )
                     )
                 }
-            
+
             Verbatim =
                 element c {text} |
                 Email |
@@ -1833,18 +1833,18 @@
                     attribute language {text}?,
                     text
                 }
-            
+
             Group |=
                 element abbr {TextSimple} |
                 element acro {TextSimple} |
                 element init {TextSimple}
-            
+
             Group |=
                 element q {TextLong} |
                 element sq {TextLong} |
                 element angles {TextLong} |
                 element dblbrackets {TextLong}
-                
+
             Group |=
                 element em {TextLong} |
                 element term {TextLong} |
@@ -1855,17 +1855,17 @@
                   XMLLang?,
                   TextLong
                 }
-            
+
             Group |=
                 element delete {TextLong} |
                 element insert {TextLong} |
                 element stale {TextLong}
-                
+
             Group |=
                 element tag {text} |
                 element tage {text} |
                 element attr {text}
-            
+
             Group |=
                 element taxon {
                     attribute ncbi {xsd:integer}?,
@@ -1877,7 +1877,7 @@
                         )
                     )
                 }
-            
+
             Generator =
                 element today {empty} |
                 element timeofday {empty} |
@@ -1901,7 +1901,7 @@
                 element ps {empty} |
                 element vs {empty} |
                 element viz {empty}
-            
+
             FillInText =
                 element fillin {
                     attribute characters {xsd:integer}?,
@@ -1911,7 +1911,7 @@
                 }
             Generator |=
                 FillInText
-            
+
             UnitSpecification =
                     attribute prefix {text}?,
                     attribute base {text},
@@ -1922,12 +1922,12 @@
                     element unit {UnitSpecification}*,
                     element per {UnitSpecification}*
                 }
-            
+
             Character |=
                 element nbsp {empty} |
                 element ndash {empty} |
                 element mdash {empty}
-            
+
             Character =
                 element lsq {empty} |
                 element rsq {empty} |
@@ -1937,7 +1937,7 @@
                 element rdblbracket {empty} |
                 element langle {empty}|
                 element rangle {empty}
-            
+
             Character |=
                 element minus {empty} |
                 element times {empty} |
@@ -1947,7 +1947,7 @@
                 element degree {empty} |
                 element prime {empty} |
                 element dblprime {empty}
-            
+
             CopyrightCharacter =
                 element copyright {empty}
             Character |=
@@ -1963,17 +1963,17 @@
                 element trademark {empty} |
                 element phonomark {empty} |
                 element servicemark {empty}
-            
+
             Character |=
                 element icon {
                     attribute name {text}
                 }
-                
+
             Character |=
                 element kbd {
                     (text | attribute name {text})
                 }
-            
+
             MusicFlat =
                 element flat {empty}
             MusicSharp =
@@ -2010,7 +2010,7 @@
                         MusicFlat)*
                     }*
                 }
-                
+
             ListGenerator =
                 element list-of {
                     attribute elements {text},
@@ -2020,20 +2020,20 @@
                 }
             NotationList =
                 element notation-list {empty}
-            
+
             DocInfo =
                 element docinfo {
                     Component?,
                     XMLLang?,
                     Configuration+
                 }
-            
+
             Configuration |=
                 element brandlogo {
                     attribute url {text}?,
                     attribute source {text}
                 }
-            
+
             Configuration |=
                     element math-package {
                         attribute latex-name {text},
@@ -2047,32 +2047,32 @@
                 element pf:prefigure-preamble {
                     external "pf-preamble-adapter.rnc"
                 }
-            
+
             Configuration |=
                 element macros {text}
-            
+
             Configuration |=
                 element
                     cross-references {
                         attribute text { XrefTextStyle }
                     }
-            
+
             Configuration |=
                 element initialism {text}
-            
+
             FeedbackUrl = element url {text}
             Configuration |=
                 element feedback {
                     FeedbackUrl
                 }
-            
+
             Configuration |=
                 element rename {
                     attribute element {text},
                     attribute xml:lang {text}?,
                     text
                 }
-            
+
             Configuration |=
                 element images {
                     element archive {
@@ -2080,19 +2080,19 @@
                         text
                     }+
                 }
-            
+
             Configuration |=
                 element author-biographies {
                     attribute length {"short" | "long"}
                 }
-            
+
             Configuration |=
                 element numbering {
                     element division {
                         attribute part {"decorative" | "structural"}
                     }?
                 }
-            
+
             Configuration |=
                 element programs {
                     attribute language {text}?,
@@ -2103,11 +2103,10 @@
                     attribute interpreter-args {text}?,
                     attribute timeout {text}?
                 }
-            
+
             Configuration |=
                 element parsons {
                     attribute language {text}?
                 }
-            
+
                     }
-                

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -1,8 +1,8 @@
 
             grammar {
-            
+
             start = Publication
-            
+
             Publication =
                 element publication {
                     Common? &
@@ -18,7 +18,7 @@
                     Text? &
                     Webwork?
                 }
-            
+
             Common =
                 element common {
                     element chunking {
@@ -96,7 +96,7 @@
                     attribute center { text }?,
                     attribute right { text }?
                 }?
-            
+
             Source =
                 element source {
                     attribute customizations { text }?,
@@ -115,7 +115,7 @@
                 element version {
                     attribute include { text }
                 }
-            
+
             Numbering =
                 element numbering {
                     Divisions? &
@@ -173,7 +173,7 @@
                 element footnotes {
                     attribute level { "0" | "1" | "2" | "3" | "4" | "5" | "6" }?
                 }
-            
+
             Latex =
                 element latex {
                     attribute latex-style {text}?,
@@ -211,12 +211,12 @@
                 element asymptote {
                     attribute links { "yes" | "no" }?
                 }
-            
+
             Pdf =
                 element pdf {
                     attribute font { "latin-modern" }?
                 }
-            
+
             Html =
                 element html {
                     attribute design-width { xsd:integer }?,
@@ -379,7 +379,6 @@
                     attribute project { "dynamic" | "static" }?
                 }
 
-            
             Revealjs =
                 element revealjs {
                     Appearance? &
@@ -411,19 +410,19 @@
                     attribute host { "local" | "cdn" | "embedded" }?,
                     attribute math { "online" | "embedded" }?
                 }
-            
+
             Epub =
                 element epub {
                     element cover {
                         attribute front { text }
                     }
                 }
-            
+
             Jupyter =
                 element jupyter {
                     attribute kernel { "sagemath" | "python3" }
                 }
-            
+
             Braille =
                 element braille {
                     element page {
@@ -431,12 +430,12 @@
                         attribute height { xsd:positiveInteger }?
                     }
                 }
-            
+
             Text =
                 element text {
                     attribute characters { "unicode" | "ascii" }?
                 }
-            
+
             Webwork =
                 element webwork {
                     attribute server { text },
@@ -445,6 +444,5 @@
                     attribute password { text }?,
                     attribute task-reveal { "preceding-correct" | "all" }?
                 }
-            
+
             }
-            

--- a/xsl/pretext-litprog.xsl
+++ b/xsl/pretext-litprog.xsl
@@ -87,12 +87,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Duplicate code, rather than default sanitization, so author -->
 <!-- needs to be cognizant of indentation in PreTeXt source and  -->
 <!-- resulting indentation of output                             -->
+<!--                                                             -->
+<!-- A "code" ends with whitespace indenting its closing tag,    -->
+<!-- which would otherwise become a whitespace-only line where   -->
+<!-- two fragments join, so trailing whitespace is trimmed away. -->
+<!-- Leading indentation is untouched, the author's to own.      -->
 <!-- TODO: indentation/relative indentation specification on a "fragment"? -->
 <!--     In "indentation units" with global value in spaces (or tabs?)?    -->
 <!-- TODO: or maybe a "mangle" attribute (newlines, and/or more)           -->
 <!-- TODO: global switch to minify (remove indentation, remove newlines?)  -->
 <xsl:template match="fragment/code">
-    <xsl:value-of select="."/>
+    <xsl:call-template name="trim-end">
+        <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
 </xsl:template>
 
 <!-- As we process a fragment, a mix of code and pointers, -->


### PR DESCRIPTION
Every derived `.rnc` file carried whitespace-only lines — 82 in `pretext.rnc`, 16 in `publication-schema.rnc`, 10 in `pretext-dev.rnc`, and one apiece in `pf-adapter.rnc` and `pf-preamble-adapter.rnc`.

They come from the generator, not from any source file. A `<code>` element's text content ends with the whitespace that indents its own closing tag, and `fragment/code` emitted that content verbatim. Concatenating fragments therefore left a run of spaces on its own line at every join. No `<code>` element in either literate source has trailing whitespace anywhere, so there was nothing to clean up on that side.

`fragment/code` now passes its content through `trim-end`, the existing utility that strips trailing whitespace and guarantees exactly one closing newline. No new helper was needed. Leading indentation is untouched — the comment above that template is explicit that indentation in the source is the author's to manage, and this changes nothing about it. The blank lines between fragments remain; they are simply empty now instead of holding spaces.

Two incidental improvements: `pf-adapter.rnc` and `pf-preamble-adapter.rnc` previously ended with a whitespace-only line and no final newline, and now end with a newline.

Source and regenerated files are one commit, since regeneration from unmodified source was verified clean beforehand. `publication-schema.rnc` is in the diff because it comes from `publication-schema.xml`, a second literate source that needs its own `pretext-litprog.xsl` run.

Verified four ways:

- All `.rng` files come out **byte-identical** to before, which is the proof that nothing semantic moved — RNC whitespace is not significant, and trang confirms it.
- Each `.rnc` is identical to its previous version once all whitespace is stripped, so no content shifted.
- Regeneration is idempotent: a second pass changes nothing.
- Validating the sample article against the regenerated `pretext.rnc` directly, via `jing -c`, produces exactly the same 52-error set as validating against `pretext.rng`.

No `.rng` file is modified by this commit.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
