### PR TITLE
Cross-reference text default joins "docinfo/defaults" as "xrefs"

### DIFF
--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -764,7 +764,7 @@
         <p>Some common wants, sorted:<ul>
             <li>Calling every <tag>activity</tag> a <q>Laboratory</q>: the <tag>rename</tag> element, in <tag>docinfo</tag><mdash/>it changes words your readers see.</li>
             <li>A <latex/> macro used throughout your mathematics: the <tag>macros</tag> element, in <tag>docinfo</tag><mdash/>your mathematics does not survive without it.</li>
-            <li>How the text of a cross-reference reads (<q>Theorem 5.2</q> versus <q>5.2</q>): the <tag>cross-references</tag> element, in <tag>docinfo</tag><mdash/>that text sits inside sentences you wrote around it.</li>
+            <li>How the text of a cross-reference reads (<q>Theorem 5.2</q> versus <q>5.2</q>): the <tag>xrefs</tag> element, in <c>docinfo/defaults</c><mdash/>that text sits inside sentences you wrote around it.</li>
             <li>The paper size or font size of the <init>PDF</init>: the publication file<mdash/>same words, different sheet.</li>
             <li>Whether each web page is a chapter or a section: the publication file.</li>
             <li>Whether solutions to exercises are visible or withheld: the publication file<mdash/>the publisher selects among whole components you provided.</li>

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1114,7 +1114,7 @@
         <subsection>
             <title>Text of a Cross-Reference</title>
 
-            <p>By default, a cross-reference will visually be text like Theorem 5.2.  Depending on your output format, it may have various devices to help you locate that theorem.  Maybe a page number, or it is a hyperlink, or the whole theorem is the content of a knowl.  You can change the default look of cross-references by setting the <attr>text</attr> attribute in <c>docinfo/cross-references</c>.  But you can also change the visual appearance of a cross-reference on a case-by-case basis.  Add a <attr>text</attr> attribute to your <tage>xref</tage> element to override the document-wide setting.  The first column of this table lists the possible attribute values, either document-wide, or on a per-cross-reference basis.  The second column has live cross-references to a section of an earlier chapter (that is far away).  The third column has live cross-references to another section of this chapter (which is close by).  For the fourth column, we have placed content (<q>Extra</q>) into the <tag>xref</tag> element as an override of, or addition to, some of the text for the cross-references of the preceding column.  Study the table and then read some more explanation following.  Note that <c>type-global</c> is the default.</p>
+            <p>By default, a cross-reference will visually be text like Theorem 5.2.  Depending on your output format, it may have various devices to help you locate that theorem.  Maybe a page number, or it is a hyperlink, or the whole theorem is the content of a knowl.  You can change the default look of cross-references by setting the <attr>text</attr> attribute of the <tag>xrefs</tag> element in <c>docinfo/defaults</c>.  But you can also change the visual appearance of a cross-reference on a case-by-case basis.  Add a <attr>text</attr> attribute to your <tage>xref</tage> element to override the document-wide setting.  The first column of this table lists the possible attribute values, either document-wide, or on a per-cross-reference basis.  The second column has live cross-references to a section of an earlier chapter (that is far away).  The third column has live cross-references to another section of this chapter (which is close by).  For the fourth column, we have placed content (<q>Extra</q>) into the <tag>xref</tag> element as an override of, or addition to, some of the text for the cross-references of the preceding column.  Study the table and then read some more explanation following.  Note that <c>type-global</c> is the default.</p>
 
             <table>
                 <title>Cross-reference visual text styles</title>
@@ -4678,7 +4678,7 @@
         <paragraphs>
             <title>The Vocabulary of the Document</title>
 
-            <p>A <tag>rename</tag> element substitutes your name for a <pretext/> element's, such as calling every <tag>activity</tag> a <q>Laboratory</q>; an <attr>xml:lang</attr> attribute makes the substitution per-language.  A <tag>cross-references</tag> element sets the document-wide style of cross-reference text via its <attr>text</attr> attribute (<xref ref="topic-cross-referencing"/>)<mdash/>this is <tag>docinfo</tag> material precisely because that text lands inside sentences you wrote around it.</p>
+            <p>A <tag>rename</tag> element substitutes your name for a <pretext/> element's, such as calling every <tag>activity</tag> a <q>Laboratory</q>; an <attr>xml:lang</attr> attribute makes the substitution per-language.</p>
         </paragraphs>
 
         <paragraphs>
@@ -4696,7 +4696,7 @@
         <paragraphs>
             <title>Defaults for Authored Attributes</title>
 
-            <p>A document-wide default for an attribute you write on individual elements lives with the source, gathered in a single <tag>defaults</tag> element.  Each child is the plural of the element it serves: an <tag>images</tag> child may carry default <attr>width</attr> and <attr>margins</attr> for every <tag>image</tag> lacking its own; a <tag>programs</tag> child defaults the attributes of <tag>program</tag> elements, notably <attr>language</attr>; a <tag>parsons</tag> child defaults the language of Parsons problems.</p>
+            <p>A document-wide default for an attribute you write on individual elements lives with the source, gathered in a single <tag>defaults</tag> element.  Each child is the plural of the element it serves: an <tag>images</tag> child may carry default <attr>width</attr> and <attr>margins</attr> for every <tag>image</tag> lacking its own; a <tag>programs</tag> child defaults the attributes of <tag>program</tag> elements, notably <attr>language</attr>; a <tag>parsons</tag> child defaults the language of Parsons problems; an <tag>xrefs</tag> child sets the document-wide style of cross-reference text via its <attr>text</attr> attribute (<xref ref="topic-cross-referencing"/>)<mdash/>that text lands inside sentences you wrote around it.</p>
         </paragraphs>
 
         <paragraphs>

--- a/examples/humanities/source/hia.xml
+++ b/examples/humanities/source/hia.xml
@@ -22,8 +22,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- May need lilyglyphs.sty from Debian/Ubuntu texlive-music -->
     <docinfo>
         <directories external="../assets"/>
-        <!-- this is the default, but supresses a warning -->
-        <cross-references text="type-global" />
+        <defaults>
+            <!-- this is the default, but supresses a warning -->
+            <xrefs text="type-global" />
+        </defaults>
     </docinfo>
     <book xml:id="hia">
         <title>Humanities in Action</title>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -78,16 +78,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- employed in a PreFigure linear algebra diagram -->
             <line stroke="blue"/>
         </prefigure-preamble>
-        <!-- We control the appearance of the text of cross-references here           -->
-        <!-- (these are the "xref" elements).  Because this changes the words         -->
-        <!-- that appear in your output, it is a decision with stays with the source. -->
-        <!-- Experiment here with different choices and a few different "xref"        -->
-        <!-- elements before you decide on a final choice.  We use 'type-global',     -->
-        <!-- which is also the default, and produces text like "Theorem 5.2", where   -->
-        <!-- "Theorem" will be translated into the document language.  Individual     -->
-        <!-- "xref" carry an explicit "text" attribute where a different scheme is    -->
-        <!-- wanted.                                                                  -->
-        <cross-references text="type-global"/>
         <!--
         Extra packages, package options, and package settings for latex-based images.
         Inserted in the preamble for LaTeX output.
@@ -135,14 +125,26 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- "image" lacking that attribute; the "programs" @language to    -->
         <!-- any program or Runestone interactive lacking one; the          -->
         <!-- "parsons" @language to Parsons problems (else the programs     -->
-        <!-- default, else natural language).                               -->
-        <!--
+        <!-- default, else natural language); the "xrefs" @text to any      -->
+        <!-- "xref" lacking its own.                                        -->
         <defaults>
+            <!--
             <images width="60%"/>
             <programs language="python"/>
             <parsons language="natural"/>
+            -->
+            <!-- The "xrefs" element controls the appearance of the text of    -->
+            <!-- cross-references (the "xref" elements).  Because this changes -->
+            <!-- the words that appear in your output, it is a decision which  -->
+            <!-- stays with the source.  Experiment with different choices and -->
+            <!-- a few different "xref" elements before you decide on a final  -->
+            <!-- choice.  We use 'type-global', which is also the default, and -->
+            <!-- produces text like "Theorem 5.2", where "Theorem" will be     -->
+            <!-- translated into the document language.  Individual "xref"     -->
+            <!-- carry an explicit "text" attribute where a different scheme   -->
+            <!-- is wanted.                                                    -->
+            <xrefs text="type-global"/>
         </defaults>
-        -->
 
         <!--
         "Names" for various parts of a document are determined exactly

--- a/examples/sample-book/bookinfo.xml
+++ b/examples/sample-book/bookinfo.xml
@@ -61,9 +61,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     \newcommand{\Null}{\operatorname{Null}}
     </macros>
 
-    <!-- this is the default, but supresses a warning -->
-    <cross-references text="type-global" />
-
     <!-- tikz package and libraries for images -->
     <latex-image-preamble>
     \usepackage{tikz}
@@ -81,6 +78,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- If not set, this would default to programs@language           -->
         <!-- If neither is set, parsons will default to "natural" language -->
         <parsons language="natural"/>
+        <!-- this is the default, but supresses a warning -->
+        <xrefs text="type-global"/>
     </defaults>
 
 </docinfo>

--- a/examples/webwork/sample-chapter/sample-chapter.ptx
+++ b/examples/webwork/sample-chapter/sample-chapter.ptx
@@ -43,8 +43,10 @@
         \newcommand{\indefiniteintegral}[2]{\int#1\,d#2} % comments get stripped
         </macros>
 
-        <!-- this is the default, but supresses a warning -->
-        <cross-references text="type-global" />
+        <defaults>
+            <!-- this is the default, but supresses a warning -->
+            <xrefs text="type-global" />
+        </defaults>
 
         <!-- 
         This initialism specifies the filename of the macro file (WWSC.pl) that 

--- a/examples/workbook/workbook-article.xml
+++ b/examples/workbook/workbook-article.xml
@@ -49,15 +49,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         \newcommand{\bvec}{{\mathbf b}}
         \newcommand{\vvec}{{\mathbf v}}
         </macros>
-        <!-- We control the appearance of the text of cross-references here           -->
-        <!-- (these are the "xref" elements).  Because this changes the words         -->
-        <!-- that appear in your output, it is a decision with stays with the source. -->
-        <!-- Experiment here with different choices and a few different "xref"        -->
-        <!-- elements before you decide on a final choice.  We set this to 'global',  -->
-        <!-- not because we think it is a good choice, but for historical reasons.    -->
-        <!-- The default is 'type-global', which produces text like "Theorem 5.2",    -->
-        <!-- where "Theorem" will be translated into the document language            -->
-        <cross-references text="global" />
+        <!-- We control the appearance of the text of cross-references with  -->
+        <!-- the "xrefs" default (cross-references are the "xref" elements). -->
+        <!-- Because this changes the words that appear in your output, it   -->
+        <!-- is a decision which stays with the source.  Experiment here     -->
+        <!-- with different choices and a few different "xref" elements      -->
+        <!-- before you decide on a final choice.  We set this to 'global',  -->
+        <!-- not because we think it is a good choice, but for historical    -->
+        <!-- reasons.  The default is 'type-global', which produces text     -->
+        <!-- like "Theorem 5.2", where "Theorem" will be translated into     -->
+        <!-- the document language                                           -->
+        <defaults>
+            <xrefs text="global" />
+        </defaults>
         <!--
         Extra packages, package options, and package settings for latex-based images.
         Inserted in the preamble for LaTeX output.

--- a/examples/workbook/workbook-book.xml
+++ b/examples/workbook/workbook-book.xml
@@ -49,15 +49,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         \newcommand{\bvec}{{\mathbf b}}
         \newcommand{\vvec}{{\mathbf v}}
         </macros>
-        <!-- We control the appearance of the text of cross-references here           -->
-        <!-- (these are the "xref" elements).  Because this changes the words         -->
-        <!-- that appear in your output, it is a decision with stays with the source. -->
-        <!-- Experiment here with different choices and a few different "xref"        -->
-        <!-- elements before you decide on a final choice.  We set this to 'global',  -->
-        <!-- not because we think it is a good choice, but for historical reasons.    -->
-        <!-- The default is 'type-global', which produces text like "Theorem 5.2",    -->
-        <!-- where "Theorem" will be translated into the document language            -->
-        <cross-references text="global" />
+        <!-- We control the appearance of the text of cross-references with  -->
+        <!-- the "xrefs" default (cross-references are the "xref" elements). -->
+        <!-- Because this changes the words that appear in your output, it   -->
+        <!-- is a decision which stays with the source.  Experiment here     -->
+        <!-- with different choices and a few different "xref" elements      -->
+        <!-- before you decide on a final choice.  We set this to 'global',  -->
+        <!-- not because we think it is a good choice, but for historical    -->
+        <!-- reasons.  The default is 'type-global', which produces text     -->
+        <!-- like "Theorem 5.2", where "Theorem" will be translated into     -->
+        <!-- the document language                                           -->
+        <defaults>
+            <xrefs text="global" />
+        </defaults>
         <!--
         Extra packages, package options, and package settings for latex-based images.
         Inserted in the preamble for LaTeX output.

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2048,12 +2048,6 @@
                 element macros {text}
 
             Configuration |=
-                element
-                    cross-references {
-                        attribute text { XrefTextStyle }
-                    }
-
-            Configuration |=
                 element initialism {text}
 
             Configuration |=
@@ -2093,6 +2087,10 @@
                     &
                     element parsons {
                         attribute language {text}?
+                    }?
+                    &
+                    element xrefs {
+                        attribute text { XrefTextStyle }
                     }?
                 }
 

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -5330,13 +5330,6 @@
     </element>
   </define>
   <define name="Configuration" combine="choice">
-    <element name="cross-references">
-      <attribute name="text">
-        <ref name="XrefTextStyle"/>
-      </attribute>
-    </element>
-  </define>
-  <define name="Configuration" combine="choice">
     <element name="initialism">
       <text/>
     </element>
@@ -5423,6 +5416,13 @@
             <optional>
               <attribute name="language"/>
             </optional>
+          </element>
+        </optional>
+        <optional>
+          <element name="xrefs">
+            <attribute name="text">
+              <ref name="XrefTextStyle"/>
+            </attribute>
           </element>
         </optional>
       </interleave>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -8,7 +8,9 @@
 <pretext>
 
     <docinfo>
-        <cross-references text="type-global" />
+        <defaults>
+            <xrefs text="type-global" />
+        </defaults>
     </docinfo>
 
     <article xml:id="pretext">
@@ -3602,7 +3604,6 @@
             </code>
             <fragref ref="preambles" />
             <fragref ref="macros" />
-            <fragref ref="cross-references" />
             <fragref ref="initialism" />
             <fragref ref="rename" />
             <fragref ref="directories" />
@@ -3642,19 +3643,6 @@
             <code>
             Configuration |=
                 element macros {text}
-            </code>
-        </fragment>
-
-        <p>The style of text used in a cross-reference (the <c>xref</c> element) is contained in the source and uses the same per-item choices.</p>
-
-        <fragment xml:id="cross-references">
-            <title>Cross-reference text style</title>
-            <code>
-            Configuration |=
-                element
-                    cross-references {
-                        attribute text { XrefTextStyle }
-                    }
             </code>
         </fragment>
 
@@ -3707,7 +3695,7 @@
             </code>
         </fragment>
 
-        <p>Document-wide defaults for attributes an author writes on individual elements are gathered in a single <c>defaults</c> element.  Each child is the plural of the element whose authored attributes it defaults: an attribute given here is employed by any <c>image</c>, <c>program</c>, or Parsons problem which does not carry that attribute itself.  The plural names also ensure this configuration is never mistaken for the content elements themselves.</p>
+        <p>Document-wide defaults for attributes an author writes on individual elements are gathered in a single <c>defaults</c> element.  Each child is the plural of the element whose authored attributes it defaults: an attribute given here is employed by any <c>image</c>, <c>program</c>, Parsons problem, or <c>xref</c> which does not carry that attribute itself.  The plural names also ensure this configuration is never mistaken for the content elements themselves.</p>
 
         <fragment xml:id="defaults">
             <title>Authored-attribute defaults</title>
@@ -3731,6 +3719,10 @@
                     &amp;
                     element parsons {
                         attribute language {text}?
+                    }?
+                    &amp;
+                    element xrefs {
+                        attribute text { XrefTextStyle }
                     }?
                 }
             </code>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -26,7 +26,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <pretext>
 
     <docinfo>
-        <cross-references text="type-global" />
+        <defaults>
+            <xrefs text="type-global" />
+        </defaults>
     </docinfo>
 
     <article xml:id="publication">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2923,17 +2923,27 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- 2026-07-30: authored-attribute defaults gather under "defaults" -->
 
-<!-- A "programs" or "parsons" element, as a child of "docinfo",  -->
-<!-- moves inside a "defaults" element.  The first of the pair    -->
-<!-- present builds the container for both, and the same match    -->
-<!-- then suppresses the other.                                   -->
-<xsl:template match="docinfo/programs | docinfo/parsons" mode="repair">
-    <xsl:if test="count(preceding-sibling::programs | preceding-sibling::parsons) = 0">
+<!-- A "programs", "parsons", or "cross-references" element, as   -->
+<!-- a child of "docinfo", moves inside a "defaults" element.     -->
+<!-- The first of the trio present builds the container for all,  -->
+<!-- and the same match then suppresses the others.  The retired  -->
+<!-- "cross-references" element is renamed "xrefs" on the way in. -->
+<xsl:template match="docinfo/programs | docinfo/parsons | docinfo/cross-references" mode="repair">
+    <xsl:if test="count(preceding-sibling::programs | preceding-sibling::parsons | preceding-sibling::cross-references) = 0">
         <xsl:element name="defaults">
-            <xsl:for-each select="../programs | ../parsons">
-                <xsl:copy>
-                    <xsl:copy-of select="@*"/>
-                </xsl:copy>
+            <xsl:for-each select="../programs | ../parsons | ../cross-references">
+                <xsl:choose>
+                    <xsl:when test="self::cross-references">
+                        <xsl:element name="xrefs">
+                            <xsl:copy-of select="@*"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:copy>
+                            <xsl:copy-of select="@*"/>
+                        </xsl:copy>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:for-each>
         </xsl:element>
     </xsl:if>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -219,19 +219,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
-<!-- Employing variants of the text displayed for a cross-reference -->
-<!-- affects the words shown to the reader, and hence is a choice   -->
-<!-- preserved in the source, and is not just a processing decision -->
-<!-- $xref-text-style is the global choice, based on                -->
-<!--   docinfo/cross-references/@text                               -->
-<!-- We control the possible values with the schema, allowing junk  -->
-<!-- NB: blank is not set, and is ignored so the legacy-autoname    -->
-<!-- scheme controls the global default.  When that goes away, we   -->
-<!-- should set the default here when there is no attribute.        -->
+<!-- Employing variants of the text displayed for a cross-reference  -->
+<!-- affects the words shown to the reader, and hence is a choice    -->
+<!-- preserved in the source, and is not just a processing decision  -->
+<!-- $xref-text-style is the global choice, based on                 -->
+<!--   docinfo/defaults/xrefs/@text                                  -->
+<!-- The "repair" phase of assembly normalizes the retired           -->
+<!-- "cross-references" element to this location, so one path serves -->
+<!-- We control the possible values with the schema, allowing junk   -->
+<!-- NB: blank is not set, and is ignored so the legacy-autoname     -->
+<!-- scheme controls the global default.  When that goes away, we    -->
+<!-- should set the default here when there is no attribute.         -->
 <xsl:variable name="xref-text-style">
     <xsl:choose>
-        <xsl:when test="$docinfo/cross-references/@text">
-            <xsl:value-of select="$docinfo/cross-references/@text" />
+        <xsl:when test="$docinfo/defaults/xrefs/@text">
+            <xsl:value-of select="$docinfo/defaults/xrefs/@text" />
         </xsl:when>
         <xsl:otherwise>
             <text />

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11878,6 +11878,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'an &quot;event&quot; element now resides in the &quot;bibinfo&quot; of the &quot;frontmatter&quot;, alongside the other bibliographic facts of a document.  We will honor an &quot;event&quot; within &quot;docinfo&quot;, but please relocate the element.'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2026-07-31  "docinfo/cross-references" becomes "xrefs" within "docinfo/defaults" -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$docinfo/cross-references&quot;" />
+        <xsl:with-param name="date-string" select="'2026-07-31'" />
+        <xsl:with-param name="message" select="'the document-wide style of cross-reference text is now a &quot;text&quot; attribute on an &quot;xrefs&quot; element within &quot;docinfo/defaults&quot;, replacing the &quot;cross-references&quot; element.  We will honor your intent, but please convert to the new form.'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3907,7 +3907,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="author-tools" select="''" />
 
 <!-- The autoname parameter is deprecated (2017-07-25) -->
-<!-- Replace with docinfo/cross-references/@text       -->
+<!-- Replace with docinfo/defaults/xrefs/@text         -->
 <xsl:param name="autoname" select="''" />
 
 <!-- 2020-11-22: latex.print to publisher file -->
@@ -4121,15 +4121,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- 2017-07-25  deprecate intentional autoname without new setting -->
     <xsl:call-template name="parameter-deprecation-message">
         <xsl:with-param name="date-string" select="'2017-07-25'" />
-        <xsl:with-param name="message" select="'the  autoname  parameter is deprecated, but is still effective since  &quot;docinfo/cross-references/@text&quot;  has not been set.  The following parameter values equate to the attribute values: &quot;no&quot; is &quot;global&quot;, &quot;yes&quot; is &quot;type-global&quot;, &quot;title&quot; is &quot;title&quot;'" />
-        <xsl:with-param name="incorrect-use" select="not($autoname = '') and not(//docinfo/cross-references)" />
+        <xsl:with-param name="message" select="'the  autoname  parameter is deprecated, but is still effective since  &quot;docinfo/defaults/xrefs/@text&quot;  has not been set.  The following parameter values equate to the attribute values: &quot;no&quot; is &quot;global&quot;, &quot;yes&quot; is &quot;type-global&quot;, &quot;title&quot; is &quot;title&quot;'" />
+        <xsl:with-param name="incorrect-use" select="not($autoname = '') and not(//docinfo/cross-references | //docinfo/defaults/xrefs)" />
     </xsl:call-template>
     <!--  -->
     <!-- 2017-07-25  deprecate intentional autoname also with new setting -->
     <xsl:call-template name="parameter-deprecation-message">
         <xsl:with-param name="date-string" select="'2017-07-25'" />
-        <xsl:with-param name="message" select="'the  autoname  parameter is deprecated, and is being overidden by a  &quot;docinfo/cross-references/@text&quot;  and so is totally ineffective and can be removed'" />
-            <xsl:with-param name="incorrect-use" select="not($autoname = '') and //docinfo/cross-references" />
+        <xsl:with-param name="message" select="'the  autoname  parameter is deprecated, and is being overidden by a  &quot;docinfo/defaults/xrefs/@text&quot;  and so is totally ineffective and can be removed'" />
+            <xsl:with-param name="incorrect-use" select="not($autoname = '') and (//docinfo/cross-references | //docinfo/defaults/xrefs)" />
     </xsl:call-template>
     <!--  -->
     <!-- 2017-12-18  deprecate three console macro characters -->


### PR DESCRIPTION
Completes the regrouping of authored-attribute defaults begun in #3094: the document-wide style of cross-reference text joins `docinfo/defaults`, as a `text` attribute on a new `xrefs` element. The retired `cross-references` element is honored by a rewrite in the "repair" phase of assembly, with a deprecation warning. The legacy `autoname` string parameter machinery now points at the new location and recognizes either form. The example documents (sample article, sample book, workbook, humanities, WeBWorK sample chapter) and the Guide move to the new form.

Verification: sample article built before and after (HTML and LaTeX) with identical output; likewise the workbook article, whose `global` setting is the one non-default value in the examples; the repair rewrite confirmed in the assembled tree; the deprecation warning and both `autoname` message branches tripped deliberately; jing error sets for the sample article identical before and after; the Guide validates against the developer schema at its established baseline; schema regeneration is idempotent.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*