### PR TITLE
Runestone: group submission goes above the progress indicator

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -754,10 +754,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="heading-level" select="$next-level"/>
         </xsl:apply-templates>
 
-        <!-- Sometimes conclude with groupwork submission items -->
-        <xsl:if test="$b-is-groupwork">
-            <xsl:apply-templates select="." mode="runestone-groupwork"/>
-        </xsl:if>
+        <!-- Groupwork submission items are not emitted here.  They belong   -->
+        <!-- above the Runestone progress indicator, which the various        -->
+        <!-- "structural-division-inner-content" templates emit as their last -->
+        <!-- act, so each of those emits the submission items just before it. -->
 
         <!-- Include permalink for the section as last child -->
         <xsl:apply-templates select="." mode="permalink"/>
@@ -813,9 +813,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="$b-is-groupwork">
             <!-- the actual list of exercises -->
             <xsl:copy-of select="$the-exercises"/>
-            <!-- Infrastructure for groupwork is provided by -->
-            <!--   "structural-division-content"             -->
-            <!-- template (early and late in "section")      -->
+            <!-- and the group selection and submission items -->
+            <xsl:apply-templates select="." mode="runestone-groupwork"/>
             <!-- No progress indicator in this case -->
         </xsl:when>
         <!-- some extra wrapping for timed exercises      -->
@@ -845,6 +844,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="*">
         <xsl:with-param name="heading-level" select="$heading-level"/>
     </xsl:apply-templates>
+    <!-- A "worksheet" electing group work arrives here, and its submission  -->
+    <!-- items go above the progress indicator: Runestone attaches the "mark -->
+    <!-- as completed" control to that indicator, and a reader chooses their -->
+    <!-- group before declaring the page done, not after.                    -->
+    <xsl:if test="$b-host-runestone and (@groupwork = 'yes') and (self::worksheet or self::exercises) and (parent::chapter or parent::appendix)">
+        <xsl:apply-templates select="." mode="runestone-groupwork"/>
+    </xsl:if>
     <!-- only at "section" level. only when building for a Runestone server -->
     <xsl:apply-templates select="." mode="runestone-progress-indicator"/>
 </xsl:template>


### PR DESCRIPTION
Addresses RunestoneInteractive/rs#875, where the group selection box appears *below* the "Mark as Completed" control instead of above it.

An aside on that issue turned out to be the whole diagnosis: the report is about a `worksheet` rather than an `exercises`. An `exercises` division electing group work takes its own branch in `structural-division-inner-content` that deliberately emits no progress indicator, so it never had the problem. A `worksheet` falls through to the default template, which always emits the indicator as its last act, and the caller then appended the group submission items after that. Runestone attaches its "mark as completed" control to the progress indicator, so the group box landed below it.

The submission items now go at the end of the inner-content templates, immediately before the progress indicator — which is what Brad suggested on the issue ("put it just before the end of whatever marks the end of a `#exercises`"). The `exercises` group-work branch emits them directly rather than depending on the caller, so the ordering is decided in one place per path rather than split across two templates.

A reader now chooses their group before declaring the page done, rather than after.

Verified by building the sample book with `publication-runestone-academy.xml`, since the markup only appears in a Runestone build. Across the whole book exactly three files differ, and two of those differ only by build timestamp. The single real change is `worksheet-groupwork.html`, where the order goes from

```
scprogresscontainer → groupsub → groupsub_button
```

to

```
groupsub → groupsub_button → scprogresscontainer
```

`exercises-groupwork.html` and `exercises-title-groupwork.html` are byte-identical, so the `exercises` path is provably untouched.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
