### PR TITLE
Script: remove the obsolete "liblouis" executable key

### DIFF
--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -625,8 +625,7 @@
                         asy="asy"
                         sage="sage"
                         pdfeps="pdftops"
-                        node="node"
-                        liblouis="file2brl" />
+                        node="node" />
 
                   ]]>
                   </code>

--- a/doc/guide/author/processing.xml
+++ b/doc/guide/author/processing.xml
@@ -623,9 +623,12 @@
                         pdflatex="pdflatex"
                         xelatex="xelatex"
                         asy="asy"
+                        mermaid="mmdc"
                         sage="sage"
                         pdfeps="pdftops"
-                        node="node" />
+                        node="node"
+                        perl="perl"
+                        fop="fop" />
 
                   ]]>
                   </code>

--- a/pretext/pretext.cfg
+++ b/pretext/pretext.cfg
@@ -55,6 +55,7 @@
 # 2025-05-29  Added perl executable line
 # 2026-06-11  Added fop executable line
 # 2026-07-04  Added jing executable line
+# 2026-07-31  Remove liblouis key, in favor of louis Python bindings
 
 
 [executables]
@@ -66,7 +67,6 @@ mermaid = mmdc
 sage = sage
 pdfeps = pdftops
 node = node
-liblouis = file2brl
 perl = perl
 fop = fop
 jing = jing


### PR DESCRIPTION
The `liblouis = file2brl` entry in `pretext/pretext.cfg` has been dead configuration since the "new" braille approach became the only approach (May 2023): no code looks up the key, and braille text translation now happens through the `louis` Python bindings. This removes the entry, with a dated history line, and drops the executable from the Guide's version 2 executables example. That example also grows to the full set of current keys—notably `mermaid`, whose executable is the non-obvious `mmdc`, plus `perl` and `fop`. The legacy-format `project.ptx` manifests keep their `<liblouis>` element, which the CLI's legacy parser still requires; retiring it there is a pretext-cli matter.

Verification: braille-emboss and braille-electronic builds of the braille test document are byte-identical before and after.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*