### PR TITLE
Copyright: sweep every notice to 2026, and record the holders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Contributing
 ------------
 

--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2013-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 PreTeXt
 =======
 

--- a/contrib/hitchman/README.md
+++ b/contrib/hitchman/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2014-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Hitchman's Linear Algebra Workbook
 ==================================
 

--- a/contrib/ups-writers/README.md
+++ b/contrib/ups-writers/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 University of Puget Sound's "Writer's Handbook"
 ===============================================
 

--- a/css/README.md
+++ b/css/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Notes on CSS structure and development
 
 PreTeXt books expect to use a `theme.css` file for its styling. SCSS is used to build that CSS file.

--- a/css/colors/_color-helpers.scss
+++ b/css/colors/_color-helpers.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // This file contains functions and mixins for working with colors in SCSS
 
 @use "sass:map";

--- a/css/colors/_color-vars.scss
+++ b/css/colors/_color-vars.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*
   Master list of color variables and default values.
   Variables are defined in SCSS to allow for calculation of values. They are

--- a/css/colors/_palette-dark.scss
+++ b/css/colors/_palette-dark.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Implements a dark theme single color palette using a --primary-color
 
 @use "sass:meta";

--- a/css/colors/_palette-dual.scss
+++ b/css/colors/_palette-dual.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Implements a palette with two main colors, --primary-color and --secondary-color
 
 @use "sass:meta";

--- a/css/colors/_palette-quad-chunks.scss
+++ b/css/colors/_palette-quad-chunks.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Defines colors for grouping elements based on four colors to identify 
 // block elements as either main, do, fact, or meta.
 

--- a/css/colors/_palette-single-bold.scss
+++ b/css/colors/_palette-single-bold.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Implements a palette with one main --primary-color
 // More dramatic than _palette-single.scss
 

--- a/css/colors/_palette-single-muted.scss
+++ b/css/colors/_palette-single-muted.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Implements a palette with one main --primary-color used in a very sparing fashion
 
 @use "sass:meta";

--- a/css/colors/_palette-single.scss
+++ b/css/colors/_palette-single.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Implements a palette with one main --primary-color
 
 @use "sass:meta";

--- a/css/components/README.md
+++ b/css/components/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Notes on components folder
 
 Components contains pieces shared by all modern scss themes. They are divided into:

--- a/css/components/_google-search.scss
+++ b/css/components/_google-search.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO - refactor
 // Make conditional on use of google search???
 

--- a/css/components/_mystery.scss
+++ b/css/components/_mystery.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Chunks of code that seem like one off fixes for books that may not exist
 // This file is not included anywhere else - kept around temporarily for reference
 

--- a/css/components/_pretext-search.scss
+++ b/css/components/_pretext-search.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 @use 'components/helpers/buttons-default' as buttons;
 @use 'components/helpers/dialogs' as dialogs;

--- a/css/components/_pretext-web.scss
+++ b/css/components/_pretext-web.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Entry point for web-based themes. Incorporates common PreTeXt styles
 // and web-specific styles.
 

--- a/css/components/_pretext.scss
+++ b/css/components/_pretext.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Entry point for common styling
 
 // It is assumed these are used by both web and epub stylesheets

--- a/css/components/_printing.scss
+++ b/css/components/_printing.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Basic rules for printing a standard PreTeXt page
 
 // Get rid of UI elements.

--- a/css/components/_rs-template.scss
+++ b/css/components/_rs-template.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use 'components/helpers/buttons-default' as buttons;
 
 // styles for the runestone template page

--- a/css/components/_spacing.scss
+++ b/css/components/_spacing.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Basic spacing for content
 
 // Breakpoint at which the navbar moves to the bottom of the screen

--- a/css/components/_worksheet.scss
+++ b/css/components/_worksheet.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO refactor
 
 // Rules in this file apply to both screen and print

--- a/css/components/chunks/README.md
+++ b/css/components/chunks/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Styling for "chunks" of content - containers that are designed to hold
 other elements and are likely to vary significantly from theme to theme.
 

--- a/css/components/chunks/_asides-basic.scss
+++ b/css/components/chunks/_asides-basic.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-width: 2px !default;
 $side-margins: 30px !default;
 

--- a/css/components/chunks/_asides-floating.scss
+++ b/css/components/chunks/_asides-floating.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $float-width: 200px !default;
 $float-offset: -248px !default;
 $min-float-width: 1280px !default;

--- a/css/components/chunks/_codelike.scss
+++ b/css/components/chunks/_codelike.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @mixin code-text {
   font-family: var(--font-monospace);
   background: var(--code-background);

--- a/css/components/chunks/_discussion-inline.scss
+++ b/css/components/chunks/_discussion-inline.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use './helpers/inline-heading-mixin';
 
 .discussion-like {

--- a/css/components/chunks/_exercises.scss
+++ b/css/components/chunks/_exercises.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../helpers/cols';
 
 // generate multi column rules for exercises

--- a/css/components/chunks/_knowls.scss
+++ b/css/components/chunks/_knowls.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*
   main knowls styles
 */

--- a/css/components/chunks/_sidebyside.scss
+++ b/css/components/chunks/_sidebyside.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Space all rows in a sbsgroup, no other styling
 .sbsgroup > *:not(:first-child)
 {

--- a/css/components/chunks/_solutions.scss
+++ b/css/components/chunks/_solutions.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // 
 
 /* stacked headings in the solutions backmatter */

--- a/css/components/chunks/helpers/README.md
+++ b/css/components/chunks/helpers/README.md
@@ -1,1 +1,20 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Helpers used to style block elements

--- a/css/components/chunks/helpers/_C-box-mixin.scss
+++ b/css/components/chunks/helpers/_C-box-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $padding: 20px !default;
 $padding-top: $padding !default;

--- a/css/components/chunks/helpers/_L-mixin.scss
+++ b/css/components/chunks/helpers/_L-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 10px !default;
 

--- a/css/components/chunks/helpers/_box-mixin.scss
+++ b/css/components/chunks/helpers/_box-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 10px !default;
 $border-radius: 0px !default;

--- a/css/components/chunks/helpers/_heading-box-mixin.scss
+++ b/css/components/chunks/helpers/_heading-box-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 20px !default;
 $border-radius: 0px !default;

--- a/css/components/chunks/helpers/_horizontal-bars-mixin.scss
+++ b/css/components/chunks/helpers/_horizontal-bars-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 0px !default;   //all sides
 $border-color: var(--block-border-color) !default;

--- a/css/components/chunks/helpers/_inline-heading-mixin.scss
+++ b/css/components/chunks/helpers/_inline-heading-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Generate styles for an inline heading
 @mixin heading {
   & > .heading:first-child {

--- a/css/components/chunks/helpers/_sidebar-mixin.scss
+++ b/css/components/chunks/helpers/_sidebar-mixin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // These values can be set on @use to avoid repeating values in each @import
 $pad: 10px !default;   //all sides
 $padside: 15px !default;   //on side with border

--- a/css/components/elements/README.md
+++ b/css/components/elements/README.md
@@ -1,1 +1,20 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Styling for basic content elements

--- a/css/components/elements/_description-lists.scss
+++ b/css/components/elements/_description-lists.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /* dl is used for glossaries and descriptions lists.
    Glossaries are simple:  bold word by itself on a line.
         Definition indented on the next line.

--- a/css/components/elements/_figures.scss
+++ b/css/components/elements/_figures.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 figure {
   clear: both;
   position: relative;

--- a/css/components/elements/_fillin.scss
+++ b/css/components/elements/_fillin.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 .fillin {
   display: inline-block;

--- a/css/components/elements/_footnotes.scss
+++ b/css/components/elements/_footnotes.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-radius: 0px !default;
 
 .ptx-footnote {

--- a/css/components/elements/_headings.scss
+++ b/css/components/elements/_headings.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // headings for standard page elements - sections/articles/etc...
 // more specialized headings (exercises) should be defined in the specific component
 // complex stylizing (like boxes) should be done by "chunks"

--- a/css/components/elements/_index.scss
+++ b/css/components/elements/_index.scss
@@ -1,4 +1,21 @@
-
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 /* the index at the back of the book */
 // TODO - refactor

--- a/css/components/elements/_links.scss
+++ b/css/components/elements/_links.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 // Reset for all links
 a {

--- a/css/components/elements/_list-styles.scss
+++ b/css/components/elements/_list-styles.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Types of ol/ul - used by web and ebooks
 // Any spacing should be in _lists.scss, not here
 

--- a/css/components/elements/_lists.scss
+++ b/css/components/elements/_lists.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Entry point for ol/ul/dl web styling
 
 @use "list-styles";

--- a/css/components/elements/_math.scss
+++ b/css/components/elements/_math.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO - refactor
 
 .displaymath {

--- a/css/components/elements/_media.scss
+++ b/css/components/elements/_media.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // ---------------------------------------------
 // containers for images, audio, video, and asymptote
 .image-box,

--- a/css/components/elements/_misc-content.scss
+++ b/css/components/elements/_misc-content.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 // Miscellaneous stylized content blocks that are not complex enough
 // to warrant their own file

--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO - refactor
 $opacity: 0.0 !default;
 

--- a/css/components/elements/_poem.scss
+++ b/css/components/elements/_poem.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /* style for poems */
 .poem {
   display: table;

--- a/css/components/elements/_prism.scss
+++ b/css/components/elements/_prism.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../chunks/codelike';
 
 // Prism stylesheets built locally as default ones don't support light/dark switching

--- a/css/components/elements/_summary-links.scss
+++ b/css/components/elements/_summary-links.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 /* Start of division toc links */
 // .ptx-content to override _links rules

--- a/css/components/elements/_tables.scss
+++ b/css/components/elements/_tables.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // limit rules targeting basic elements to just content area
 .ptx-content {
   table {

--- a/css/components/elements/extras/_heading-underlines.scss
+++ b/css/components/elements/extras/_heading-underlines.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $color-light: var(--primary-color-white-30) !default;
 $color-dark: var(--primary-color-black-30) !default;
 $thickness: 2px !default;

--- a/css/components/helpers/README.md
+++ b/css/components/helpers/README.md
@@ -1,1 +1,20 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Mixins used to build style rules in other files

--- a/css/components/helpers/_accessibility.scss
+++ b/css/components/helpers/_accessibility.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 // Accessibility helper classes
 

--- a/css/components/helpers/_buttons-default.scss
+++ b/css/components/helpers/_buttons-default.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-radius: 0 !default;
 $border-width: 1px !default;
 

--- a/css/components/helpers/_cols.scss
+++ b/css/components/helpers/_cols.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 // columns are arranged in row-major order to match print output in LaTeX
 :is(.cols2, .cols3, .cols4, .cols5, .cols6) {

--- a/css/components/helpers/_dialogs.scss
+++ b/css/components/helpers/_dialogs.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use "components/helpers/buttons-default" as buttons;
 
 $border-radius: 0 !default;

--- a/css/components/helpers/_expandable.scss
+++ b/css/components/helpers/_expandable.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Styling for elements in ptx-main that are allowed to expand past normal width
 // of ptx-content.
 

--- a/css/components/interactives/README.md
+++ b/css/components/interactives/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Interactive elements.
 
 These could be made conditional in the build process if we passed the requisite info from PTX to cssbuilder.

--- a/css/components/interactives/_calculators.scss
+++ b/css/components/interactives/_calculators.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // GeoGebra calculator
 @use 'components/helpers/dialogs' as dialogs;
 

--- a/css/components/interactives/_other.scss
+++ b/css/components/interactives/_other.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Misc styles for interactive bits that should only be incldued in a web context
 // (not ebook)
 

--- a/css/components/interactives/_runestone.scss
+++ b/css/components/interactives/_runestone.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // extra specific to override Runestone margin
 .ptx-content .ptx-runestone-container .runestone {
   margin: unset;

--- a/css/components/interactives/_sagecell.scss
+++ b/css/components/interactives/_sagecell.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO - refactor
 
 .sagecell_sessionOutput pre {

--- a/css/components/interactives/_webwork.scss
+++ b/css/components/interactives/_webwork.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // TODO - needs refactoring and dark mode update
 
 @use 'components/helpers/buttons-default' as buttons;

--- a/css/components/page-parts/README.md
+++ b/css/components/page-parts/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Styling for large display regions on the page
 
 It is expected that a file like `_parts-default.scss` will be used to aggregate the

--- a/css/components/page-parts/_banner.scss
+++ b/css/components/page-parts/_banner.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $max-width: 1200px !default;  // 0 == no max width
 $navbar-breakpoint: 800px !default;
 $centered-content: false !default;

--- a/css/components/page-parts/_body.scss
+++ b/css/components/page-parts/_body.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Body level styling
 $max-width: 1200px !default;  // 0 == no max width
 $standalone-max-width: 1600px !default;  // used for iframe standalones

--- a/css/components/page-parts/_footer.scss
+++ b/css/components/page-parts/_footer.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $max-width: 0 !default;  // 0 == no max width
 $navbar-breakpoint: 856px !default;
 

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $max-width: 1200px !default;  // 0 == no max width
 // applied to the contents of the navbar
 

--- a/css/components/page-parts/_toc-basics.scss
+++ b/css/components/page-parts/_toc-basics.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // shared toc styling used by _toc-default, etc...
 
 $sidebar-width: 240px !default;

--- a/css/components/page-parts/_toc-default.scss
+++ b/css/components/page-parts/_toc-default.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $scrolling: true !default;
 $sidebar-width: 240px !default;
 $nav-height: 36px !default;

--- a/css/components/page-parts/_toc-overlay.scss
+++ b/css/components/page-parts/_toc-overlay.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $sidebar-width: 240px !default;
 $nav-height: 36px !default;
 $navbar-breakpoint: 800px !default;

--- a/css/components/page-parts/extras/README.md
+++ b/css/components/page-parts/extras/README.md
@@ -1,1 +1,20 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Options that can be added by a theme to tweak a parts file

--- a/css/components/page-parts/extras/_navbar-btn-borders.scss
+++ b/css/components/page-parts/extras/_navbar-btn-borders.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 $border-width: 1px !default;
 

--- a/css/components/page-parts/extras/_toc-borders.scss
+++ b/css/components/page-parts/extras/_toc-borders.scss
@@ -1,3 +1,21 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
 
 $border-width: 1px !default;
 

--- a/css/components/page-parts/extras/_toc-expand-chevrons.scss
+++ b/css/components/page-parts/extras/_toc-expand-chevrons.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Use chevrons instead of +/- in ToC expander control
 
 .ptx-toc.focused {

--- a/css/components/page-parts/extras/_toc-hidden-scrollbar.scss
+++ b/css/components/page-parts/extras/_toc-hidden-scrollbar.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // blend in with page until hover
 .ptx-toc {
   scrollbar-color: var(--content-background) var(--content-background);

--- a/css/components/page-parts/extras/_toc-last-level-plain.scss
+++ b/css/components/page-parts/extras/_toc-last-level-plain.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // levels 2 & 3 only get new colors if they contain further levels
 // that way bottom level has default styling
 

--- a/css/fonts/_fonts-google.scss
+++ b/css/fonts/_fonts-google.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use "sass:map";
 @use "sass:string";
 @use "sass:list";

--- a/css/legacy/colors/all_colors.scss
+++ b/css/legacy/colors/all_colors.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Entrypoint to get all legacy color schemes
 
 @use 'colors_blue_green.css';

--- a/css/targets/ebook/ebook-common.scss
+++ b/css/targets/ebook/ebook-common.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Use this file for anything common to kindle and epub
 @use 'components/pretext';
 

--- a/css/targets/ebook/epub/epub.scss
+++ b/css/targets/ebook/epub/epub.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: epub */
 @use '../ebook-common';
 

--- a/css/targets/ebook/kindle/kindle.scss
+++ b/css/targets/ebook/kindle/kindle.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: kindle */
 @use '../ebook-common';
 

--- a/css/targets/html/README.md
+++ b/css/targets/html/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 HTML themes using the modern tooling.
 
 Other than default-modern, the intent is to use city names to identify themes.

--- a/css/targets/html/boulder/_customization.scss
+++ b/css/targets/html/boulder/_customization.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 //$color: var(--primary-color) !default;
 //$text-color: white !default;
 

--- a/css/targets/html/boulder/theme-boulder.scss
+++ b/css/targets/html/boulder/theme-boulder.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: boulder */
 // Theme designed for short articles (i.e., research papers) or course documents.
 // Minimal navigation bar; there is likely only one html page per document.

--- a/css/targets/html/default-modern/_chunks-default.scss
+++ b/css/targets/html/default-modern/_chunks-default.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Standard collection of chunks. This file should only be modified
 // to fix bugs or improve the default-modern theme. If you want to
 // make changes for use in some other theme, create a _chunks-XXX file

--- a/css/targets/html/default-modern/_customization.scss
+++ b/css/targets/html/default-modern/_customization.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // turn on some optional design features
 @use 'components/page-parts/extras/navbar-btn-borders';
 @use 'components/page-parts/extras/toc-last-level-plain';

--- a/css/targets/html/default-modern/_parts-default.scss
+++ b/css/targets/html/default-modern/_parts-default.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Left aligned "page" with limited width, beyond which it is centered
 
 $max-width: 1200px !default;

--- a/css/targets/html/default-modern/theme-default-modern.scss
+++ b/css/targets/html/default-modern/theme-default-modern.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: default-modern */
 
 // Variables used by theme. CSSBuilder overrides these by prepending

--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-radius: 0 !default;
 $chunk-heading-font-size: 1.125em !default;
 

--- a/css/targets/html/denver/_customizations.scss
+++ b/css/targets/html/denver/_customizations.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $color: var(--primary-color) !default;
 $text-color: white !default;
 

--- a/css/targets/html/denver/_parts-paper.scss
+++ b/css/targets/html/denver/_parts-paper.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 //Some basic variables
 $centered-content: true !default;
 $scrolling-toc: true !default;

--- a/css/targets/html/denver/theme-denver.scss
+++ b/css/targets/html/denver/theme-denver.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: denver */
 // Theme that uses bold content blocks with a visible centered "page" of content
 

--- a/css/targets/html/greeley/_chunks-greeley.scss
+++ b/css/targets/html/greeley/_chunks-greeley.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-radius: 8px !default;
 
 // One stop include for default style content blocks

--- a/css/targets/html/greeley/_customization.scss
+++ b/css/targets/html/greeley/_customization.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 //$color: var(--primary-color) !default;
 //$text-color: white !default;
 

--- a/css/targets/html/greeley/theme-greeley.scss
+++ b/css/targets/html/greeley/theme-greeley.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: greeley */
 // Theme designed for short articles (i.e., research papers).
 

--- a/css/targets/html/legacy/crc/theme-crc.scss
+++ b/css/targets/html/legacy/crc/theme-crc.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: crc-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';

--- a/css/targets/html/legacy/default/theme-default.scss
+++ b/css/targets/html/legacy/default/theme-default.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: default-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';

--- a/css/targets/html/legacy/min/theme-min.scss
+++ b/css/targets/html/legacy/min/theme-min.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: min-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';

--- a/css/targets/html/legacy/oscarlevin/theme-oscarlevin.scss
+++ b/css/targets/html/legacy/oscarlevin/theme-oscarlevin.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: oscarlevin-legacy */
 // Designed to support custom styling for oscarlevin style
 // Imports in this file should be relative to css root

--- a/css/targets/html/legacy/soundwriting/theme-soundwriting.scss
+++ b/css/targets/html/legacy/soundwriting/theme-soundwriting.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: soundwriting-legacy */
 // Designed to support custom styling for https://github.com/UPS-CWLT/soundwriting
 // Imports in this file should be relative to css root

--- a/css/targets/html/legacy/wide/banner_wide.scss
+++ b/css/targets/html/legacy/wide/banner_wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../default/banner_default.css';
 
 :root {

--- a/css/targets/html/legacy/wide/navbar_wide.scss
+++ b/css/targets/html/legacy/wide/navbar_wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../default/navbar_default.css';
 
 

--- a/css/targets/html/legacy/wide/shell_wide.scss
+++ b/css/targets/html/legacy/wide/shell_wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../default/shell_default.css';
 
 :root {

--- a/css/targets/html/legacy/wide/style_wide.scss
+++ b/css/targets/html/legacy/wide/style_wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../default/style_default.css';
 
 /* handle margin of articles that items might be nested inside */

--- a/css/targets/html/legacy/wide/theme-wide.scss
+++ b/css/targets/html/legacy/wide/theme-wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: wide-legacy */
 // Imports in this file should be relative to css root
 @use 'legacy/pretext.css';

--- a/css/targets/html/legacy/wide/toc_wide.scss
+++ b/css/targets/html/legacy/wide/toc_wide.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 @use '../default/toc_default';
 
 .pretext .ptx-sidebar {

--- a/css/targets/html/salem/_chunks-salem.scss
+++ b/css/targets/html/salem/_chunks-salem.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Standard collection of chunks. This file should only be modified
 // to fix bugs or improve the default-modern theme. If you want to
 // make changes for use in some other theme, create a _chunks-XXX file

--- a/css/targets/html/salem/_heading-tweaks.scss
+++ b/css/targets/html/salem/_heading-tweaks.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // underlines to headings
 @use 'components/elements/extras/heading-underlines';
 

--- a/css/targets/html/salem/_other-widen.scss
+++ b/css/targets/html/salem/_other-widen.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // --------------------------------------------------------------------------
 // Flexible / centered widening of other components
 

--- a/css/targets/html/salem/_parts-salem.scss
+++ b/css/targets/html/salem/_parts-salem.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Produces a centered "page" with borders and centered banner
 // TOC will be an initially hidden overlay
 

--- a/css/targets/html/salem/_rs-widen.scss
+++ b/css/targets/html/salem/_rs-widen.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // --------------------------------------------------------------------------
 // Flexible / centered widening of rs elements and other components
 

--- a/css/targets/html/salem/_sizing-globals.scss
+++ b/css/targets/html/salem/_sizing-globals.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // This file can be @use'd with overrides once
 // Then future @uses will get those overrides instead of the values listed here
 

--- a/css/targets/html/salem/theme-salem.scss
+++ b/css/targets/html/salem/theme-salem.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: salem */
 // A theme focused on displaying wide content gracefully
 

--- a/css/targets/html/tacoma/_chunks-minimal.scss
+++ b/css/targets/html/tacoma/_chunks-minimal.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 $border-radius: 8px !default;
 
 // One stop include for default style content blocks

--- a/css/targets/html/tacoma/_customization.scss
+++ b/css/targets/html/tacoma/_customization.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // more generous spacing for sections/articles
 
 @use 'components/page-parts/extras/toc-expand-chevrons';

--- a/css/targets/html/tacoma/_parts-tacoma.scss
+++ b/css/targets/html/tacoma/_parts-tacoma.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Left aligned "page" with limited width, beyond which it is centered
 
 $max-width: 1000px !default;

--- a/css/targets/html/tacoma/theme-tacoma.scss
+++ b/css/targets/html/tacoma/theme-tacoma.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: tacoma */
 // A theme focused on a minimal distraction reading environment
 

--- a/css/targets/print-worksheet/_chunks-worksheet.scss
+++ b/css/targets/print-worksheet/_chunks-worksheet.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Standard collection of chunks. This file should only be modified
 // to fix bugs or improve the default-modern theme. If you want to
 // make changes for use in some other theme, create a _chunks-XXX file

--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: print-worksheet */
 
 // Used for print versions of worksheets (including their previews) for all themes

--- a/css/targets/revealjs/reveal.scss
+++ b/css/targets/revealjs/reveal.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2024-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 /*! Theme: reveal */
 
 // Tip: to build just this file directly to a folder for testing, do something like:

--- a/doc/guide/COPYING
+++ b/doc/guide/COPYING
@@ -2,7 +2,7 @@
                         by
   Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller
 
-Copyright (C) 2013-2016
+Copyright (C) 2013-2026
 Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller
 
 Permission is granted to copy, distribute and/or modify this document

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # The PreTeXt Guide
 
 PDF and HTML versions of this guide are available at the [PreTeXt](https://pretextbook.org) site in the Documentation area.

--- a/doc/guide/appendices/cli-transition.xml
+++ b/doc/guide/appendices/cli-transition.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="cli-transition">

--- a/doc/guide/appendices/cli-v1vsv2.xml
+++ b/doc/guide/appendices/cli-v1vsv2.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="cli-v1vsv2">

--- a/doc/guide/appendices/editors.xml
+++ b/doc/guide/appendices/editors.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="editors">

--- a/doc/guide/appendices/git.xml
+++ b/doc/guide/appendices/git.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="git-author">

--- a/doc/guide/appendices/glossary.xml
+++ b/doc/guide/appendices/glossary.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2018  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <glossary xml:id="glossary">

--- a/doc/guide/appendices/journals-table.xml
+++ b/doc/guide/appendices/journals-table.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <table>
   <title>Journals supported by PreTeXt</title>
   <tabular>

--- a/doc/guide/appendices/journals.xml
+++ b/doc/guide/appendices/journals.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2019  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="appendix-journals" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/doc/guide/appendices/latex-conversion.xml
+++ b/doc/guide/appendices/latex-conversion.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="latex-conversion">

--- a/doc/guide/appendices/liblouis.xml
+++ b/doc/guide/appendices/liblouis.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2023  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="liblouis">

--- a/doc/guide/appendices/mac-os.xml
+++ b/doc/guide/appendices/mac-os.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2019  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="mac-os-install-notes">

--- a/doc/guide/appendices/node-npm.xml
+++ b/doc/guide/appendices/node-npm.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="node-and-npm">

--- a/doc/guide/appendices/offline-mathjax.xml
+++ b/doc/guide/appendices/offline-mathjax.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="offline-mathjax">

--- a/doc/guide/appendices/python.xml
+++ b/doc/guide/appendices/python.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="python">

--- a/doc/guide/appendices/references.xml
+++ b/doc/guide/appendices/references.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2020  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <references xml:id="references">

--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="schema-install">

--- a/doc/guide/appendices/welcome.xml
+++ b/doc/guide/appendices/welcome.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2018  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="welcome">

--- a/doc/guide/appendices/windows-cli.xml
+++ b/doc/guide/appendices/windows-cli.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="windows-cli">

--- a/doc/guide/appendices/windows-wsl.xml
+++ b/doc/guide/appendices/windows-wsl.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="windows-subsystem-linux">

--- a/doc/guide/appendices/windows.xml
+++ b/doc/guide/appendices/windows.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <appendix xml:id="windows-install-notes">

--- a/doc/guide/author/advice.xml
+++ b/doc/guide/author/advice.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2018  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="advice">

--- a/doc/guide/author/author-faq.xml
+++ b/doc/guide/author/author-faq.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="author-faq">

--- a/doc/guide/author/overview.xml
+++ b/doc/guide/author/overview.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="overview">

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="processing">

--- a/doc/guide/author/schema.xml
+++ b/doc/guide/author/schema.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="schema">

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="topics" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/doc/guide/author/webwork.xml
+++ b/doc/guide/author/webwork.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="webwork-author">

--- a/doc/guide/backmatter.xml
+++ b/doc/guide/backmatter.xml
@@ -4,7 +4,7 @@
 <!--                                                                -->
 <!--         The PreTeXt Guide                                      -->
 <!--                                                                -->
-<!-- Copyright (C) 2013-2019                                        -->
+<!-- Copyright (C) 2013-2026                                        -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
 <!-- See the file COPYING for copying conditions.                   -->
 

--- a/doc/guide/basics/README.md
+++ b/doc/guide/basics/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Contributing to the *Basics Reference* portion of The PreTeXt Guide
 
 ## `xml:id` usage

--- a/doc/guide/basics/aside.ptx
+++ b/doc/guide/basics/aside.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <aside>
   <title>A Sample Aside</title>
   <p>

--- a/doc/guide/basics/axiom.ptx
+++ b/doc/guide/basics/axiom.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <axiom>
     <title>Optional</title>
     <creator>Peano</creator>

--- a/doc/guide/basics/basics-part.xml
+++ b/doc/guide/basics/basics-part.xml
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <part xml:id="part-basics" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Basics Reference</title>
   <chapter xml:id="basics-ch-about">

--- a/doc/guide/basics/blockquote.ptx
+++ b/doc/guide/basics/blockquote.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <blockquote>
   <title>Lorem ipsum</title>
   <p>

--- a/doc/guide/basics/definition.ptx
+++ b/doc/guide/basics/definition.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <definition>
 
   <notation>

--- a/doc/guide/basics/example-simple.ptx
+++ b/doc/guide/basics/example-simple.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <example>
   <title>Differentiating a polynomial</title>
   <p>

--- a/doc/guide/basics/example-structured.ptx
+++ b/doc/guide/basics/example-structured.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <example>
   <title>Differentiating a polynomial</title>
   <statement>

--- a/doc/guide/basics/exercise-task.ptx
+++ b/doc/guide/basics/exercise-task.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <exercise>
   <title>A structured exercise</title>
   <introduction>

--- a/doc/guide/basics/exercise.ptx
+++ b/doc/guide/basics/exercise.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <exercise>
   <statement>
     <p>

--- a/doc/guide/basics/exercisegroup.ptx
+++ b/doc/guide/basics/exercisegroup.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <exercises xml:id="basics-s-sample-exercises">
   <exercisegroup>
 

--- a/doc/guide/basics/figure.ptx
+++ b/doc/guide/basics/figure.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <figure xml:id="fig-graph">
   <caption>A small graph (from <pubtitle>Applied
   Combinatorics</pubtitle> by Keller and

--- a/doc/guide/basics/image.ptx
+++ b/doc/guide/basics/image.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <image source="small-graph" width="20%">
     <description><p>A graph on five vertices. One of the vertices is isolated, while the other four form a path on four vertices.</p></description>
 </image>

--- a/doc/guide/basics/md-bare.ptx
+++ b/doc/guide/basics/md-bare.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <p>
   <md>
     \frac{d}{dx} \int_1^x \frac{1}{t}\, dt = \frac{1}{x}

--- a/doc/guide/basics/md.ptx
+++ b/doc/guide/basics/md.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <p>
   <md>
     <mrow>x \amp = r\cos\theta</mrow>

--- a/doc/guide/basics/ol.ptx
+++ b/doc/guide/basics/ol.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <p>
   <ol>
     <li>First item.</li>

--- a/doc/guide/basics/p.ptx
+++ b/doc/guide/basics/p.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <p>
   This is a new <term>piece of terminology</term>.
   Here is a word we have chosen to <em>emphasize</em>.

--- a/doc/guide/basics/porism.ptx
+++ b/doc/guide/basics/porism.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <algorithm>
   <statement>
     <p>

--- a/doc/guide/basics/project.ptx
+++ b/doc/guide/basics/project.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <project>
   <title>A structured project</title>
   <introduction>

--- a/doc/guide/basics/reading-questions.ptx
+++ b/doc/guide/basics/reading-questions.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <reading-questions xml:id="basics-reading-questions">
   <title>Check your understanding!</title>
   <introduction>

--- a/doc/guide/basics/remark.ptx
+++ b/doc/guide/basics/remark.ptx
@@ -1,4 +1,21 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
 
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 
 <remark>
   <title>A little remark</title>

--- a/doc/guide/basics/sage.ptx
+++ b/doc/guide/basics/sage.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <sage>
 <input>
 2+2

--- a/doc/guide/basics/sageplot.ptx
+++ b/doc/guide/basics/sageplot.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <figure xml:id="fig-sage-cubic">
   <caption>A cubic plotted by SageMath on
   <m>[-3,2]</m></caption>

--- a/doc/guide/basics/sbsgroup.ptx
+++ b/doc/guide/basics/sbsgroup.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <sbsgroup widths="25% 50%" margins="5% 10%">
     <sidebyside>
         <image source="small-graph" />

--- a/doc/guide/basics/section-sub.ptx
+++ b/doc/guide/basics/section-sub.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <section>
   <title>Mandatory</title>
   <introduction>

--- a/doc/guide/basics/section.ptx
+++ b/doc/guide/basics/section.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <section>
   <title>Mandatory</title>
   <p>

--- a/doc/guide/basics/sidebyside.ptx
+++ b/doc/guide/basics/sidebyside.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <sidebyside widths="25% 25%" valign="middle">
   <figure>
     <caption>Small graph with the caption only associated to the

--- a/doc/guide/basics/sidebyside2.ptx
+++ b/doc/guide/basics/sidebyside2.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <figure>
   <caption>A graphic next to a paragraph of
   text with the caption assigned to both.</caption>

--- a/doc/guide/basics/table.ptx
+++ b/doc/guide/basics/table.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <table>
   <title>A simple table</title>
   <tabular halign="center">

--- a/doc/guide/basics/theorem.ptx
+++ b/doc/guide/basics/theorem.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <theorem>
     <title>Optional</title>
     <creator>I. Newton</creator>

--- a/doc/guide/basics/tikz.ptx
+++ b/doc/guide/basics/tikz.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <figure xml:id="fig-tikz">
   <caption>A figure generated with TikZ in
   <latex /></caption>

--- a/doc/guide/basics/ul.ptx
+++ b/doc/guide/basics/ul.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <p>
   <ul>
     <li>First item.</li>

--- a/doc/guide/basics/worksheet.ptx
+++ b/doc/guide/basics/worksheet.ptx
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <worksheet xml:id="basics-sample-worksheet">
   <title>A Skeletal Worksheet</title>
   <objectives>

--- a/doc/guide/developer/code-style.xml
+++ b/doc/guide/developer/code-style.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2019-2023                                  -->
+<!-- Copyright (C) 2019-2026                                  -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan              -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/coding.xml
+++ b/doc/guide/developer/coding.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2019-2019                                  -->
+<!-- Copyright (C) 2019-2026                                  -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan              -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/debugging.xml
+++ b/doc/guide/developer/debugging.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2019-2019                                  -->
+<!-- Copyright (C) 2019-2026                                  -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan              -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/git.xml
+++ b/doc/guide/developer/git.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2019-2019                                  -->
+<!-- Copyright (C) 2019-2026                                  -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan              -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/localization.xml
+++ b/doc/guide/developer/localization.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2019-2019                                  -->
+<!-- Copyright (C) 2019-2026                                  -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan              -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/messaging.xml
+++ b/doc/guide/developer/messaging.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--        PreTeXt Developer's Guide                         -->
 <!--                                                          -->
-<!-- Copyright (C) 2026                                       -->
+<!-- Copyright (C) 2026-2026                                  -->
 <!-- Robert A. Beezer                                         -->
 <!-- See the file COPYING for copying conditions.             -->
 

--- a/doc/guide/developer/pretext-script.xml
+++ b/doc/guide/developer/pretext-script.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="pretext-script">

--- a/doc/guide/developer/xsltproc.xml
+++ b/doc/guide/developer/xsltproc.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="xsltproc">

--- a/doc/guide/frontmatter.xml
+++ b/doc/guide/frontmatter.xml
@@ -4,7 +4,7 @@
 <!--                                                                -->
 <!--         The PreTeXt Guide                                      -->
 <!--                                                                -->
-<!-- Copyright (C) 2013-2019                                        -->
+<!-- Copyright (C) 2013-2026                                        -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
 <!-- See the file COPYING for copying conditions.                   -->
 

--- a/doc/guide/guide.xml
+++ b/doc/guide/guide.xml
@@ -4,7 +4,7 @@
 <!--                                                                -->
 <!--         The PreTeXt Guide                                      -->
 <!--                                                                -->
-<!-- Copyright (C) 2013-2019                                        -->
+<!-- Copyright (C) 2013-2026                                        -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
 <!-- See the file COPYING for copying conditions.                   -->
 

--- a/doc/guide/guideinfo.xml
+++ b/doc/guide/guideinfo.xml
@@ -4,7 +4,7 @@
 <!--                                                                -->
 <!--         The PreTeXt Guide                                      -->
 <!--                                                                -->
-<!-- Copyright (C) 2013-2019                                        -->
+<!-- Copyright (C) 2013-2026                                        -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
 <!-- See the file COPYING for copying conditions.                   -->
 

--- a/doc/guide/introduction/start-here.xml
+++ b/doc/guide/introduction/start-here.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="start-here">

--- a/doc/guide/introduction/tutorial.xml
+++ b/doc/guide/introduction/tutorial.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2023  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="tutorial">

--- a/doc/guide/preface.xml
+++ b/doc/guide/preface.xml
@@ -4,7 +4,7 @@
 <!--                                                                -->
 <!--         The PreTeXt Guide                                      -->
 <!--                                                                -->
-<!-- Copyright (C) 2013-2019                                        -->
+<!-- Copyright (C) 2013-2026                                        -->
 <!-- Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller -->
 <!-- See the file COPYING for copying conditions.                   -->
 

--- a/doc/guide/project.ptx
+++ b/doc/guide/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2022-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/doc/guide/publication-styled.xml
+++ b/doc/guide/publication-styled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/doc/guide/publication.xml
+++ b/doc/guide/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/doc/guide/publisher/ancillaries.xml
+++ b/doc/guide/publisher/ancillaries.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="ancillaries">

--- a/doc/guide/publisher/braille.xml
+++ b/doc/guide/publisher/braille.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2023-2023  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2023-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="publisher-braille">

--- a/doc/guide/publisher/conversions.xml
+++ b/doc/guide/publisher/conversions.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="conversions">

--- a/doc/guide/publisher/cover-design.xml
+++ b/doc/guide/publisher/cover-design.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="cover-design">

--- a/doc/guide/publisher/custom-versions.xml
+++ b/doc/guide/publisher/custom-versions.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2022  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="custom-versions">

--- a/doc/guide/publisher/epub.xml
+++ b/doc/guide/publisher/epub.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2021  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="epub">

--- a/doc/guide/publisher/further-customizations.xml
+++ b/doc/guide/publisher/further-customizations.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2022  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="further-customizations">

--- a/doc/guide/publisher/instructor-version.xml
+++ b/doc/guide/publisher/instructor-version.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="instructor-version">

--- a/doc/guide/publisher/jupyter-notebook.xml
+++ b/doc/guide/publisher/jupyter-notebook.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="jupyter-notebook" label="jupyter-notebook">

--- a/doc/guide/publisher/latex-fonts.xml
+++ b/doc/guide/publisher/latex-fonts.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="latex-fonts">

--- a/doc/guide/publisher/latex-styling.xml
+++ b/doc/guide/publisher/latex-styling.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="latex-styles">

--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="online-html">

--- a/doc/guide/publisher/open-licenses.xml
+++ b/doc/guide/publisher/open-licenses.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="open-licenses">

--- a/doc/guide/publisher/pdf-print.xml
+++ b/doc/guide/publisher/pdf-print.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="pdf-print">

--- a/doc/guide/publisher/print-on-demand.xml
+++ b/doc/guide/publisher/print-on-demand.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="print-on-demand">

--- a/doc/guide/publisher/production.xml
+++ b/doc/guide/publisher/production.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="production">

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <!-- NB: This chapter is organized by the hierarchy -->

--- a/doc/guide/publisher/publisher-faq.xml
+++ b/doc/guide/publisher/publisher-faq.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="publisher-faq">

--- a/doc/guide/publisher/runestone.xml
+++ b/doc/guide/publisher/runestone.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="runestone">

--- a/doc/guide/publisher/slides.xml
+++ b/doc/guide/publisher/slides.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <chapter xml:id="publisher-slides">
     <title>Conversion to Slides</title>
     <idx>slides</idx>

--- a/doc/guide/publisher/web-hosting.xml
+++ b/doc/guide/publisher/web-hosting.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Publisher's Guide                           -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2017  Robert A. Beezer, David Farmer  -->
+<!-- Copyright (C) 2013-2026                                  -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="web-hosting">

--- a/doc/guide/publisher/webwork.xml
+++ b/doc/guide/publisher/webwork.xml
@@ -4,7 +4,7 @@
 <!--                                                          -->
 <!--      PreTeXt Author's Guide                              -->
 <!--                                                          -->
-<!-- Copyright (C) 2013-2016  Robert A. Beezer                -->
+<!-- Copyright (C) 2013-2026  Robert A. Beezer                -->
 <!-- See the file COPYING for copying conditions.             -->
 
 <chapter xml:id="webwork-publisher">

--- a/doc/pretext-fo-roadmap.md
+++ b/doc/pretext-fo-roadmap.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Roadmap: PreTeXt to PDF via XSL-FO (LaTeX-free)
 
 This documents the long-running development of `xsl/pretext-fo.xsl`, a

--- a/doc/quickref/README.md
+++ b/doc/quickref/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2022-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Quick Reference (aka "quickrefs")
 
 These "cheat sheets" are in the style of similar quick reference sheets pioneered for topical areas of Sage Math software.  Two pages maximum, so they can be printed on one sheet of paper (two-sided).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # PreTeXt Examples
 
 Some directories have their own `README`.  This is an overview of the contents of the `examples/` directory, with the date of the last update for each entry.

--- a/examples/braille/braille-test-book.xml
+++ b/examples/braille/braille-test-book.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2019 Robert A. Beezer
+Copyright (C) 2019-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/braille/braille-test.xml
+++ b/examples/braille/braille-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/braille/publication.xml
+++ b/examples/braille/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/custom-theming/README.md
+++ b/examples/custom-theming/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 #  Styling/Theming Samples for PreTeXt
 
 This project has samples to illustrate how the HTML output of PreTeXt can be customized. The `projects.ptx` file defines the following build targets:

--- a/examples/custom-theming/mytheme/_chunks-customized.scss
+++ b/examples/custom-theming/mytheme/_chunks-customized.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // Grab everything from tacoma's chunks but tell it to use 0 border radius
 @use 'targets/html/tacoma/chunks-minimal' with (
   $border-radius: 0

--- a/examples/custom-theming/mytheme/mytheme.scss
+++ b/examples/custom-theming/mytheme/mytheme.scss
@@ -1,3 +1,22 @@
+//********************************************************************
+// Copyright (C) 2025-2026  Robert A. Beezer
+//
+// This file is part of PreTeXt.
+//
+// PreTeXt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 or version 3 of the
+// License (at your option).
+//
+// PreTeXt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+//********************************************************************
+
 // A custom theme that is a modified version of the tacoma theme
 
 // This will get compiled into "theme.css" and placed into the output directory

--- a/examples/custom-theming/project.ptx
+++ b/examples/custom-theming/project.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <project ptx-version="2">
     <targets>
         <!-- default web styling -->

--- a/examples/custom-theming/publication/publication-custom-colors.ptx
+++ b/examples/custom-theming/publication/publication-custom-colors.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->

--- a/examples/custom-theming/publication/publication-custom-theme.ptx
+++ b/examples/custom-theming/publication/publication-custom-theme.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->

--- a/examples/custom-theming/publication/publication-salem.ptx
+++ b/examples/custom-theming/publication/publication-salem.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->

--- a/examples/custom-theming/publication/publication.ptx
+++ b/examples/custom-theming/publication/publication.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
   <!-- Set where external assets and generated assets will be   -->
   <!-- stored or created.  Directories are relative to the main -->

--- a/examples/custom-theming/source/ch-chapter-title.ptx
+++ b/examples/custom-theming/source/ch-chapter-title.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <chapter xml:id="ch-chapter-title" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Chapter Title</title>
     

--- a/examples/custom-theming/source/docinfo.ptx
+++ b/examples/custom-theming/source/docinfo.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!-- The docinfo block is the analogue to the latex preamble -->
 <!-- This is where you can define macros and other book-wide -->
 <!-- settings. -->

--- a/examples/custom-theming/source/main.ptx
+++ b/examples/custom-theming/source/main.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <pretext xml:lang="en-US" xmlns:xi="http://www.w3.org/2001/XInclude">
     <!-- we first include a file which contains the docinfo element: -->
     <xi:include href="./docinfo.ptx" />

--- a/examples/custom-theming/source/sec-section-name.ptx
+++ b/examples/custom-theming/source/sec-section-name.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <section xml:id="sec-section-name" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Section Title</title>
 

--- a/examples/epub/README.md
+++ b/examples/epub/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # EPUB Sampler
 
 This short book is designed for testing conversions to EPUB.

--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016-2021 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/epub/publication.xml
+++ b/examples/epub/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/errors/sample-errors-and-warnings.xml
+++ b/examples/errors/sample-errors-and-warnings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/errors/sample-errors-and-warnings.xml
+++ b/examples/errors/sample-errors-and-warnings.xml
@@ -2,20 +2,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!--
 To process this file, at the command-line issue:

--- a/examples/fonts/README.md
+++ b/examples/fonts/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 Characters, Fonts, and Languages
 ================================
 

--- a/examples/fonts/fonts-and-characters.xml
+++ b/examples/fonts/fonts-and-characters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/fonts/fonts-and-characters.xml
+++ b/examples/fonts/fonts-and-characters.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!--

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # "Hello, World" Example
 
 `hello-world.xml` is a one-page article that has only a single paragraph with a single sentence.  Guess what it says?  For a more informative small example, see the `examples/minimal` directory.

--- a/examples/hello-world/hello-world.xml
+++ b/examples/hello-world/hello-world.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016-2026 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/hello-world/publication.xml
+++ b/examples/hello-world/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/humanities/README.md
+++ b/examples/humanities/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Humanities Example
 
 `source/main.ptx` is a small document that primarily illustrates (and tests) markup for music and poetry.

--- a/examples/humanities/project.ptx
+++ b/examples/humanities/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/humanities/publication/publication.ptx
+++ b/examples/humanities/publication/publication.ptx
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!-- This is the publication file for a newly generated PreTeXt book.     -->
 <!-- By changing the values of attributes here, you can change how        -->
 <!-- the output looks and functions.  For the complete documentation      -->

--- a/examples/humanities/source/hia.xml
+++ b/examples/humanities/source/hia.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
     <!-- May need lilyglyphs.sty from Debian/Ubuntu texlive-music -->
     <docinfo>

--- a/examples/humanities/source/music.xml
+++ b/examples/humanities/source/music.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <chapter xml:id="music">
     <title>Music</title>
     <section xml:id="symbols">

--- a/examples/humanities/source/poetry.xml
+++ b/examples/humanities/source/poetry.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <chapter xml:id="poetry">
     <title>Poetry</title>
     <introduction>

--- a/examples/letter/README.md
+++ b/examples/letter/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Sample Letter
 
 Letters convert only to LaTeX.  See the XML source for instructions on customizing letterhead.  Be aware that the two PNG files need to be available when you process the LaTeX source to make a PDF.

--- a/examples/letter/sample-letter.xml
+++ b/examples/letter/sample-letter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/letter/sample-letter.xml
+++ b/examples/letter/sample-letter.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- A sample letter -->

--- a/examples/memo/README.md
+++ b/examples/memo/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Sample Memo
 
 Letters convert only to LaTeX.  See the XML source for instructions on customizing masthead.  Be aware that a PNG and a PDF graphics file each need to be available when you process the LaTeX source to make a PDF.

--- a/examples/memo/sample-memo.xml
+++ b/examples/memo/sample-memo.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- A sample memo -->

--- a/examples/memo/sample-memo.xml
+++ b/examples/memo/sample-memo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Minimal Example
 
 `source/main.ptx` is a one-page article that might be your first exercise in setting up PreTeXt.

--- a/examples/minimal/project.ptx
+++ b/examples/minimal/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/minimal/publication/publication.ptx
+++ b/examples/minimal/publication/publication.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
     <source>

--- a/examples/minimal/source/main.ptx
+++ b/examples/minimal/source/main.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/minimal/source/main.ptx
+++ b/examples/minimal/source/main.ptx
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- Build this file with the PreTeXt-CLI.  Each of the following

--- a/examples/numbering/README.md
+++ b/examples/numbering/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # `examples/numbering` — a numbering stress test
 
 `main.ptx` is a synthetic PreTeXt document that exercises the numbering system

--- a/examples/numbering/main.ptx
+++ b/examples/numbering/main.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/numbering/publication.xml
+++ b/examples/numbering/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/pdf-fo-development/publication.xml
+++ b/examples/pdf-fo-development/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2019-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/bibliography.xml
+++ b/examples/sample-article/bibliography.xml
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 <!-- 2024-07-26: this is from a quasi-experiment addition in February 2020  -->
 <!-- at e8977a78cb10f3c86aefc6c44a3017517174e604.  This file can be used    -->
 <!-- to test/refine that new feature.                                       -->

--- a/examples/sample-article/customizations-one.xml
+++ b/examples/sample-article/customizations-one.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/customizations-two.xml
+++ b/examples/sample-article/customizations-two.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/media/favicon/README.md
+++ b/examples/sample-article/media/favicon/README.md
@@ -1,1 +1,20 @@
+<!--********************************************************************
+Copyright (C) 2018-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 This favicon is the test image from [https://realfavicongenerator.net/](RealFaviconGenerator).

--- a/examples/sample-article/media/stack/01_integration_with_feedback.xml
+++ b/examples/sample-article/media/stack/01_integration_with_feedback.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
 <!-- question: 17332  -->
   <question type="stack">

--- a/examples/sample-article/media/stack/Adding-vectors-in-triangles.xml
+++ b/examples/sample-article/media/stack/Adding-vectors-in-triangles.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
   <question type="stack">
     <name>

--- a/examples/sample-article/media/stack/Checkbox.xml
+++ b/examples/sample-article/media/stack/Checkbox.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
   <question type="stack">
     <name>

--- a/examples/sample-article/media/stack/Matrix.xml
+++ b/examples/sample-article/media/stack/Matrix.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
   <question type="stack">
     <name>

--- a/examples/sample-article/media/stack/basic-plot.xml
+++ b/examples/sample-article/media/stack/basic-plot.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
 <!-- question: 206867  -->
   <question type="stack">

--- a/examples/sample-article/privatesolutions.xml
+++ b/examples/sample-article/privatesolutions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/project.ptx
+++ b/examples/sample-article/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2022-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/sample-article/publication-crc.xml
+++ b/examples/sample-article/publication-crc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/publication-oscarlevin.xml
+++ b/examples/sample-article/publication-oscarlevin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/publication-print.xml
+++ b/examples/sample-article/publication-print.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/publication-solution-manual.xml
+++ b/examples/sample-article/publication-solution-manual.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- Overall element for a Mathbook XML document; mandatory, always  -->

--- a/examples/sample-book/README.md
+++ b/examples/sample-book/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # PreTeXt Sample Book
 
 This sample book began as a subset of Tom Judson's

--- a/examples/sample-book/appendix-two.xml
+++ b/examples/sample-book/appendix-two.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/appendix-two.xml
+++ b/examples/sample-book/appendix-two.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <appendix xml:id="appendix-two">

--- a/examples/sample-book/backmatter.xml
+++ b/examples/sample-book/backmatter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/backmatter.xml
+++ b/examples/sample-book/backmatter.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/bookinfo.xml
+++ b/examples/sample-book/bookinfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/bookinfo.xml
+++ b/examples/sample-book/bookinfo.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/cyclic.xml
+++ b/examples/sample-book/cyclic.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2016/03/25)                     -->

--- a/examples/sample-book/cyclic.xml
+++ b/examples/sample-book/cyclic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/exercises/cyclic.xml
+++ b/examples/sample-book/exercises/cyclic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/exercises/cyclic.xml
+++ b/examples/sample-book/exercises/cyclic.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2016/03/25)                     -->

--- a/examples/sample-book/exercises/groups.xml
+++ b/examples/sample-book/exercises/groups.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/exercises/groups.xml
+++ b/examples/sample-book/exercises/groups.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/exercises/integers.xml
+++ b/examples/sample-book/exercises/integers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/exercises/integers.xml
+++ b/examples/sample-book/exercises/integers.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/exercises/sets.xml
+++ b/examples/sample-book/exercises/sets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/exercises/sets.xml
+++ b/examples/sample-book/exercises/sets.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/gfdl-mathbook.xml
+++ b/examples/sample-book/gfdl-mathbook.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2015-2016 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/gfdl-mathbook.xml
+++ b/examples/sample-book/gfdl-mathbook.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This is a faithful copy of Version 1.3 of the GFDL. -->

--- a/examples/sample-book/groups.xml
+++ b/examples/sample-book/groups.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/groups.xml
+++ b/examples/sample-book/groups.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/integers.xml
+++ b/examples/sample-book/integers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/integers.xml
+++ b/examples/sample-book/integers.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/project.ptx
+++ b/examples/sample-book/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/sample-book/publication-decorative.xml
+++ b/examples/sample-book/publication-decorative.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-book/publication-noparts.xml
+++ b/examples/sample-book/publication-noparts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-book/publication-runestone-academy.xml
+++ b/examples/sample-book/publication-runestone-academy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-book/publication-solution-manual.xml
+++ b/examples/sample-book/publication-solution-manual.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-book/publication-structural.xml
+++ b/examples/sample-book/publication-structural.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2016/03/25)                     -->

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sage/cyclic-info.xml
+++ b/examples/sample-book/sage/cyclic-info.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2016/03/25)                     -->

--- a/examples/sample-book/sage/cyclic-info.xml
+++ b/examples/sample-book/sage/cyclic-info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sage/cyclic-sage-exercises.xml
+++ b/examples/sample-book/sage/cyclic-sage-exercises.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2016 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sage/cyclic-sage-exercises.xml
+++ b/examples/sample-book/sage/cyclic-sage-exercises.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2016-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2016/03/25)                     -->

--- a/examples/sample-book/sage/groups-info.xml
+++ b/examples/sample-book/sage/groups-info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 <!-- See the file COPYING for copying conditions.  -->
 
 <remark>

--- a/examples/sample-book/sage/groups-info.xml
+++ b/examples/sample-book/sage/groups-info.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/groups-sage-exercises.xml
+++ b/examples/sample-book/sage/groups-sage-exercises.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <exercises xml:id="groups-sage-exercises">
     <title>Sage Exercises</title>

--- a/examples/sample-book/sage/groups-sage-exercises.xml
+++ b/examples/sample-book/sage/groups-sage-exercises.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/groups-sage.xml
+++ b/examples/sample-book/sage/groups-sage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <section xml:id="groups-sage" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Sage</title>

--- a/examples/sample-book/sage/groups-sage.xml
+++ b/examples/sample-book/sage/groups-sage.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/integers-info.xml
+++ b/examples/sample-book/sage/integers-info.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/integers-info.xml
+++ b/examples/sample-book/sage/integers-info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <remark>
     <title>Sage</title>

--- a/examples/sample-book/sage/integers-sage-exercises.xml
+++ b/examples/sample-book/sage/integers-sage-exercises.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <exercises xml:id="integers-sage-exercises">
     <title>Sage Exercises</title>

--- a/examples/sample-book/sage/integers-sage-exercises.xml
+++ b/examples/sample-book/sage/integers-sage-exercises.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/integers-sage.xml
+++ b/examples/sample-book/sage/integers-sage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <section xml:id="integers-sage">
     <title>Sage</title>

--- a/examples/sample-book/sage/integers-sage.xml
+++ b/examples/sample-book/sage/integers-sage.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/sets-info.xml
+++ b/examples/sample-book/sage/sets-info.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/sets-info.xml
+++ b/examples/sample-book/sage/sets-info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <remark>
     <title>Sage</title>

--- a/examples/sample-book/sage/sets-sage-exercises.xml
+++ b/examples/sample-book/sage/sets-sage-exercises.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <exercises xml:id="sets-sage-exercises">
     <title>Sage Exercises</title>

--- a/examples/sample-book/sage/sets-sage-exercises.xml
+++ b/examples/sample-book/sage/sets-sage-exercises.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sage/sets-sage.xml
+++ b/examples/sample-book/sage/sets-sage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 
@@ -23,7 +23,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!--   Abstract Algebra: Theory and Applications   -->
 <!--                                               -->
-<!-- Copyright (C) 2010-2014  Robert A. Beezer     -->
+<!-- Copyright (C) 2010-2026  Robert A. Beezer     -->
 
 <section xml:id="sets-sage">
     <title>Sage</title>

--- a/examples/sample-book/sage/sets-sage.xml
+++ b/examples/sample-book/sage/sets-sage.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sample-book-parts.xml
+++ b/examples/sample-book/sample-book-parts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sample-book-parts.xml
+++ b/examples/sample-book/sample-book-parts.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sample-book-solutions-manual.xml
+++ b/examples/sample-book/sample-book-solutions-manual.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sample-book-solutions-manual.xml
+++ b/examples/sample-book/sample-book-solutions-manual.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sample-book-solutions-manual.xsl
+++ b/examples/sample-book/sample-book-solutions-manual.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sample-book-solutions-manual.xsl
+++ b/examples/sample-book/sample-book-solutions-manual.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">

--- a/examples/sample-book/sample-book.xml
+++ b/examples/sample-book/sample-book.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sample-book.xml
+++ b/examples/sample-book/sample-book.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-book/sets.xml
+++ b/examples/sample-book/sets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/sample-book/sets.xml
+++ b/examples/sample-book/sets.xml
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 <!-- This file was originally part of the book     -->
 <!-- (as copied on 2015/07/12)                     -->

--- a/examples/sample-slideshow/publication-embedded.xml
+++ b/examples/sample-slideshow/publication-embedded.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-slideshow/publication-single-file.xml
+++ b/examples/sample-slideshow/publication-single-file.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-slideshow/publication.xml
+++ b/examples/sample-slideshow/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2019 Robert A. Beezer
+Copyright (C) 2019-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 #PreTeXt Showcase Article
 
 This folder contains the components for the PreTeXt

--- a/examples/showcase/project.ptx
+++ b/examples/showcase/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2022-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/pretext-showcase.ptx`

--- a/examples/showcase/publisher/publication.xml
+++ b/examples/showcase/publisher/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/stack/README.md
+++ b/examples/stack/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # STACK examples
 
 These examples demonstrate how to author, and process, [STACK](https://stack-assessment.org/) problems for inclusion in a [PreTeXt](https://pretextbook.org) document.

--- a/examples/stack/minimal/assets/stack/01_integration_with_feedback.xml
+++ b/examples/stack/minimal/assets/stack/01_integration_with_feedback.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <quiz>
 <!-- question: 17332  -->
   <question type="stack">

--- a/examples/stack/minimal/project.ptx
+++ b/examples/stack/minimal/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/stack/minimal/publication/publication.ptx
+++ b/examples/stack/minimal/publication/publication.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/stack/minimal/source/main.ptx
+++ b/examples/stack/minimal/source/main.ptx
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- To process this file with PreTeXt-CLI do                                                     -->

--- a/examples/stack/minimal/source/main.ptx
+++ b/examples/stack/minimal/source/main.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/examples/webwork/Makefile
+++ b/examples/webwork/Makefile
@@ -1,5 +1,5 @@
 ## ********************************************************************* ##
-## Copyright 2015-7                                                      ##
+## Copyright (C) 2015-2026                                               ##
 ## Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             ##
 ##                                                                       ##
 ## This file is part of PreTeXt.                                         ##

--- a/examples/webwork/Makefile.paths.example
+++ b/examples/webwork/Makefile.paths.example
@@ -1,5 +1,5 @@
 ## ********************************************************************* ##
-## Copyright 2015-7                                                      ##
+## Copyright (C) 2015-2026                                               ##
 ## Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             ##
 ##                                                                       ##
 ## This file is part of PreTeXt.                                         ##

--- a/examples/webwork/Makefile.paths.original
+++ b/examples/webwork/Makefile.paths.original
@@ -1,5 +1,5 @@
 ## ********************************************************************* ##
-## Copyright 2015-7                                                      ##
+## Copyright (C) 2015-2026                                               ##
 ## Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             ##
 ##                                                                       ##
 ## This file is part of PreTeXt.                                         ##

--- a/examples/webwork/README.md
+++ b/examples/webwork/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2016-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # WeBWorK examples
 
 These examples demonstrate how to author, and process, [WeBWorK](http://webwork.maa.org/) automated homework problems for inclusion in a [PreTeXt](https://pretextbook.org) document.

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!-- ********************************************************************* -->
-<!-- Copyright 2015-7                                                      -->
+<!-- Copyright (C) 2015-2026                                               -->
 <!-- Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             -->
 <!--                                                                       -->
 <!-- This file is part of PreTeXt.                                         -->

--- a/examples/webwork/minimal/publication.xml
+++ b/examples/webwork/minimal/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/webwork/sample-chapter/project.ptx
+++ b/examples/webwork/sample-chapter/project.ptx
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--********************************************************************
+Copyright (C) 2023-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--
     This file provides the overall configuration for your PreTeXt
     project. To edit the content of your document, open `source/main.ptx`

--- a/examples/webwork/sample-chapter/publisher/publication-academy.xml
+++ b/examples/webwork/sample-chapter/publisher/publication-academy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/webwork/sample-chapter/publisher/publication.xml
+++ b/examples/webwork/sample-chapter/publisher/publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!-- ********************************************************************* -->
-<!-- Copyright 2015-7                                                      -->
+<!-- Copyright (C) 2015-2026                                               -->
 <!-- Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             -->
 <!--                                                                       -->
 <!-- This file is part of PreTeXt.                                         -->

--- a/examples/workbook/README.md
+++ b/examples/workbook/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 ## Sample Workbooks
 
 As of 2024-11-22 these are first attempts at coherent 

--- a/examples/workbook/ho-reference-card.xml
+++ b/examples/workbook/ho-reference-card.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/workbook-article-publication.xml
+++ b/examples/workbook/workbook-article-publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/workbook-article.xml
+++ b/examples/workbook/workbook-article.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/workbook-book-publication.xml
+++ b/examples/workbook/workbook-book-publication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/workbook-book.xml
+++ b/examples/workbook/workbook-book.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/ws-activity-with-task.xml
+++ b/examples/workbook/ws-activity-with-task.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/ws-dot-products.xml
+++ b/examples/workbook/ws-dot-products.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/ws-geometric-prelude.xml
+++ b/examples/workbook/ws-geometric-prelude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/ws-networks.xml
+++ b/examples/workbook/ws-networks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/examples/workbook/ws-testing.xml
+++ b/examples/workbook/ws-testing.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--********************************************************************
-Copyright 2024 Robert A. Beezer
+Copyright (C) 2024-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Fonts bundled with PreTeXt
 
 The XSL-FO / Apache-FOP route to a PDF (the `pdf-fo` format of the

--- a/fonts/make-symbol-font.py
+++ b/fonts/make-symbol-font.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2026 Robert A. Beezer
+# Copyright (C) 2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/journals/README.md
+++ b/journals/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Journals supported by PreTeXt
 
 This folder contains a single `journals.xml` file which holds all relevant data about the journals currently supported by PreTeXt.

--- a/journals/journals-to-table.xsl
+++ b/journals/journals-to-table.xsl
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>

--- a/journals/journals.xml
+++ b/journals/journals.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <ptx-journals>
   <!-- We might want some categories or other way to break these up?  More likely just use tags -->
 

--- a/journals/texstyles/ams.xml
+++ b/journals/texstyles/ams.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>ams</code>

--- a/journals/texstyles/dependents/bull-amer-math-soc.xml
+++ b/journals/texstyles/dependents/bull-amer-math-soc.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>bull-amer-math-soc</code>

--- a/journals/texstyles/dependents/conform-geom-dyn.xml
+++ b/journals/texstyles/dependents/conform-geom-dyn.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>conform-geom-dyn</code>

--- a/journals/texstyles/dependents/j-algebraic-geom.xml
+++ b/journals/texstyles/dependents/j-algebraic-geom.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>j-algebraic-geom</code>

--- a/journals/texstyles/dependents/j-amer-math-soc.xml
+++ b/journals/texstyles/dependents/j-amer-math-soc.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>j-amer-math-soc</code>

--- a/journals/texstyles/dependents/math-comp.xml
+++ b/journals/texstyles/dependents/math-comp.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>math-comp</code>

--- a/journals/texstyles/dependents/proc-amer-math-soc.xml
+++ b/journals/texstyles/dependents/proc-amer-math-soc.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>proc-amer-math-soc</code>

--- a/journals/texstyles/dependents/quart-appl-math.xml
+++ b/journals/texstyles/dependents/quart-appl-math.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>quart-appl-math</code>

--- a/journals/texstyles/dependents/represent-theory.xml
+++ b/journals/texstyles/dependents/represent-theory.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>represent-theory</code>

--- a/journals/texstyles/dependents/theory-probab-math-statist.xml
+++ b/journals/texstyles/dependents/theory-probab-math-statist.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>theory-probab-math-statist</code>

--- a/journals/texstyles/dependents/trans-ams.xml
+++ b/journals/texstyles/dependents/trans-ams.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>trans-ams</code>

--- a/journals/texstyles/elsevier.xml
+++ b/journals/texstyles/elsevier.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>elsevier</code>

--- a/journals/texstyles/springer-nature.xml
+++ b/journals/texstyles/springer-nature.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>springer-nature</code>

--- a/journals/texstyles/taylor-francis.xml
+++ b/journals/texstyles/taylor-francis.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <texstyle>
     <metadata>
         <code>taylor-francis</code>

--- a/legal/copyright-holders.md
+++ b/legal/copyright-holders.md
@@ -1,0 +1,137 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+Copyright Holders
+=================
+
+Most files in this repository are copyright Robert A. Beezer alone, and are
+covered by the GNU General Public License (see `COPYING`, and the license texts
+in this directory).  This file records every exception.
+
+Keep it current.  When a file listed here is removed from the repository, drop
+its row.  When permission is obtained to change a notice, add an entry under
+Permissions below and set that row's status to `permitted`, with the date.
+
+Status values:
+
+* `as-is` — leave the notice alone, including its years.
+* `permitted` — permission obtained; see Permissions, with the date.
+
+## Beezer with co-holders
+
+The date range in these notices is maintained along with the rest of the
+repository.  The list of holders is not changed.
+
+| Holders | Files | Location | Status |
+|---|---|---|---|
+| Beezer, David Farmer, Alex Jordan, Mitchel T. Keller | 6 | `doc/guide/` — `COPYING`, `guide.xml`, `guideinfo.xml`, front and back matter | as-is |
+| Beezer, Michael Gage, Geoff Goehle, Alex Jordan | 7 | WeBWorK support — `xsl/extract-pg.xsl`, `xsl/pretext-ww-problem-sets.xsl`, `examples/webwork/` | as-is |
+| Beezer, David Farmer, Alex Jordan | 5 | `doc/guide/developer/` | as-is |
+| Oscar Levin, Andrew Rechnitzer, Steven Clontz, Beezer | 1 | `xsl/pretext-beamer.xsl` | as-is |
+| Andrew Rechnitzer, Steven Clontz, Beezer | 1 | `xsl/pretext-revealjs.xsl` | as-is |
+| Beezer, Alex Jordan | 1 | `xsl/pretext-merge.xsl` | as-is |
+
+## Other holders
+
+These notices are not altered at all, years included.
+
+| Holder | Files | Location | Status |
+|---|---|---|---|
+| Thomas W. Judson | 17 | `examples/sample-book/` — the *Abstract Algebra: Theory and Applications* content | as-is |
+| Glyph & Cog, LLC | 8 | `examples/showcase/generated/latex-image/` — produced files | as-is |
+| The PreTeXt Organization | 7 | `examples/showcase/source/` | as-is |
+| Free Software Foundation | 5 | `legal/gpl-license-v2.txt`, `legal/gpl-license-v3.txt`, `doc/guide/COPYING`, `doc/guide/appendices/gfdl-pretext.xml`, `examples/sample-book/gfdl-mathbook.xml` | as-is — verbatim license texts, whose own terms forbid modification |
+| Bryan A. Jones | 3 | `codechat_config.yaml` in `examples/humanities`, `examples/minimal`, `examples/sample-book` | as-is |
+| O'Reilly Media, Inc. | 3 | `xsl/entities.ent`, `xsl/pretext-epub.xsl`, `xsl/pretext-text-utilities.xsl` | as-is — the headers quote O'Reilly's own permission for code examples |
+| Aalto University | 2 | `js/pretext-stack/stackjsvle.js` and its copy under `js/dist/` | as-is — carries no license statement and has no nearby README |
+| Andrew Rechnitzer | 1 | `xsl/latex/pretext-latex-CLP.xsl` | as-is |
+| Oscar Levin | 1 | `xsl/latex/pretext-latex-texstyle.xsl` | as-is |
+| Jason Siefken | 1 | `xsl/xml-to-json.xsl` | as-is |
+| Evan Lenz | 1 | `xsl/xml-to-string.xsl` | as-is |
+| The MathJax Consortium | 1 | `script/mjsre/mj-sre-page.js` | as-is |
+| Mitchel T. Keller | 1 | `doc/guide/appendices/gfdl-pretext.xml` | as-is |
+| three.js authors | 1 | `examples/sample-article/media/code/threejs/splines.js` | as-is — the full MIT license text is inline |
+| STIX Fonts Project Authors, Adobe Systems, Elsevier, MicroPress | 1 | `fonts/LICENSE-STIX.txt` — one upstream license naming all four | as-is |
+| The Inconsolata Project Authors | 1 | `fonts/LICENSE-Inconsolata.txt` | as-is |
+| American Mathematical Society, The LaTeX Project, Radical Eye Software | 1 | `examples/showcase/generated/asymptote/AreaUnderCurve.eps` — a produced file | as-is |
+
+## Files carrying no notice
+
+| Files | Location | Note |
+|---|---|---|
+| 6 | `contrib/hitchman/`, `contrib/ups-writers/` | Contributed stylesheets, no notice at all.  Each directory has a README but no license.  Needs a decision. |
+| 1 | `xsl/support/play-button/README.md` | Left deliberately: it states that its content does not meet the threshold of originality for copyright protection. |
+
+## Permissions
+
+When a holder grants permission to change a notice, record it here and set that
+row's status above to `permitted`, referring to the date.
+
+Say precisely what was granted.  Permission to relicense is not the same as
+permission to restate a notice, and neither is the same as an upstream project
+changing its own license; naming the scope per entry keeps a narrow permission
+from being read broadly later.
+
+For evidence, record where it lives rather than reproducing it.  Pasting
+correspondence into a public repository publishes a third party's address and
+words, so prefer a mailing list archive link, a message identifier, or an issue
+or pull request number.  Public artifacts, such as an upstream license change,
+can be linked directly.
+
+| Date | Holder | Files | What was granted | Evidence |
+|---|---|---|---|---|
+| | | | | |
+
+## Maintaining the notices
+
+The notice for Beezer-held files reads
+
+    Copyright (C) <first year>-2026  Robert A. Beezer
+
+on one line, or with the holders on the line following, for files with several.
+An annual update advances the end year in both shapes.  Two rules:
+
+1. **Never move a start year later.**  Many files carry a notice that predates
+   the file's own history in the repository, because the file was split out of a
+   larger one or moved into a subdirectory.  A start year taken from the
+   repository would shorten those claims.  Use the earlier of the two.
+2. **Leave verbatim license texts alone.**  They carry copyright lines that look
+   like ordinary notices, but each one reproduces somebody else's license, and
+   their own terms forbid modification: `legal/gpl-license-v2.txt`,
+   `legal/gpl-license-v3.txt`, `doc/guide/appendices/gfdl-pretext.xml`,
+   `examples/sample-book/gfdl-mathbook.xml`, and the `fonts/LICENSE-*.txt`
+   files.  `doc/guide/COPYING` needs care rather than exclusion: the guide's own
+   notice at the top is maintained, while the GNU Free Documentation License
+   appended below it is not.
+
+Note also that a few files carry two distinct notices: those under
+`examples/sample-book/sage/` have a PreTeXt file header and a separate notice
+for the book content, with an earlier start year.  Both are maintained
+independently.
+
+## Rebuilding this list
+
+    git grep -nIE "[Cc]opyright[^A-Za-z]*(\(c\)|\(C\)|\(©\))? *[0-9]{4}" \
+      | grep -viE "showCopyright|\.copyright|localization|string-id=|ref name=|threshold of originality"
+
+For each result, the holder is the text following the year range — or, when that
+is empty, the *next* line.  A search that reads only the matching line will miss
+holders, and a search for a name alone will pick up prose: `Elsevier` appears as
+a journal publisher in `journals/journals.xml`, and `STIX` as a font name in
+`pretext/fop.xconf`.

--- a/pretext/README.md
+++ b/pretext/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2020-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 PreTeXt `pretext` Python Package
 ================================
 

--- a/pretext/fop.xconf
+++ b/pretext/fop.xconf
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2020 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/lib/braille_translate.py
+++ b/pretext/lib/braille_translate.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2026 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2026 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2020 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/lib/stack.py
+++ b/pretext/lib/stack.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2026 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/lib/webwork.py
+++ b/pretext/lib/webwork.py
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2010-2026 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/module-test.py
+++ b/pretext/module-test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ********************************************************************
-# Copyright 2010-2020 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ********************************************************************
-# Copyright 2010-2020 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -1,7 +1,7 @@
 # Configuration file for PreTeXt's "pretext" script
 
 # **********************************************************************
-# Copyright 2014 Robert A. Beezer
+# Copyright (C) 2014-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2014-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 ===========================
 Release Notes, MathBook XML
 ===========================

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2017-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # PreTeXt RELAX-NG Schema
 
 A RELAX-NG schema is the formal specification of the PreTeXt vocabulary.  Read the Author's Guide for complete documentation.

--- a/schema/braille-preprint.rnc
+++ b/schema/braille-preprint.rnc
@@ -1,5 +1,5 @@
 # ********************************************************************
-# Copyright 2026 Robert A. Beezer
+# Copyright (C) 2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/schema/build.sh
+++ b/schema/build.sh
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 #
 # Schema build script

--- a/schema/build.sh
+++ b/schema/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # ********************************************************************
-# Copyright 2017-2019 Robert A. Beezer
+# Copyright (C) 2017-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2020-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!--   = one, mandatory -->
 <!-- ? = one, optional  -->
 <!-- * = zero or more   -->

--- a/schema/publication.xml
+++ b/schema/publication.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <publication>
     <common>
         <tableofcontents level="1"/>

--- a/script/README.md
+++ b/script/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 PreTeXt Script Directory
 ========================
 

--- a/script/cssbuilder/README.md
+++ b/script/cssbuilder/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2024-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # CSS Builder
 
 ## Installing Node and Dependencies

--- a/script/dynsub/README.md
+++ b/script/dynsub/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Dynamic Substitutions Extraction
 
 Static formats of documents that contain exercises with dynamically-defined content

--- a/script/jsbuilder/README.md
+++ b/script/jsbuilder/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # PreTeXt JavaScript Builder
 
 Bundles and minifies the PreTeXt JavaScript source files in [`js/`](../../js/)

--- a/script/mbx
+++ b/script/mbx
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ********************************************************************
-# Copyright 2010-2020 Robert A. Beezer
+# Copyright (C) 2010-2026  Robert A. Beezer
 #
 # This file is part of PreTeXt.
 #

--- a/script/mjsre/README.md
+++ b/script/mjsre/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2020-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # MathJax (MJ) and Speech Rule Engine (SRE)
 
 Offline support for conversions to EPUB, Kindle, braille,

--- a/script/utilities/README.md
+++ b/script/utilities/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Developer Utilities
 
 Small helper scripts for developers working on the PreTeXt source.

--- a/script/utilities/find_xml_pattern.py
+++ b/script/utilities/find_xml_pattern.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python3
 
+#********************************************************************
+# Copyright (C) 2026  Robert A. Beezer
+#
+# This file is part of PreTeXt.
+#
+# PreTeXt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 or version 3 of the
+# License (at your option).
+#
+# PreTeXt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+#********************************************************************
 """Find XML elements matching an XPath-like pattern in PreTeXt source files."""
 
 import argparse

--- a/script/utilities/trim_changed_trailing_whitespace.py
+++ b/script/utilities/trim_changed_trailing_whitespace.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python3
 
+#********************************************************************
+# Copyright (C) 2026  Robert A. Beezer
+#
+# This file is part of PreTeXt.
+#
+# PreTeXt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 or version 3 of the
+# License (at your option).
+#
+# PreTeXt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+#********************************************************************
 # Usage:
 #   script/utilities/trim_changed_trailing_whitespace.py [--base <ref>] [--check]
 # This script identifies lines with trailing whitespace that have been

--- a/script/webwork/pg-ptx.pl
+++ b/script/webwork/pg-ptx.pl
@@ -1,5 +1,23 @@
 #!/usr/bin/env perl
 
+#********************************************************************
+# Copyright (C) 2025-2026  Robert A. Beezer
+#
+# This file is part of PreTeXt.
+#
+# PreTeXt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 or version 3 of the
+# License (at your option).
+#
+# PreTeXt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+#********************************************************************
 use Mojo::Base -signatures, -async_await;
 use Mojo::IOLoop;
 use Getopt::Long qw(:config bundling);

--- a/xsl/README.md
+++ b/xsl/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2019-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 eXtensible Stylesheet Language (XSL) Stylesheets
 ================================================
 

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -2,20 +2,20 @@
 <!-- Copyright 2016                                                        -->
 <!-- Robert A. Beezer                                                      -->
 <!--                                                                       -->
-<!-- This file is part of MathBook XML.                                    -->
+<!-- This file is part of PreTeXt.                                    -->
 <!--                                                                       -->
-<!-- MathBook XML is free software: you can redistribute it and/or modify  -->
+<!-- PreTeXt is free software: you can redistribute it and/or modify  -->
 <!-- it under the terms of the GNU General Public License as published by  -->
 <!-- the Free Software Foundation, either version 2 or version 3 of the    -->
 <!-- License (at your option).                                             -->
 <!--                                                                       -->
-<!-- MathBook XML is distributed in the hope that it will be useful,       -->
+<!-- PreTeXt is distributed in the hope that it will be useful,       -->
 <!-- but WITHOUT ANY WARRANTY; without even the implied warranty of        -->
 <!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         -->
 <!-- GNU General Public License for more details.                          -->
 <!--                                                                       -->
 <!-- You should have received a copy of the GNU General Public License     -->
-<!-- along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>. -->
+<!-- along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>. -->
 <!-- ********************************************************************* -->
 
 <!-- XSLT Cookbook, 2nd Edition                                     -->

--- a/xsl/extract-asymptote.xsl
+++ b/xsl/extract-asymptote.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-asymptote.xsl
+++ b/xsl/extract-asymptote.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates <asymptote> elements          -->

--- a/xsl/extract-biblio-csl.xsl
+++ b/xsl/extract-biblio-csl.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2025 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-datafile.xsl
+++ b/xsl/extract-datafile.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-dynamic.xsl
+++ b/xsl/extract-dynamic.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-identity.xsl
+++ b/xsl/extract-identity.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-identity.xsl
+++ b/xsl/extract-identity.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet does nothing but traverse the tree         -->

--- a/xsl/extract-interactive.xsl
+++ b/xsl/extract-interactive.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-latex-image.xsl
+++ b/xsl/extract-latex-image.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates <latex-image> elements    -->

--- a/xsl/extract-latex-image.xsl
+++ b/xsl/extract-latex-image.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-mermaid.xsl
+++ b/xsl/extract-mermaid.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-mom.xsl
+++ b/xsl/extract-mom.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-mom.xsl
+++ b/xsl/extract-mom.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2018-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates video/@youtube elements and -->

--- a/xsl/extract-pg.xsl
+++ b/xsl/extract-pg.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!-- ********************************************************************* -->
-<!-- Copyright 2015-7                                                      -->
+<!-- Copyright (C) 2015-2026                                               -->
 <!-- Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             -->
 <!--                                                                       -->
 <!-- This file is part of PreTeXt.                                         -->

--- a/xsl/extract-prefigure.xsl
+++ b/xsl/extract-prefigure.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-prefigure.xsl
+++ b/xsl/extract-prefigure.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates <prefigure> elements and copies them for processing -->

--- a/xsl/extract-qrcode.xsl
+++ b/xsl/extract-qrcode.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-runestone-page-template.xsl
+++ b/xsl/extract-runestone-page-template.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-sageplot.xsl
+++ b/xsl/extract-sageplot.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> 
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/extract-sageplot.xsl
+++ b/xsl/extract-sageplot.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates <sageplot> elements     -->

--- a/xsl/extract-stack.xsl
+++ b/xsl/extract-stack.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-trace.xsl
+++ b/xsl/extract-trace.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/extract-youtube.xsl
+++ b/xsl/extract-youtube.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2014-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This stylesheet locates video/@youtube elements and -->

--- a/xsl/extract-youtube.xsl
+++ b/xsl/extract-youtube.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2014-2016 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/latex/pretext-latex-AIM.xsl
+++ b/xsl/latex/pretext-latex-AIM.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/latex/pretext-latex-chaos.xsl
+++ b/xsl/latex/pretext-latex-chaos.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/latex/pretext-latex-dyslexic-font.xsl
+++ b/xsl/latex/pretext-latex-dyslexic-font.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/latex/pretext-latex-guide.xsl
+++ b/xsl/latex/pretext-latex-guide.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/README.md
+++ b/xsl/localizations/README.md
@@ -1,5 +1,5 @@
 <!--********************************************************************
-Copyright 2013-2021 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/af-ZA.xml
+++ b/xsl/localizations/af-ZA.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/bg-BG.xml
+++ b/xsl/localizations/bg-BG.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/ca-ES.xml
+++ b/xsl/localizations/ca-ES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/cs-CZ.xml
+++ b/xsl/localizations/cs-CZ.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/de-DE.xml
+++ b/xsl/localizations/de-DE.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/en-US.xml
+++ b/xsl/localizations/en-US.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/es-ES.xml
+++ b/xsl/localizations/es-ES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/fi-FI.xml
+++ b/xsl/localizations/fi-FI.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/fr-CA.xml
+++ b/xsl/localizations/fr-CA.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016-2021 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 This file is part of PreTeXt.
 PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/xsl/localizations/fr-FR.xml
+++ b/xsl/localizations/fr-FR.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2016-2021 Robert A. Beezer
+Copyright (C) 2016-2026  Robert A. Beezer
 This file is part of PreTeXt.
 PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/xsl/localizations/hu-HU.xml
+++ b/xsl/localizations/hu-HU.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/ku-CKB.xml
+++ b/xsl/localizations/ku-CKB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/localizations.xml
+++ b/xsl/localizations/localizations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/nl-NL.xml
+++ b/xsl/localizations/nl-NL.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/pt-BR.xml
+++ b/xsl/localizations/pt-BR.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/pt-PT.xml
+++ b/xsl/localizations/pt-PT.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2015-2021 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/localizations/zh-HANS.xml
+++ b/xsl/localizations/zh-HANS.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--********************************************************************
-Copyright 2014-2021 Robert A. Beezer
+Copyright (C) 2014-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-basic-html.xsl
+++ b/xsl/pretext-basic-html.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-basic-html.xsl
+++ b/xsl/pretext-basic-html.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2018-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-dynamic.xsl
+++ b/xsl/pretext-dynamic.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2022-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-json-manifest.xsl
+++ b/xsl/pretext-json-manifest.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2015-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2015 Robert A. Beezer
+Copyright (C) 2015-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-litprog.xsl
+++ b/xsl/pretext-litprog.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013-2020 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-markdown.xsl
+++ b/xsl/pretext-markdown.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2026 Robert A. Beezer
+Copyright (C) 2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -6,7 +6,7 @@
 ]>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-runestone-fitb.xsl
+++ b/xsl/pretext-runestone-fitb.xsl
@@ -1,5 +1,23 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
+<!--********************************************************************
+Copyright (C) 2023-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!DOCTYPE xsl:stylesheet>
 
 <xsl:stylesheet

--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2022-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2022-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-sage-doctest.xsl
+++ b/xsl/pretext-sage-doctest.xsl
@@ -1,5 +1,23 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
+<!--********************************************************************
+Copyright (C) 2013-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->
 <!DOCTYPE xsl:stylesheet [
     <!ENTITY % entities SYSTEM "entities.ent">

--- a/xsl/pretext-smc.xsl
+++ b/xsl/pretext-smc.xsl
@@ -1,5 +1,23 @@
 <?xml version='1.0'?>
 
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->
 <!DOCTYPE xsl:stylesheet [
     <!ENTITY % entities SYSTEM "entities.ent">

--- a/xsl/pretext-solution-manual-latex.xsl
+++ b/xsl/pretext-solution-manual-latex.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-solution-manual-latex.xsl
+++ b/xsl/pretext-solution-manual-latex.xsl
@@ -5,18 +5,18 @@ Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2022-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2018-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-units.xsl
+++ b/xsl/pretext-units.xsl
@@ -6,20 +6,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- This file contains unit-related abbreviations, such as 'kilo' => 'k'           -->

--- a/xsl/pretext-units.xsl
+++ b/xsl/pretext-units.xsl
@@ -4,7 +4,7 @@
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/pretext-view-source.xsl
+++ b/xsl/pretext-view-source.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2019 Robert A. Beezer
+Copyright (C) 2019-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/pretext-ww-problem-sets.xsl
+++ b/xsl/pretext-ww-problem-sets.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!-- ********************************************************************* -->
-<!-- Copyright 2015-18                                                     -->
+<!-- Copyright (C) 2015-2026                                               -->
 <!-- Robert A. Beezer, Michael Gage, Geoff Goehle, Alex Jordan             -->
 <!--                                                                       -->
 <!-- This file is part of PreTeXt.                                         -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/support/README.md
+++ b/xsl/support/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2022-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # PreTeXt (Miscellaneous) Support Files
 
 ### Runestone Services

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/support/package-math.xsl
+++ b/xsl/support/package-math.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/support/webpack_static_imports.xml
+++ b/xsl/support/webpack_static_imports.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" ?>
+
+<!--********************************************************************
+Copyright (C) 2021-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <all>
 	<js type="list">
 		<item type="str">prefix-runtime.00db6230172ad960.bundle.js</item>

--- a/xsl/tests/README.md
+++ b/xsl/tests/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # XSL Automated Tests
 
 This folder contains testing utilities for XSL templates. The tests focus on function-like templates for tasks like string manipulation that are used as helpers throughout the XSL stylesheets. Most of these functions are otherwise only observable indirectly through their effects on the output of the main XSL stylesheets.

--- a/xsl/tests/null.xml
+++ b/xsl/tests/null.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
+<!--********************************************************************
+Copyright (C) 2025-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
 <!-- intentionally empty valid XML file for use with pretext-text-utilities-text.xsl -->
 <nothing>
 </nothing>

--- a/xsl/tests/pretext-text-utilities-test.xsl
+++ b/xsl/tests/pretext-text-utilities-test.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2022 Robert A. Beezer
+Copyright (C) 2022-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/utilities/README.md
+++ b/xsl/utilities/README.md
@@ -1,3 +1,22 @@
+<!--********************************************************************
+Copyright (C) 2017-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************-->
+
 # Utilities
 
 ## Source-to-Source conversions

--- a/xsl/utilities/author-report.xsl
+++ b/xsl/utilities/author-report.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2018 Robert A. Beezer
+Copyright (C) 2018-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/utilities/fix-deprecations.xsl
+++ b/xsl/utilities/fix-deprecations.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2017-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- Identify as a stylesheet -->

--- a/xsl/utilities/fix-deprecations.xsl
+++ b/xsl/utilities/fix-deprecations.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2017 Robert A. Beezer
+Copyright (C) 2017-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/utilities/pretext-enhanced-source.xsl
+++ b/xsl/utilities/pretext-enhanced-source.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--********************************************************************
-Copyright 2020 Robert A. Beezer
+Copyright (C) 2020-2026  Robert A. Beezer
 
 This file is part of PreTeXt.
 

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright (C) 2013-2026  Robert A. Beezer
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!-- http://pimpmyxslt.com/articles/entity-tricks-part2/ -->

--- a/xsl/utilities/report-publisher-variables.xsl
+++ b/xsl/utilities/report-publisher-variables.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?> <!-- As XML file -->
 
 <!--********************************************************************
-Copyright 2013 Robert A. Beezer
+Copyright (C) 2013-2026  Robert A. Beezer
 
 This file is part of MathBook XML.
 

--- a/xsl/xml-to-json.xsl
+++ b/xsl/xml-to-json.xsl
@@ -3,20 +3,20 @@
 <!--********************************************************************
 Copyright 2023 Jason Siefken
 
-This file is part of MathBook XML.
+This file is part of PreTeXt.
 
-MathBook XML is free software: you can redistribute it and/or modify
+PreTeXt is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 or version 3 of the
 License (at your option).
 
-MathBook XML is distributed in the hope that it will be useful,
+PreTeXt is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************-->
 
 <!--


### PR DESCRIPTION
Every copyright notice in the repository now carries a range ending in 2026, in one consistent form, and the files that were missing a notice have one. A register of every holder other than Robert A. Beezer alone is recorded in `legal/copyright-holders.md`, so next year's update is mechanical.

Nine commits, each doing one thing:

| commit | files |
|---|---|
| advance Robert A. Beezer notice ranges to 2026 | 197 |
| advance multi-holder notice ranges to 2026 | 31 |
| spell out the abbreviated end year in WeBWorK support files | 7 |
| name PreTeXt in place of MathBook XML in license headers | 58 |
| add the license header to source files missing one | 7 |
| add the license header to SCSS sources | 117 |
| add the license header to example and support source | 82 |
| add the license header to README and documentation files | 49 |
| record the register of other copyright holders | 1 |

Files carrying a real notice go from 264 to 530.

**The one decision worth checking.** Setting each start year from when the file entered the repository, applied literally, would *shorten* 119 copyright claims: that many files carry a notice predating their own path history, because they were split out of a larger file or moved into a subdirectory. `pretext/lib/common.py` computes as 2026 but claims 2010; the guide appendices claim 2013 but were split out as late as 2025. The rule used instead is **the earlier of the existing start year and the repository entry year** — never later. Measured afterwards: 204 start years unchanged, 2 moved earlier, none moved later.

**Two things a bulk pass must never touch,** both learned the hard way here and both written into `legal/copyright-holders.md` for next time. Verbatim license texts carry copyright lines that look like ordinary notices, and their own terms forbid modification — `doc/guide/COPYING` needs particular care, since the guide's own notice sits above an appended GNU Free Documentation License. And a few files carry two distinct notices: those under `examples/sample-book/sage/` have a PreTeXt file header alongside a separate notice for the *Abstract Algebra* content with an earlier start year, and both are maintained independently.

**Verification.** The sample article LaTeX build is byte-identical to master apart from its two build timestamps, as it must be for comment-only changes; the sample book builds clean. Every modified XML and PTX file is well-formed. The SCSS additions were rebuilt through `script/cssbuilder` and every `css/dist/*.css` came out byte-identical. Comment terminators kept their original column on all 70 padded lines that were rewritten. No third-party copyright line is altered anywhere in the branch.

**Left alone deliberately.** The stylesheets under `contrib/` carry no notice at all and are contributed work; `js/pretext-stack/stackjsvle.js` has a copyright line but no license statement; and prose that names the old MathBook XML system historically — the glossary entry explaining the name, the release notes covering that era, and example content — is untouched, since rewriting authored prose is an editorial decision rather than a licensing one. The register records each of these.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
