### PR TITLE
Guide: workflow corollary of the "docinfo" dividing line

### DIFF
--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -770,6 +770,8 @@
             <li>Whether solutions to exercises are visible or withheld: the publication file<mdash/>the publisher selects among whole components you provided.</li>
             <li>How deep the numbering of divisions runs: the publication file<mdash/>numbers are generated apparatus, not authored words.</li>
         </ul></p>
+
+        <p>This division has a corollary for your workflow.  Because <tag>docinfo</tag> items determine words on the page, your prose grows around them and they become woven into your writing: change the document-wide style of cross-reference text late, and every sentence written around an <tag>xref</tag> deserves a re-read.  So settle <tag>docinfo</tag> early.  Publisher switches are the reverse: they never require revisiting what you wrote, and most can be safely ignored until authoring is complete, then changed with little effort.  (A few publication file entries are part of the build machinery you use while authoring<mdash/>the destination directory for generated files, the address of a WeBWorK server<mdash/>so those get set early, but even they remain cheap to change.)</p>
     </section>
 
     <section xml:id="processing-directory-management">

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4669,6 +4669,8 @@
 
         <p>A <tag>docinfo</tag> element, first below the root <tag>pretext</tag> element, is a small database about your document.  Everything in it shares one character: it is a fact required to <em>interpret or build</em> your source.  Remove an item and the document no longer means the same thing, or no longer builds.  Choices about how the same content is <em>presented</em> belong instead in a publication file (<xref ref="publication-file-reference"/>); the dividing line is discussed for authors in <xref ref="processing-customizations"/> and rigorously in <xref ref="developer-configuration-homes"/>.</p>
 
+        <p>A corollary for your workflow: because these items determine words on the page, your prose grows around them<mdash/>settle them early, and expect some effort to reconsider one later (change the document-wide style of cross-reference text, say, and every sentence written around an <tag>xref</tag> deserves a re-read).  Publication file switches are the reverse: they never require revisiting what you wrote, and most can wait until authoring is complete.</p>
+
         <paragraphs>
             <title>Identity and Catalog</title>
 


### PR DESCRIPTION
A workflow corollary of the `docinfo`/publication file dividing line, added to the two Guide passages where that discussion lives: the fuller statement joins the sorted examples in the author's Customizations section, and a compact echo opens the `docinfo` topic.

The corollary: because `docinfo` determines words on the page, an author's prose grows around its choices—settle them early, and expect some effort to reconsider one later. Publisher switches are the reverse: they never require revisiting what the author wrote, and most can be safely ignored until authoring is complete, then changed with little effort.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*