### PR TITLE
Read aloud

### DIFF
--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -32,6 +32,11 @@ $center-content: true !default;
 
 @use 'components/page-parts/extras/navbar-btn-borders';
 
+@use 'components/page-parts/read-aloud' with (
+  $nav-height: $nav-height,
+  $navbar-breakpoint: $navbar-breakpoint
+);
+
 .ptx-navbar {
   position: sticky;
   top: 0;
@@ -188,7 +193,7 @@ $center-content: true !default;
     display: none;
   }
 
-  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .ptx-calculator-toggle, .ptx-embed-button, .ptx-readability-options-button) .name {
+  :is(.runestone-profile, .activecode-toggle, .ptx-search-button, .ptx-calculator-toggle, .ptx-embed-button, .ptx-readability-options-button, .ptx-read-aloud-button) .name {
     @include accessibility.sr-only;
   }
 

--- a/css/components/page-parts/_read-aloud.scss
+++ b/css/components/page-parts/_read-aloud.scss
@@ -1,0 +1,231 @@
+// Styles for the read-aloud (text-to-speech) feature: the in-navbar player,
+// its settings dialog, and the current-sentence highlight.  Included via
+// _navbar.scss so every theme with a navbar gets it; the markup only exists
+// when the read-aloud publication option is on.
+
+$nav-height: 36px !default;
+$navbar-breakpoint: 800px !default;
+
+@use 'components/helpers/dialogs' as dialogs;
+
+// ---------------------------------------------------------------------------
+// Player bar
+//
+// The player is emitted inside .nav-other-controls and simply unhides in
+// place, growing the navbar row to the right of the button that opened it.
+// It is deliberately *not* a floating bubble: a second styled surface hovering
+// over the page competed with the navbar it was anchored to, and on narrow
+// screens (where the navbar moves to the foot of the page) it had to be moved
+// again to avoid covering the content.  Living in the row, it inherits the
+// navbar's own button styling and needs no positioning of its own — only
+// below the breakpoint, where it lifts onto a second row, does it position
+// at all.
+
+.ptx-read-aloud-player {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+
+  &[hidden] {
+    display: none;
+  }
+
+  // The toggle button carries both glyphs; data-state picks one.
+  //
+  // `display: contents` rather than inline/block: prev and next hold their
+  // .icon as the button's direct flex child, where align-items centers it.
+  // A wrapper of its own would be the flex item instead, and as a blockified
+  // line box it stood 29px tall with the 24px glyph pinned to its top —
+  // leaving the play triangle riding ~2.5px above its neighbours.  Dropping
+  // the wrapper from the box tree makes this button structurally identical to
+  // the other two rather than merely tuned to match.
+  .ptx-read-aloud-icon-play {
+    display: contents;
+  }
+
+  .ptx-read-aloud-icon-pause {
+    display: none;
+  }
+}
+
+.ptx-read-aloud-player[data-state="speaking"] {
+  .ptx-read-aloud-icon-play {
+    display: none;
+  }
+  .ptx-read-aloud-icon-pause {
+    display: contents;
+  }
+}
+
+// After cross-page continuation, invite the single click that browsers
+// require before speech can start again.  An inset ring rather than an outer
+// glow: the button now shares an edge with its neighbours in the navbar.
+.ptx-read-aloud-player[data-state="continue-ready"] .ptx-read-aloud-toggle {
+  animation: ptx-read-aloud-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes ptx-read-aloud-pulse {
+  50% {
+    box-shadow: inset 0 0 0 3px rgba(100, 150, 255, 0.6);
+  }
+}
+
+// The continue link only appears at end of page, and is the only control
+// carrying a word, so it is allowed to shrink before the buttons do.
+//
+// The [hidden] rule has to out-specify `.ptx-navbar .button { display: flex }`.
+// Both are (0,2,0), and this file is @use'd from the top of _navbar.scss, so on
+// a tie the navbar wins and the link shows on every page.  Qualifying by the
+// player breaks the tie in the direction the hidden attribute intends.
+.ptx-read-aloud-continue {
+  min-width: 0;
+}
+
+.ptx-read-aloud-player .ptx-read-aloud-continue[hidden] {
+  display: none;
+}
+
+// An open player needs room from somewhere, and *where* it takes it decides
+// whether the navbar appears to move.  Everything left of the player — the
+// contents button, search, and the read-aloud button itself — has to stay
+// nailed in place; a reader who presses a button should not watch it slide
+// out from under the cursor.  So the room comes from the right instead: the
+// tree buttons are last in the row and already right-aligned within their own
+// span, so narrowing them moves nothing except themselves.
+//
+// This only bites under real pressure.  Flex items shrink toward these floors
+// rather than to them, so at comfortable widths Prev/Up/Next keep their names
+// and full 75px, and the whole rule is invisible.
+@media screen and (min-width: $navbar-breakpoint) {
+  .ptx-navbar:has(.ptx-read-aloud-player:not([hidden])) {
+    // .ptx-navbar-contents is `flex: 1` with the default `min-width: auto`, so
+    // it refuses to shrink below its own min-content and overflows the navbar
+    // instead — which meant no child ever felt the squeeze the rules below
+    // describe.  Releasing the floor is what lets the shrinking start.
+    .ptx-navbar-contents {
+      min-width: 0;
+    }
+
+    // Aim that squeeze.  Without this the fixed-width contents button gives
+    // first, dragging search and the read-aloud button left with it; pinning
+    // everything but the right-hand groups leaves the tree buttons as the
+    // only thing that can yield.
+    .ptx-navbar-contents > *:not(.treebuttons, .nav-runestone-controls) {
+      flex-shrink: 0;
+    }
+
+    // Same `min-width: auto` trap one level down: the tree buttons are
+    // nowrap, so their min-content is the full width of "Prev"/"Up"/"Next"
+    // and the group would not give up a pixel.  With the floor released it
+    // can always shrink, so the navbar never actually spills — worst case
+    // the labels ellipsize.
+    .treebuttons {
+      min-width: 0;
+    }
+
+    .treebuttons > * {
+      min-width: 35px;
+    }
+  }
+
+  // Where the squeeze is real, drop to chevrons rather than ellipsized words.
+  // The threshold is cosmetic, not structural: it is the width below which an
+  // end-of-page player (the widest it gets, with "Continue" showing) stops
+  // fitting beside full-width tree buttons.  If a translation or theme moves
+  // that point, the rule above still keeps the row intact — the labels just
+  // clip instead of vanishing cleanly, which is why this number is allowed to
+  // be approximate.
+  @media screen and (max-width: 900px) {
+    .ptx-navbar:has(.ptx-read-aloud-player:not([hidden])) .treebuttons .name {
+      display: none;
+    }
+  }
+}
+
+// Below the breakpoint there is no room for the player *beside* six other
+// buttons, and the navbar centers its contents — so an overflow would spill
+// off both edges and lose the leading button rather than simply running long.
+// Rather than take the row and hide the page's navigation, the player lifts
+// onto a second row directly above it, leaving every original button in
+// place.  The navbar is fixed to the foot of the page here, so "above" is
+// where a phone already expects a media bar to stack.
+@media screen and (max-width: $navbar-breakpoint) {
+  .ptx-navbar .ptx-read-aloud-player {
+    // Positioned against .ptx-navbar-contents, which is the navbar's only
+    // positioned ancestor and spans its full width at this size.
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    height: $nav-height;
+    // Grouped in the middle, spaced like any other run of navbar buttons —
+    // stretching five controls across the width reads as a tab bar, not as
+    // the transport it is.
+    justify-content: center;
+    background: var(--navbar-background);
+    border-top: 1px solid var(--page-border-color);
+  }
+
+  // The extra row is fixed over the page like the navbar itself, so the
+  // content underneath needs the matching reservation or its last line hides.
+  body.pretext:has(.ptx-read-aloud-player:not([hidden])) {
+    padding-bottom: calc(2 * #{$nav-height});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Settings dialog
+//
+// Reuses the readability dialog's group/label classes so the two reading
+// dialogs stay visually identical; only the trigger and contents differ.
+
+.ptx-navbar .ptx-read-aloud-settings-popup {
+  padding: 10px;
+  margin-top: $nav-height;
+  min-width: 16rem;
+  max-width: 600px;
+  margin-bottom: 0.5em;
+  width: 90%;
+
+  @include dialogs.ptx-dialog-modal;
+}
+
+@media screen and (max-width: $navbar-breakpoint) {
+  .ptx-navbar .ptx-read-aloud-settings-popup {
+    margin-top: unset;
+    margin-bottom: 0;
+    top: auto;
+    bottom: $nav-height;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Current-sentence highlight
+//
+// ::highlight() paints text ranges without touching the DOM.  Colors must
+// satisfy contrast in both themes; only a translucent background is set so
+// the theme's own text color continues to apply.
+
+::highlight(ptx-read-aloud) {
+  background-color: var(--ptx-read-aloud-highlight, rgba(255, 213, 79, 0.45));
+}
+
+:root.dark-mode ::highlight(ptx-read-aloud) {
+  background-color: var(--ptx-read-aloud-highlight, rgba(255, 213, 79, 0.28));
+}
+
+// Math is highlighted by class on the mjx-container (CHTML internals do not
+// expose highlightable text nodes), and block-level fallback covers browsers
+// without the Custom Highlight API.
+.ptx-read-aloud-current-math,
+.ptx-read-aloud-current-block {
+  background-color: var(--ptx-read-aloud-highlight, rgba(255, 213, 79, 0.45));
+  border-radius: 3px;
+}
+
+:root.dark-mode {
+  .ptx-read-aloud-current-math,
+  .ptx-read-aloud-current-block {
+    background-color: var(--ptx-read-aloud-highlight, rgba(255, 213, 79, 0.28));
+  }
+}

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -5736,6 +5736,11 @@
             </li>
 
             <li>
+                <title>Built-in Screen Reader</title>
+                <p>We provide a screen reader, which is a JavaScript library that will read aloud the content of a page.  It is activated by clicking on the <c>Read Aloud</c> button in the navigation bar at the top of the page.  The reader will read the content of the page, and will also read any mathematics that is present.  While not as comprehensive as a commercial screen reader like NVDA or JAWS, it provides an easy way for users who prefer to listen to the main content of the page.</p>
+            </li>
+
+            <li>
                 <title>3D Images</title>
                 <p>Asymptote is a language for describing 2D and 3D images, which we support as much as possible.  The 3D images produced are rotatable for exploration via a mouse or finger.  For those with motor limitations, the images may also be manipulated with keyboard controls.  (Many assistive technologies rely on, or emulate, keyboards.)</p>
             </li>

--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -55,6 +55,19 @@
             </paragraphs>
         </subsection>
 
+        <subsection xml:id="online-html-read-aloud">
+            <title>Read Aloud</title>
+            <idx><h>read aloud</h><h>HTML</h></idx>
+
+            <p>One of the many reasons to use <init>HTML</init> output of <pretext/> is screen reader support, based largely on MathJax.  While most accessibility-focused screen readers (like NVDA and JAWS) now do a very good job switching between MathJax-rendered mathematics and the surrounding text, a casual user of screen readers is unlikely to learn how to use this specialized software.  Browser plugins that offer text-to-speech often fail to handle the text-to-math handoff.</p>
+
+            <p>So <pretext/> provides its own browser based screen reading support for the <init>HTML</init> output via the <tag>read-aloud</tag> element of the publication file (<xref ref="online-read-aloud-options"/>).  This feature will turn on by default, but can be turned off by the publisher.  When enabled, a small button appears in the navigation bar of each page.  Clicking it will expose player controls to play/pause and skip back or ahead (by sentence).  More complicated elements, like tables and interactive elements are announced and skipped.</p>
+
+            <p>Hidden knowls are also announced and skipped, unless the reader selects an option to read all of them.  Alternatively, using the up and down arrow keys will jump the reader between different paragraphs, and pressing <kbd>SPACE</kbd> while on a knowl's title will trigger reading it in full.</p>
+
+            <p>Additional options in the read-aloud settings menu (next to the playback controls) allow the reader to change the voice (which voices are included depends entirely on the browser and operating system), reading speed, and whether to continue to the next page once reaching the end.</p>
+        </subsection>
+
         <subsection xml:id="online-html-annotation">
             <title>Annotation</title>
             <idx><h>Hypothes.is</h></idx>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1093,6 +1093,22 @@
               </ul>
             </p>
         </subsection>
+
+        <subsection xml:id="online-read-aloud-options">
+            <title>Read Aloud Options</title>
+            <idx><h>read aloud</h><h>publisher options</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/html</cline>
+            </cd>element can have an attribute <attr>read-aloud</attr> with values:<ul>
+                <li><c>yes</c>: the default, enable read-aloud functionality.</li>
+                <li><c>no</c>: disable read-aloud functionality.</li>
+            </ul></p>
+
+            <p>
+                When enabled, the read-aloud functionality will use the Web Speech API to read aloud the text content of the page. The user can control the playback using the provided controls, as well as options to adjust the reading speed and voice selection (if supported by the browser), whether to expand and read knowls when it comes to them, and whether to continue directly to the next page when it reaches the end of the content.
+            </p>
+        </subsection>
     </section>
 
     <section xml:id="publication-file-revealjs">

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1106,7 +1106,7 @@
             </ul></p>
 
             <p>
-                When enabled, the read-aloud functionality will use the Web Speech API to read aloud the text content of the page. The user can control the playback using the provided controls, as well as options to adjust the reading speed and voice selection (if supported by the browser), whether to expand and read knowls when it comes to them, and whether to continue directly to the next page when it reaches the end of the content.
+                When enabled, the read-aloud functionality will use the Web Speech API to read aloud the text content of the page. The user can control the playback using the provided controls, as well as options to adjust the reading speed and voice selection (if supported by the browser), whether to expand and read knowls when it comes to them, and whether to continue directly to the next page when it reaches the end of the content.  See <xref ref="online-html-read-aloud"/> for more information.
             </p>
         </subsection>
     </section>

--- a/js/mathjax_startup.js
+++ b/js/mathjax_startup.js
@@ -122,6 +122,22 @@ export function startMathJax(opts) {
     }
   }
 
+  // Speech generation.  MathJax's Speech Rule Engine produces the spoken
+  // form of every expression and attaches it as an aria-label; screen
+  // readers use it, and so does the read-aloud feature, which hands off to
+  // it rather than trying to voice the visual output.  This is on by
+  // default in v4's combined components, but assert it explicitly so a
+  // future change of default cannot silently break either consumer.
+  mathJaxOpts['options']['enableSpeech'] = true;
+
+  // Match the speech locale to the document language when SRE supports it,
+  // otherwise leave SRE's own default in place (graceful degradation).
+  const sreLocales = ['en', 'fr', 'es', 'de', 'it'];
+  const primaryTag = (opts.lang || '').split('-')[0].toLowerCase();
+  if(sreLocales.includes(primaryTag)) {
+    mathJaxOpts['options']['sre'] = { "locale": primaryTag };
+  }
+
   // Apply the options
   window.MathJax = mathJaxOpts;
 

--- a/js/src/read-aloud/collector.js
+++ b/js/src/read-aloud/collector.js
@@ -1,0 +1,590 @@
+/*******************************************************************************
+ * collector.js — live DOM → IR stage of the read-aloud pipeline
+ *******************************************************************************
+ * Walks the main content region at *play time* and emits the intermediate
+ * representation consumed by segmenter.js (see that file for the IR shape).
+ * Because collection happens at play time, content revealed since page load
+ * (opened knowls, unfolded solutions) is naturally included, and content
+ * still hidden is naturally excluded.
+ *
+ * Content policy (decision #6 in the design doc): read what a sighted reader
+ * would read aloud — headings, paragraphs, lists, display math, captions,
+ * image alt text; announce-and-skip tables, code, and interactives; silently
+ * skip anything hidden, including screen-reader-only text (read-aloud mimics
+ * *visual* reading, so e.g. the assistive watermark is skipped).
+ *
+ * An interactive *exercise* is the one place that policy needs care.  A
+ * Runestone component is not a black box like a video: its prompt and its
+ * answer choices are prose, and skipping the whole widget threw away the
+ * question along with the machinery.  So a component that Runestone has
+ * finished building is entered — prose read, controls skipped, kind announced
+ * first — while one it has not yet built is still announced and skipped,
+ * because the authoring markup underneath holds the answers.
+ *
+ * Two exceptions to "hidden means skipped", both about <details>: content
+ * inside a *closed* one is collected anyway, and each block records its
+ * ancestry in the document tree.  Together those let the listener navigate
+ * asides (see navigation.js) without re-collecting or re-fetching anything.
+ * Collection is complete and static; the listening mode governs traversal,
+ * and opening a <details> is a presentation side effect of arriving there.
+ ******************************************************************************/
+
+import { nodeDescriptor } from "./nodes.js";
+
+// Blocks announced-and-skipped rather than read.  Order matters: the first
+// matching selector wins, so put more specific selectors first.
+const ANNOUNCE_SELECTORS = [
+    { selector: ".table-like, table", stringId: "read-aloud-skip-table" },
+    {
+        selector:
+            "pre, .code-box, .program, .console, .sage, .sagecell-practice, " +
+            // Runestone's two code surfaces: the ActiveCode editor and the
+            // scrambled blocks of a Parsons problem.  Both are code, and the
+            // Parsons blocks are in a deliberately wrong order besides.
+            ".ac_code_div, .sortable-code-container",
+        stringId: "read-aloud-skip-code",
+    },
+    {
+        selector:
+            "iframe, audio, video, .video-box, .jxgbox, " +
+            ".interactive-iframe-container, .exercise-interactive",
+        stringId: "read-aloud-skip-interactive",
+    },
+];
+
+// A Runestone component: an interactive exercise whose prompt and answer
+// choices are ordinary prose worth reading, wrapped around machinery that is
+// not.  PreTeXt emits the container; Runestone's own JavaScript rewrites what
+// is inside it at page load and marks the result "ready".
+const RUNESTONE_SELECTOR = ".ptx-runestone-container, .runestone";
+const RUNESTONE_READY = ".runestone-component-ready";
+const RUNESTONE_CAPTION = ".runestone_caption";
+
+// Before Runestone rewrites it, a component is still the authoring markup:
+// for a multiple-choice question that means every wrong answer *and its
+// feedback*, in the DOM, waiting to be read out.  So an unrewritten component
+// is announced and skipped, exactly as the whole category used to be.
+const RUNESTONE_UNBUILT = "[data-component]";
+
+// Machinery inside a rendered component.  A listener cannot press a button or
+// fill a box by ear, and the labels on them ("Check me", "Reset") are chrome
+// rather than content.  The caption is spoken up front instead (see
+// runestoneKind), and PreTeXt's CSS hides it anyway.
+const RUNESTONE_CONTROL_SELECTOR = [
+    "button",
+    "input",
+    "textarea",
+    "select",
+    // ActiveCode's toolbar, whose history slider reads out as "Original - 1
+    // of 1" — a control's state, not anything the exercise says.
+    ".ac_actions",
+    RUNESTONE_CAPTION,
+].join(", ");
+
+// Elements never entered at all: invisible-to-the-eye content, chrome, and
+// duplicated assistive text.
+const SKIP_SELECTOR = [
+    "[aria-hidden='true']",
+    "[hidden]",
+    ".hidden-content",
+    ".autopermalink",
+    // Material Symbols draw their glyph from the element's *text*, so an icon
+    // is literally the word "content_copy" or "expand_more" in the DOM.  Most
+    // are marked aria-hidden already; the copy-code button's is not, and read
+    // out as "content copy" beside every program listing.
+    ".material-symbols-outlined",
+    "mjx-assistive-mml",
+    "script",
+    "style",
+    "noscript",
+    ".ptx-content-footer",
+    ".instructions", // WW instructor-only material
+    // Runestone's drag-and-drop parks one off-screen live region per card
+    // ("Incorrect drop zone for Monroe Doctrine") at the end of the page.
+    // Positioned rather than hidden, so checkVisibility() reports it visible
+    // and only naming it keeps it out of the reading.
+    ".vh-dnd-error",
+].join(", ");
+
+// Elements whose children form their own paragraph-level blocks.  Reaching
+// one of these flushes the inline token run in progress.
+const CONTAINER_SELECTOR = [
+    "div.para",
+    "section",
+    "article",
+    "ul",
+    "ol",
+    "dl",
+    "li",
+    "dt",
+    "dd",
+    "blockquote",
+    "figure",
+    "details",
+    // A <summary> must end its block, or an aside whose body is not itself a
+    // block element (a footnote's contents div) gets appended to the title's
+    // block and inherits its always-spoken status.
+    "summary",
+    ".exercise-statement",
+    ".knowl__content",
+    ".ptx-runestone-container",
+    // Runestone writes real <p> for the prose it generates, where PreTeXt
+    // uses div.para; without this every choice of a multiple-choice question
+    // runs into the next as one block.  PreTeXt's own <p> (author bylines)
+    // are standalone blocks too, so nothing else changes.
+    "p",
+    // One block per answer: a choice, a card to drag, a drop target.  Kept
+    // separate so a listener hears them apart and can step between them.
+    "label",
+    "legend",
+    ".draggable-drag",
+    ".draggable-drop",
+    ".matching-workspace .box",
+].join(", ");
+
+// Leaf-ish elements that start a fresh text block of their own.
+const HEADING_SELECTOR = "h1, h2, h3, h4, h5, h6, figcaption, caption";
+
+// Media elements carry no text but are certainly content, so they are never
+// judged empty; anything else with no text in it has nothing to announce.
+const MEDIA_SELECTOR = "img, svg, canvas, iframe, video, audio, object, embed";
+
+export function isEmptyOfContent(el) {
+    if (el.textContent.trim() !== "") return false;
+    return !el.matches(MEDIA_SELECTOR) && !el.querySelector(MEDIA_SELECTOR);
+}
+
+/**
+ * The child nodes of `el` in the order they should be *heard*.
+ *
+ * PreTeXt sets a figure's caption below the thing it captions, which is right
+ * for the eye: a reader takes in the picture first and then reads what it was.
+ * Heard in that order it inverts, because a listener has no picture to take
+ * in — the alt text arrives with nothing yet to attach it to, and the caption
+ * that would have framed it lands only once the description is over.  So a
+ * caption is spoken ahead of its figure's contents wherever it sits in the
+ * document.  Captions PreTeXt already places on top (tables, listings, named
+ * lists) are untouched, since hoisting a first child moves nothing.
+ */
+export function readingOrder(el) {
+    const children = Array.from(el.childNodes);
+    // Direct child only: each panel of a "sidebyside" is its own figure with
+    // its own caption, and those belong to the panels rather than the whole.
+    const caption = el.querySelector(":scope > figcaption");
+    if (!caption) return children;
+    return [caption, ...children.filter((child) => child !== caption)];
+}
+
+/**
+ * Name the kind of component `el` is, for the announcement that precedes it.
+ *
+ * Runestone labels each rendered component with its own name for it —
+ * "Multiple Choice", "Fill in the Blank", "Drag-N-Drop", "Parsons" — so that
+ * name is read back out of the page rather than duplicated here as a table of
+ * component classes that would drift as Runestone grows new ones.  Components
+ * that render no caption fall back to the generic announcement.
+ */
+export function runestoneKind(el, strings = {}) {
+    const caption = el.querySelector(RUNESTONE_CAPTION);
+    const name = caption && caption.textContent.trim().replace(/\s+/g, " ");
+    if (!name) return strings["read-aloud-interactive"] || null;
+    const template = strings["read-aloud-interactive-kind"];
+    return template ? template.replace("{kind}", name) : name;
+}
+
+function isElementVisible(el) {
+    if (typeof el.checkVisibility === "function") {
+        return el.checkVisibility();
+    }
+    // Fallback for browsers without checkVisibility (Safari < 17.4)
+    return !!(el.offsetParent || el.getClientRects().length);
+}
+
+// SRE builds its speech for screen readers, which identify the expression as
+// a math region by appending the word "math".  Spliced into a spoken
+// sentence that marker just interrupts the prose — "f of x equals x squared,
+// math, which opens upward" — so drop it.  Never strip it down to nothing:
+// an expression whose entire speech is "math" keeps that word.
+const MATH_REGION_MARKER = /[,;.]?\s*\bmath\b[\s.]*$/i;
+
+// PreTeXt pulls the punctuation that follows inline math *into* the math
+// (`\(f(x) = x^2\text{,}\)`) so it sets and line-breaks correctly, and SRE
+// duly speaks it as a word: "f of x equals x squared comma".  Put the
+// character back so the voice renders it as a pause instead of saying it.
+// The words are English, so other SRE locales simply do not match and keep
+// their existing behaviour rather than getting it wrong.
+const TRAILING_PUNCTUATION = {
+    comma: ",",
+    period: ".",
+    "full stop": ".",
+    semicolon: ";",
+    colon: ":",
+    "question mark": "?",
+    "exclamation mark": "!",
+};
+const TRAILING_PUNCTUATION_RE = new RegExp(
+    `[\\s,]*\\b(${Object.keys(TRAILING_PUNCTUATION).join("|")})\\s*$`,
+    "i"
+);
+
+export function cleanMathSpeech(value) {
+    if (!value) return null;
+    // SRE also produces an SSML-marked-up rendering (<mark/>, <break/>,
+    // <say-as>…</say-as>).  speechSynthesis takes plain text only — it would
+    // read the tags — so reduce any markup to the text it wraps.
+    const text = value.replace(/<[^>]*>/g, " ");
+    const stripped = text.replace(MATH_REGION_MARKER, "").trim();
+    const speech = (stripped || text).replace(/\s+/g, " ").trim();
+    return (
+        speech.replace(
+            TRAILING_PUNCTUATION_RE,
+            (match, word) => TRAILING_PUNCTUATION[word.toLowerCase()]
+        ) || null
+    );
+}
+
+// Attributes that can hold speech, in order of preference.  MathJax 4 puts
+// the plain-text rendering in `aria-label` and an SSML-marked-up copy in
+// `data-semantic-speech`, so the plain forms must win; `-none` is SRE's own
+// markup-free variant.  The marked-up attribute stays as a last resort
+// because stripped markup still beats announcing "equation".
+const SPEECH_ATTRIBUTES = [
+    "aria-label",
+    "data-semantic-speech-none",
+    "data-semantic-speech",
+];
+
+// The container's own value first, then the outermost descendant carrying
+// the attribute.  querySelector walks in document order, so that descendant
+// is the top of the expression rather than one of its sub-expressions.
+function speechAttribute(el, attribute) {
+    const own = el.getAttribute(attribute);
+    if (own) return own;
+    const node = el.querySelector(`[${attribute}]`);
+    return (node && node.getAttribute(attribute)) || null;
+}
+
+/**
+ * Read the speech text already present for one typeset expression.
+ *
+ * Where it lives varies by MathJax version and configuration; MathJax 4
+ * attaches SRE's output to the mjx-container's subtree (alongside
+ * `data-speech-attached`), while other builds use `aria-label` directly.
+ * Assistive MathML is off by default in v4, so that branch usually finds
+ * nothing.  Returns null when no speech exists yet.
+ */
+export function readMathSpeech(el) {
+    for (const attribute of SPEECH_ATTRIBUTES) {
+        const raw = speechAttribute(el, attribute);
+        if (raw) return cleanMathSpeech(raw);
+    }
+
+    // Assistive MathML, when a publisher has turned it back on.  Only
+    // @alttext is usable: the MathML text content is bare glyphs, which is
+    // exactly the garbled reading this feature exists to avoid.
+    const mml = el.querySelector("mjx-assistive-mml math");
+    const alt = mml && mml.getAttribute("alttext");
+    return alt ? cleanMathSpeech(alt) : null;
+}
+
+// Memoized so the wait is paid at most once per page: a page with no MathJax
+// at all would otherwise poll out its full deadline on every play.
+let mathTypeset = null;
+
+/**
+ * Resolve once MathJax has finished its initial typesetting — or immediately,
+ * on a page that has no MathJax.
+ *
+ * Collection identifies math purely by the presence of mjx-container
+ * elements, which do not exist before typesetting: run too early and every
+ * expression is collected as ordinary text and read out as raw LaTeX.  A
+ * reader clicking play is always late enough for this to be settled; the
+ * auto-continue path, which starts at DOMContentLoaded, is not.
+ *
+ * MathJax is loaded asynchronously and the `window.MathJax` present at parse
+ * time is only the configuration object — `startup` is grafted on later — so
+ * the promise has to be waited *for* before it can be waited *on*.
+ */
+export function whenMathTypeset(timeoutMs = 10000) {
+    if (mathTypeset) return mathTypeset;
+    mathTypeset = (async () => {
+        // No configuration object at all: this page never asked for MathJax.
+        if (!window.MathJax) return;
+        const deadline = Date.now() + timeoutMs;
+        while (!(window.MathJax.startup && window.MathJax.startup.promise)) {
+            if (Date.now() >= deadline) return;
+            await new Promise((r) => setTimeout(r, 50));
+        }
+        // Never let a MathJax failure hang the reader: the collector degrades
+        // to reading whatever is in the DOM, which is the old behaviour.
+        await Promise.race([
+            window.MathJax.startup.promise.catch(() => {}),
+            new Promise((r) => setTimeout(r, Math.max(0, deadline - Date.now()))),
+        ]);
+    })();
+    return mathTypeset;
+}
+
+/**
+ * Resolve speech text for one mjx-container, waiting briefly if MathJax's
+ * speech worker has not finished with this expression yet.  Resolves to null
+ * if nothing arrives in time; the caller substitutes the localized
+ * "equation" announcement so a reader hears something either way.
+ */
+function resolveMathSpeech(el, timeoutMs) {
+    const direct = readMathSpeech(el);
+    if (direct) {
+        return Promise.resolve(direct);
+    }
+    return new Promise((resolve) => {
+        let done = false;
+        const finish = (value) => {
+            if (done) return;
+            done = true;
+            observer.disconnect();
+            clearTimeout(timer);
+            resolve(value);
+        };
+        // Speech generation runs in a web worker and patches the container
+        // after typesetting, so watch the whole subtree, not just the
+        // container's own attributes.
+        const observer = new MutationObserver(() => {
+            const speech = readMathSpeech(el);
+            if (speech) finish(speech);
+        });
+        observer.observe(el, {
+            attributes: true,
+            childList: true,
+            subtree: true,
+        });
+        const timer = setTimeout(() => finish(readMathSpeech(el)), timeoutMs);
+    });
+}
+
+/**
+ * Collect the readable blocks of `root` (usually #ptx-content).
+ *
+ * opts:
+ *   strings         stringId → localized text (for the equation fallback)
+ *   mathTimeoutMs   how long to wait for a missing aria-label (default 3000)
+ *
+ * Returns a Promise of the blocks array; async only because math speech may
+ * need a brief wait on freshly loaded pages.
+ */
+export async function collect(root, opts = {}) {
+    const strings = opts.strings || {};
+    const mathTimeoutMs = opts.mathTimeoutMs || 3000;
+    // Before walking the DOM at all: an untypeset page has no math in it to
+    // find.  Resolves instantly once MathJax has run, so this costs a reader
+    // who clicks play nothing.
+    await whenMathTypeset();
+    const blocks = [];
+    const pendingMath = [];
+
+    // The block currently accumulating inline tokens, or null.
+    let current = null;
+
+    const flush = () => {
+        if (current && current.tokens.some(isSpeakable)) {
+            blocks.push(current);
+        }
+        current = null;
+    };
+    const isSpeakable = (t) =>
+        t.kind !== "text" || t.value.trim() !== "";
+
+    const ensureBlock = (el, ctx) => {
+        if (!current) {
+            current = { el, tokens: [], path: ctx.path, summary: ctx.summary };
+        }
+    };
+
+    /**
+     * ctx carries position in the tree down the walk:
+     *   path      ancestry so far (nodes.js descriptors), root first
+     *   summary   inside an aside's always-read title
+     *   closed    inside a closed <details>, so the visibility gate is off
+     *   runestone inside a rendered interactive exercise, so its controls
+     *             are skipped and its nested containers announce nothing
+     */
+    const visit = (node, blockEl, ctx) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+            if (node.nodeValue.trim() !== "") {
+                ensureBlock(blockEl, ctx);
+                current.tokens.push({ kind: "text", value: node.nodeValue, node });
+            }
+            return;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        const el = node;
+
+        if (el.matches(SKIP_SELECTOR)) return;
+        // Content in a collapsed <details> is hidden only because the reader
+        // has not clicked yet — exactly the content the aside modes exist to
+        // reach — so the visibility gate is suspended below one.  Genuinely
+        // hidden material is still excluded by SKIP_SELECTOR above.
+        if (!ctx.closed && !isElementVisible(el)) return;
+
+        const descriptor = nodeDescriptor(el);
+        if (descriptor) {
+            ctx = { ...ctx, path: ctx.path.concat(descriptor) };
+        }
+        if (el.tagName === "DETAILS" && !el.open) {
+            ctx = { ...ctx, closed: true };
+        }
+        if (el.tagName === "SUMMARY") {
+            ctx = { ...ctx, summary: true };
+        }
+
+        // A footnote's clickable summary is a bare superscript numeral, which
+        // reads as a stray "one" in the middle of a sentence.  PreTeXt already
+        // renders the localized, numbered name into the tooltip ("Footnote
+        // 3.1"), so speak that instead of the numeral.
+        if (el.matches(".ptx-footnote__number")) {
+            const label = (el.getAttribute("title") || "").trim();
+            if (label) {
+                flush();
+                ensureBlock(el, ctx);
+                current.tokens.push({ kind: "text", value: label, node: null, el });
+                flush();
+                return;
+            }
+        }
+
+        // Runestone interactive exercises.  Handled before the announce list
+        // so a rendered component is *entered* for its prose; the code and
+        // table rules below then still apply to what is found inside it.
+        if (!ctx.runestone && el.matches(RUNESTONE_SELECTOR)) {
+            if (el.matches(RUNESTONE_READY) || el.querySelector(RUNESTONE_READY)) {
+                flush();
+                const kind = runestoneKind(el, strings);
+                if (kind) {
+                    blocks.push({
+                        el,
+                        tokens: [{ kind: "text", value: kind, node: null, el }],
+                        path: ctx.path,
+                        summary: ctx.summary,
+                    });
+                }
+                ctx = { ...ctx, runestone: true };
+            } else if (
+                el.matches(RUNESTONE_UNBUILT) ||
+                el.querySelector(RUNESTONE_UNBUILT)
+            ) {
+                flush();
+                blocks.push({
+                    el,
+                    tokens: [
+                        {
+                            kind: "announce",
+                            stringId: "read-aloud-skip-interactive",
+                            el,
+                        },
+                    ],
+                    path: ctx.path,
+                    summary: ctx.summary,
+                });
+                return;
+            }
+            // Neither: a container Runestone left empty of any component.
+            // Nothing special to do, so fall through and walk it normally.
+        }
+
+        if (ctx.runestone && el.matches(RUNESTONE_CONTROL_SELECTOR)) return;
+
+        // Announce-and-skip categories
+        for (const { selector, stringId } of ANNOUNCE_SELECTORS) {
+            if (el.matches(selector)) {
+                // An empty one is a pane waiting to be filled, not content
+                // being passed over — every ActiveCode ships with a blank
+                // output <pre>, and saying "Code. Skipping." over it twice
+                // per exercise is worse than saying nothing.
+                if (isEmptyOfContent(el)) return;
+                flush();
+                blocks.push({
+                    el,
+                    tokens: [{ kind: "announce", stringId, el }],
+                    path: ctx.path,
+                    summary: ctx.summary,
+                });
+                return;
+            }
+        }
+
+        // Typeset math: a token in the current block; display math becomes
+        // its own block so it is spoken with a natural pause around it.
+        if (el.tagName === "MJX-CONTAINER") {
+            const display = el.getAttribute("display") === "true";
+            if (display) flush();
+            ensureBlock(display ? el : blockEl, ctx);
+            const token = { kind: "math", speech: "", display, el };
+            current.tokens.push(token);
+            pendingMath.push(token);
+            if (display) flush();
+            return;
+        }
+
+        // Images speak their alt text (part of visual reading).  Alt text is
+        // written to stand in for a picture, not to be read as prose, so it
+        // is introduced rather than spliced silently into the sentence around
+        // it — otherwise a listener cannot tell where the author's sentence
+        // stopped and the description of the picture began.
+        if (el.tagName === "IMG") {
+            const alt = (el.getAttribute("alt") || "").trim();
+            if (alt) {
+                const label = strings["read-aloud-image-alt"];
+                ensureBlock(blockEl, ctx);
+                current.tokens.push({
+                    kind: "text",
+                    value: label ? `${label} ${alt}` : alt,
+                    node: null,
+                    el,
+                });
+            }
+            return;
+        }
+
+        if (el.matches(HEADING_SELECTOR) || el.matches(CONTAINER_SELECTOR)) {
+            flush();
+            for (const child of readingOrder(el)) visit(child, el, ctx);
+            flush();
+            return;
+        }
+
+        // Anything else is treated as inline: descend with the same block.
+        for (const child of el.childNodes) visit(child, blockEl, ctx);
+    };
+
+    visit(root, root, {
+        path: [],
+        summary: false,
+        closed: false,
+        runestone: false,
+    });
+    flush();
+
+    // Resolve math speech in parallel under a shared deadline.
+    let fallbackCount = 0;
+    await Promise.all(
+        pendingMath.map(async (token) => {
+            const speech = await resolveMathSpeech(token.el, mathTimeoutMs);
+            if (!speech) fallbackCount++;
+            token.speech =
+                speech ||
+                strings["read-aloud-equation-fallback"] ||
+                "equation";
+        })
+    );
+    if (fallbackCount) {
+        // Every expression reading as "equation" means MathJax produced no
+        // speech at all — worth saying out loud, since the page otherwise
+        // reads perfectly well and the cause is invisible.
+        console.warn(
+            `PreTeXt read-aloud: no MathJax speech text for ${fallbackCount} of ` +
+            `${pendingMath.length} expression(s); reading the fallback instead. ` +
+            `Run PTXReadAloud.debugMath() to see what MathJax produced.`
+        );
+    }
+
+    return blocks;
+}

--- a/js/src/read-aloud/highlighter.js
+++ b/js/src/read-aloud/highlighter.js
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * highlighter.js — sentence-level highlight + auto-scroll for read-aloud
+ *******************************************************************************
+ * Text spans are highlighted with the CSS Custom Highlight API
+ * (::highlight(ptx-read-aloud) — no DOM mutation, so MathJax layout is never
+ * disturbed).  Math is always highlighted by toggling a class on its
+ * mjx-container: CHTML internals don't expose reliable text nodes for Range
+ * highlighting.  Browsers without CSS.highlights (older Firefox) fall back to
+ * a class on the whole block.
+ *
+ * Auto-scroll centers the current block, but a wheel/touch/keyboard scroll by
+ * the reader suppresses it until the next explicit player action — the reader
+ * looking elsewhere must always win over the machine.
+ ******************************************************************************/
+
+const HIGHLIGHT_NAME = "ptx-read-aloud";
+const MATH_CLASS = "ptx-read-aloud-current-math";
+const BLOCK_CLASS = "ptx-read-aloud-current-block";
+
+export class Highlighter {
+    constructor() {
+        this.supportsRanges =
+            typeof CSS !== "undefined" && "highlights" in CSS;
+        this.markedElements = [];
+        this.autoScroll = true;
+        this.scrollSuppressed = false;
+
+        // Any manual scroll gesture suppresses auto-scroll.
+        for (const evt of ["wheel", "touchmove"]) {
+            window.addEventListener(evt, () => {
+                this.scrollSuppressed = true;
+            }, { passive: true });
+        }
+    }
+
+    /** Call from explicit player actions (play/skip/click-to-start). */
+    resetScrollSuppression() {
+        this.scrollSuppressed = false;
+    }
+
+    show(planItem, blocks) {
+        this.clear();
+        const block = blocks[planItem.blockIndex];
+        if (!block) return;
+
+        const ranges = [];
+        for (const r of planItem.ranges) {
+            const token = block.tokens[r.tokenIndex];
+            if (!token) continue;
+            if (token.kind === "math") {
+                token.el.classList.add(MATH_CLASS);
+                this.markedElements.push({ el: token.el, cls: MATH_CLASS });
+            } else if (
+                this.supportsRanges &&
+                token.kind === "text" &&
+                token.node &&
+                token.node.isConnected
+            ) {
+                try {
+                    const range = new Range();
+                    range.setStart(token.node, r.start);
+                    range.setEnd(token.node, r.end);
+                    ranges.push(range);
+                } catch (e) {
+                    // Offsets can go stale if the DOM changed mid-read; the
+                    // block-level fallback below still shows position.
+                }
+            }
+        }
+
+        if (this.supportsRanges && ranges.length) {
+            CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges));
+        } else if (block.el && block.el.isConnected) {
+            // No range support (or nothing rangeable): mark the whole block.
+            block.el.classList.add(BLOCK_CLASS);
+            this.markedElements.push({ el: block.el, cls: BLOCK_CLASS });
+        }
+
+        if (this.autoScroll && !this.scrollSuppressed) {
+            const target =
+                (block.el && block.el.isConnected && block.el) ||
+                (ranges.length && ranges[0].startContainer.parentElement);
+            if (target && typeof target.scrollIntoView === "function") {
+                target.scrollIntoView({ block: "center", behavior: "smooth" });
+            }
+        }
+    }
+
+    clear() {
+        if (this.supportsRanges) {
+            CSS.highlights.delete(HIGHLIGHT_NAME);
+        }
+        for (const { el, cls } of this.markedElements) {
+            el.classList.remove(cls);
+        }
+        this.markedElements = [];
+    }
+}

--- a/js/src/read-aloud/index.js
+++ b/js/src/read-aloud/index.js
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * index.js — entry point for the pretext-read-aloud bundle
+ *******************************************************************************
+ * Feature-detects speechSynthesis, wires the toolbar button, and initializes
+ * the player lazily on first press.  The XSL emits the markup and this
+ * <script> only when the read-aloud publication option is enabled, so an
+ * opted-out build ships zero read-aloud bytes.
+ ******************************************************************************/
+
+import { ReadAloudPlayer, continuationMode } from "./player-ui.js";
+import { collect, readMathSpeech } from "./collector.js";
+import { buildPlan, sentenceBoundaries } from "./segmenter.js";
+import { SpeechQueue } from "./speech-queue.js";
+
+window.addEventListener("DOMContentLoaded", () => {
+    const button = document.getElementById("ptx-read-aloud-button");
+    const playerElement = document.getElementById("ptx-read-aloud-player");
+    if (!button || !playerElement) return;
+
+    // No speech engine (or no voices ever): hide the feature entirely.
+    if (!("speechSynthesis" in window)) {
+        button.hidden = true;
+        return;
+    }
+
+    let player = null;
+    const ensurePlayer = () => {
+        if (!player) {
+            player = new ReadAloudPlayer(button, playerElement);
+        }
+        return player;
+    };
+
+    button.addEventListener("click", () => {
+        const p = ensurePlayer();
+        if (p.isOpen) {
+            p.close();
+        } else {
+            p.open();
+        }
+    });
+
+    // Cross-page continuation (decision #10): the previous page set a flag on
+    // its way out.  Read the mode before open(), which clears the flag so a
+    // later reload of this page is an ordinary visit.
+    //
+    //   "manual"  the reader clicked "Continue".  Browsers generally refuse
+    //             speech without fresh user activation after navigation, so
+    //             present the player open and ready — one click resumes.
+    //   "auto"    the auto-continue setting is on, and the previous page
+    //             finished by itself.  Try to start reading straight away;
+    //             the player falls back to the "manual" presentation if the
+    //             browser turns out to refuse.
+    const continuation = continuationMode();
+    if (continuation) {
+        const p = ensurePlayer();
+        p.open();
+        playerElement.dataset.state = "continue-ready";
+        if (continuation === "auto") p.resumeContinuation();
+    }
+
+    // Console access for debugging and by-ear experimentation during the
+    // prototype phase: PTXReadAloud.speakPage() in devtools.
+    window.PTXReadAloud = {
+        collect,
+        buildPlan,
+        sentenceBoundaries,
+        SpeechQueue,
+        player: ensurePlayer,
+        speakPage: () => ensurePlayer().playFromTop(),
+
+        // Reports what MathJax actually produced for each expression, which
+        // is the only way to tell a speech-generation problem apart from a
+        // read-aloud one: if aria-label is null everywhere, the fault is in
+        // MathJax's speech setup, not in this feature.
+        debugMath: () => {
+            const containers = document.querySelectorAll("mjx-container");
+            console.log("MathJax version:", window.MathJax?.version);
+            console.log("enableSpeech:", window.MathJax?.config?.options?.enableSpeech);
+            console.log("sre options:", window.MathJax?.config?.options?.sre);
+            console.log(`${containers.length} typeset expression(s):`);
+            const inner = (el, attr) => {
+                const node = el.querySelector(`[${attr}]`);
+                return node && node.getAttribute(attr);
+            };
+            containers.forEach((el, i) => {
+                console.log(i, {
+                    resolved: readMathSpeech(el),
+                    ownAriaLabel: el.getAttribute("aria-label"),
+                    ownSemanticSpeech: el.getAttribute("data-semantic-speech"),
+                    ownSpeechNone: el.getAttribute("data-semantic-speech-none"),
+                    innerAriaLabel: inner(el, "aria-label"),
+                    innerSemanticSpeech: inner(el, "data-semantic-speech"),
+                    assistiveMml: !!el.querySelector("mjx-assistive-mml"),
+                });
+            });
+        },
+    };
+});

--- a/js/src/read-aloud/navigation.js
+++ b/js/src/read-aloud/navigation.js
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * navigation.js — moving around the document tree, statelessly
+ *******************************************************************************
+ * Every function here answers "where should the reader go next?" purely from
+ * *where they are*, never from how they arrived.  That is the whole design:
+ * a stack of frames recording how the listener got somewhere would desync the
+ * moment they clicked into the middle of a proof (click-to-start) or stepped
+ * across a knowl boundary with the arrow keys.  Ancestry is derived from
+ * position, so there is nothing to keep in sync and every entry point behaves
+ * correctly.
+ *
+ * No DOM access: blocks are the plain data collector.js produces, so this file
+ * unit-tests alongside the segmenter (see test/navigation.test.js).
+ *
+ * INPUT — blocks, as produced by collector.js:
+ *   Block: { el?, tokens, path: Node[], summary: boolean }
+ *     path     root-to-leaf ancestry, from nodes.js
+ *     summary  true for the always-read title of an aside, false for its body
+ *
+ * Nodes are compared by identity (their `el`), so tests can use plain objects.
+ * Every "find" returns a block index, or -1 when there is nowhere to go.
+ ******************************************************************************/
+
+const pathOf = (blocks, index) => (blocks[index] && blocks[index].path) || [];
+
+const pathHas = (path, node) => path.some((n) => n.el === node.el);
+
+/**
+ * The innermost node containing this block that satisfies `predicate`.
+ * Innermost wins because the listener's "skip this" means the tightest thing
+ * they are inside — the proof, not the section containing it.
+ */
+export function innermost(blocks, index, predicate = () => true) {
+    const path = pathOf(blocks, index);
+    for (let i = path.length - 1; i >= 0; i--) {
+        if (predicate(path[i])) return path[i];
+    }
+    return null;
+}
+
+/** The innermost aside (born-hidden knowl, footnote, description) around a block. */
+export function enclosingAside(blocks, index) {
+    return innermost(blocks, index, (n) => n.aside);
+}
+
+/**
+ * The innermost *content* node around a block — a theorem, example, proof —
+ * ignoring divisions.  This is what "skip the current block" acts on; without
+ * the filter it would skip the whole enclosing section.
+ */
+export function enclosingBlock(blocks, index) {
+    return innermost(blocks, index, (n) => n.family !== "division");
+}
+
+/** First block belonging to `node`, or -1. */
+export function firstBlockIn(blocks, node) {
+    for (let i = 0; i < blocks.length; i++) {
+        if (pathHas(blocks[i].path, node)) return i;
+    }
+    return -1;
+}
+
+/** First block of `node`'s body, skipping its always-read title. */
+export function firstBodyBlockIn(blocks, node) {
+    for (let i = 0; i < blocks.length; i++) {
+        if (pathHas(blocks[i].path, node) && !blocks[i].summary) return i;
+    }
+    return -1;
+}
+
+/**
+ * First block at or after `index` that is no longer inside `node` — where
+ * reading resumes when the listener skips or finishes a subtree.  Returns -1
+ * when the node runs to the end of the page, which the caller reads as "stop".
+ */
+export function nextBlockOutside(blocks, index, node) {
+    for (let i = Math.max(0, index); i < blocks.length; i++) {
+        if (!pathHas(blocks[i].path, node)) return i;
+    }
+    return -1;
+}
+
+/**
+ * The next block that *begins* a node matching `predicate`, after `index`.
+ * "Begins" matters: without it, walking forward inside a long theorem would
+ * report that same theorem as the next one.
+ */
+export function nextNodeStart(blocks, index, predicate) {
+    const current = pathOf(blocks, index);
+    for (let i = index + 1; i < blocks.length; i++) {
+        const path = pathOf(blocks, i);
+        for (const node of path) {
+            if (!predicate(node)) continue;
+            // Newly entered: not an ancestor we were already inside.
+            if (!pathHas(current, node) && !pathHas(pathOf(blocks, i - 1), node)) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+/** Next node of a given "-like" family, e.g. jump to the next theorem. */
+export function nextOfFamily(blocks, index, family) {
+    return nextNodeStart(blocks, index, (n) => n.family === family);
+}
+
+/**
+ * Where reading should continue when the listener skips the block they are
+ * in — the next block outside the innermost theorem/example/proof.
+ */
+export function skipTarget(blocks, index) {
+    const node = enclosingBlock(blocks, index);
+    return node ? nextBlockOutside(blocks, index, node) : -1;
+}
+
+//------------------------------------------------------------------
+// Block-level movement along the page
+//
+// Distinct from the tree predicates above: these walk the reading order one
+// block at a time, which is how the arrow keys behave.  They take the *plan*
+// rather than the blocks, since "am I part-way through this block?" is a
+// question about utterances.
+
+/** First plan index belonging to the same block as `planIndex`. */
+export function blockStart(plan, planIndex) {
+    const item = plan[planIndex];
+    if (!item) return -1;
+    let i = planIndex;
+    while (i > 0 && plan[i - 1].blockIndex === item.blockIndex) i--;
+    return i;
+}
+
+/**
+ * Start of the previous block, or of this one when the listener is part-way
+ * through it — "up" means "back to where this started" before it means
+ * "back one block", which is what makes repeated presses walk backwards.
+ */
+export function previousBlockStart(plan, planIndex, allowed) {
+    const start = blockStart(plan, planIndex);
+    if (start === -1) return -1;
+    if (start !== planIndex) return start;
+    for (let i = start - 1; i >= 0; i--) {
+        if (plan[i].blockIndex !== plan[start].blockIndex) {
+            const candidate = blockStart(plan, i);
+            if (!allowed || allowed(plan[candidate].blockIndex)) return candidate;
+            i = candidate;
+        }
+    }
+    return -1;
+}
+
+/** Start of the next block in reading order. */
+export function nextBlockStart(plan, planIndex, allowed) {
+    const item = plan[planIndex];
+    if (!item) return -1;
+    for (let i = planIndex + 1; i < plan.length; i++) {
+        if (plan[i].blockIndex !== item.blockIndex) {
+            if (!allowed || allowed(plan[i].blockIndex)) return i;
+            // Skip the whole of a disallowed block, not just its first line.
+            const skipped = plan[i].blockIndex;
+            while (i + 1 < plan.length && plan[i + 1].blockIndex === skipped) i++;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Traversal filter for the aside listening modes.
+ *
+ * Titles are always read: a sighted reader sees an aside's heading whether or
+ * not they click it, so "skip" must still announce that the aside exists —
+ * otherwise it is invisible to the listener and the arrow keys have nothing
+ * to land on.  The mode governs only the body.
+ *
+ * `entered` is the set of aside nodes the listener explicitly opened, which
+ * override the mode for that aside alone.
+ */
+export function shouldSpeak(blocks, index, mode, entered) {
+    const block = blocks[index];
+    if (!block) return false;
+    const asides = block.path.filter((n) => n.aside);
+
+    // A title is always read, so the aside it names does not gate it — but
+    // any aside *containing* that one still does.  Without this, skipping a
+    // theorem's body would still announce the proof nested inside it, which
+    // the listener has no way to reach and did not ask to hear.
+    const gating = block.summary ? asides.slice(0, -1) : asides;
+    return gating.every(
+        (n) => mode === "read" || (entered ? entered.has(n.el) : false)
+    );
+}
+
+/**
+ * The next block to speak at or after `index` under the current mode, or -1
+ * at the end of the page.
+ */
+export function nextSpeakable(blocks, index, mode, entered) {
+    for (let i = Math.max(0, index); i < blocks.length; i++) {
+        if (shouldSpeak(blocks, i, mode, entered)) return i;
+    }
+    return -1;
+}

--- a/js/src/read-aloud/nodes.js
+++ b/js/src/read-aloud/nodes.js
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * nodes.js — which DOM elements count as navigable tree nodes
+ *******************************************************************************
+ * PreTeXt's HTML preserves the authoring tree: every major block is emitted as
+ * an element carrying both its PreTeXt element name and its "-like" family
+ * (e.g. `<article class="lemma theorem-like">`), and divisions nest as
+ * `<section>`s.  That is the tree a listener wants to move around in, so this
+ * file is the single place that maps CSS classes to node descriptors — the one
+ * spot coupled to PreTeXt's class vocabulary.
+ *
+ * A descriptor is plain data plus the element:
+ *   { el, type, family, aside }
+ *     type    the PreTeXt element name  ("lemma", "example", "section")
+ *     family  the "-like" grouping      ("theorem-like") or "division"
+ *     aside   true for content a sighted reader must click to see
+ *
+ * Granularity is deliberately coarse: the major blocks an author thinks in,
+ * not every list item.  Navigating to "the next theorem-like" is useful;
+ * stopping at every `case` or `li` would make navigation unusable.
+ ******************************************************************************/
+
+// The "-like" families PreTeXt emits.  Membership here is what makes a block
+// a navigable node, so adding a family is how navigation grows later.
+const FAMILIES = new Set([
+    "theorem-like",
+    "definition-like",
+    "example-like",
+    "project-like",
+    "remark-like",
+    "computation-like",
+    "assemblage-like",
+    "goal-like",
+    "openproblem-like",
+    "exercise-like",
+    "solution-like",
+    "discussion-like",
+    "aside-like",
+    "figure-like",
+    "table-like",
+]);
+
+// Divisions, which nest to form the document's spine.  Only ever read off a
+// <section>, since these words also appear as classes on unrelated wrappers
+// (e.g. `<div class="pretext article ignore-math">`).
+const DIVISIONS = new Set([
+    "article",
+    "chapter",
+    "section",
+    "subsection",
+    "subsubsection",
+    "appendix",
+    "exercises",
+    "worksheet",
+    "introduction",
+    "conclusion",
+    "paragraphs",
+    "reading-questions",
+    "references",
+    "solutions",
+    "glossary",
+    "backmatter",
+    "frontmatter",
+]);
+
+// Blocks with no "-like" family that still deserve to be nodes, because they
+// are routinely born hidden and so are things a listener steps into or past.
+// A born-hidden proof is emitted as "hiddenproof", not "proof", and missing
+// that spelling makes it invisible to navigation: it is not recognized as an
+// aside, so skipping its theorem still reads it, and the blocks inside it
+// report the enclosing theorem as their type.
+const BARE_BLOCKS = new Set(["proof", "hiddenproof"]);
+
+// Content a sighted reader must click to reveal.  Each is a <details>, so the
+// content is already in the DOM and needs no fetching (unlike xref knowls).
+const ASIDE_CLASSES = {
+    "born-hidden-knowl": null, // type comes from its own block classes
+    "ptx-footnote": "footnote",
+    "image-description": "description",
+};
+
+/**
+ * Describe `el` as a tree node, or return null if it is not one.
+ *
+ * Called on every element during collection, so it stays allocation-light:
+ * a single pass over classList with no regex.
+ */
+export function nodeDescriptor(el) {
+    const classes = el.classList;
+    if (!classes || classes.length === 0) return null;
+
+    let family = null;
+    let type = null;
+    let aside = false;
+
+    for (const name of classes) {
+        if (FAMILIES.has(name)) {
+            family = name;
+        } else if (name in ASIDE_CLASSES) {
+            aside = true;
+            if (ASIDE_CLASSES[name]) type = ASIDE_CLASSES[name];
+        }
+    }
+
+    // The PreTeXt element name is the first class token: "lemma theorem-like"
+    // yields "lemma".  A block emitted with only its family (some generated
+    // content does this) falls back to the family name.
+    if (family && !type) {
+        type = classes[0] === family ? family : classes[0];
+    }
+
+    if (!type && BARE_BLOCKS.has(classes[0])) {
+        type = classes[0];
+    }
+
+    if (!type && el.tagName === "SECTION" && DIVISIONS.has(classes[0])) {
+        type = classes[0];
+        family = "division";
+    }
+
+    return type ? { el, type, family, aside } : null;
+}
+
+/** True when the node is one the listener chose not to see by default. */
+export function isAside(node) {
+    return !!node && node.aside;
+}

--- a/js/src/read-aloud/package.json
+++ b/js/src/read-aloud/package.json
@@ -1,0 +1,4 @@
+{
+    "//": "Marks the read-aloud sources as ES modules so Node can run the unit tests in test/ directly (node --test).  esbuild ignores this file when bundling.",
+    "type": "module"
+}

--- a/js/src/read-aloud/player-ui.js
+++ b/js/src/read-aloud/player-ui.js
@@ -1,0 +1,575 @@
+/*******************************************************************************
+ * player-ui.js — in-navbar player, click-to-start, MediaSession, continue flow
+ *******************************************************************************
+ * The markup (button #ptx-read-aloud-button, player #ptx-read-aloud-player)
+ * is emitted by the XSL only when the publication option is on.  Words this
+ * file speaks or writes into tooltips come from strings.js; the XSL's own
+ * labels are literal text there.  Read-aloud is HTML-only, so neither side
+ * goes through xsl/localizations.
+ *
+ * DOM contract with the XSL:
+ *   #ptx-read-aloud-button     toolbar button; a disclosure toggle for the
+ *                              player, and the only way to dismiss it
+ *   #ptx-read-aloud-player     navbar strip; data-state attr drives CSS
+ *     #ptx-read-aloud-prev / -toggle / -next            control buttons
+ *     #ptx-read-aloud-continue                          next-section link
+ *     #ptx-read-aloud-settings-button                   opens the dialog below
+ *   #ptx-read-aloud-settings-popup   voice / rate / asides / auto-scroll /
+ *                                    auto-continue
+ *     #ptx-read-aloud-settings-close-button
+ ******************************************************************************/
+
+import { collect } from "./collector.js";
+import { buildPlan } from "./segmenter.js";
+import { SpeechQueue } from "./speech-queue.js";
+import { Highlighter } from "./highlighter.js";
+import { enclosingBlock } from "./navigation.js";
+import { STRINGS } from "./strings.js";
+import {
+    initSettingsControls,
+    getSavedVoice,
+    getSavedRate,
+    getSavedAutoScroll,
+    getSavedAutoContinue,
+    getSavedAsideMode,
+    whenVoicesReady,
+    documentLang,
+} from "./settings.js";
+
+// Set as one page hands off to the next.  Two values, because the next page
+// has to behave differently: "true" is the reader clicking Continue, which
+// only asks for a player ready to play; "auto" is the auto-continue setting,
+// which asks the new page to start reading by itself if the browser lets it.
+const CONTINUE_FLAG = "ptxReadAloudContinue";
+const CONTINUE_AUTO = "auto";
+
+// How long to let a continued page prove it is actually speaking before
+// giving up and asking for a click.  Generous, because the first utterance
+// on a fresh page can wait on voice loading; a browser that refuses outright
+// usually fires its error well inside this.
+const AUTOPLAY_GRACE_MS = 3000;
+
+// How many times to explain the open key before trusting the reader to know.
+const OPEN_HINT_KEY = "readAloudOpenHintShown";
+const OPEN_HINT_LIMIT = 3;
+
+// Clicks on (or inside) these are navigation/interaction, not click-to-start.
+const INTERACTIVE_SELECTOR =
+    "a, button, input, select, textarea, summary, label, iframe, " +
+    "audio, video, [data-knowl], .knowl__link, .sagecell";
+
+export class ReadAloudPlayer {
+    constructor(button, player) {
+        this.button = button;
+        this.player = player;
+        this.strings = STRINGS;
+        this.content = document.getElementById("ptx-content");
+        this.blocks = [];
+        // Whether the current reading has produced any actual sound.  Guards
+        // both auto-continue and the autoplay fallback; see _shouldAutoContinue.
+        this.hasSpoken = false;
+
+        this.highlighter = new Highlighter();
+        this.highlighter.autoScroll = getSavedAutoScroll();
+
+        this.queue = new SpeechQueue({
+            onUtterance: (i, item) => this._onUtterance(i, item),
+            onState: (state) => this._onState(state),
+            onEnded: () => this._onEnded(),
+            mode: getSavedAsideMode(),
+            describeBlock: (blockIndex) => this._describeBlock(blockIndex),
+        });
+        this.queue.setLang(documentLang());
+
+        initSettingsControls(({ voice, rate, autoScroll, asideMode }) => {
+            this.queue.setVoice(voice);
+            this.queue.setRate(rate);
+            // Takes effect at the next block boundary — no recollection, so
+            // the listener can change their mind mid-page.
+            this.queue.setMode(asideMode);
+            this.highlighter.autoScroll = autoScroll;
+        });
+
+        this._wireControls();
+        this._wireSettingsDialog();
+        this._wireClickToStart();
+        this._wireMediaSession();
+    }
+
+    /**
+     * The settings dialog, opened from the player's own settings button.
+     *
+     * These controls used to sit in the readability-options dialog, but they
+     * are only meaningful while something is being read, and burying them
+     * behind a general typography menu made them hard to find at the moment
+     * they mattered.  PTXDialog comes from pretext-core.js, which the XSL
+     * always loads first; guard anyway so a missing bundle costs the settings
+     * button rather than the whole player.
+     */
+    _wireSettingsDialog() {
+        const popup = document.getElementById("ptx-read-aloud-settings-popup");
+        const button = document.getElementById("ptx-read-aloud-settings-button");
+        if (!popup || !button || !window.PTXDialog) return;
+        this.settingsPopup = popup;
+        // "light-close": a click anywhere outside dismisses it.  Settings are
+        // a detour from listening, so getting back should not require aiming
+        // at the close button.
+        this.settingsDialog = new window.PTXDialog(popup, button, {
+            kind: "light-close",
+            closeButton: document.getElementById(
+                "ptx-read-aloud-settings-close-button"
+            ),
+        });
+    }
+
+    //------------------------------------------------------------------
+    // Opening and closing
+
+    open() {
+        this.player.hidden = false;
+        this._setButtonState(true);
+        // Continuation from the previous page (decision #10): don't fight
+        // the browser's activation rules — present a ready-to-play player.
+        sessionStorage.removeItem(CONTINUE_FLAG);
+    }
+
+    close() {
+        this.queue.stop();
+        this.highlighter.clear();
+        // The settings dialog belongs to the player; leaving it open over a
+        // navbar that no longer shows a player is orphaned UI.  Only when it
+        // is actually open — PTXDialog.close() also moves focus to its own
+        // trigger, which would yank focus on every ordinary player close.
+        if (this.settingsPopup && this.settingsPopup.open) {
+            this.settingsDialog.close();
+        }
+        // Hand focus back before hiding, but only if it is ours to hand back:
+        // closing the settings dialog above leaves focus on its trigger,
+        // which is inside the player and about to disappear.
+        const focusWasInside = this.player.contains(document.activeElement);
+        this.player.hidden = true;
+        this._setButtonState(false);
+        if (focusWasInside) this.button.focus();
+        if (navigator.mediaSession) {
+            navigator.mediaSession.playbackState = "none";
+        }
+    }
+
+    /**
+     * Keep the toolbar button reading as the disclosure toggle it now is.
+     *
+     * With the player's own close button gone, this button is the only way
+     * back, so its tooltip has to name the action rather than the feature —
+     * "Read aloud" on a control that hides the read-aloud player is worse
+     * than no tooltip at all.
+     */
+    _setButtonState(open) {
+        this.button.setAttribute("aria-expanded", String(open));
+        const title = open
+            ? this.strings["read-aloud-hide"]
+            : this.strings["read-aloud-show"];
+        if (title) this.button.title = title;
+    }
+
+    get isOpen() {
+        return !this.player.hidden;
+    }
+
+    //------------------------------------------------------------------
+    // Playback
+
+    async _ensurePlan() {
+        // Collect from the live DOM so opened knowls are included.  (collect
+        // waits for MathJax itself: an untypeset page has no math to find.)
+        this.blocks = await collect(this.content, { strings: this.strings });
+        const plan = buildPlan(this.blocks, {
+            locale: documentLang(),
+            strings: this.strings,
+        });
+        // The engine reports no voices until it is ready, and an unset voice
+        // silently means "system default" — so asking too early discards the
+        // reader's saved choice without any error to notice.
+        await whenVoicesReady();
+        this.queue.setVoice(getSavedVoice());
+        this.queue.setRate(getSavedRate());
+        this.queue.setPlan(plan, this.blocks);
+    }
+
+    async playFromTop() {
+        this.highlighter.resetScrollSuppression();
+        // Reset per-reading, not per-page: it answers "did this run actually
+        // produce sound?", which is what both the autoplay watchdog and the
+        // auto-continue guard need.
+        this.hasSpoken = false;
+        await this._ensurePlan();
+        this.queue.playFrom(0);
+    }
+
+    /**
+     * Start a page that the previous one handed off to via auto-continue.
+     *
+     * Speech is gated behind user activation in Chrome and Safari, and
+     * whether a navigation carries that activation into the new document
+     * varies by browser and by how the navigation was made — so this tries,
+     * and is built to be refused.  If nothing has actually spoken by the end
+     * of the grace period, it drops into exactly the state the manual
+     * Continue link produces: player open, play button pulsing, one click
+     * away from reading.  The listener is never left in silence with no
+     * visible next step.
+     */
+    async resumeContinuation() {
+        await this.playFromTop();
+        setTimeout(() => {
+            if (this.hasSpoken) return;
+            this.queue.stop();
+            this.highlighter.clear();
+            this.player.dataset.state = "continue-ready";
+        }, AUTOPLAY_GRACE_MS);
+    }
+
+    async toggle() {
+        this.highlighter.resetScrollSuppression();
+        if (this.queue.state === "idle" || this.queue.state === "ended") {
+            await this.playFromTop();
+        } else {
+            this.queue.toggle();
+        }
+    }
+
+    //------------------------------------------------------------------
+    // Queue callbacks
+
+    _onUtterance(index, item) {
+        this.hasSpoken = true;
+        this._reveal(this.blocks[item.blockIndex]);
+        this.highlighter.show(item, this.blocks);
+    }
+
+    /**
+     * Open any collapsed <details> around the block about to be spoken.
+     *
+     * Collection deliberately reaches inside closed knowls, so playback can
+     * arrive somewhere the reader cannot see.  Opening on arrival keeps the
+     * page in step with the audio — and the highlighter needs the text
+     * rendered to highlight it at all.
+     *
+     * A title is the exception: reading "Theorem 3.2" is not a reason to
+     * expand the theorem, since in skip mode the body is never read and a
+     * sighted reader would still be looking at a closed knowl.
+     */
+    _reveal(block) {
+        if (!block || !block.el) return;
+        let details = block.el.closest("details");
+        // Skip the aside this title belongs to; ancestors still open, so a
+        // knowl nested in an opened knowl stays visible.
+        if (block.summary && details) {
+            details = details.parentElement
+                ? details.parentElement.closest("details")
+                : null;
+        }
+        while (details) {
+            if (!details.open) details.open = true;
+            details = details.parentElement
+                ? details.parentElement.closest("details")
+                : null;
+        }
+    }
+
+    /**
+     * What kind of block the arrow keys have landed on, for the spoken
+     * announcement.  PreTeXt already renders localized type names into the
+     * page — in a knowl's heading and in every permalink's @data-description
+     * — so they are read back out of the DOM rather than duplicated as new
+     * localization strings that could drift out of step.
+     */
+    _describeBlock(blockIndex) {
+        const block = this.blocks[blockIndex];
+        if (!block || !block.el) return null;
+        const node = enclosingBlock(this.blocks, blockIndex);
+
+        // A title names its block; anything else names *itself*.  Without the
+        // split, every paragraph of a proof announces as "Proof" — the block
+        // it happens to sit in rather than what the listener landed on.
+        const name = block.summary
+            ? this._typeName(node)
+            : this._selfName(block) || this._typeName(node);
+        if (!name) return null;
+
+        const hint = this._openableAside(blockIndex) ? this._openHint() : null;
+        return hint ? `${name} ${hint}` : name;
+    }
+
+    /** The type name PreTeXt rendered for a node, e.g. "Theorem", "Proof.". */
+    _typeName(node) {
+        if (!node || !node.el || !node.el.querySelector) return null;
+        const typeSpan = node.el.querySelector(
+            ":scope > summary .type, :scope > .heading .type, " +
+            ":scope > h1 .type, :scope > h2 .type, :scope > h3 .type, " +
+            ":scope > h4 .type, :scope > h5 .type, :scope > h6 .type"
+        );
+        const name = typeSpan && typeSpan.textContent.trim();
+        if (name) return name;
+
+        // A footnote's name *and number* are in its tooltip ("Footnote 3.1"),
+        // which beats the bare "Footnote" below: on a page of footnotes the
+        // number is the only thing telling one announcement from the next.
+        // Read only the footnote's tooltip — an image description's says the
+        // untranslated literal "details".
+        const tooltip = node.el.querySelector(
+            ":scope > summary.ptx-footnote__number[title]"
+        );
+        if (tooltip) {
+            const label = tooltip.getAttribute("title").trim();
+            if (label) return label;
+        }
+
+        // Footnotes and image descriptions render no type name at all — just
+        // a superscript number or an icon — so they are the two blocks whose
+        // names have to be supplied rather than read back out of the page.
+        return this.strings[node.type] || null;
+    }
+
+    /** What a non-title block calls itself, from its own permalink. */
+    _selfName(block) {
+        if (!block.el.querySelector) return null;
+        const permalink = block.el.querySelector(":scope > [data-description]");
+        return (permalink && permalink.getAttribute("data-description")) || null;
+    }
+
+    /** The aside this block titles, if it is one and it is still closed. */
+    _openableAside(blockIndex) {
+        const block = this.blocks[blockIndex];
+        if (!block || !block.summary) return null;
+        const asides = block.path.filter((n) => n.aside);
+        const own = asides[asides.length - 1];
+        return own && !this.queue.entered.has(own.el) ? own : null;
+    }
+
+    /**
+     * "Press space to open", for the first few knowls a reader meets.
+     *
+     * An audio interface has no affordances to look at, so the only way to
+     * learn the key is to be told — but being told every time, on a page with
+     * forty knowls, is unbearable.  The count persists across pages so the
+     * hint fades over a session rather than restarting with every navigation.
+     */
+    _openHint() {
+        const hint = this.strings["read-aloud-open-hint"];
+        if (!hint) return null;
+        const shown = Number(localStorage.getItem(OPEN_HINT_KEY)) || 0;
+        if (shown >= OPEN_HINT_LIMIT) return null;
+        localStorage.setItem(OPEN_HINT_KEY, String(shown + 1));
+        return hint;
+    }
+
+    _onState(state) {
+        this.player.dataset.state = state;
+        const toggleButton = document.getElementById("ptx-read-aloud-toggle");
+        if (toggleButton) {
+            const speaking = state === "speaking";
+            toggleButton.title = speaking
+                ? this.strings["read-aloud-pause"]
+                : this.strings["read-aloud-play"];
+            toggleButton.setAttribute("aria-pressed", String(speaking));
+        }
+        if (navigator.mediaSession) {
+            navigator.mediaSession.playbackState =
+                state === "speaking" ? "playing"
+                : state === "paused" ? "paused"
+                : "none";
+        }
+    }
+
+    /** Where the page's own "next" navigation button points, or null. */
+    _nextPageHref() {
+        const nextLink = document.querySelector(".next-button:not(.disabled)");
+        const href = nextLink && nextLink.getAttribute("href");
+        return href || null;
+    }
+
+    /**
+     * May the reading carry itself on to the next page?
+     *
+     * The setting is necessary but not sufficient.  `hasSpoken` is the guard
+     * that matters: an engine that refuses to speak reports an error per
+     * utterance, and the queue's own error handling would otherwise reach
+     * this same "finished the page" callback in a few milliseconds without a
+     * word having been heard.  Auto-continuing from there would do it again
+     * on the next page, and the one after — a silent runaway through the
+     * whole book.  Requiring that something was actually spoken keeps a
+     * refused page from ever handing off.
+     */
+    _shouldAutoContinue() {
+        return getSavedAutoContinue() && this.hasSpoken;
+    }
+
+    _onEnded() {
+        this.highlighter.clear();
+        const href = this._nextPageHref();
+        if (!href) return;
+
+        // Offer the manual link either way: if auto-continue is refused or
+        // the announcement is cut short, this is the fallback in place.
+        const continueLink = document.getElementById("ptx-read-aloud-continue");
+        if (continueLink) {
+            continueLink.href = href;
+            continueLink.hidden = false;
+        }
+
+        if (this._shouldAutoContinue()) {
+            sessionStorage.setItem(CONTINUE_FLAG, CONTINUE_AUTO);
+            this.queue.speakOnce(this.strings["read-aloud-continuing"], () => {
+                window.location.href = href;
+            });
+        }
+    }
+
+    //------------------------------------------------------------------
+    // Wiring
+
+    _wireControls() {
+        const on = (id, handler) => {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener("click", handler);
+        };
+        on("ptx-read-aloud-toggle", () => this.toggle());
+        on("ptx-read-aloud-next", () => {
+            this.highlighter.resetScrollSuppression();
+            this.queue.next();
+        });
+        on("ptx-read-aloud-prev", () => {
+            this.highlighter.resetScrollSuppression();
+            this.queue.prev();
+        });
+
+        const continueLink = document.getElementById("ptx-read-aloud-continue");
+        if (continueLink) {
+            continueLink.addEventListener("click", () => {
+                // Ask the next page to present the player ready to play.
+                sessionStorage.setItem(CONTINUE_FLAG, "true");
+            });
+        }
+
+        // Two axes: horizontal moves along the reading line, vertical moves
+        // through the document tree.  Horizontal works whenever the player has
+        // focus; vertical is bound document-wide, since the whole point is to
+        // steer asides while listening rather than while pointing at buttons.
+        this.player.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowRight") {
+                e.preventDefault();
+                this.queue.next();
+            } else if (e.key === "ArrowLeft") {
+                e.preventDefault();
+                this.queue.prev();
+            }
+        });
+
+        document.addEventListener("keydown", (e) => {
+            // Only while actually reading, or the page cannot be scrolled and
+            // arrow keys are stolen from every form control on it.
+            if (this.queue.state !== "speaking" && this.queue.state !== "paused") {
+                return;
+            }
+            if (e.altKey || e.ctrlKey || e.metaKey) return;
+            if (e.target.closest("input, textarea, select, [contenteditable]")) {
+                return;
+            }
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                this.queue.nextBlock();
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                this.queue.previousBlock();
+            } else if (e.key === " " || e.key === "ArrowRight") {
+                // Accept the block the arrow keys landed on and read it.
+                if (this.queue.pendingStart) {
+                    e.preventDefault();
+                    this.queue.resume();
+                }
+            }
+        });
+    }
+
+    _wireClickToStart() {
+        if (!this.content) return;
+        this.content.addEventListener("click", (e) => {
+            if (!this.isOpen) return;
+            if (e.target.closest(INTERACTIVE_SELECTOR)) return;
+            // Find the deepest collected block containing the click.
+            let blockIndex = -1;
+            this.blocks.forEach((b, i) => {
+                if (b.el && b.el.contains(e.target)) blockIndex = i;
+            });
+            if (blockIndex < 0) return;
+            const planIndex = this._planIndexForClick(blockIndex, e.target);
+            if (planIndex >= 0) {
+                this.highlighter.resetScrollSuppression();
+                this.queue.playFrom(planIndex);
+            }
+        });
+    }
+
+    /**
+     * The utterance a click landed on, falling back to the head of the block.
+     *
+     * Clicking the fourth sentence of a paragraph should start there, not
+     * restart the paragraph, so this matches the clicked text node against
+     * the plan's range map (segmenter.js keeps ranges pointing at the
+     * original DOM text nodes precisely so this is possible).
+     */
+    _planIndexForClick(blockIndex, target) {
+        const block = this.blocks[blockIndex];
+        const fallback = this.queue.indexForBlock(blockIndex);
+        if (!block || !target) return fallback;
+
+        // The clicked text nodes, in the element the reader actually hit.
+        const clicked = new Set();
+        const walk = (el) => {
+            for (const child of el.childNodes) {
+                if (child.nodeType === Node.TEXT_NODE) clicked.add(child);
+                else if (child.nodeType === Node.ELEMENT_NODE) walk(child);
+            }
+        };
+        if (target.nodeType === Node.ELEMENT_NODE) walk(target);
+
+        for (let i = 0; i < this.queue.plan.length; i++) {
+            const item = this.queue.plan[i];
+            if (item.blockIndex !== blockIndex) continue;
+            for (const range of item.ranges) {
+                const token = block.tokens[range.tokenIndex];
+                if (!token) continue;
+                if (token.node && clicked.has(token.node)) return i;
+                if (token.el && (token.el === target || token.el.contains(target))) {
+                    return i;
+                }
+            }
+        }
+        return fallback;
+    }
+
+    _wireMediaSession() {
+        if (!("mediaSession" in navigator)) return;
+        try {
+            navigator.mediaSession.metadata = new MediaMetadata({
+                title: document.title,
+            });
+            navigator.mediaSession.setActionHandler("play", () => this.toggle());
+            navigator.mediaSession.setActionHandler("pause", () => this.queue.pause());
+            navigator.mediaSession.setActionHandler("previoustrack", () => this.queue.prev());
+            navigator.mediaSession.setActionHandler("nexttrack", () => this.queue.next());
+        } catch (e) {
+            // MediaSession is progressive enhancement; never let it break playback.
+        }
+    }
+}
+
+/**
+ * How the previous page's reading session asked this one to carry on:
+ * "auto" to start reading unprompted, "manual" to present a ready player,
+ * or null when the reader simply navigated here themselves.
+ */
+export function continuationMode() {
+    const flag = sessionStorage.getItem(CONTINUE_FLAG);
+    if (flag === CONTINUE_AUTO) return "auto";
+    return flag === "true" ? "manual" : null;
+}

--- a/js/src/read-aloud/segmenter.js
+++ b/js/src/read-aloud/segmenter.js
@@ -1,0 +1,286 @@
+/*******************************************************************************
+ * segmenter.js — pure IR → utterance-plan stage of the read-aloud pipeline
+ *******************************************************************************
+ * No DOM access here: input and output are plain data so this file can be
+ * unit-tested with Node's built-in test runner (see test/segmenter.test.js).
+ *
+ * INPUT — blocks, as produced by collector.js:
+ *   Block: { el?, tokens: Token[] }
+ *   Token:
+ *     { kind: "text",     value, node? }          one token per DOM text node
+ *     { kind: "math",     speech, display, el? }  speech text from MathJax
+ *     { kind: "announce", stringId, el? }         "Table. Skipping." etc.
+ *
+ * OUTPUT — plan, consumed by speech-queue.js and highlighter.js:
+ *   Utterance: {
+ *     kind: "speech" | "announce",
+ *     text,                    what speechSynthesis will say
+ *     blockIndex,              index into the input blocks array
+ *     ranges: Range[]          source map for highlighting
+ *   }
+ *   Range:
+ *     { tokenIndex, start, end }   char span in a text token's ORIGINAL value
+ *     { tokenIndex }               a math or announce token, highlighted whole
+ *
+ * Sentence boundaries come from Intl.Segmenter when available (locale-aware),
+ * with a regex fallback.  Two invariants the tests enforce:
+ *   - a boundary never falls inside spliced math speech (which may contain
+ *     periods, e.g. "equals 3.2"), and
+ *   - utterances longer than maxLength are split at clause boundaries, never
+ *     inside math.
+ ******************************************************************************/
+
+// Default maximum utterance length in characters.  Chrome's speech synthesis
+// silently dies partway through very long utterances (notoriously ~15s with
+// network voices), so outliers are clamped at clause boundaries.
+const DEFAULT_MAX_LENGTH = 250;
+
+/**
+ * Collapse runs of whitespace to single spaces, keeping a map from each
+ * collapsed-string index back to the index in the original string.  The map
+ * is what lets highlight ranges refer to original DOM text-node offsets even
+ * though sentence math is done on normalized text.
+ */
+export function collapseWhitespace(value) {
+    let text = "";
+    const map = [];
+    let inSpace = false;
+    for (let i = 0; i < value.length; i++) {
+        if (/\s/.test(value[i])) {
+            if (!inSpace && text.length > 0) {
+                text += " ";
+                map.push(i);
+            }
+            inSpace = true;
+        } else {
+            text += value[i];
+            map.push(i);
+            inSpace = false;
+        }
+    }
+    // Drop a trailing space introduced by trailing whitespace
+    if (text.endsWith(" ")) {
+        text = text.slice(0, -1);
+        map.pop();
+    }
+    return { text, map };
+}
+
+// ICU (via Intl.Segmenter) already keeps "e.g. when" and "Fig. 4" together
+// because the continuation is lowercase or a digit; it only mis-splits when
+// an abbreviation is followed by a capitalized word ("Dr. Smith",
+// "e.g. Theorem").  Suppress boundaries preceded by either
+//   - one of these common title/reference abbreviations, or
+//   - a dotted initialism: two or more single letters each followed by a
+//     period ("e.g.", "i.e.", "a.m.", "U.S.").  These need a shape rule
+//     rather than a word list because the piece before the final period is
+//     itself a lone letter, so no whitespace precedes it.
+// The abbreviation may be preceded by an opening bracket or quote as well as
+// by whitespace, so that "(e.g. Theorem 3.2)" is also handled.
+const ABBREVIATION_RE =
+    /(?:^|[\s(\[{"'“‘])(?:Dr|Mr|Mrs|Ms|Prof|St|Mt|Fig|Eq|Ex|Sec|Ch|Thm|Cor|Lem|Def|Rem|Prop|vs|cf|No|Vol|pp?|ed|eds|etc|al|Ph\.D|(?:[A-Za-z]\.)+[A-Za-z])\.\s*$/;
+
+/**
+ * Return sentence-start boundaries (indices > 0) for `text`.
+ * Uses Intl.Segmenter when available; otherwise a conservative regex:
+ * split after .!?… followed by space + capital/digit/quote.
+ */
+export function sentenceBoundaries(text, locale) {
+    let boundaries = [];
+    if (typeof Intl !== "undefined" && Intl.Segmenter) {
+        const seg = new Intl.Segmenter(locale || undefined, { granularity: "sentence" });
+        for (const s of seg.segment(text)) {
+            if (s.index > 0) {
+                boundaries.push(s.index);
+            }
+        }
+    } else {
+        const re = /[.!?…]["')\]]?\s+(?=["'([]?[A-Z0-9])/g;
+        let m;
+        while ((m = re.exec(text)) !== null) {
+            boundaries.push(m.index + m[0].length);
+        }
+    }
+    return boundaries.filter((b) => !ABBREVIATION_RE.test(text.slice(0, b)));
+}
+
+// Insert a joining space between two concatenated parts unless the next part
+// begins with punctuation that should hug the previous word (e.g. the "."
+// after inline math in "\(f(x)\).").
+function needsJoinSpace(prev, next) {
+    if (prev === "" || next === "") return false;
+    if (/\s$/.test(prev)) return false;
+    if (/^\s/.test(next)) return false;
+    if (/^[.,;:!?…)\]}%]/.test(next)) return false;
+    return true;
+}
+
+/**
+ * Flatten a run of text/math tokens into one combined string plus spans.
+ * Each span records which slice of the combined string came from which token
+ * (and, for text tokens, the offset map back into the original value).
+ */
+function flattenRun(run) {
+    let combined = "";
+    const spans = [];
+    for (const { token, tokenIndex } of run) {
+        let part, map = null;
+        if (token.kind === "text") {
+            ({ text: part, map } = collapseWhitespace(token.value));
+        } else {
+            ({ text: part } = collapseWhitespace(token.speech || ""));
+        }
+        if (part === "") continue;
+        if (needsJoinSpace(combined, part)) {
+            combined += " ";
+        }
+        spans.push({
+            start: combined.length,
+            end: combined.length + part.length,
+            tokenIndex,
+            kind: token.kind,
+            map,
+        });
+        combined += part;
+    }
+    return { combined, spans };
+}
+
+// True if position `pos` in the combined string falls strictly inside a
+// math span — a place a sentence boundary or clamp split must never land.
+function insideMath(pos, spans) {
+    return spans.some(
+        (s) => s.kind === "math" && pos > s.start && pos < s.end
+    );
+}
+
+/**
+ * Split an over-long sentence [start, end) at clause boundaries.  Prefers
+ * ",;:—–" then a space, searching backward from the length limit; never
+ * splits inside a math span.  Returns an array of [start, end) pairs.
+ */
+function clampChunks(combined, spans, start, end, maxLength) {
+    const chunks = [];
+    let s = start;
+    while (end - s > maxLength) {
+        const limit = s + maxLength;
+        let cut = -1;
+        // Prefer cutting just after clause punctuation, then at any space.
+        const clauseCut = (i) => /[,;:—–]/.test(combined[i - 1]) && combined[i] === " ";
+        const spaceCut = (i) => combined[i] === " ";
+        for (const acceptable of [clauseCut, spaceCut]) {
+            for (let i = limit; i > s + 1; i--) {
+                if (insideMath(i, spans)) continue;
+                if (acceptable(i)) {
+                    cut = i;
+                    break;
+                }
+            }
+            if (cut >= 0) break;
+        }
+        if (cut < 0) {
+            // No safe split point at all (one giant unbroken token): hard cut,
+            // but step past any math span rather than bisect it.
+            cut = limit;
+            for (const sp of spans) {
+                if (sp.kind === "math" && cut > sp.start && cut < sp.end) {
+                    cut = sp.end;
+                    break;
+                }
+            }
+        }
+        chunks.push([s, cut]);
+        s = cut;
+    }
+    chunks.push([s, end]);
+    return chunks;
+}
+
+// Build one utterance from a [start, end) slice of the combined string.
+function makeUtterance(combined, spans, start, end, blockIndex) {
+    // Trim surrounding whitespace off the slice.
+    while (start < end && /\s/.test(combined[start])) start++;
+    while (end > start && /\s/.test(combined[end - 1])) end--;
+    if (start >= end) return null;
+
+    const ranges = [];
+    for (const span of spans) {
+        const s = Math.max(start, span.start);
+        const e = Math.min(end, span.end);
+        if (s >= e) continue;
+        if (span.kind === "text") {
+            // Map combined-string offsets back to original token offsets.
+            const localStart = s - span.start;
+            const localEnd = e - span.start;
+            ranges.push({
+                tokenIndex: span.tokenIndex,
+                start: span.map[localStart],
+                end: span.map[localEnd - 1] + 1,
+            });
+        } else {
+            ranges.push({ tokenIndex: span.tokenIndex });
+        }
+    }
+    return {
+        kind: "speech",
+        text: combined.slice(start, end),
+        blockIndex,
+        ranges,
+    };
+}
+
+/**
+ * Main entry: blocks → utterance plan.
+ *
+ * opts:
+ *   locale     BCP-47 tag for sentence segmentation (document language)
+ *   maxLength  clamp limit in characters (default 250)
+ *   strings    map stringId → localized text for announce tokens
+ */
+export function buildPlan(blocks, opts = {}) {
+    const locale = opts.locale;
+    const maxLength = opts.maxLength || DEFAULT_MAX_LENGTH;
+    const strings = opts.strings || {};
+    const plan = [];
+
+    blocks.forEach((block, blockIndex) => {
+        // Announce tokens split the block into runs of speakable tokens.
+        let run = [];
+        const flushRun = () => {
+            if (run.length === 0) return;
+            const { combined, spans } = flattenRun(run);
+            run = [];
+            if (combined.trim() === "") return;
+
+            // Sentence boundaries, merged across math spans.
+            const rawBoundaries = sentenceBoundaries(combined, locale);
+            const boundaries = rawBoundaries.filter((b) => !insideMath(b, spans));
+
+            const starts = [0, ...boundaries];
+            starts.forEach((s, i) => {
+                const e = i + 1 < starts.length ? starts[i + 1] : combined.length;
+                for (const [cs, ce] of clampChunks(combined, spans, s, e, maxLength)) {
+                    const utt = makeUtterance(combined, spans, cs, ce, blockIndex);
+                    if (utt) plan.push(utt);
+                }
+            });
+        };
+
+        block.tokens.forEach((token, tokenIndex) => {
+            if (token.kind === "announce") {
+                flushRun();
+                plan.push({
+                    kind: "announce",
+                    text: strings[token.stringId] || token.stringId,
+                    blockIndex,
+                    ranges: [{ tokenIndex }],
+                });
+            } else {
+                run.push({ token, tokenIndex });
+            }
+        });
+        flushRun();
+    });
+
+    return plan;
+}

--- a/js/src/read-aloud/settings.js
+++ b/js/src/read-aloud/settings.js
@@ -1,0 +1,277 @@
+/*******************************************************************************
+ * settings.js — voice / rate / scroll / continue persistence, dialog controls
+ *******************************************************************************
+ * Mirrors the readability-options.js patterns: values live in localStorage,
+ * controls sit in the readability dialog (XSL emits them when the read-aloud
+ * publication option is on), and this module keeps both in sync.
+ *
+ * The voice picker is populated from speechSynthesis.getVoices(), which is
+ * empty until the voiceschanged event fires on Chrome — so population runs
+ * both immediately and on that event.  Voices are filtered to the document
+ * language (decision #9), falling back to the full list when nothing matches.
+ ******************************************************************************/
+
+const VOICE_KEY = "readAloudVoice";
+const RATE_KEY = "readAloudRate";
+const AUTOSCROLL_KEY = "readAloudAutoScroll";
+const ASIDES_KEY = "readAloudAsides";
+const AUTOCONTINUE_KEY = "readAloudAutoContinue";
+
+// What happens to a knowl's body once its always-spoken title has been read.
+// No "ask": the arrow keys already stop at every block.
+const ASIDE_MODES = ["skip", "read"];
+
+/**
+ * Default "skip": a listener who has not touched the setting gets what a
+ * reader who never clicks a knowl sees, which is also what the page looked
+ * like before this feature existed.
+ */
+export function getSavedAsideMode() {
+    const value = localStorage.getItem(ASIDES_KEY);
+    return ASIDE_MODES.includes(value) ? value : "skip";
+}
+
+export function getSavedRate() {
+    const value = Number(localStorage.getItem(RATE_KEY));
+    return value >= 0.5 && value <= 2 ? value : 1;
+}
+
+export function getSavedAutoScroll() {
+    return localStorage.getItem(AUTOSCROLL_KEY) !== "false";
+}
+
+/**
+ * Whether finishing a page should carry the reading on to the next one.
+ *
+ * Default off, unlike auto-scroll: this one navigates.  A listener who walked
+ * away from a page that has just gone quiet expects to still be on it, and a
+ * reader who left the player open while doing something else would otherwise
+ * find the browser several pages downstream.  Opt in, and it persists.
+ */
+export function getSavedAutoContinue() {
+    return localStorage.getItem(AUTOCONTINUE_KEY) === "true";
+}
+
+export function documentLang() {
+    return (document.documentElement.lang || "en").toLowerCase();
+}
+
+// Primary subtag of a language tag.  Engines are inconsistent about the
+// separator — speech-dispatcher reports POSIX-style locales ("en_US") while
+// the Web Speech spec uses BCP-47 ("en-US") — so normalize before comparing,
+// or the language filter silently matches nothing.
+function primaryLanguage(tag) {
+    return (tag || "").toLowerCase().replace(/_/g, "-").split("-")[0];
+}
+
+/** Voices matching the document language, or all voices if none match. */
+export function candidateVoices() {
+    const all = window.speechSynthesis.getVoices();
+    const lang = primaryLanguage(documentLang());
+    const matching = all.filter((v) => primaryLanguage(v.lang) === lang);
+    return matching.length ? matching : all;
+}
+
+// Voice quality varies enormously, and the voice a system reports as its
+// default is often not the best one installed: on Linux, speech-dispatcher
+// answers with espeak-ng even when a far better engine is present.  Rank by
+// well-known engine names so a reader hears the best available voice without
+// hunting through the picker.  Their own choice always wins and is
+// remembered; this only decides where to start and how to order the list.
+const VOICE_QUALITY_RULES = [
+    { test: /neural|natural|premium|enhanced|siri/i, score: 3 },
+    { test: /google|rhvoice|piper/i, score: 2 },
+    { test: /espeak|flite|festival|dummy/i, score: -1 },
+];
+
+function voiceQuality(voice) {
+    const name = `${voice.name} ${voice.voiceURI}`;
+    const rule = VOICE_QUALITY_RULES.find((r) => r.test.test(name));
+    return rule ? rule.score : 0;
+}
+
+/** Candidate voices, best first; ties keep the browser's own ordering. */
+export function rankedVoices() {
+    // Array.prototype.sort is stable, so equal-ranked voices stay in the
+    // order the browser reported them.
+    return candidateVoices()
+        .slice()
+        .sort(
+            (a, b) =>
+                voiceQuality(b) - voiceQuality(a) ||
+                (b.default ? 1 : 0) - (a.default ? 1 : 0)
+        );
+}
+
+// Memoized: on platforms that never enumerate voices this waits out its full
+// deadline, and doing that on every play would put a pause before each one.
+let voicesReady = null;
+
+/**
+ * Resolve once the engine has reported its voices — or once it is clear it
+ * never will.
+ *
+ * getVoices() is empty until the voiceschanged event on Chrome, and
+ * getSavedVoice() answers null for an empty list, which the engine reads as
+ * "use the system default".  So asking too early does not fail loudly; it
+ * quietly speaks in the wrong voice, ignoring both the reader's saved choice
+ * and the quality ranking.  Only a start at page load is early enough to hit
+ * this — auto-continue, in practice.
+ *
+ * The timeout is not a failure path: Firefox on Linux may enumerate nothing
+ * while still speaking perfectly well through speech-dispatcher, and there
+ * the system default is genuinely the right answer.
+ */
+export function whenVoicesReady(timeoutMs = 2500) {
+    if (voicesReady) return voicesReady;
+    voicesReady = new Promise((resolve) => {
+        if (rankedVoices().length) {
+            resolve();
+            return;
+        }
+        let done = false;
+        const finish = () => {
+            if (done) return;
+            done = true;
+            clearInterval(poll);
+            clearTimeout(timer);
+            window.speechSynthesis.removeEventListener("voiceschanged", check);
+            resolve();
+        };
+        const check = () => {
+            if (rankedVoices().length) finish();
+        };
+        // Both, for the same reason the picker does: Chrome fires
+        // voiceschanged exactly once, and this may be either side of it.
+        window.speechSynthesis.addEventListener("voiceschanged", check);
+        const poll = setInterval(check, 100);
+        const timer = setTimeout(finish, timeoutMs);
+    });
+    return voicesReady;
+}
+
+/** The voice to use right now: saved choice if it still exists, else best. */
+export function getSavedVoice() {
+    const voices = rankedVoices();
+    const saved = localStorage.getItem(VOICE_KEY);
+    if (saved) {
+        const match = voices.find((v) => v.voiceURI === saved);
+        if (match) return match;
+    }
+    return voices[0] || null;
+}
+
+/**
+ * Wire the readability-dialog controls (if present) and the player's rate
+ * slider (if present).  `onChange` fires with {voice, rate, autoScroll}
+ * whenever the user changes anything, so the queue can pick it up live.
+ */
+export function initSettingsControls(onChange) {
+    const voiceSelect = document.getElementById("ptx-read-aloud-voice");
+    const rateInput = document.getElementById("ptx-read-aloud-rate");
+    const rateOutput = document.getElementById("ptx-read-aloud-rate-value");
+    const autoScrollInput = document.getElementById("ptx-read-aloud-autoscroll");
+    const autoContinueInput = document.getElementById("ptx-read-aloud-autocontinue");
+    const asidesSelect = document.getElementById("ptx-read-aloud-asides");
+
+    const notify = () => {
+        onChange({
+            voice: getSavedVoice(),
+            rate: getSavedRate(),
+            autoScroll: getSavedAutoScroll(),
+            asideMode: getSavedAsideMode(),
+        });
+    };
+
+    const voiceLabel = document.querySelector('label[for="ptx-read-aloud-voice"]');
+
+    const populateVoices = () => {
+        if (!voiceSelect) return;
+        // Best-sounding first: the top of the list is what readers try.
+        const voices = rankedVoices();
+
+        // Some platforms report no voices at all while still speaking with a
+        // system default — notably Firefox on Linux, where the browser may
+        // not enumerate speech-dispatcher's list.  Offering an empty picker
+        // looks broken, so hide the control until there is a real choice;
+        // playback is unaffected, since an unset voice means "system
+        // default" to every engine.
+        const hidden = voices.length === 0;
+        voiceSelect.hidden = hidden;
+        if (voiceLabel) voiceLabel.hidden = hidden;
+        if (hidden) return;
+
+        const selected = getSavedVoice();
+        voiceSelect.replaceChildren();
+        for (const voice of voices) {
+            const option = document.createElement("option");
+            option.value = voice.voiceURI;
+            option.textContent = `${voice.name} (${voice.lang})`;
+            option.selected = selected && voice.voiceURI === selected.voiceURI;
+            voiceSelect.appendChild(option);
+        }
+    };
+    populateVoices();
+    window.speechSynthesis.addEventListener("voiceschanged", populateVoices);
+
+    // Chrome fills its voice list asynchronously but fires "voiceschanged"
+    // only once — and these controls are built lazily, on the first click of
+    // the read-aloud button, which can be either side of that event.  Miss it
+    // and the picker stays empty for the whole session, so poll briefly as
+    // well.  Stops as soon as voices appear.
+    let attempts = 0;
+    const poll = setInterval(() => {
+        if (rankedVoices().length || ++attempts > 10) {
+            clearInterval(poll);
+            populateVoices();
+        }
+    }, 250);
+
+    if (voiceSelect) {
+        voiceSelect.addEventListener("change", () => {
+            localStorage.setItem(VOICE_KEY, voiceSelect.value);
+            notify();
+        });
+    }
+
+    if (rateInput) {
+        rateInput.value = getSavedRate();
+        if (rateOutput) rateOutput.value = `${getSavedRate()}×`;
+        rateInput.addEventListener("input", () => {
+            const rate = Number(rateInput.value);
+            if (rate >= 0.5 && rate <= 2) {
+                localStorage.setItem(RATE_KEY, String(rate));
+                if (rateOutput) rateOutput.value = `${rate}×`;
+                notify();
+            }
+        });
+    }
+
+    if (asidesSelect) {
+        asidesSelect.value = getSavedAsideMode();
+        asidesSelect.addEventListener("change", () => {
+            localStorage.setItem(ASIDES_KEY, asidesSelect.value);
+            notify();
+        });
+    }
+
+    if (autoScrollInput) {
+        autoScrollInput.checked = getSavedAutoScroll();
+        autoScrollInput.addEventListener("change", () => {
+            localStorage.setItem(AUTOSCROLL_KEY, String(autoScrollInput.checked));
+            notify();
+        });
+    }
+
+    // No notify(): unlike the others this setting changes nothing about
+    // playback in progress, and the player reads it once, at end of page.
+    if (autoContinueInput) {
+        autoContinueInput.checked = getSavedAutoContinue();
+        autoContinueInput.addEventListener("change", () => {
+            localStorage.setItem(
+                AUTOCONTINUE_KEY,
+                String(autoContinueInput.checked)
+            );
+        });
+    }
+}

--- a/js/src/read-aloud/speech-queue.js
+++ b/js/src/read-aloud/speech-queue.js
@@ -1,0 +1,398 @@
+/*******************************************************************************
+ * speech-queue.js — state machine driving window.speechSynthesis
+ *******************************************************************************
+ * States: idle → speaking(i) → paused(i) → ended, where i indexes the
+ * utterance plan produced by segmenter.js.  One SpeechSynthesisUtterance per
+ * plan entry; onend advances to the next.  Callbacks let the UI layer drive
+ * the highlighter, auto-scroll, and MediaSession without this file touching
+ * any of them.
+ *
+ * Platform quirks handled here (see the design doc's quirk table):
+ *   - onend also fires after cancel(): a generation counter distinguishes a
+ *     natural end from our own cancellation.
+ *   - pause() is unreliable on Android Chrome: there, pause is implemented as
+ *     cancel + remember-the-index, and resume re-speaks the current sentence.
+ *     Sentence-sized utterances make that restart unnoticeable.
+ *
+ * The plan holds *every* block on the page, including the bodies of asides the
+ * listener has not opened.  The listening mode is applied here, while
+ * advancing, rather than at collection time — which is why the mode can change
+ * mid-page with no recollection, and why the navigation keys can reach content
+ * that is not currently being read.
+ ******************************************************************************/
+
+import {
+    nextBlockStart,
+    nextSpeakable,
+    previousBlockStart,
+    shouldSpeak,
+    skipTarget,
+} from "./navigation.js";
+
+export class SpeechQueue {
+    /**
+     * opts:
+     *   synth        the SpeechSynthesis instance (injectable for testing)
+     *   onUtterance  (index, planItem) fired as each utterance starts
+     *   onState      (state) fired on every state change
+     *   onEnded      () fired when the plan runs out naturally
+     */
+    constructor(opts = {}) {
+        this.synth = opts.synth || window.speechSynthesis;
+        this.onUtterance = opts.onUtterance || (() => {});
+        this.onState = opts.onState || (() => {});
+        this.onEnded = opts.onEnded || (() => {});
+
+        // Names the kind of block the arrow keys have landed on ("Theorem",
+        // "Paragraph"); the UI layer supplies it, since it reads the DOM.
+        this.describeBlock = opts.describeBlock || (() => null);
+
+        this.plan = [];
+        this.blocks = [];
+        // "read" | "skip" — what happens to an aside's body once its
+        // always-spoken title has been read.  There is no "pause and ask"
+        // mode: the arrow keys already stop at every block, so asking would
+        // be a second way to do the same thing.
+        this.mode = opts.mode || "skip";
+        // Asides the listener explicitly descended into, which override the
+        // mode for that aside alone.
+        this.entered = new Set();
+        // Parked at a block head after an arrow jump, awaiting play/right.
+        this.pendingStart = false;
+        this.index = 0;
+        this.state = "idle";
+        this.voice = null;
+        this.rate = 1;
+        this.lang = null;
+
+        // Incremented on every cancel so stale onend events are ignored.
+        this.generation = 0;
+
+        // Native pause is broken on Android Chrome; use cancel+restart there.
+        this.nativePause = !/Android/i.test(navigator.userAgent);
+    }
+
+    setPlan(plan, blocks) {
+        this.stop();
+        this.plan = plan;
+        this.blocks = blocks || [];
+        this.entered = new Set();
+        // Parked at a block head after an arrow jump, awaiting play/right.
+        this.pendingStart = false;
+        this.index = 0;
+    }
+
+    /** Change listening mode live; takes effect at the next block boundary. */
+    setMode(mode) {
+        this.mode = mode;
+    }
+
+    setVoice(voice) {
+        this.voice = voice;
+        this._restartIfSpeaking();
+    }
+
+    setRate(rate) {
+        this.rate = rate;
+        this._restartIfSpeaking();
+    }
+
+    setLang(lang) {
+        this.lang = lang;
+    }
+
+    _setState(state) {
+        if (this.state !== state) {
+            this.state = state;
+            this.onState(state);
+        }
+    }
+
+    _restartIfSpeaking() {
+        // Voice/rate cannot change mid-utterance; restart the current
+        // sentence so the change is heard immediately.
+        if (this.state === "speaking") {
+            this.playFrom(this.index);
+        }
+    }
+
+    playFrom(index) {
+        if (!this.plan.length) return;
+        this.generation++;
+        this.synth.cancel();
+        this.index = Math.max(0, Math.min(index, this.plan.length - 1));
+        this._setState("speaking");
+        this._speakCurrent();
+    }
+
+    _speakCurrent() {
+        const item = this.plan[this.index];
+        const generation = this.generation;
+        const utterance = new SpeechSynthesisUtterance(item.text);
+        if (this.voice) utterance.voice = this.voice;
+        if (this.lang) utterance.lang = this.lang;
+        utterance.rate = this.rate;
+
+        utterance.onstart = () => {
+            if (generation !== this.generation) return;
+            this.onUtterance(this.index, item);
+        };
+        const advance = () => {
+            if (generation !== this.generation) return;
+            const next = this._nextIndex();
+            if (next >= 0) {
+                this.index = next;
+                this._speakCurrent();
+            } else {
+                this._setState("ended");
+                this.onEnded();
+            }
+        };
+        utterance.onend = advance;
+        // A voice/synthesis error on one sentence should not kill the whole
+        // reading session; skip to the next utterance.
+        utterance.onerror = (e) => {
+            if (e.error === "canceled" || e.error === "interrupted") return;
+            // "not-allowed" is different in kind: the engine refused to speak
+            // at all, because nothing on this page has been clicked yet.  It
+            // will refuse every following sentence too, so advancing would
+            // race silently through the entire page and then report a
+            // natural end — which the auto-continue setting would act on.
+            // Fall back to idle: pressing play is itself the user gesture
+            // the engine was waiting for, and nothing was heard, so starting
+            // the page over is what the listener expects.
+            if (e.error === "not-allowed") {
+                this._setState("idle");
+                return;
+            }
+            advance();
+        };
+        this.synth.speak(utterance);
+    }
+
+    /**
+     * Speak one string outside the plan, then call `done` — exactly once.
+     *
+     * For announcements that must be heard before something irreversible
+     * happens to this queue, currently only the auto-continue warning ahead
+     * of navigating away.  Neither onend nor onerror is guaranteed to arrive
+     * (an engine with no voices may drop the utterance in silence), so a
+     * timer backstops them: `done` is a navigation, and never firing it
+     * would strand the listener on a page that has stopped reading.
+     */
+    speakOnce(text, done) {
+        let finished = false;
+        const finish = () => {
+            if (finished) return;
+            finished = true;
+            clearTimeout(timer);
+            done();
+        };
+        const timer = setTimeout(finish, 6000);
+        try {
+            const utterance = new SpeechSynthesisUtterance(text);
+            if (this.voice) utterance.voice = this.voice;
+            if (this.lang) utterance.lang = this.lang;
+            utterance.rate = this.rate;
+            utterance.onend = finish;
+            utterance.onerror = finish;
+            this.synth.speak(utterance);
+        } catch (e) {
+            finish();
+        }
+    }
+
+    pause() {
+        if (this.state !== "speaking") return;
+        if (this.nativePause) {
+            this.synth.pause();
+        } else {
+            this.generation++;
+            this.synth.cancel();
+        }
+        this._setState("paused");
+    }
+
+    resume() {
+        if (this.state !== "paused") return;
+        // Parked at the head of a block after an arrow-key jump: nothing is
+        // queued in the engine, so resuming means starting that block.
+        if (this.pendingStart) {
+            this.pendingStart = false;
+            // Accepting a knowl's title opens the knowl.  This is the only
+            // way into hidden content while in skip mode, and it mirrors what
+            // the title means on screen: clicking it reveals the body.
+            this.enterAsideHere();
+            this.playFrom(this.index);
+            return;
+        }
+        if (this.nativePause) {
+            this.synth.resume();
+            this._setState("speaking");
+        } else {
+            this.playFrom(this.index);
+        }
+    }
+
+    toggle() {
+        if (this.state === "speaking") {
+            this.pause();
+        } else if (this.state === "paused") {
+            this.resume();
+        } else {
+            this.playFrom(this.index);
+        }
+    }
+
+    stop() {
+        this.generation++;
+        this.synth.cancel();
+        this._setState("idle");
+    }
+
+    next() {
+        const next = this._nextIndex();
+        if (next >= 0) this.playFrom(next);
+    }
+
+    prev() {
+        const prev = this._prevIndex();
+        if (prev >= 0) this.playFrom(prev);
+    }
+
+    /** First plan index at or after the given block, for click-to-start. */
+    indexForBlock(blockIndex) {
+        for (let i = 0; i < this.plan.length; i++) {
+            if (this.plan[i].blockIndex >= blockIndex) return i;
+        }
+        return -1;
+    }
+
+    /** Block index behind a plan index, or -1. */
+    _blockIndex(planIndex = this.index) {
+        const item = this.plan[planIndex];
+        return item ? item.blockIndex : -1;
+    }
+
+    /**
+     * The next plan index to speak, honouring the listening mode, or -1 at
+     * the end of the page.  With no block data (console use, tests) this is
+     * plain linear advance.
+     */
+    _nextIndex() {
+        const candidate = this.index + 1;
+        if (candidate >= this.plan.length) return -1;
+        if (!this.blocks.length) return candidate;
+
+        const blockIndex = this._blockIndex(candidate);
+        if (shouldSpeak(this.blocks, blockIndex, this.mode, this.entered)) {
+            return candidate;
+        }
+        const target = nextSpeakable(
+            this.blocks,
+            blockIndex,
+            this.mode,
+            this.entered
+        );
+        if (target < 0) return -1;
+        const planIndex = this.indexForBlock(target);
+        // Never move backwards, however odd the block data: that would loop.
+        return planIndex > this.index ? planIndex : -1;
+    }
+
+    /**
+     * The previous plan index to speak, or -1 at the top of the page.
+     *
+     * Stepping back has to honour the mode just as advancing does, or the
+     * sentence after a skipped knowl steps *into* content the listener never
+     * heard — going backwards through a theorem they were never read.
+     */
+    _prevIndex() {
+        if (!this.blocks.length) return this.index > 0 ? this.index - 1 : -1;
+        for (let i = this.index - 1; i >= 0; i--) {
+            if (this._allowed(this.plan[i].blockIndex)) return i;
+        }
+        return -1;
+    }
+
+    /** Jump to a block, reporting whether there was anywhere to go. */
+    _goToBlock(blockIndex) {
+        if (blockIndex < 0) return false;
+        const planIndex = this.indexForBlock(blockIndex);
+        if (planIndex < 0) return false;
+        this.playFrom(planIndex);
+        return true;
+    }
+
+    /**
+     * Move to the head of the previous block, or of the current one when the
+     * listener is part-way through it, then announce and wait.
+     */
+    previousBlock() {
+        return this._jumpAnnouncing(
+            previousBlockStart(this.plan, this.index, (b) => this._allowed(b))
+        );
+    }
+
+    /** Move to the head of the next block, then announce and wait. */
+    nextBlock() {
+        return this._jumpAnnouncing(
+            nextBlockStart(this.plan, this.index, (b) => this._allowed(b))
+        );
+    }
+
+    /**
+     * If the current block is the title of an aside that is not being read,
+     * mark it opened so the mode filter lets its body through.  Returns the
+     * aside, or null when there was nothing to open.
+     */
+    enterAsideHere() {
+        const block = this.blocks[this._blockIndex()];
+        if (!block || !block.summary) return null;
+        const asides = block.path.filter((n) => n.aside);
+        const own = asides[asides.length - 1];
+        if (!own || this.entered.has(own.el)) return null;
+        this.entered.add(own.el);
+        return own;
+    }
+
+    _allowed(blockIndex) {
+        if (!this.blocks.length) return true;
+        return shouldSpeak(this.blocks, blockIndex, this.mode, this.entered);
+    }
+
+    /**
+     * Park at a block: say what kind of block it is, then stop and wait for
+     * the listener rather than reading on.  Arrow keys are for surveying the
+     * page, so landing somewhere must not commit to reading it.
+     */
+    _jumpAnnouncing(planIndex) {
+        if (planIndex < 0) return false;
+        this.generation++;
+        this.synth.cancel();
+        this.index = planIndex;
+        this.pendingStart = true;
+
+        const item = this.plan[planIndex];
+        this.onUtterance(planIndex, item);
+
+        const text = this.describeBlock(item.blockIndex);
+        this._setState("paused");
+        if (text) this._speakOnce(text);
+        return true;
+    }
+
+    /** Speak one throwaway line that is not part of the plan. */
+    _speakOnce(text) {
+        const utterance = new SpeechSynthesisUtterance(text);
+        if (this.voice) utterance.voice = this.voice;
+        if (this.lang) utterance.lang = this.lang;
+        utterance.rate = this.rate;
+        this.synth.speak(utterance);
+    }
+
+    /** Skip the innermost theorem/example/proof and resume after it. */
+    skipBlock() {
+        return this._goToBlock(skipTarget(this.blocks, this._blockIndex()));
+    }
+}

--- a/js/src/read-aloud/strings.js
+++ b/js/src/read-aloud/strings.js
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * strings.js — the user-facing words read-aloud speaks or shows
+ *******************************************************************************
+ * These deliberately do *not* come from xsl/localizations.  That mechanism is
+ * reserved for content reaching more than one output format, and read-aloud is
+ * HTML-only: nothing here has a LaTeX or EPUB counterpart.  The remaining
+ * words — button tooltips, dialog labels — are literal text in the XSL for the
+ * same reason.
+ *
+ * Collecting them in one module keeps the eventual JavaScript-side translation
+ * layer to a single swap: replace this object, and every announcement follows.
+ *
+ * Keys are the ids the rest of the feature already speaks in — announce tokens
+ * carry `stringId` (collector.js), and block type names are keyed by the
+ * `type` that nodes.js assigns.
+ ******************************************************************************/
+
+export const STRINGS = {
+    // Toggle-button tooltips, one per state of the player's disclosure.
+    "read-aloud-show": "Read aloud",
+    "read-aloud-hide": "Hide reading controls",
+    "read-aloud-play": "Play",
+    "read-aloud-pause": "Pause",
+
+    // Spoken in place of a block that has no useful linear reading.
+    "read-aloud-skip-table": "Table. Skipping.",
+    "read-aloud-skip-code": "Code. Skipping.",
+    "read-aloud-skip-interactive": "Interactive element. Skipping.",
+
+    // Spoken *before* an interactive exercise, whose prose is then read out:
+    // the listener needs to know a question is coming and that answering it
+    // means looking at the screen.  {kind} is Runestone's own name for the
+    // component ("Multiple Choice", "Parsons", "Drag-N-Drop"), read out of
+    // the page; the second form covers components that render no name.
+    "read-aloud-interactive-kind": "{kind} exercise.",
+    "read-aloud-interactive": "Interactive exercise.",
+
+    // Spoken when MathJax reports no speech text for an equation.
+    "read-aloud-equation-fallback": "equation",
+
+    // Introduces an image's alt text, which is written to replace a picture
+    // rather than to be read as part of the surrounding prose.
+    "read-aloud-image-alt": "Image. Alt text is:",
+
+    // Spoken at the end of a page before auto-continue navigates away.  A
+    // listener with the page out of view has no other warning that they are
+    // about to be somewhere else, and the pause it occupies is also their
+    // chance to stop it.
+    "read-aloud-continuing": "Continuing to the next page.",
+
+    // Spoken after the name of a hidden block the listener has navigated to,
+    // for the first few only: an audio interface shows no keys, so the only
+    // way to learn one is to be told.
+    "read-aloud-open-hint": "Press space to open.",
+
+    // Type names for the two blocks whose headings carry no visible type: a
+    // footnote shows only its number, an image description only an icon.
+    // Every other block announces the name PreTeXt already renders.
+    footnote: "Footnote",
+    description: "Description",
+};

--- a/js/src/read-aloud/test/collector.test.js
+++ b/js/src/read-aloud/test/collector.test.js
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Unit tests for the collector's element-level decisions.
+ *
+ * Run from the repository root with:
+ *     node --test js/src/read-aloud/test/*.test.js
+ *
+ * The full walk needs a live DOM (and, for Runestone components, Runestone's
+ * own JavaScript to have rewritten the page), so it is exercised by hand
+ * against the sample book rather than here.  What *is* testable without a
+ * browser are the two per-element judgements the walk defers to, so those are
+ * the ones pinned down below.  Plain objects stand in for elements, as in
+ * nodes.test.js; the class names and captions are copied from real rendered
+ * Runestone output.
+ ******************************************************************************/
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isEmptyOfContent, readingOrder, runestoneKind } from "../collector.js";
+
+const STRINGS = {
+    "read-aloud-interactive-kind": "{kind} exercise.",
+    "read-aloud-interactive": "Interactive exercise.",
+};
+
+// A stand-in element: `caption` is what querySelector(".runestone_caption")
+// finds, if anything.
+const component = (caption) => ({
+    querySelector: (sel) =>
+        sel === ".runestone_caption" && caption !== null
+            ? { textContent: caption }
+            : null,
+});
+
+test("a component announces the name Runestone rendered for it", () => {
+    assert.equal(
+        runestoneKind(component("Multiple Choice"), STRINGS),
+        "Multiple Choice exercise."
+    );
+    assert.equal(
+        runestoneKind(component("Fill in the Blank"), STRINGS),
+        "Fill in the Blank exercise."
+    );
+});
+
+test("the caption is trimmed and its whitespace collapsed", () => {
+    // Runestone lays the caption out across several source lines.
+    assert.equal(
+        runestoneKind(component("\n  Drag-N-Drop\n"), STRINGS),
+        "Drag-N-Drop exercise."
+    );
+});
+
+test("a component with no caption falls back to the generic name", () => {
+    // The newer <matching> component renders none.
+    assert.equal(runestoneKind(component(null), STRINGS), "Interactive exercise.");
+    assert.equal(runestoneKind(component("   "), STRINGS), "Interactive exercise.");
+});
+
+test("without strings the announcement is the bare caption, never a key", () => {
+    assert.equal(runestoneKind(component("Parsons")), "Parsons");
+    assert.equal(runestoneKind(component(null)), null);
+});
+
+// isEmptyOfContent guards the announce-and-skip categories: every ActiveCode
+// ships with an output <pre> that stays empty until the reader runs the
+// program, and announcing "Code. Skipping." over it is noise.
+const el = (text, media = false) => ({
+    textContent: text,
+    matches: () => false,
+    querySelector: () => (media ? {} : null),
+});
+
+test("an element with no text and no media has nothing to announce", () => {
+    assert.equal(isEmptyOfContent(el("")), true);
+    assert.equal(isEmptyOfContent(el("\n   \n")), true);
+});
+
+test("an element with text is never judged empty", () => {
+    assert.equal(isEmptyOfContent(el("print('hi')")), false);
+});
+
+test("media counts as content even though it carries no text", () => {
+    // A figure holding only an image, or a JSXGraph box whose canvas the
+    // library has already inserted.
+    assert.equal(isEmptyOfContent(el("", true)), false);
+    // The media element itself, which contains nothing at all.
+    assert.equal(
+        isEmptyOfContent({
+            textContent: "",
+            matches: (sel) => sel.includes("iframe"),
+            querySelector: () => null,
+        }),
+        false
+    );
+});
+
+// readingOrder decides where a caption is heard.  PreTeXt sets a figure's
+// caption below its image, so by ear the alt text would otherwise arrive
+// before the listener knows what is being described.
+const container = (children, caption = null) => ({
+    childNodes: children,
+    querySelector: (sel) => (sel === ":scope > figcaption" ? caption : null),
+});
+
+test("a figure's caption is heard before the image it captions", () => {
+    const caption = "figcaption";
+    const image = "image-box";
+    const order = readingOrder(container([image, caption], caption));
+    assert.deepEqual(order, [caption, image]);
+});
+
+test("a caption already on top stays where it is", () => {
+    // Tables, listings and named lists caption above the content already.
+    const caption = "figcaption";
+    const tabular = "tabular";
+    assert.deepEqual(
+        readingOrder(container([caption, tabular], caption)),
+        [caption, tabular]
+    );
+});
+
+test("a container with no caption of its own is left alone", () => {
+    // Including a "sidebyside" whose captions all belong to its panels: the
+    // direct-child query finds none, so the panels keep their own order.
+    const children = ["panel", "panel", "panel"];
+    assert.deepEqual(readingOrder(container(children)), children);
+});

--- a/js/src/read-aloud/test/navigation.test.js
+++ b/js/src/read-aloud/test/navigation.test.js
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Unit tests for read-aloud tree navigation (pure blocks → block index).
+ *
+ * Run from the repository root with:
+ *     node --test js/src/read-aloud/test/*.test.js
+ *
+ * Nodes are compared by identity of their `el`, so the fixtures below use
+ * plain strings in place of elements and never touch a DOM.
+ ******************************************************************************/
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    blockStart,
+    enclosingAside,
+    enclosingBlock,
+    firstBlockIn,
+    firstBodyBlockIn,
+    innermost,
+    nextBlockOutside,
+    nextOfFamily,
+    nextBlockStart,
+    nextSpeakable,
+    previousBlockStart,
+    shouldSpeak,
+    skipTarget,
+} from "../navigation.js";
+
+//------------------------------------------------------------------
+// Fixture: a section holding a born-hidden theorem (with a born-hidden
+// proof inside it), then a paragraph, then a born-hidden example.
+//
+//   0  para                      [S]
+//   1  theorem title             [S,T]    summary
+//   2  theorem body              [S,T]
+//   3  proof title               [S,T,P]  summary
+//   4  proof body                [S,T,P]
+//   5  para                      [S]
+//   6  example title             [S,X]    summary
+//   7  example body              [S,X]
+//   8  para                      [S]
+
+const S = { el: "S", type: "section", family: "division", aside: false };
+const T = { el: "T", type: "theorem", family: "theorem-like", aside: true };
+const P = { el: "P", type: "proof", family: null, aside: true };
+const X = { el: "X", type: "example", family: "example-like", aside: true };
+
+const b = (path, summary = false) => ({ el: {}, tokens: [], path, summary });
+
+const blocks = [
+    b([S]),
+    b([S, T], true),
+    b([S, T]),
+    b([S, T, P], true),
+    b([S, T, P]),
+    b([S]),
+    b([S, X], true),
+    b([S, X]),
+    b([S]),
+];
+
+const NONE = new Set();
+
+//------------------------------------------------------------------
+// Ancestry lookups
+
+test("innermost finds the tightest matching ancestor", () => {
+    assert.equal(innermost(blocks, 4, (n) => n.aside), P);
+    assert.equal(innermost(blocks, 4, (n) => n.family === "division"), S);
+    assert.equal(innermost(blocks, 0, (n) => n.aside), null);
+});
+
+test("enclosingBlock ignores divisions", () => {
+    // A bare paragraph sits in a section only, so there is no block to skip.
+    assert.equal(enclosingBlock(blocks, 0), null);
+    assert.equal(enclosingBlock(blocks, 2), T);
+    assert.equal(enclosingBlock(blocks, 4), P);
+});
+
+test("firstBlockIn finds the title, firstBodyBlockIn skips it", () => {
+    assert.equal(firstBlockIn(blocks, T), 1);
+    assert.equal(firstBodyBlockIn(blocks, T), 2);
+    assert.equal(firstBlockIn(blocks, P), 3);
+    assert.equal(firstBodyBlockIn(blocks, P), 4);
+});
+
+test("nextBlockOutside leaves the whole subtree, not just the node", () => {
+    // Leaving the theorem must also leave the proof nested inside it.
+    assert.equal(nextBlockOutside(blocks, 2, T), 5);
+    assert.equal(nextBlockOutside(blocks, 4, P), 5);
+    // A node running to the end of the page reports "nowhere".
+    assert.equal(nextBlockOutside(blocks, 0, S), -1);
+});
+
+//------------------------------------------------------------------
+// Skipping
+
+test("skipTarget skips the innermost block, not the section", () => {
+    assert.equal(skipTarget(blocks, 2), 5); // out of the theorem
+    assert.equal(skipTarget(blocks, 4), 5); // out of the proof, into prose
+    assert.equal(skipTarget(blocks, 7), 8); // out of the example
+});
+
+test("skipTarget has nowhere to go from bare prose", () => {
+    assert.equal(skipTarget(blocks, 0), -1);
+});
+
+//------------------------------------------------------------------
+// Family jumps (the "next theorem" style navigation, wired up later)
+
+test("nextOfFamily finds the next node of a family", () => {
+    assert.equal(nextOfFamily(blocks, 0, "theorem-like"), 1);
+    assert.equal(nextOfFamily(blocks, 0, "example-like"), 6);
+});
+
+test("nextOfFamily does not re-report the node already inside", () => {
+    // Standing in the theorem body, the next theorem-like is not this one.
+    assert.equal(nextOfFamily(blocks, 2, "theorem-like"), -1);
+});
+
+//------------------------------------------------------------------
+// Block-level movement (the arrow keys)
+//
+// A plan over the fixture above: block 0 has three sentences, block 2 has
+// two, everything else one.  That is what makes "part-way through a block"
+// testable.
+
+const plan = [
+    { blockIndex: 0 }, { blockIndex: 0 }, { blockIndex: 0 },
+    { blockIndex: 1 },
+    { blockIndex: 2 }, { blockIndex: 2 },
+    { blockIndex: 3 },
+    { blockIndex: 4 },
+    { blockIndex: 5 },
+];
+
+test("blockStart finds the head of the block being read", () => {
+    assert.equal(blockStart(plan, 2), 0);
+    assert.equal(blockStart(plan, 0), 0);
+    assert.equal(blockStart(plan, 5), 4);
+});
+
+test("up goes to the head of the current block when part-way through", () => {
+    // Reading the third sentence of block 0: back to its first.
+    assert.equal(previousBlockStart(plan, 2), 0);
+    assert.equal(previousBlockStart(plan, 5), 4);
+});
+
+test("up goes to the previous block when already at a head", () => {
+    assert.equal(previousBlockStart(plan, 3), 0);
+    assert.equal(previousBlockStart(plan, 4), 3);
+});
+
+test("up has nowhere to go from the first block", () => {
+    assert.equal(previousBlockStart(plan, 0), -1);
+});
+
+test("down goes to the head of the next block", () => {
+    assert.equal(nextBlockStart(plan, 0), 3);
+    assert.equal(nextBlockStart(plan, 2), 3);
+    assert.equal(nextBlockStart(plan, 4), 6);
+});
+
+test("down has nowhere to go from the last block", () => {
+    assert.equal(nextBlockStart(plan, 8), -1);
+});
+
+test("movement steps over blocks the mode suppresses", () => {
+    // Suppress block 2 entirely: from block 1, down lands on block 3.
+    const allowed = (b) => b !== 2;
+    assert.equal(nextBlockStart(plan, 3, allowed), 6);
+    // And coming back up from block 3 skips it too.
+    assert.equal(previousBlockStart(plan, 6, allowed), 3);
+});
+
+//------------------------------------------------------------------
+// Listening modes
+
+test("titles are always spoken, so an aside is never invisible", () => {
+    assert.equal(shouldSpeak(blocks, 1, "skip", NONE), true);
+    assert.equal(shouldSpeak(blocks, 6, "skip", NONE), true);
+});
+
+test("skip mode suppresses bodies", () => {
+    assert.equal(shouldSpeak(blocks, 2, "skip", NONE), false);
+    assert.equal(shouldSpeak(blocks, 7, "skip", NONE), false);
+});
+
+test("read mode speaks everything", () => {
+    for (let i = 0; i < blocks.length; i++) {
+        assert.equal(shouldSpeak(blocks, i, "read", NONE), true, `block ${i}`);
+    }
+});
+
+test("a nested aside's title is suppressed with its parent's body", () => {
+    // Skipping the theorem must not announce the proof buried inside it.
+    assert.equal(shouldSpeak(blocks, 3, "skip", NONE), false);
+});
+
+test("entering an aside reads its body but not nested asides", () => {
+    const entered = new Set(["T"]);
+    assert.equal(shouldSpeak(blocks, 2, "skip", entered), true);
+    assert.equal(shouldSpeak(blocks, 3, "skip", entered), true, "proof announced");
+    assert.equal(shouldSpeak(blocks, 4, "skip", entered), false, "proof body");
+});
+
+test("nextSpeakable walks past suppressed subtrees", () => {
+    // From the theorem body in skip mode: 2,3,4 are all suppressed.
+    assert.equal(nextSpeakable(blocks, 2, "skip", NONE), 5);
+    assert.equal(nextSpeakable(blocks, 7, "skip", NONE), 8);
+    assert.equal(nextSpeakable(blocks, 2, "read", NONE), 2);
+});
+
+test("nextSpeakable reports the end of the page", () => {
+    assert.equal(nextSpeakable(blocks, 9, "skip", NONE), -1);
+});

--- a/js/src/read-aloud/test/nodes.test.js
+++ b/js/src/read-aloud/test/nodes.test.js
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Unit tests for the read-aloud node vocabulary (CSS classes → tree nodes).
+ *
+ * Run from the repository root with:
+ *     node --test js/src/read-aloud/test/*.test.js
+ *
+ * nodeDescriptor only reads `classList` and `tagName`, so a plain object
+ * stands in for an element and these tests need no DOM.  The class strings
+ * below are copied from real PreTeXt output (sample article + demo), because
+ * the whole risk this file guards against is a spelling we did not expect.
+ ******************************************************************************/
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { nodeDescriptor } from "../nodes.js";
+
+const el = (className, tagName = "ARTICLE") => {
+    const list = className.split(/\s+/);
+    list.contains = (c) => list.includes(c);
+    return { classList: list, tagName };
+};
+
+test("a block carries its PreTeXt name and its family", () => {
+    const d = nodeDescriptor(el("lemma theorem-like"));
+    assert.equal(d.type, "lemma");
+    assert.equal(d.family, "theorem-like");
+    assert.equal(d.aside, false);
+});
+
+test("born-hidden blocks are asides, keeping their own type", () => {
+    const d = nodeDescriptor(el("example example-like born-hidden-knowl", "DETAILS"));
+    assert.equal(d.type, "example");
+    assert.equal(d.family, "example-like");
+    assert.equal(d.aside, true);
+});
+
+test("a born-hidden proof is spelled 'hiddenproof', not 'proof'", () => {
+    // Missing this spelling made proofs invisible to navigation: skipping a
+    // theorem still read the proof inside it, and every block within the
+    // proof announced itself as the enclosing theorem.
+    const d = nodeDescriptor(el("hiddenproof born-hidden-knowl", "DETAILS"));
+    assert.equal(d.type, "hiddenproof");
+    assert.equal(d.aside, true);
+    // Non-hidden proofs keep the plain spelling.
+    assert.equal(nodeDescriptor(el("proof")).type, "proof");
+});
+
+test("footnotes and image descriptions are asides with supplied names", () => {
+    const fn = nodeDescriptor(el("ptx-footnote", "DETAILS"));
+    assert.equal(fn.type, "footnote");
+    assert.equal(fn.aside, true);
+    const desc = nodeDescriptor(el("image-description", "DETAILS"));
+    assert.equal(desc.type, "description");
+    assert.equal(desc.aside, true);
+});
+
+test("solutions, hints and answers inside a block are asides", () => {
+    for (const cls of ["solution solution-like", "hint solution-like", "answer solution-like"]) {
+        const d = nodeDescriptor(el(`${cls} born-hidden-knowl`, "DETAILS"));
+        assert.equal(d.aside, true, cls);
+        assert.equal(d.family, "solution-like", cls);
+    }
+});
+
+test("a block emitted with only its family name still resolves", () => {
+    const d = nodeDescriptor(el("solution-like born-hidden-knowl", "DETAILS"));
+    assert.equal(d.type, "solution-like");
+    assert.equal(d.aside, true);
+});
+
+test("divisions are nodes only on <section>", () => {
+    assert.equal(nodeDescriptor(el("subsection", "SECTION")).family, "division");
+    // The same word appears on wrappers that are not divisions.
+    assert.equal(nodeDescriptor(el("pretext article ignore-math", "DIV")), null);
+});
+
+test("page chrome is not a node", () => {
+    assert.equal(nodeDescriptor(el("print-options", "DETAILS")), null);
+    assert.equal(nodeDescriptor(el("instructions diagcess__instructions", "DETAILS")), null);
+    assert.equal(nodeDescriptor(el("para", "DIV")), null);
+});
+
+test("an element with no classes is not a node", () => {
+    assert.equal(nodeDescriptor({ classList: [], tagName: "DIV" }), null);
+});

--- a/js/src/read-aloud/test/segmenter.test.js
+++ b/js/src/read-aloud/test/segmenter.test.js
@@ -1,0 +1,367 @@
+/*******************************************************************************
+ * Unit tests for the read-aloud segmenter (pure IR → utterance plan).
+ *
+ * Run from the repository root (or anywhere) with:
+ *     node --test js/src/read-aloud/test/
+ *
+ * These are the first JavaScript unit tests in core PreTeXt; they use Node's
+ * built-in test runner so there is no framework dependency.
+ ******************************************************************************/
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    buildPlan,
+    collapseWhitespace,
+    sentenceBoundaries,
+} from "../segmenter.js";
+import { cleanMathSpeech } from "../collector.js";
+
+// Convenience IR constructors
+const text = (value) => ({ kind: "text", value });
+const math = (speech, display = false) => ({ kind: "math", speech, display });
+const announce = (stringId) => ({ kind: "announce", stringId });
+const block = (...tokens) => ({ tokens });
+
+//------------------------------------------------------------------
+// collapseWhitespace
+
+test("collapseWhitespace collapses runs and maps back to original offsets", () => {
+    const { text: t, map } = collapseWhitespace("a  b\n\tc");
+    assert.equal(t, "a b c");
+    // 'c' in collapsed position 4 came from original position 6
+    assert.equal(map[4], 6);
+    assert.equal("a  b\n\tc"[map[2]], "b");
+});
+
+//------------------------------------------------------------------
+// Sentence splitting
+
+test("two plain sentences become two utterances", () => {
+    const plan = buildPlan(
+        [block(text("The dog barks. The cat meows."))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 2);
+    assert.equal(plan[0].text, "The dog barks.");
+    assert.equal(plan[1].text, "The cat meows.");
+});
+
+test("common abbreviations do not split sentences (Intl.Segmenter)", () => {
+    const plan = buildPlan(
+        [block(text("See Dr. Smith for details. Then rest."))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 2);
+    assert.equal(plan[0].text, "See Dr. Smith for details.");
+});
+
+test("dotted initialisms do not split sentences", () => {
+    // The final period of "e.g." is preceded by a lone letter, not by a word
+    // in the abbreviation list, so it needs the shape rule to survive.
+    for (const abbr of ["e.g.", "i.e.", "U.S."]) {
+        const plan = buildPlan(
+            [block(text(`As in ${abbr} Theorem 3.2, we are done. Then rest.`))],
+            { locale: "en" }
+        );
+        assert.equal(plan.length, 2, `split inside ${abbr}`);
+        assert.equal(plan[0].text, `As in ${abbr} Theorem 3.2, we are done.`);
+    }
+});
+
+test("abbreviations after an opening bracket do not split sentences", () => {
+    const plan = buildPlan(
+        [block(text("A result (e.g. Theorem 3.2) holds. Then rest."))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 2);
+    assert.equal(plan[0].text, "A result (e.g. Theorem 3.2) holds.");
+});
+
+test("the read-aloud demo abbreviation sentence stays whole", () => {
+    const sentence =
+        "The abbreviations in this one: see Dr. Smith, or e.g. Theorem 3.2, " +
+        "or cf. Fig. 4 for details.";
+    const plan = buildPlan([block(text(sentence))], { locale: "en" });
+    assert.equal(plan.length, 1);
+    assert.equal(plan[0].text, sentence);
+});
+
+test("suppression does not swallow ordinary sentence ends", () => {
+    // A single letter plus period is an ordinary end, not an initialism.
+    const plan = buildPlan(
+        [block(text("The unknown is x. Then we solve for y."))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 2);
+    assert.equal(plan[0].text, "The unknown is x.");
+});
+
+test("regex fallback boundaries look reasonable", () => {
+    // Exercise the fallback path directly (as if Intl.Segmenter were absent)
+    const boundaries = sentenceBoundaries("One two. Three four! Five?", "en");
+    // Either engine should find at least the two obvious boundaries
+    assert.ok(boundaries.includes(9));
+    assert.ok(boundaries.includes(21));
+});
+
+//------------------------------------------------------------------
+// Math splicing
+
+test("inline math mid-sentence yields a single spliced utterance", () => {
+    const plan = buildPlan(
+        [
+            block(
+                text("Consider the function "),
+                math("f of x equals x squared"),
+                text(" which opens upward.")
+            ),
+        ],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 1);
+    assert.equal(
+        plan[0].text,
+        "Consider the function f of x equals x squared which opens upward."
+    );
+    // The math token participates in the range map
+    assert.ok(plan[0].ranges.some((r) => r.tokenIndex === 1 && r.start === undefined));
+});
+
+test("punctuation directly after math hugs the math speech", () => {
+    const plan = buildPlan(
+        [block(text("We define "), math("f of x"), text(". Then we continue."))],
+        { locale: "en" }
+    );
+    assert.equal(plan[0].text, "We define f of x.");
+    assert.equal(plan[1].text, "Then we continue.");
+});
+
+test("math at sentence start and end", () => {
+    const plan = buildPlan(
+        [block(math("x"), text(" is small but "), math("y"))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 1);
+    assert.equal(plan[0].text, "x is small but y");
+});
+
+test("adjacent math tokens are separated by a space", () => {
+    const plan = buildPlan(
+        [block(math("alpha"), math("beta"))],
+        { locale: "en" }
+    );
+    assert.equal(plan[0].text, "alpha beta");
+});
+
+test("periods inside math speech never split the sentence", () => {
+    const plan = buildPlan(
+        [
+            block(
+                text("The answer "),
+                math("x equals 3.2. approximately"),
+                text(" is small.")
+            ),
+        ],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 1);
+});
+
+test("display math becomes its own utterance from its own block", () => {
+    const plan = buildPlan(
+        [
+            block(text("We compute the following.")),
+            block(math("integral from 0 to 1 of x squared d x", true)),
+            block(text("The result is one third.")),
+        ],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 3);
+    assert.equal(plan[1].text, "integral from 0 to 1 of x squared d x");
+    assert.deepEqual(plan[1].ranges, [{ tokenIndex: 0 }]);
+});
+
+//------------------------------------------------------------------
+// Announcements
+
+test("announce tokens become localized announcement utterances", () => {
+    const plan = buildPlan(
+        [block(announce("read-aloud-skip-table"))],
+        { strings: { "read-aloud-skip-table": "Table. Skipping." } }
+    );
+    assert.equal(plan.length, 1);
+    assert.equal(plan[0].kind, "announce");
+    assert.equal(plan[0].text, "Table. Skipping.");
+});
+
+test("announce token without a string falls back to its id", () => {
+    const plan = buildPlan([block(announce("read-aloud-skip-code"))], {});
+    assert.equal(plan[0].text, "read-aloud-skip-code");
+});
+
+test("announce token splits a mixed block", () => {
+    const plan = buildPlan(
+        [block(text("Before."), announce("read-aloud-skip-code"), text("After."))],
+        { locale: "en", strings: { "read-aloud-skip-code": "Code. Skipping." } }
+    );
+    assert.deepEqual(
+        plan.map((u) => u.text),
+        ["Before.", "Code. Skipping.", "After."]
+    );
+});
+
+//------------------------------------------------------------------
+// Length clamping
+
+test("over-long sentences are clamped at clause boundaries", () => {
+    const clause = "we continue the argument with great care and patience";
+    const long = Array(8).fill(clause).join(", ") + ".";
+    assert.ok(long.length > 250);
+    const plan = buildPlan([block(text(long))], { locale: "en" });
+    assert.ok(plan.length > 1, "long sentence should be split");
+    for (const u of plan) {
+        assert.ok(u.text.length <= 250, `chunk too long: ${u.text.length}`);
+    }
+    // Chunks reassemble the original (modulo the collapsed join spaces)
+    assert.equal(plan.map((u) => u.text).join(" "), long);
+});
+
+test("clamping never bisects a math span", () => {
+    const mathSpeech = "a very long spoken form of an expression " +
+        "that goes on and on and on for quite a while indeed";
+    const plan = buildPlan(
+        [
+            block(
+                text("Start of a sentence that runs long "),
+                math(mathSpeech),
+                text(" and then keeps going with more prose after the mathematics ".repeat(4))
+            ),
+        ],
+        { locale: "en", maxLength: 80 }
+    );
+    // The full math speech text must appear intact in exactly one utterance
+    const containing = plan.filter((u) => u.text.includes(mathSpeech));
+    assert.equal(containing.length, 1);
+});
+
+//------------------------------------------------------------------
+// Range-map integrity
+
+test("text ranges index real substrings of the original token values", () => {
+    const tokens = [
+        text("First sentence here.  Second\n sentence, with  a clause."),
+        math("x plus y"),
+        text(" Tail text."),
+    ];
+    const plan = buildPlan([block(...tokens)], { locale: "en" });
+    for (const u of plan) {
+        for (const r of u.ranges) {
+            if (r.start === undefined) continue;
+            const original = tokens[r.tokenIndex].value;
+            const slice = original.slice(r.start, r.end);
+            // Every mapped slice must appear in the utterance text once
+            // whitespace is normalized the same way.
+            const normalized = slice.replace(/\s+/g, " ").trim();
+            assert.ok(
+                u.text.includes(normalized),
+                `range slice "${normalized}" not in utterance "${u.text}"`
+            );
+        }
+    }
+});
+
+test("ranges of one utterance stay within its sentence", () => {
+    const t = text("Alpha beta. Gamma delta.");
+    const plan = buildPlan([block(t)], { locale: "en" });
+    assert.equal(plan.length, 2);
+    const [u1, u2] = plan;
+    const slice1 = t.value.slice(u1.ranges[0].start, u1.ranges[0].end);
+    const slice2 = t.value.slice(u2.ranges[0].start, u2.ranges[0].end);
+    assert.equal(slice1.trim(), "Alpha beta.");
+    assert.equal(slice2.trim(), "Gamma delta.");
+});
+
+//------------------------------------------------------------------
+// Math speech cleanup (SRE's screen-reader region marker)
+
+test("trailing math region marker is stripped", () => {
+    assert.equal(
+        cleanMathSpeech("f of x equals x squared, math"),
+        "f of x equals x squared"
+    );
+    assert.equal(cleanMathSpeech("x plus y math"), "x plus y");
+    assert.equal(cleanMathSpeech("x plus y, Math."), "x plus y");
+});
+
+test("cleanup leaves ordinary speech untouched", () => {
+    assert.equal(cleanMathSpeech("a squared plus b squared"), "a squared plus b squared");
+    // "mathematics" must not be mistaken for the marker
+    assert.equal(cleanMathSpeech("the set of all mathematics"), "the set of all mathematics");
+});
+
+test("cleanup never empties a speech string", () => {
+    assert.equal(cleanMathSpeech("math"), "math");
+});
+
+test("cleanup normalizes whitespace and handles empties", () => {
+    assert.equal(cleanMathSpeech("x  plus\n y, math"), "x plus y");
+    assert.equal(cleanMathSpeech(""), null);
+    assert.equal(cleanMathSpeech(null), null);
+});
+
+test("SSML markup is reduced to the text it wraps", () => {
+    // speechSynthesis has no SSML support and would read the tags aloud.
+    const ssml =
+        '<mark name="0"/> <say-as interpret-as="character">f</say-as> ' +
+        '<mark name="9"/> of <mark name="2"/> ' +
+        '<say-as interpret-as="character">x</say-as> <break time="250ms"/> ' +
+        '<mark name="4"/> equals <mark name="5"/> ' +
+        '<say-as interpret-as="character">x</say-as> <mark name="6"/> squared';
+    assert.equal(cleanMathSpeech(ssml), "f of x equals x squared");
+});
+
+test("markup-only speech yields null rather than an empty utterance", () => {
+    assert.equal(cleanMathSpeech('<mark name="0"/> <break time="250ms"/>'), null);
+});
+
+test("spoken trailing punctuation becomes real punctuation", () => {
+    // PreTeXt absorbs the punctuation after inline math into the expression,
+    // so SRE says the word; the voice should pause instead.
+    assert.equal(
+        cleanMathSpeech("f of x equals x squared comma, math"),
+        "f of x equals x squared,"
+    );
+    assert.equal(cleanMathSpeech("x period"), "x.");
+    assert.equal(cleanMathSpeech("y semicolon"), "y;");
+});
+
+test("punctuation words inside an expression are left alone", () => {
+    // Only a trailing word is PreTeXt's absorbed punctuation; "comma" in the
+    // middle is how SRE reads a genuine separator.
+    assert.equal(cleanMathSpeech("1 comma 2 comma 3"), "1 comma 2 comma 3");
+});
+
+test("non-English locales keep their own rendering", () => {
+    assert.equal(cleanMathSpeech("f de x égale x carré virgule"), "f de x égale x carré virgule");
+});
+
+//------------------------------------------------------------------
+// Degenerate input
+
+test("empty and whitespace-only blocks yield no utterances", () => {
+    const plan = buildPlan(
+        [block(text("   \n  ")), block(), block(text(""))],
+        { locale: "en" }
+    );
+    assert.deepEqual(plan, []);
+});
+
+test("math with empty speech is dropped rather than spoken as garbage", () => {
+    const plan = buildPlan(
+        [block(text("Before "), math(""), text(" after."))],
+        { locale: "en" }
+    );
+    assert.equal(plan.length, 1);
+    assert.equal(plan[0].text, "Before after.");
+});

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -429,6 +429,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 element html {
                     attribute design-width { xsd:integer }?,
                     attribute favicon { "none" | "simple" }?,
+                    attribute read-aloud { "yes" | "no" }?,
                     attribute short-answer-responses { "graded" | "always" }?,
                     (
                         Analytics? &amp;

--- a/script/jsbuilder/jsbuilder.mjs
+++ b/script/jsbuilder/jsbuilder.mjs
@@ -14,7 +14,8 @@
  * four categories based on how they are loaded and whether they need bundling:
  *
  *  IIFE bundles  — multiple source files combined into one IIFE.
- *    pretext-core    js/src/pretext-core.js  (pretext.js + pretext_add_on.js + knowl.js)
+ *    pretext-core        js/src/pretext-core.js  (pretext.js + pretext_add_on.js + knowl.js)
+ *    pretext-read-aloud  js/src/read-aloud/index.js  (embedded text-to-speech)
  *
  *  ES module     — loaded via `import` from an inline <script type="module">.
  *    mathjax_startup  js/mathjax_startup.js
@@ -193,6 +194,16 @@ function getAllTargets() {
       name: 'pretext-core',
       group: 'bundle',
       in: path.join(jsRoot, 'src/pretext-core.js'),
+    },
+
+    // Read-aloud (embedded text-to-speech): collector/segmenter/speech-queue
+    // pipeline plus player UI.  Conditional: the <script> is only emitted
+    // when the read-aloud publication option is enabled.
+    // Entry point: js/src/read-aloud/index.js
+    {
+      name: 'pretext-read-aloud',
+      group: 'bundle',
+      in: path.join(jsRoot, 'src/read-aloud/index.js'),
     },
 
     // ------------------------------------------------------------------

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -12569,6 +12569,116 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </dialog>
 </xsl:template>
 
+<!-- Read-aloud (embedded text-to-speech): a toolbar button, a minimal      -->
+<!-- expanding player (prev, play/pause, next, continue, settings), and the  -->
+<!-- settings dialog that button opens.                                     -->
+<!--                                                                        -->
+<!-- The words below are literal English rather than localization           -->
+<!-- string-ids.  xsl/localizations is for content that reaches more than   -->
+<!-- one output format, and this is an HTML-only control surface.  Nothing  -->
+<!-- here has a LaTeX or EPUB counterpart.  The strings the player *speaks* -->
+<!-- live in js/src/read-aloud/strings.js for the same reason; a            -->
+<!-- JavaScript-side translation layer will eventually address both halves. -->
+<xsl:template name="read-aloud-controls">
+    <button id="ptx-read-aloud-button" class="ptx-read-aloud-button button" title="Read aloud" aria-expanded="false">
+        <xsl:call-template name="insert-symbol">
+            <xsl:with-param name="name" select="'text_to_speech'"/>
+        </xsl:call-template>
+        <span class="name">Read aloud</span>
+    </button>
+    <!-- player-ui.js retitles the toolbar and play/pause buttons as their -->
+    <!-- states change; the titles here are the pre-JavaScript defaults.   -->
+    <div id="ptx-read-aloud-player" class="ptx-read-aloud-player" hidden="hidden" role="group" aria-label="Read aloud">
+        <button id="ptx-read-aloud-prev" class="button" title="Previous sentence">
+            <xsl:call-template name="insert-symbol">
+                <xsl:with-param name="name" select="'skip_previous'"/>
+            </xsl:call-template>
+        </button>
+        <button id="ptx-read-aloud-toggle" class="ptx-read-aloud-toggle button" title="Play">
+            <span class="ptx-read-aloud-icon-play">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'play_arrow'"/>
+                </xsl:call-template>
+            </span>
+            <span class="ptx-read-aloud-icon-pause">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'pause'"/>
+                </xsl:call-template>
+            </span>
+        </button>
+        <button id="ptx-read-aloud-next" class="button" title="Next sentence">
+            <xsl:call-template name="insert-symbol">
+                <xsl:with-param name="name" select="'skip_next'"/>
+            </xsl:call-template>
+        </button>
+        <a id="ptx-read-aloud-continue" class="ptx-read-aloud-continue button" hidden="hidden">
+            <xsl:text>Continue</xsl:text>
+            <xsl:call-template name="insert-symbol">
+                <xsl:with-param name="name" select="'play_arrow'"/>
+            </xsl:call-template>
+        </a>
+        <button id="ptx-read-aloud-settings-button" class="ptx-read-aloud-settings-button button" title="Reading settings">
+            <xsl:call-template name="insert-symbol">
+                <xsl:with-param name="name" select="'tune'"/>
+            </xsl:call-template>
+        </button>
+        <!-- No close button: the toolbar button that opened the player is  -->
+        <!-- a disclosure toggle and collapses it again, so a second        -->
+        <!-- dismissal control would only cost space in the navbar row.     -->
+    </div>
+    <!-- Read-aloud settings, opened from the player's own settings button.   -->
+    <!-- Deliberately a sibling of the player rather than a child: the player -->
+    <!-- is a flex row, and a dialog inside it would be a flex item.          -->
+    <dialog class="ptx-dialog ptx-read-aloud-settings-popup" id="ptx-read-aloud-settings-popup">
+        <div class="ptx-readability-options-popup-controls">
+            <h2 class="heading">Read aloud settings</h2>
+            <button class="ptx-read-aloud-settings-close-button button" id="ptx-read-aloud-settings-close-button" title="Close">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'close'"/>
+                </xsl:call-template>
+            </button>
+        </div>
+        <div class="ptx-readability-options-group">
+            <label for="ptx-read-aloud-voice">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'record_voice_over'"/>
+                </xsl:call-template>
+                <span>Voice</span>
+            </label>
+            <!-- options populated by settings.js from speechSynthesis.getVoices() -->
+            <select id="ptx-read-aloud-voice"></select>
+            <label class="ptx-readability-slider-label" for="ptx-read-aloud-rate">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'speed'"/>
+                </xsl:call-template>
+                <span>Reading speed</span>
+                <output id="ptx-read-aloud-rate-value" for="ptx-read-aloud-rate">1×</output>
+            </label>
+            <input type="range" id="ptx-read-aloud-rate" min="0.5" max="2" step="0.1" value="1"/>
+            <label for="ptx-read-aloud-asides">
+                <xsl:call-template name="insert-symbol">
+                    <xsl:with-param name="name" select="'unfold_more'"/>
+                </xsl:call-template>
+                <span>Collapsed content</span>
+            </label>
+            <!-- What happens to a knowl's body once its title is read. -->
+            <select id="ptx-read-aloud-asides">
+                <option value="skip">Announce, do not read</option>
+                <option value="read">Read automatically</option>
+            </select>
+            <label for="ptx-read-aloud-autoscroll">
+                <input type="checkbox" id="ptx-read-aloud-autoscroll" checked="checked"/>
+                <span>Follow along (auto-scroll)</span>
+            </label>
+            <!-- Unchecked by default: this one navigates, so it is opt-in. -->
+            <label for="ptx-read-aloud-autocontinue">
+                <input type="checkbox" id="ptx-read-aloud-autocontinue"/>
+                <span>Continue to the next page automatically</span>
+            </label>
+        </div>
+    </dialog>
+</xsl:template>
+
 <xsl:template name="embed-button">
     <xsl:variable name="embed-localization">
         <xsl:apply-templates select="." mode="type-name">
@@ -12843,6 +12953,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Button to show code for embedding in an LMS or webpage  -->
          <xsl:if test="$b-has-embed-button">
              <xsl:call-template name="embed-button" />
+        </xsl:if>
+        <!-- Read-aloud button and expanding player  -->
+        <xsl:if test="$b-read-aloud">
+            <xsl:call-template name="read-aloud-controls" />
         </xsl:if>
         <xsl:call-template name="readability-options" />
     </span>
@@ -13730,6 +13844,8 @@ TODO:
             <xsl:text>hasSage: </xsl:text><xsl:value-of select="$b-has-sage"/><xsl:text>,&#xa;</xsl:text>
             <xsl:text>isReact: </xsl:text><xsl:value-of select="$b-debug-react"/><xsl:text>,&#xa;</xsl:text>
             <xsl:text>htmlPresentation: </xsl:text><xsl:value-of select="$b-html-presentation"/><xsl:text>,&#xa;</xsl:text>
+            <!-- Added to support read-aloud functionality; shouldn't hurt anything else -->
+            <xsl:text>lang: "</xsl:text><xsl:value-of select="$document-language"/><xsl:text>",&#xa;</xsl:text>
         <xsl:text>});&#xa;</xsl:text>
     </script>
     <!-- MathJax 4 CDN -->
@@ -14301,6 +14417,11 @@ TODO:
                  ?v= query string busts the browser cache when the CLI version changes,
                  restoring the cache-busting that pretext_add_on.js?x=1 previously provided. -->
             <script src="{$html.js.dir}/pretext-core.js?v={$cli.version}"></script>
+            <!-- Read-aloud bundle: only when the publication option is on,
+                 so an opted-out build ships zero text-to-speech bytes. -->
+            <xsl:if test="$b-read-aloud">
+                <script src="{$html.js.dir}/pretext-read-aloud.js?v={$cli.version}"></script>
+            </xsl:if>
         </xsl:when>
         <xsl:when test="$b-debug-react-local">
             <script type="module" defer="" src="./static/js/main.js"></script>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2765,6 +2765,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="b-has-embed-button" select="$embed-button = 'yes'"/>
 
+<!--                           -->
+<!-- HTML Read-aloud control   -->
+<!--                           -->
+
+<xsl:variable name="read-aloud">
+    <xsl:apply-templates select="$publisher-attribute-options/html/pi:pub-attribute[@name='read-aloud']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-read-aloud" select="not($read-aloud = 'no')"/>
 
 <!--                            -->
 <!-- HTML Banner options        -->
@@ -3489,6 +3497,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </common>
     <html>
         <pi:pub-attribute name="short-answer-responses" default="graded" options="always"/>
+        <pi:pub-attribute name="read-aloud" default="yes" options="no"/>
         <pi:pub-attribute name="favicon" default="none" options="simple"/>
         <pi:pub-attribute name="embed-button" default="no" options="yes"/>
         <pi:pub-attribute name="design-width" freeform="yes"/>


### PR DESCRIPTION
While a commercial screen reader is likely the preferred tool for a blind reader, there are many people who might benefit from an easy way to have the text in a pretext book read to them (including students who would like to hear what a particular math symbol is called). 

This adds an embedded text-to-speech player that will do a quite serviceable job reading the content of a page.  Some basic settings (reading speed, voice, whether to read knowled content, whether to jump to the next page) are available for readers as well.

Publisher variable to turn on or off (with on as the default). 

How it works: All javascript magic.  Modern browsers provide text-to-speech technology, often falling back to the speech engine provided by the operating system.  We provide some additional logic to get the reading order, and handoff between regular text and mathjax.  Basic keyboard navigation is also used to jump up and down the page.