### PR TITLE
Update PreFigure schema (pf_schema.rnc)

### DIFF
--- a/schema/pf_schema.rnc
+++ b/schema/pf_schema.rnc
@@ -82,21 +82,27 @@ Read = element read {
     attribute delimiter {text}?,
     attribute quotechar {text}?,
     attribute string-columns {text}?,
-    attribute type {text}
+    attribute type {text}?
 }
 
+# template elements only carry default attributes, so no
+# attribute is required inside a template
 Templates = element templates {
-    GraphicalElements+
+    TemplateElement+
+}
+
+TemplateElement = element * {
+    (attribute * {text} | text | TemplateElement)*
 }
 
 # the next elements group other elements together
 GroupElements =
 (
-    Coordinates? &
-    Group? &
-    Repeat? &
-    Clip? &
-    Transform?
+    Coordinates |
+    Group |
+    Repeat |
+    Clip |
+    Transform
 )
 
 # coordinates are special in that they can contain everything a diagram can
@@ -105,12 +111,13 @@ Coordinates = element coordinates {
     attribute destination {text}?,
     attribute aspect-ratio {text}?,
     attribute preserve-y-range {"yes"|"no"}?,
+    attribute scales {text}?,
     (
-        DefinitionElements* &
-        GraphicalElements* &
-        GroupElements* &
-        TransformElements*
-    )
+        DefinitionElements |
+        GraphicalElements |
+        GroupElements |
+        TransformElements
+    )*
 }
 
 Group = element group {
@@ -119,11 +126,11 @@ Group = element group {
     attribute transform {text}?,
     CommonAttributes,
     (
-        DefinitionElements* &
-        GraphicalElements* &
-        GroupElements* &
-        TransformElements*
-    )
+        DefinitionElements |
+        GraphicalElements |
+        GroupElements |
+        TransformElements
+    )*
 }
 
 Repeat = element repeat {
@@ -131,11 +138,11 @@ Repeat = element repeat {
     attribute at {text}?,
     CommonAttributes,
     (
-        DefinitionElements* &
-        GraphicalElements* &
-        GroupElements* &
-        TransformElements*
-    )
+        DefinitionElements |
+        GraphicalElements |
+        GroupElements |
+        TransformElements
+    )*
 }
 
 Clip = element clip {
@@ -143,35 +150,46 @@ Clip = element clip {
     attribute shape {text},
     CommonAttributes,
     (
-        DefinitionElements* &
-        GraphicalElements* &
-        GroupElements* &
-        TransformElements*
-    )
+        DefinitionElements |
+        GraphicalElements |
+        GroupElements |
+        TransformElements
+    )*
 }
 
 Transform = element transform {
-    DefinitionElements* &
-    GraphicalElements* &
-    GroupElements* &
-    TransformElements*
+    (
+        DefinitionElements |
+        GraphicalElements |
+        GroupElements |
+        TransformElements
+    )*
 }
 
 TransformElements = (
     element translate {
         attribute by {text}
-    }* &
+    } |
     element rotate {
         attribute by {text},
         attribute about {text}?,
         attribute degrees {"yes"|"no"}?
-    }* &
+    } |
     element scale {
         attribute by {text}
-    }* &
+    } |
+    element scale3d {
+        attribute by {text}
+    } |
     element change-basis {
         attribute basis {text}
-    }*
+    } |
+    element center {
+        empty
+    } |
+    element set-eye {
+        attribute eye {text}
+    }
 )
 
 # attributes and text for labels
@@ -310,10 +328,10 @@ StrokeAttributes =
     attribute linecap {text}?,
     attribute dash {text}?,
     attribute cliptobbox {"yes"|"no"}?,
-    attribute outline {"yes"|"no"}?,
+    attribute outline {text}?,
     TactileStrokeAttributes?
 
-TactileStrokeAttributes = 
+TactileStrokeAttributes =
     attribute tactile-stroke {text}?,
     attribute tactile-thickness {text}?,
     attribute tactile-miterlimit {text}?,
@@ -442,14 +460,15 @@ Axes = element axes {
     attribute v-pi-format {"yes"|"no"}?,
     attribute h-frame {"bottom"|"top"}?,
     attribute v-frame {"left"|"right"}?,
-    attribute stroke {text}?,
-    attribute thickness {text}?,
+    attribute hticks {text}?,
+    attribute vticks {text}?,
     attribute tick-size {text}?,
     attribute axes {"horizontal"|"vertical"}?,
     attribute bounding-box {"yes"|"no"}?,
     attribute h-zero-label {"yes"|"no"}?,
     attribute v-zero-label {"yes"|"no"}?,
     attribute label-commas {"yes"|"no"}?,
+    StrokeAttributes,
     CommonAttributes,
     XLabel?,
     YLabel?
@@ -485,16 +504,20 @@ Grid-Axes = element grid-axes {
     attribute ylabel {text}?,
     attribute arrows {text}?,
     attribute decorations {"yes"|"no"}?,
+    attribute hticks {text}?,
+    attribute vticks {text}?,
     attribute tick-size {text}?,
     attribute axes {"horizontal"|"vertical"}?,
     attribute bounding-box {"yes"|"no"}?,
     attribute h-zero-label {"yes"|"no"}?,
     attribute v-zero-label {"yes"|"no"}?,
     attribute label-commas {"yes"|"no"}?,
+    attribute coordinates {"cartesian"|"polar"}?,
+    attribute clear-background {"yes"|"no"}?,
     StrokeAttributes,
     CommonAttributes,
     XLabel?,
-    YLabel?    
+    YLabel?
 }
 
 Tick-Mark = element tick-mark {
@@ -547,6 +570,7 @@ Graph = element graph {
     attribute domain-degrees {"yes"|"no"}?,
     attribute closed {"yes"|"no"}?,
     attribute fill {text}?,
+    attribute arrows {text}?,
     StrokeAttributes,
     CommonAttributes
 }
@@ -561,7 +585,8 @@ Image = element image {
     attribute filetype {"svg"|"png"|"gif"|"jpeg"|"jpg"}?,
     attribute rotate {text}?,
     attribute scale {text}?,
-    CommonAttributes
+    CommonAttributes,
+    GraphicalElements*
 }
 
 Histogram = element histogram {
@@ -605,12 +630,14 @@ Line = element line {
     attribute p1 {text}?,
     attribute p2 {text}?,
     attribute endpoint-offsets {text}?,
+    attribute tactile-endpoint-offsets {text}?,
     attribute infinite {"yes"|"no"}?,
     attribute arrows {text}?,
     attribute arrow-width {text}?,
     attribute arrow-angles {text}?,
     attribute reverse {"yes"|"no"}?,
-    attribute additional-arrows {"yes"|"no"}?,
+    attribute additional-arrows {text}?,
+    attribute label-location {text}?,
     StrokeAttributes,
     CommonAttributes,
     LabelAttributes,
@@ -638,6 +665,16 @@ Network = element network {
     attribute node-thickness {text}?,
     attribute node-style {text}?,
     attribute node-size {text}?,
+    attribute tactile-edge-stroke {text}?,
+    attribute tactile-edge-thickness {text}?,
+    attribute tactile-edge-dash {text}?,
+    attribute tactile-node-fill {text}?,
+    attribute tactile-node-stroke {text}?,
+    attribute tactile-node-thickness {text}?,
+    attribute tactile-node-style {text}?,
+    attribute tactile-node-size {text}?,
+    attribute edge-spread {text}?,
+    attribute tactile-edge-spread {text}?,
     attribute labels {"yes"|"no"}?,
     attribute label-dictionary {text}?,
     (
@@ -753,9 +790,12 @@ Rectangle = element rectangle {
 Riemann-Sum = element riemann-sum {
     attribute at {text}?,
     attribute function {text},
-    attribute N {text},
+    attribute N {text}?,
     attribute domain {text}?,
     attribute rule {text}?,
+    attribute partition {text}?,
+    attribute samples {text}?,
+    attribute subinterval-text {text}?,
     FillAttributes,
     CommonAttributes
 }
@@ -768,6 +808,8 @@ Scatter = element scatter {
     attribute y {text}?,
     attribute filter {text}?,
     attribute point-text {text}?,
+    attribute style {text}?,
+    attribute size {text}?,
     FillAttributes,
     CommonAttributes
 }
@@ -797,6 +839,7 @@ Spline = element spline {
     attribute at {text}?,
     attribute bc {text}?,
     attribute points {text},
+    attribute t-values {text}?,
     attribute parameter {text}?,
     attribute N {text}?,
     attribute arrows {text}?,
@@ -814,6 +857,7 @@ Tangent-line = element tangent-line {
     attribute at {text}?,
     attribute function {text},
     attribute point {text},
+    attribute name {text}?,
     attribute domain {text}?,
     attribute infinite {"yes"|"no"}?,
     StrokeAttributes,
@@ -856,6 +900,7 @@ Vector-Field = element vector-field {
     attribute N {text}?,
     attribute arrow-width {text}?,
     attribute arrow-angles {text}?,
+    attribute exponent {text}?,
     StrokeAttributes,
     CommonAttributes
 }

--- a/schema/pf_schema.rng
+++ b/schema/pf_schema.rng
@@ -168,35 +168,45 @@
       <optional>
         <attribute name="string-columns"/>
       </optional>
-      <attribute name="type"/>
+      <optional>
+        <attribute name="type"/>
+      </optional>
     </element>
   </define>
+  <!--
+    template elements only carry default attributes, so no
+    attribute is required inside a template
+  -->
   <define name="Templates">
     <element name="templates">
       <oneOrMore>
-        <ref name="GraphicalElements"/>
+        <ref name="TemplateElement"/>
       </oneOrMore>
+    </element>
+  </define>
+  <define name="TemplateElement">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="TemplateElement"/>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <!-- the next elements group other elements together -->
   <define name="GroupElements">
-    <interleave>
-      <optional>
-        <ref name="Coordinates"/>
-      </optional>
-      <optional>
-        <ref name="Group"/>
-      </optional>
-      <optional>
-        <ref name="Repeat"/>
-      </optional>
-      <optional>
-        <ref name="Clip"/>
-      </optional>
-      <optional>
-        <ref name="Transform"/>
-      </optional>
-    </interleave>
+    <choice>
+      <ref name="Coordinates"/>
+      <ref name="Group"/>
+      <ref name="Repeat"/>
+      <ref name="Clip"/>
+      <ref name="Transform"/>
+    </choice>
   </define>
   <!-- coordinates are special in that they can contain everything a diagram can -->
   <define name="Coordinates">
@@ -216,20 +226,17 @@
           </choice>
         </attribute>
       </optional>
-      <interleave>
-        <zeroOrMore>
+      <optional>
+        <attribute name="scales"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
           <ref name="DefinitionElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GraphicalElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GroupElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="TransformElements"/>
-        </zeroOrMore>
-      </interleave>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Group">
@@ -244,20 +251,14 @@
         <attribute name="transform"/>
       </optional>
       <ref name="CommonAttributes"/>
-      <interleave>
-        <zeroOrMore>
+      <zeroOrMore>
+        <choice>
           <ref name="DefinitionElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GraphicalElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GroupElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="TransformElements"/>
-        </zeroOrMore>
-      </interleave>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Repeat">
@@ -267,20 +268,14 @@
         <attribute name="at"/>
       </optional>
       <ref name="CommonAttributes"/>
-      <interleave>
-        <zeroOrMore>
+      <zeroOrMore>
+        <choice>
           <ref name="DefinitionElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GraphicalElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GroupElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="TransformElements"/>
-        </zeroOrMore>
-      </interleave>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Clip">
@@ -290,74 +285,63 @@
       </optional>
       <attribute name="shape"/>
       <ref name="CommonAttributes"/>
-      <interleave>
-        <zeroOrMore>
+      <zeroOrMore>
+        <choice>
           <ref name="DefinitionElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GraphicalElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GroupElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="TransformElements"/>
-        </zeroOrMore>
-      </interleave>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Transform">
     <element name="transform">
-      <interleave>
-        <zeroOrMore>
+      <zeroOrMore>
+        <choice>
           <ref name="DefinitionElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GraphicalElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="GroupElements"/>
-        </zeroOrMore>
-        <zeroOrMore>
           <ref name="TransformElements"/>
-        </zeroOrMore>
-      </interleave>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
   <define name="TransformElements">
-    <interleave>
-      <zeroOrMore>
-        <element name="translate">
-          <attribute name="by"/>
-        </element>
-      </zeroOrMore>
-      <zeroOrMore>
-        <element name="rotate">
-          <attribute name="by"/>
-          <optional>
-            <attribute name="about"/>
-          </optional>
-          <optional>
-            <attribute name="degrees">
-              <choice>
-                <value>yes</value>
-                <value>no</value>
-              </choice>
-            </attribute>
-          </optional>
-        </element>
-      </zeroOrMore>
-      <zeroOrMore>
-        <element name="scale">
-          <attribute name="by"/>
-        </element>
-      </zeroOrMore>
-      <zeroOrMore>
-        <element name="change-basis">
-          <attribute name="basis"/>
-        </element>
-      </zeroOrMore>
-    </interleave>
+    <choice>
+      <element name="translate">
+        <attribute name="by"/>
+      </element>
+      <element name="rotate">
+        <attribute name="by"/>
+        <optional>
+          <attribute name="about"/>
+        </optional>
+        <optional>
+          <attribute name="degrees">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
+      </element>
+      <element name="scale">
+        <attribute name="by"/>
+      </element>
+      <element name="scale3d">
+        <attribute name="by"/>
+      </element>
+      <element name="change-basis">
+        <attribute name="basis"/>
+      </element>
+      <element name="center">
+        <empty/>
+      </element>
+      <element name="set-eye">
+        <attribute name="eye"/>
+      </element>
+    </choice>
   </define>
   <!-- attributes and text for labels -->
   <define name="LabelAttributes">
@@ -733,12 +717,7 @@
       </attribute>
     </optional>
     <optional>
-      <attribute name="outline">
-        <choice>
-          <value>yes</value>
-          <value>no</value>
-        </choice>
-      </attribute>
+      <attribute name="outline"/>
     </optional>
     <optional>
       <ref name="TactileStrokeAttributes"/>
@@ -1081,10 +1060,10 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="stroke"/>
+        <attribute name="hticks"/>
       </optional>
       <optional>
-        <attribute name="thickness"/>
+        <attribute name="vticks"/>
       </optional>
       <optional>
         <attribute name="tick-size"/>
@@ -1129,6 +1108,7 @@
           </choice>
         </attribute>
       </optional>
+      <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>
       <optional>
         <ref name="XLabel"/>
@@ -1266,6 +1246,12 @@
         </attribute>
       </optional>
       <optional>
+        <attribute name="hticks"/>
+      </optional>
+      <optional>
+        <attribute name="vticks"/>
+      </optional>
+      <optional>
         <attribute name="tick-size"/>
       </optional>
       <optional>
@@ -1302,6 +1288,22 @@
       </optional>
       <optional>
         <attribute name="label-commas">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="coordinates">
+          <choice>
+            <value>cartesian</value>
+            <value>polar</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="clear-background">
           <choice>
             <value>yes</value>
             <value>no</value>
@@ -1434,6 +1436,9 @@
       <optional>
         <attribute name="fill"/>
       </optional>
+      <optional>
+        <attribute name="arrows"/>
+      </optional>
       <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>
     </element>
@@ -1474,6 +1479,9 @@
         <attribute name="scale"/>
       </optional>
       <ref name="CommonAttributes"/>
+      <zeroOrMore>
+        <ref name="GraphicalElements"/>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Histogram">
@@ -1567,6 +1575,9 @@
         <attribute name="endpoint-offsets"/>
       </optional>
       <optional>
+        <attribute name="tactile-endpoint-offsets"/>
+      </optional>
+      <optional>
         <attribute name="infinite">
           <choice>
             <value>yes</value>
@@ -1592,12 +1603,10 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="additional-arrows">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
-        </attribute>
+        <attribute name="additional-arrows"/>
+      </optional>
+      <optional>
+        <attribute name="label-location"/>
       </optional>
       <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>
@@ -1683,6 +1692,36 @@
       </optional>
       <optional>
         <attribute name="node-size"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-edge-stroke"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-edge-thickness"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-edge-dash"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-node-fill"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-node-stroke"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-node-thickness"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-node-style"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-node-size"/>
+      </optional>
+      <optional>
+        <attribute name="edge-spread"/>
+      </optional>
+      <optional>
+        <attribute name="tactile-edge-spread"/>
       </optional>
       <optional>
         <attribute name="labels">
@@ -1976,12 +2015,23 @@
         <attribute name="at"/>
       </optional>
       <attribute name="function"/>
-      <attribute name="N"/>
+      <optional>
+        <attribute name="N"/>
+      </optional>
       <optional>
         <attribute name="domain"/>
       </optional>
       <optional>
         <attribute name="rule"/>
+      </optional>
+      <optional>
+        <attribute name="partition"/>
+      </optional>
+      <optional>
+        <attribute name="samples"/>
+      </optional>
+      <optional>
+        <attribute name="subinterval-text"/>
       </optional>
       <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
@@ -2009,6 +2059,12 @@
       </optional>
       <optional>
         <attribute name="point-text"/>
+      </optional>
+      <optional>
+        <attribute name="style"/>
+      </optional>
+      <optional>
+        <attribute name="size"/>
       </optional>
       <ref name="FillAttributes"/>
       <ref name="CommonAttributes"/>
@@ -2077,6 +2133,9 @@
       </optional>
       <attribute name="points"/>
       <optional>
+        <attribute name="t-values"/>
+      </optional>
+      <optional>
         <attribute name="parameter"/>
       </optional>
       <optional>
@@ -2119,6 +2178,9 @@
       </optional>
       <attribute name="function"/>
       <attribute name="point"/>
+      <optional>
+        <attribute name="name"/>
+      </optional>
       <optional>
         <attribute name="domain"/>
       </optional>
@@ -2226,6 +2288,9 @@
       </optional>
       <optional>
         <attribute name="arrow-angles"/>
+      </optional>
+      <optional>
+        <attribute name="exponent"/>
       </optional>
       <ref name="StrokeAttributes"/>
       <ref name="CommonAttributes"/>


### PR DESCRIPTION
This PR syncs `pretext/schema/pf_schema.rnc` with the updated version in the prefigure repository. There are no changes to the underlying PreTeXt schema.

A recently introduced snapshot testing framework in the prefigure repo, combined with validating two large corpora — the ULA linear algebra textbook and the prefigure documentation source — against the schema surfaced a number of places where the schema rejected real, engine-valid PreFigure diagrams. The fixes fall into three areas: a few typos that prevented the schema from compiling at all, interleaved content models that were rewritten in an equivalent but less expensive form, and missing attributes that the engine accepts but the schema didn't know about.

\`pf_schema.rnc\` remains namespace-free so PreTeXt's own adapter continues to supply the namespace unchanged.