### PR TITLE
chore: fix unintentional(?) missing borders for blocks in Greeley theme

### DIFF
--- a/css/targets/html/greeley/_chunks-greeley.scss
+++ b/css/targets/html/greeley/_chunks-greeley.scss
@@ -44,6 +44,8 @@ $border-radius: 8px !default;
 .openproblem-like,
 .computation-like,
 .commentary  {
+  @include L-mixin.border;
+
   > .heading {
     display: block;
     font-size: 1.1em;


### PR DESCRIPTION
`border-left: 2px solid var(--block-border-color)` is now generated for `.remark-like` (and .example-like, .project-like, .openproblem-like, .computation-like, .commentary), matching default-modern's L-border treatment.

Root cause: css/targets/html/greeley/_chunks-greeley.scss imported the L-mixin helper and even had knowl-content reset rules assuming a left border existed (`border-left: none` override for knowls), but the actual `@include L-mixin.border;` call was missing from the .example-like etc. rule — it was left out since the theme's original commit (aa56f70e).

Fix: added `@include L-mixin.border;` to that rule block, mirroring how default-modern applies it.