### PR TITLE
Guide: FAQ entry for navigation upset by colliding identifiers

### DIFF
--- a/doc/guide/author/author-faq.xml
+++ b/doc/guide/author/author-faq.xml
@@ -95,6 +95,16 @@
                Please check to see if there was a warning you missed.  (If not, we can improve the warning if you tell us how your source was organized.  So please do, since we would love to hear about it.)</p>
         </li>
 
+        <li xml:id="faq-navigation-collision">
+            <title>Why is my <init>HTML</init> navigation acting so oddly?</title>
+
+            <p>The symptoms vary.  The <q>next</q> and <q>previous</q> buttons circle back on themselves, a link arrives at a division you did not ask for, or a page you were expecting seems to have been replaced by a different one.  We cannot promise a single explanation for every report of this, but there is one situation we know produces exactly these effects, and it is worth ruling out first.</p>
+
+            <p>It needs two things to be true at once.  First, some of your divisions carry an <attr>xml:id</attr> or a <attr>label</attr> built out of numbers, in a hierarchical pattern such as <c>ch-3</c>, and then <c>ch-3-4</c> for something inside it.  Second, other divisions nearby carry neither attribute.  A division with neither is not left nameless: we manufacture an identifier for it, from the nearest ancestor that does have one, together with the division's position among its siblings.  So an unnamed second child of a division you called <c>ch-3</c> becomes <c>ch-3-2</c><mdash/>and if you also authored a division named <c>ch-3-2</c>, then two different divisions now answer to the same name.  Those names become file names in <init>HTML</init> output, so the two pages collide and the navigation between them misbehaves.</p>
+
+            <p>We are aware of this and do not have a good solution.  So the practical remedy is the advice in <xref ref="overview-structure"/>: do not build your identifiers out of numbers.  Let <pretext/> do the numbering, and name a division for what it contains.  <xref ref="overview-cross-references"/> tells the full story of <attr>xml:id</attr> and <attr>label</attr>, including what happens for a division that has neither.</p>
+        </li>
+
         <li xml:id="faq-pull-regularly">
             <title>I don't like surprises and have not updated in months.  Why do I now have a problem?</title>
             <p>We almost never release mistaken code that breaks output produced from valid source (<xref ref="schema" />).  And when we have, the cause is usually a small typo, or something that gets fixed easily and quickly.  We do sometimes make backwards-incompatible changes, but you always get warnings, often the changes can wait, there are announcements on the mailing lists, and whenever possible, we update tools that automate the changes.</p>


### PR DESCRIPTION
An author reported on `pretext-support` that his HTML navigation deadlocked between two chapters. He had numbered identifiers — `ch-1`, `ch-2`, `ch-2-1`, `ch-2-2` — and an `introduction` inside `ch-2` carrying no identifier at all. The introduction was given a manufactured one, `ch-2-2`, which collided with the chapter he had authored under that name. Two divisions answered to a single file name, and the navigation between them went in circles.

This adds an Author FAQ entry, "Why is my HTML navigation acting so oddly?", covering the symptoms, the mechanism, and what to do.

It takes care not to overclaim. The symptoms of a collision vary and other causes are possible, so the entry says we cannot promise one explanation for every report, then describes the situation we do know: numbered identifiers on some divisions, no identifier at all on others nearby, and a manufactured identifier that lands on a name already in use. The mechanism is spelled out with a worked example, so an author can recognise their own document rather than just recognising the symptom.

It closes by saying plainly that we are aware of this and have no good solution, and points at the existing advice not to build identifiers out of numbers, along with the fuller `@xml:id` and `@label` discussion that arrived with #3100.

The entry carries `xml:id="faq-navigation-collision"` so it can be linked directly from a support reply.

Checked: dev-schema errors are 2 before and after, the Guide's existing baseline. The Guide builds to HTML, the entry renders as expected, and both cross-references resolve.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
