### PR TITLE
Braille Formatting Changes

### DIFF
--- a/pretext/lib/braille_format.py
+++ b/pretext/lib/braille_format.py
@@ -665,7 +665,7 @@ class PageComposer:
             emit("7" * self.layout.text_width(position, 0))
         elif blk.box == "nemeth":
             emit(translate_print(NEMETH_OPEN))
-            emit('')
+            #emit('')
 
         for child in blk.xml.xpath("segment|block"):
             if child.tag == "segment":
@@ -702,7 +702,7 @@ class PageComposer:
         if blk.box == "standard":
             emit("g" * self.layout.text_width(position, 0))
         elif blk.box == "nemeth":
-            emit('')
+            #emit('')
             close_brf = NEMETH_CLOSE
             if blk.punctuation:
                 close_brf += blk.punctuation

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -1913,7 +1913,7 @@ Book (with parts), "section" at level 3
     <xsl:variable name="math-punctuation">
         <xsl:choose>
             <!-- drop punctuation after display math, if moving to math -->
-            <xsl:when test="$b-include-display and contains($clause-ending-marks, $first-char) and preceding-sibling::node()[1][self::md[mrow]]">
+            <xsl:when test="$b-include-display and contains($clause-ending-marks, $first-char) and preceding-sibling::node()[1][self::md]">
                 <xsl:call-template name="strip-leading-whitespace">
                     <xsl:with-param name="text">
                         <xsl:call-template name="drop-clause-punctuation">
@@ -1986,7 +1986,7 @@ Book (with parts), "section" at level 3
             <xsl:variable name="original" select="$text-processed" />
             <xsl:variable name="front-cleaned">
                 <xsl:choose>
-                    <xsl:when test="not(preceding-sibling::node()[self::*|self::text()]) or preceding-sibling::node()[self::*|self::text()][1][self::md[mrow]|self::cd|self::pre|self::ol/parent::p|self::ul/parent::p|self::dl/parent::p]">
+                    <xsl:when test="not(preceding-sibling::node()[self::*|self::text()]) or preceding-sibling::node()[self::*|self::text()][1][self::md|self::cd|self::pre|self::ol/parent::p|self::ul/parent::p|self::dl/parent::p]">
                         <xsl:call-template name="strip-leading-whitespace">
                             <xsl:with-param name="text" select="$original" />
                         </xsl:call-template>
@@ -1998,7 +1998,7 @@ Book (with parts), "section" at level 3
             </xsl:variable>
             <xsl:variable name="back-cleaned">
                 <xsl:choose>
-                    <xsl:when test="not(following-sibling::node()[self::*|self::text()])  or following-sibling::node()[self::*|self::text()][1][self::md[mrow]|self::cd|self::pre|self::ol/parent::p|self::ul/parent::p|self::dl/parent::p]">
+                    <xsl:when test="not(following-sibling::node()[self::*|self::text()])  or following-sibling::node()[self::*|self::text()][1][self::md|self::cd|self::pre|self::ol/parent::p|self::ul/parent::p|self::dl/parent::p]">
                         <xsl:call-template name="strip-trailing-whitespace">
                             <xsl:with-param name="text" select="$front-cleaned" />
                         </xsl:call-template>


### PR DESCRIPTION
Removed extraneous whitespace inside of <md> environments.

Removed punctuation doubling at end of <md> environments.