### PR TITLE
The external directory is a fact of the source

### DIFF
--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -831,9 +831,11 @@
                     <cline>            sloth.jpg</cline>
                 </cd></p>
 
-                <p>In your publication files you would then have the entry, as a sub-element of the <c>source</c> element,<cd>
-                    <cline>&lt;directories external="../ext" generated="../gen"/&gt;</cline>
-                </cd>Notice that we have deliberately named our directories <c>ext</c> and <c>gen</c> as part of this illustration, so that they are not identical to the <em>attribute</em> names on the <tag>directories</tag> element.  The two attribute values are <em>relative</em> to the location of the main <pretext/> file, in this case <c>aota.ptx</c>.  The two periods, <c>..</c>, mean to go up a level, here to the <c>aota</c> directory, then the slash indicates a step down to either <c>gen</c> or <c>ext</c>.  Note that <c>latex-image</c> and <c>youtube</c> within <c>gen</c> <em>must</em> be specified exactly that way.  Now every <pretext/> production tool can deduce where your files are.</p>
+                <p>The two directories are declared in two places, by their nature.  The external directory holds files <em>you</em> curate<mdash/>swap that directory for another and your document's content changes<mdash/>so it is a fact of the source, declared in your <tag>docinfo</tag> (<xref ref="topic-docinfo"/>):<cd>
+                    <cline>&lt;directories external="../ext"/&gt;</cline>
+                </cd>The generated directory is a destination the build machinery manages, so it is a publication file entry, a sub-element of the <c>source</c> element:<cd>
+                    <cline>&lt;directories generated="../gen"/&gt;</cline>
+                </cd>(An <attr>external</attr> attribute in the publication file is deprecated, but honored while the <tag>docinfo</tag> is silent.)  Notice that we have deliberately named our directories <c>ext</c> and <c>gen</c> as part of this illustration, so that they are not identical to the <em>attribute</em> names on the <tag>directories</tag> elements.  Both attribute values are <em>relative</em> to the location of the main <pretext/> file, in this case <c>aota.ptx</c>.  The two periods, <c>..</c>, mean to go up a level, here to the <c>aota</c> directory, then the slash indicates a step down to either <c>gen</c> or <c>ext</c>.  Note that <c>latex-image</c> and <c>youtube</c> within <c>gen</c> <em>must</em> be specified exactly that way.  Now every <pretext/> production tool can deduce where your files are.</p>
 
                 <p>How do you specify in your <pretext/> source which file to use where?  Suppose you want your two (external) photographs to be used in a <tag>sidebyside</tag> element.  You would author<cd>
                     <cline>&lt;sidebyside widths="50% 30%"&gt;</cline>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4686,7 +4686,7 @@
         <paragraphs>
             <title>What the Images Need, and Where Files Live</title>
 
-            <p>A <tag>latex-image-preamble</tag> and an <tag>asymptote-preamble</tag> supply setup for images described by source code, and a <c>pf:prefigure-preamble</c> does the same for PreFigure (<xref ref="topic-images"/>).  A <tag>directories</tag> element with a <attr>data</attr> attribute names the directory of data files that images and programs consume; the directories of external and generated images are named in the publication file (<xref ref="processing-directory-management"/>).</p>
+            <p>A <tag>latex-image-preamble</tag> and an <tag>asymptote-preamble</tag> supply setup for images described by source code, and a <c>pf:prefigure-preamble</c> does the same for PreFigure (<xref ref="topic-images"/>).  A <tag>directories</tag> element declares the directories that run with your source: <attr>external</attr> names the directory of files you curate (images and other assets<mdash/>a different directory is a different document), and <attr>data</attr> the directory of data files that images and programs consume.  The <em>destination</em> for generated files remains a publication file entry (<xref ref="processing-directory-management"/>).</p>
         </paragraphs>
 
         <paragraphs>

--- a/doc/guide/developer/coding.xml
+++ b/doc/guide/developer/coding.xml
@@ -47,7 +47,7 @@
             <li>Exercise-component visibility <em>changes which letters appear on the page</em>, yet is the publication file: the publisher selects among whole units the author supplied, altering none of them.</li>
             <li>The depth of division numbering changes visible glyphs, yet is the publication file: numbers are generated apparatus.</li>
             <li>A document-wide default image width is <tag>docinfo</tag> by principle 3: it is a default for the authored <attr>width</attr> attribute, a convenience for a per-image authoring decision.</li>
-            <li>Managed directories illustrate that one <em>concept</em> can straddle the line: the files an author curates (external images, data) are source material<mdash/>swap the directory and it is a different book<mdash/>while the destination for generated build products is publisher convenience.  Judge each piece by its nature, not by keeping a family together.</li>
+            <li>Managed directories illustrate that one <em>concept</em> can straddle the line: the files an author curates (external images, data) are source material<mdash/>swap the directory and it is a different book<mdash/>while the destination for generated build products is publisher convenience.  The homes now match: <attr>external</attr> and <attr>data</attr> are declared on <c>docinfo/directories</c>, <attr>generated</attr> in the publication file.  Judge each piece by its nature, not by keeping a family together.</li>
         </ul></p>
 
         <p>When a proposed feature resists these tests, that is usually a sign it bundles an authoring concern with a presentation concern, and should be split.</p>

--- a/doc/guide/guideinfo.xml
+++ b/doc/guide/guideinfo.xml
@@ -9,6 +9,7 @@
 <!-- See the file COPYING for copying conditions.                   -->
 
 <docinfo>
+    <directories external="external"/>
     <rename element="note" xml:lang="en-US">Best Practice</rename>
     <rename element="insight" xml:lang="en-US">Tip</rename>
     <!-- a demonstration in Basic Reference -->

--- a/doc/guide/publication-styled.xml
+++ b/doc/guide/publication-styled.xml
@@ -37,7 +37,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Relative path, relative to "main" source file -->
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
 
 </publication>

--- a/doc/guide/publication.xml
+++ b/doc/guide/publication.xml
@@ -43,7 +43,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Relative path, relative to "main" source file -->
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
 
 </publication>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1222,12 +1222,11 @@
         <subsection xml:id="publication-file-directory-management">
             <title>Directory Management</title>
 
-            <p>Two directories of additional files need to be specified, as paths relative to the main <pretext/> source file, in order that they can be managed automatically for the construction of various output formats.  Study <xref ref="processing-directory-management"/> carefully for the exact details.  To set these directories, the<cd>
+            <p>The destination for files produced automatically via <pretext/> tools is specified as a path relative to the main <pretext/> source file.  Study <xref ref="processing-directory-management"/> carefully for the exact details.  The<cd>
                 <cline>/publication/source/directories</cline>
-            </cd>element must have the following two attributes:<ul>
-                <li><attr>external</attr>: a directory of files produced independently of your project.</li>
+            </cd>element has the attribute:<ul>
                 <li><attr>generated</attr>: a directory of files produced automatically via <pretext/> tools, from aspects of your <pretext/> source.</li>
-            </ul>It is an error to only specify one of the two directories.  It is all or nothing.</p>
+            </ul>The companion directory of files produced independently of the project is a fact of the <em>source</em>, declared with a <attr>external</attr> attribute on a <tag>directories</tag> element within <tag>docinfo</tag> (<xref ref="topic-docinfo"/>); an <attr>external</attr> attribute here is deprecated, but honored while the <tag>docinfo</tag> is silent.  Managed directories require both declarations<mdash/>it is an error to supply only one.</p>
         </subsection>
 
         <subsection xml:id="publication-file-source-version">

--- a/examples/custom-theming/publication/publication-custom-colors.ptx
+++ b/examples/custom-theming/publication/publication-custom-colors.ptx
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- relative to your main source file.                               -->
     <!-- the @external value is where any file specified by               -->
     <!--  html.css.extra CSS should be                                    -->
-    <directories external="../assets" generated="../generated-assets" />
+    <directories generated="../generated-assets" />
   </source>
 
   <html>

--- a/examples/custom-theming/publication/publication-custom-theme.ptx
+++ b/examples/custom-theming/publication/publication-custom-theme.ptx
@@ -25,7 +25,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   <source>
     <!-- Paths to folders containing external assets and generated assets -->
     <!-- relative to your main source file.                               -->
-    <directories external="../assets" generated="../generated-assets" />
+    <directories generated="../generated-assets" />
   </source>
 
   <html>

--- a/examples/custom-theming/publication/publication-salem.ptx
+++ b/examples/custom-theming/publication/publication-salem.ptx
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- relative to your main source file.                               -->
     <!-- the @external value is where any file specified by               -->
     <!--  html.css.extra CSS should be                                    -->
-    <directories external="../assets" generated="../generated-assets" />
+    <directories generated="../generated-assets" />
   </source>
 
   <html>

--- a/examples/custom-theming/publication/publication.ptx
+++ b/examples/custom-theming/publication/publication.ptx
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- relative to your main source file.                               -->
     <!-- the @external value is where any file specified by               -->
     <!--  html.css.extra CSS should be                                    -->
-    <directories external="../assets" generated="../generated-assets" />
+    <directories generated="../generated-assets" />
 
     <!-- If not specified, theme will default to "default-modern" -->
     <!-- <theme name="default-modern" /> -->

--- a/examples/custom-theming/source/docinfo.ptx
+++ b/examples/custom-theming/source/docinfo.ptx
@@ -22,6 +22,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This is where you can define macros and other book-wide -->
 <!-- settings. -->
 <docinfo xmlns:xi="http://www.w3.org/2001/XInclude">
+    <directories external="../assets"/>
 
 
   <!-- brandlogo is the image that may appear next to the title in the banner -->

--- a/examples/epub/epub-sampler.xml
+++ b/examples/epub/epub-sampler.xml
@@ -22,6 +22,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext>
 
     <docinfo>
+        <directories external="ext"/>
         <macros>
         \newcommand{\doubler}[1]{2#1}
         \newcommand{\definiteintegral}[4]{\int_{#1}^{#2}\,#3\,d#4} % this comment will be stripped

--- a/examples/epub/publication.xml
+++ b/examples/epub/publication.xml
@@ -22,7 +22,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
     </source>
 
     <!-- EPUB-Specific Options -->

--- a/examples/humanities/publication/publication.ptx
+++ b/examples/humanities/publication/publication.ptx
@@ -31,7 +31,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   <!-- stored or created.  Directories are relative to the main -->
   <!-- source PreTeXt file                                      -->
   <source>
-    <directories external="../assets" generated="../generated-assets"/>
+    <directories generated="../generated-assets"/>
   </source>
 
   <numbering>

--- a/examples/humanities/source/hia.xml
+++ b/examples/humanities/source/hia.xml
@@ -21,6 +21,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
     <!-- May need lilyglyphs.sty from Debian/Ubuntu texlive-music -->
     <docinfo>
+        <directories external="../assets"/>
         <!-- this is the default, but supresses a warning -->
         <cross-references text="type-global" />
     </docinfo>

--- a/examples/minimal/publication/publication.ptx
+++ b/examples/minimal/publication/publication.ptx
@@ -21,6 +21,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
     <!-- directories are relative to the main source PreTeXt file -->
     <source>
-        <directories external="../assets" generated="../generated-assets"/>
+        <directories generated="../generated-assets"/>
     </source>
 </publication>

--- a/examples/minimal/source/main.ptx
+++ b/examples/minimal/source/main.ptx
@@ -31,6 +31,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext>
 
     <docinfo>
+        <directories external="../assets"/>
         <macros>
         \newcommand{\doubler}[1]{2#1}
         </macros>

--- a/examples/numbering/main.ptx
+++ b/examples/numbering/main.ptx
@@ -62,6 +62,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext>
 
     <docinfo>
+        <directories external="ext"/>
         <macros>
         </macros>
     </docinfo>

--- a/examples/numbering/publication.xml
+++ b/examples/numbering/publication.xml
@@ -38,7 +38,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
     </source>
 
     <numbering>

--- a/examples/pdf-fo-development/pdf-fo-development.xml
+++ b/examples/pdf-fo-development/pdf-fo-development.xml
@@ -26,6 +26,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <pretext>
 
+    <docinfo>
+        <directories external="external"/>
+    </docinfo>
+
     <article xml:id="pdf-fo-development" label="pdf-fo-development">
         <title>XSL-FO Conversion Development</title>
 

--- a/examples/pdf-fo-development/publication.xml
+++ b/examples/pdf-fo-development/publication.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <publication>
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
     <latex font-size="11" print="no"/>
 </publication>

--- a/examples/sample-article/publication-crc.xml
+++ b/examples/sample-article/publication-crc.xml
@@ -23,7 +23,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-one for the plain sample article -->
     <source customizations="customizations-two.xml">
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
     </source>
 
     <!-- HTML-Specific Options -->

--- a/examples/sample-article/publication-oscarlevin.xml
+++ b/examples/sample-article/publication-oscarlevin.xml
@@ -23,7 +23,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-one for the plain sample article -->
     <source customizations="customizations-two.xml">
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
     </source>
 
     <!-- HTML-Specific Options -->

--- a/examples/sample-article/publication-print.xml
+++ b/examples/sample-article/publication-print.xml
@@ -76,7 +76,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-two for the oscarlevin style example -->
     <source customizations="customizations-one.xml">
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>

--- a/examples/sample-article/publication-solution-manual.xml
+++ b/examples/sample-article/publication-solution-manual.xml
@@ -37,7 +37,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- to locate this file, which is not what we have done   -->
     <!-- here with this sample.                                -->
     <source private-solutions="privatesolutions.xml"> 
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
     </source>
 
     <html>

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -70,7 +70,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-two for the oscarlevin style example -->
     <source customizations="customizations-one.xml">
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -172,7 +172,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- certain items completely.  For example, a data file -->
         <!-- for an plot image. Illustrated here, search for the -->
         <!-- use of the translation, "external/"                 -->
-        <directories data="numerical"/>
+        <directories external="media" data="numerical"/>
 
         <!-- A blurb that briefly describes the document -->
         <blurb>

--- a/examples/sample-book/bookinfo.xml
+++ b/examples/sample-book/bookinfo.xml
@@ -25,6 +25,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!--                                               -->
 <!-- Copyright (C) 1997-2014  Thomas W. Judson     -->
 <docinfo>
+    <directories external="ext"/>
 
     <!-- the other option is "long" which will produce an -->
     <!-- entire front matter section with more headings   -->

--- a/examples/sample-book/publication-decorative.xml
+++ b/examples/sample-book/publication-decorative.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- managed directories, standard directory names in source  -->
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
         <version include="with-parts"/>
     </source>
 

--- a/examples/sample-book/publication-noparts.xml
+++ b/examples/sample-book/publication-noparts.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- managed directories, standard directory names in source  -->
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
         <version include="no-parts"/>
     </source>
 

--- a/examples/sample-book/publication-runestone-academy.xml
+++ b/examples/sample-book/publication-runestone-academy.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- managed directories, standard directory names in source  -->
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
         <version include="no-parts"/>
     </source>
 

--- a/examples/sample-book/publication-solution-manual.xml
+++ b/examples/sample-book/publication-solution-manual.xml
@@ -30,7 +30,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- not used, and a separate preface is used.  Only chapter  -->
     <!-- contents get recycled.                                   -->
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
         <version include="no-parts"/>
     </source>
 

--- a/examples/sample-book/publication-structural.xml
+++ b/examples/sample-book/publication-structural.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- managed directories, standard directory names in source  -->
     <source>
-        <directories external="ext" generated="gen"/>
+        <directories generated="gen"/>
         <version include="with-parts"/>
     </source>
 

--- a/examples/sample-slideshow/publication-embedded.xml
+++ b/examples/sample-slideshow/publication-embedded.xml
@@ -25,7 +25,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
 
     <revealjs>

--- a/examples/sample-slideshow/publication-single-file.xml
+++ b/examples/sample-slideshow/publication-single-file.xml
@@ -27,7 +27,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
 
     <revealjs>

--- a/examples/sample-slideshow/publication.xml
+++ b/examples/sample-slideshow/publication.xml
@@ -24,7 +24,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-        <directories external="external" generated="generated"/>
+        <directories generated="generated"/>
     </source>
 
     <revealjs>

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -21,6 +21,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext>
 
     <docinfo>
+        <directories external="external"/>
         <macros>
         \newcommand{\definiteintegral}[4]{\int_{#1}^{#2}\,#3\,d#4}
         </macros>

--- a/examples/showcase/publisher/publication.xml
+++ b/examples/showcase/publisher/publication.xml
@@ -34,7 +34,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Relative path, relative to "main" source file -->
     <source>
-	    <directories generated="../generated" external="../external"/>
+	    <directories generated="../generated"/>
     </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->

--- a/examples/showcase/source/pretext-showcase.ptx
+++ b/examples/showcase/source/pretext-showcase.ptx
@@ -8,6 +8,7 @@
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <docinfo>
+      <directories external="../external"/>
 
     <macros>
       \newcommand{\order}[1]{\left\lvert#1\right\rvert}

--- a/examples/stack/features/publication/publication.ptx
+++ b/examples/stack/features/publication/publication.ptx
@@ -22,7 +22,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-      <directories generated="generated" external="../assets"/>
+      <directories generated="generated"/>
     </source>
 
     <!-- This public server is for testing and demonstration only. -->

--- a/examples/stack/features/source/main.ptx
+++ b/examples/stack/features/source/main.ptx
@@ -20,6 +20,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude">
 
     <docinfo>
+        <directories external="../assets"/>
         <macros>
         \newcommand{\doubler}[1]{2#1}
         </macros>

--- a/examples/stack/minimal/publication/publication.ptx
+++ b/examples/stack/minimal/publication/publication.ptx
@@ -22,7 +22,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <publication>
 
     <source>
-      <directories generated="generated" external="../assets"/>
+      <directories generated="generated"/>
     </source>
 
     <!-- This public server is for testing and demonstration only. -->

--- a/examples/stack/minimal/source/main.ptx
+++ b/examples/stack/minimal/source/main.ptx
@@ -50,6 +50,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude">
 
     <docinfo>
+        <directories external="../assets"/>
         <macros>
         \newcommand{\doubler}[1]{2#1}
         </macros>

--- a/examples/webwork/minimal/mini.xml
+++ b/examples/webwork/minimal/mini.xml
@@ -24,6 +24,10 @@
 <!-- This is a skeleton file to hold WeBWorK problems authored in PreTeXt. -->
 
 <pretext xmlns:xi="http://www.w3.org/2001/XInclude">
+  <docinfo>
+      <directories external="external"/>
+  </docinfo>
+
   <article xml:id="webwork-mini">
     <title><webwork /> Minimal Example</title>
     <frontmatter>

--- a/examples/webwork/minimal/publication.xml
+++ b/examples/webwork/minimal/publication.xml
@@ -26,7 +26,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </common>
 
     <source>
-      <directories generated="generated" external="external"/>
+      <directories generated="generated"/>
     </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->

--- a/examples/webwork/sample-chapter/publisher/publication-academy.xml
+++ b/examples/webwork/sample-chapter/publisher/publication-academy.xml
@@ -25,7 +25,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </common>
 
     <source>
-        <directories generated="my-generated" external="my-external"/>
+        <directories generated="my-generated"/>
     </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->

--- a/examples/webwork/sample-chapter/publisher/publication.xml
+++ b/examples/webwork/sample-chapter/publisher/publication.xml
@@ -25,7 +25,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </common>
 
     <source>
-      <directories generated="my-generated" external="my-external"/>
+      <directories generated="my-generated"/>
     </source>
 
     <!-- These are the defaults but written explicitly here to serve as a model. -->

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -28,6 +28,7 @@
     <!-- information which a reader mostly will never see. -->
 
     <docinfo>
+        <directories external="my-external"/>
 
         <!-- To aid uniqueness of database identifiers in Runestone -->
         <document-id edition="2">PTXWW</document-id>

--- a/examples/workbook/workbook-article-publication.xml
+++ b/examples/workbook/workbook-article-publication.xml
@@ -42,7 +42,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-two for the oscarlevin style example -->
     <source>
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>

--- a/examples/workbook/workbook-article.xml
+++ b/examples/workbook/workbook-article.xml
@@ -32,6 +32,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     So on a first reading, skip ahead to the article tag.
     -->
     <docinfo>
+        <directories external="media"/>
         <!--
         In the HTML version there is room for a picture or logo
         in the upper left corner.  An image of a cover for a

--- a/examples/workbook/workbook-book-publication.xml
+++ b/examples/workbook/workbook-book-publication.xml
@@ -42,7 +42,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- we use customizations-two for the oscarlevin style example -->
     <source>
-        <directories external="media" generated="gen"/>
+        <directories generated="gen"/>
         <!-- this is an example of placing @generated *outside* of revision control -->
         <!-- <directories external="media" generated="../../../altgen"/> -->
     </source>

--- a/examples/workbook/workbook-book.xml
+++ b/examples/workbook/workbook-book.xml
@@ -32,6 +32,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     So on a first reading, skip ahead to the article tag.
     -->
     <docinfo>
+        <directories external="media"/>
         <!--
         In the HTML version there is room for a picture or logo
         in the upper left corner.  An image of a cover for a

--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -674,19 +674,37 @@ def verify_input_directory(inputdir):
 
 
 def get_managed_directories(xml_source, pub_file):
-    """Returns pair: (generated, external) absolute paths, derived from publisher file"""
+    """Returns pair: (generated, external) absolute paths, from source and publisher file"""
 
     # N.B. manage attributes carefully to distinguish
     # absent (None) versus empty string value ('')
 
-    # Examine /publication/source/directories element carefully
-    # for attributes which we code here for convenience
+    # The external directory is a fact of the source, declared as
+    # "directories/@external" within "docinfo" (2026-07-30).  A publisher
+    # file "source/directories/@external" is deprecated, but honored
+    # while the "docinfo" is silent.  The generated directory remains a
+    # publisher file entry.
     gen_attr = "generated"
     ext_attr = "external"
 
     # prepare for relative paths later
     source_dir = get_source_path(xml_source)
     # some parameterized error messages used later
+    src_abs_path_error = " ".join(
+        [
+            "the directory path for a managed directory, given in the",
+            'source file as "directories/@{}" within "docinfo" must be relative to',
+            'the PreTeXt source file location, and not the absolute path "{}"',
+        ]
+    )
+    src_missing_dir_error = " ".join(
+        [
+            'the directory "{}" implied by the value "{}" in the',
+            '"directories/@{}" entry within "docinfo" of the source file does not',
+            "exist. Check the spelling, create the necessary directory, or remove",
+            'the attribute.'
+        ]
+    )
     pub_abs_path_error = " ".join(
         [
             "the directory path for a managed directory, given in the",
@@ -706,6 +724,23 @@ def get_managed_directories(xml_source, pub_file):
     # Unknown until running the gauntlet
     generated = None
     external = None
+
+    # the source's declaration of the external directory
+    src_tree = guarded_xml_include_parser(xml_source)
+    directories_list = src_tree.xpath("/pretext/docinfo/directories")
+    if directories_list:
+        attributes_dict = directories_list[0].attrib
+        if ext_attr in attributes_dict.keys():
+            raw_path = attributes_dict[ext_attr]
+            if os.path.isabs(raw_path):
+                raise ValueError(src_abs_path_error.format(ext_attr, raw_path))
+            else:
+                abs_path = os.path.join(source_dir, raw_path)
+            try:
+                external = verify_input_directory(abs_path)
+            except:
+                raise ValueError(src_missing_dir_error.format(abs_path, raw_path, ext_attr))
+
     if pub_file:
         # parse publisher file, xinclude is conceivable
         # for multiple similar publisher files with common parts
@@ -730,15 +765,34 @@ def get_managed_directories(xml_source, pub_file):
                     raise ValueError(pub_missing_dir_error.format(abs_path, raw_path, gen_attr))
             # attribute absent => None
             if ext_attr in attributes_dict.keys():
-                raw_path = attributes_dict[ext_attr]
-                if os.path.isabs(raw_path):
-                    raise ValueError(pub_abs_path_error.format(ext_attr, raw_path))
+                if external is not None:
+                    log.warning(" ".join(
+                        [
+                            "the external directory is specified both within",
+                            '"docinfo" ("directories/@external") and in the publisher',
+                            'file ("source/directories/@external").  The "docinfo"',
+                            "value is used; please remove the publisher file entry.",
+                        ]
+                    ))
                 else:
-                    abs_path = os.path.join(source_dir, raw_path)
-                try:
-                    external = verify_input_directory(abs_path)
-                except:
-                    raise ValueError(pub_missing_dir_error.format(abs_path, raw_path, ext_attr))
+                    log.warning(" ".join(
+                        [
+                            "(2026-07-30) the external directory is a fact of the",
+                            "source, and is now declared with a",
+                            '"directories/@external" attribute within "docinfo".',
+                            'The publisher file entry "source/directories/@external"',
+                            "is honored meanwhile, but please relocate it.",
+                        ]
+                    ))
+                    raw_path = attributes_dict[ext_attr]
+                    if os.path.isabs(raw_path):
+                        raise ValueError(pub_abs_path_error.format(ext_attr, raw_path))
+                    else:
+                        abs_path = os.path.join(source_dir, raw_path)
+                    try:
+                        external = verify_input_directory(abs_path)
+                    except:
+                        raise ValueError(pub_missing_dir_error.format(abs_path, raw_path, ext_attr))
 
     # pair of discovered absolute paths
     return (generated, external)

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2063,6 +2063,12 @@
                 }
 
             Configuration |=
+                element directories {
+                    attribute external {text}?,
+                    attribute data {text}?
+                }
+
+            Configuration |=
                 element author-biographies {
                     attribute length {"short" | "long"}
                 }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -5348,6 +5348,16 @@
     </element>
   </define>
   <define name="Configuration" combine="choice">
+    <element name="directories">
+      <optional>
+        <attribute name="external"/>
+      </optional>
+      <optional>
+        <attribute name="data"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Configuration" combine="choice">
     <element name="author-biographies">
       <attribute name="length">
         <choice>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3604,6 +3604,7 @@
             <fragref ref="cross-references" />
             <fragref ref="initialism" />
             <fragref ref="rename" />
+            <fragref ref="directories" />
             <fragref ref="authorbiographylength" />
             <fragref ref="defaults" />
             <fragref ref="doenetml" />
@@ -3676,6 +3677,19 @@
                     attribute element {text},
                     attribute xml:lang {text}?,
                     text
+                }
+            </code>
+        </fragment>
+
+        <p>The directories an author curates run with the source, as paths relative to the location of the main source file.  The <attr>external</attr> attribute names the directory of externally-produced files an author provides (images, and other assets); swap that directory and the document's content changes, so it is a fact of the source.  The <attr>data</attr> attribute names the directory of data files consumed when building certain images and programs.  The <em>destination</em> for files <pretext/> generates is a publisher convenience, and remains a publication file entry.</p>
+
+        <fragment xml:id="directories">
+            <title>Source directories</title>
+            <code>
+            Configuration |=
+                element directories {
+                    attribute external {text}?,
+                    attribute data {text}?
                 }
             </code>
         </fragment>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -107,7 +107,11 @@
 
             Directories =
                 element directories {
-                    attribute external { text },
+                    # deprecated (2026-07-30): the external directory is a
+                    # fact of the source and is declared as
+                    # "directories/@external" within "docinfo"; this entry
+                    # is honored while the "docinfo" is silent
+                    attribute external { text }?,
                     attribute generated { text }
                 }
 

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -286,7 +286,15 @@
   </define>
   <define name="Directories">
     <element name="directories">
-      <attribute name="external"/>
+      <optional>
+        <!--
+          deprecated (2026-07-30): the external directory is a
+          fact of the source and is declared as
+          "directories/@external" within "docinfo"; this entry
+          is honored while the "docinfo" is silent
+        -->
+        <attribute name="external"/>
+      </optional>
       <attribute name="generated"/>
     </element>
   </define>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -243,7 +243,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             Directories =
                 element directories {
-                    attribute external { text },
+                    # deprecated (2026-07-30): the external directory is a
+                    # fact of the source and is declared as
+                    # "directories/@external" within "docinfo"; this entry
+                    # is honored while the "docinfo" is silent
+                    attribute external { text }?,
                     attribute generated { text }
                 }
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -1156,12 +1156,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- while a trailing slash will be reliably added if                     -->
 <!--     (a) not present in publisher file specification                  -->
 <!--     (b) the path is not empty                                        -->
+<!-- The external directory is a fact of the source (a different       -->
+<!-- directory of files is a different document), so its declaration    -->
+<!-- is "directories/@external" within "docinfo" (2026-07-30).  The     -->
+<!-- publication file "source/directories/@external" is deprecated but  -->
+<!-- honored while the "docinfo" is silent.  NB: the version tree is    -->
+<!-- consulted, since machinery within the assembly chain consumes      -->
+<!-- directory variables and the tree behind  $docinfo  does not exist  -->
+<!-- yet at that point (referencing it is a circular definition).       -->
 <xsl:variable name="external-directory-source">
-    <xsl:variable name="raw-input" select="$publication/source/directories/@external"/>
+    <xsl:variable name="raw-input">
+        <xsl:choose>
+            <xsl:when test="$version-docinfo/directories/@external">
+                <xsl:if test="$publication/source/directories/@external">
+                    <xsl:message>PTX:WARNING: the external directory is specified both within "docinfo" ("directories/@external") and in the publication file ("source/directories/@external").  The "docinfo" value is used; please remove the publication file entry.</xsl:message>
+                </xsl:if>
+                <xsl:value-of select="$version-docinfo/directories/@external"/>
+            </xsl:when>
+            <xsl:when test="$publication/source/directories/@external">
+                <xsl:message>PTX:DEPRECATE: (2026-07-30) the external directory is a fact of the source, and is now declared with a "directories/@external" attribute within "docinfo".  The publication file entry "source/directories/@external" is honored meanwhile, but please relocate it.</xsl:message>
+                <xsl:value-of select="$publication/source/directories/@external"/>
+            </xsl:when>
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:variable>
     <xsl:choose>
         <!-- leading path separator is an error -->
         <xsl:when test="substring($raw-input, 1, 1) = '/'">
-            <xsl:message>PTX:FALLBACK:   an external-image directory (source/directories/@external in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   an external-image directory ("directories/@external", within "docinfo" or the publication file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
             <xsl:text/>
         </xsl:when>
         <!-- trailing path separator is good and -->
@@ -1216,21 +1238,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- or not (older, historical).  So we create a boolean based on the  -->
 <!-- presence of the publisher file specification.                     -->
 <xsl:variable name="managed-directories">
+    <xsl:if test="$version-docinfo/directories/@external = ''">
+        <xsl:message terminate="yes">PTX:FATAL:   the value of "directories/@external" within "docinfo" must be nonempty</xsl:message>
+    </xsl:if>
     <xsl:if test="$publication/source/directories/@external = ''">
         <xsl:message terminate="yes">PTX:FATAL:   the value of source/directories/@external in the publisher file must be nonempty</xsl:message>
     </xsl:if>
     <xsl:if test="$publication/source/directories/@generated = ''">
         <xsl:message terminate="yes">PTX:FATAL:   the value of source/directories/@generated in the publisher file must be nonempty</xsl:message>
     </xsl:if>
+    <!-- The external directory may be declared in "docinfo" (preferred) -->
+    <!-- or the publication file (deprecated, honored); the generated    -->
+    <!-- directory is a publication file entry.  Management requires an  -->
+    <!-- external declaration, from either home, together with the       -->
+    <!-- generated declaration.                                          -->
+    <xsl:variable name="b-has-external" select="boolean($version-docinfo/directories/@external) or boolean($publication/source/directories/@external)"/>
     <xsl:choose>
-        <xsl:when test="$publication/source/directories/@external and $publication/source/directories/@generated">
+        <xsl:when test="$b-has-external and $publication/source/directories/@generated">
             <xsl:text>yes</xsl:text>
         </xsl:when>
-        <xsl:when test="not($publication/source/directories/@external) and not($publication/source/directories/@generated)">
+        <xsl:when test="not($b-has-external) and not($publication/source/directories/@generated)">
             <xsl:text>no</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-            <xsl:message>PTX:FALLBACK:   the publisher file specifies one of source/directories/@external and source/directories/@generated, but not both. Proceeding as if neither was specified.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   an external directory ("directories/@external" within "docinfo", or the deprecated publication file form) and a generated directory (source/directories/@generated in the publication file) must be specified together; only one was found. Proceeding as if neither was specified.</xsl:message>
             <xsl:text>no</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
@@ -1272,19 +1303,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- This is a directory that may need to be copied to a      -->
 <!-- scratch location in anticipation of data files necessary -->
 <!-- for compilation of images, such as pie charts or plots   -->
-<!-- NB: this is broken and waiting for generated and external to settle down -->
+<!-- The data directory runs with the source, declared as     -->
+<!-- "directories/@data" within "docinfo" (the version tree,  -->
+<!-- for the same reason as the external directory above).    -->
+<!-- An earlier form of this variable consulted a publication -->
+<!-- file "source/directories/@data" which was never in the   -->
+<!-- publication schema, and hard-coded the value "data".     -->
 <xsl:variable name="data-directory">
     <xsl:variable name="raw-input">
-        <xsl:choose>
-            <xsl:when test="$publication/source/directories/@data">
-                <xsl:value-of select="'data'"/>
-            </xsl:when>
-            <xsl:otherwise/>
-        </xsl:choose>
+        <xsl:value-of select="$version-docinfo/directories/@data"/>
     </xsl:variable>
     <xsl:choose>
         <xsl:when test="substring($raw-input, 1, 1) = '/'">
-            <xsl:message>PTX:FALLBACK:   a data directory (source/directories/@data in the publisher file) must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
+            <xsl:message>PTX:FALLBACK:   a data directory ("directories/@data" within "docinfo") must be a relative path and not begin with "/" as in "<xsl:value-of select="$raw-input"/>".  Proceeding with the default, which is an empty string, and may lead to unexpected results.</xsl:message>
             <xsl:text/>
         </xsl:when>
         <!-- trailing path separator is good -->


### PR DESCRIPTION
A follow-up to the `docinfo` reform (#3094), completing its one deliberate deferral: managed directories were declared entirely in the publication file, but the two directories are not the same kind of thing. The directory of *externally-produced files an author curates* is source material — swap it for a directory of same-named, different images and the document's content changes — while the *destination for generated build products* is publisher convenience. This pull request homes each by its nature.

**The new shape.** A `directories` element within `docinfo` declares what runs with the source: `@external` (new home) and `@data` (which has lived there for years, now schema-blessed at last). The publication file's `source/directories` keeps `@generated` only. Both declarations remain paths relative to the main source file, and managed-directories mode still requires an external and a generated declaration together.

**Honoring.** A publication file `@external` is deprecated but honored while the `docinfo` is silent, with a warning; if both are given, the `docinfo` wins, with a warning. The same election is implemented on both consumers — the stylesheets (`publisher-variables.xsl`, reading the version tree, since machinery within the assembly chain consumes the directory variables before the fully-repaired tree exists) and the Python layer (`get_managed_directories`, which now consults the source first).

**A truth-fix along the way.** The stylesheet `$data-directory` variable was self-described as broken: it consulted a publication `@data` that was never in the publication schema and hard-coded the value `data`, and nothing consumed it. It now reports the actual `docinfo` value, matching what the Python layer has always done.

**Every shipped project moves.** Fourteen example families (the sample article and book, showcase, EPUB sampler, minimal, numbering test document, Humanities in Action, sample slideshow, XSL-FO development article, STACK, WeBWorK, workbook, custom theming) plus the Guide itself now declare `@external` in their `docinfo`; every one of an example's publication variants had agreed on the value — evidence for the source-fact reading. Two sources and the Guide acquired their first `docinfo` in the process. The Guide's directory-management discussion, publication-file reference, `topic-docinfo` section, and developer dividing-line note are all updated to the split declaration.

**Verification.** The sample article builds byte-identically (timestamps aside) through the legacy publication-file form, the honored path, and the new `docinfo` form; warnings fire on the legacy form and fall silent after migration, on both the stylesheet and Python paths. All five relative-path shapes in the examples (`media`, `ext`, `external`, `my-external`, `../assets`) build warning-free after the sweep. The sample article's `docinfo` — including `directories`, this branch's addition — validates with zero complaints against both schemas, and the Guide holds its two known pre-existing validation errors with no unresolved cross-references.

**Coordination note:** pretext-cli's project scaffolding writes `source/directories` with `@external`; those projects keep working through the honoring path, and a follow-up there can modernize its templates at leisure.

One possible future this enables: since `@external` now rides the source, the version machinery could select different external directories for different versions — a color edition and a black-and-white edition as image-set variants.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
