### PR TITLE
Validation-plus: character advice is withheld where markup is not allowed

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2834,7 +2834,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- “She kept repeating to herself, ‘I have a lover! a lover!’  -->
                     <!-- savoring the idea as if a new puberty had come upon her.”   -->
 
-                    <p>Primary only: <q>La liberté commence où l’ignorance finit.</q> Primary and secondary: <q>Elle se répétait : <sq>J’ai un amant ! un amant !</sq> se délectant à cette idée comme à celle d’une autre puberté qui lui serait survenue</q>. (Victor Hugo, Les Misérables; Gustave Flaubert, Madame Bovary)</p>
+                    <p>Primary only: <q>La liberté commence où l'ignorance finit.</q> Primary and secondary: <q>Elle se répétait : <sq>J'ai un amant ! un amant !</sq> se délectant à cette idée comme à celle d'une autre puberté qui lui serait survenue</q>. (Victor Hugo, Les Misérables; Gustave Flaubert, Madame Bovary)</p>
                 </paragraphs>
 
                 <paragraphs xml:lang="fr-CA">
@@ -2849,7 +2849,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- “She kept repeating to herself, ‘I have a lover! a lover!’  -->
                     <!-- savoring the idea as if a new puberty had come upon her.”   -->
 
-                    <p>Primary only: <q>La liberté commence où l’ignorance finit.</q> Primary and secondary: <q>Elle se répétait : <sq>J’ai un amant ! un amant !</sq> se délectant à cette idée comme à celle d’une autre puberté qui lui serait survenue</q>. (Victor Hugo, Les Misérables; Gustave Flaubert, Madame Bovary)</p>
+                    <p>Primary only: <q>La liberté commence où l'ignorance finit.</q> Primary and secondary: <q>Elle se répétait : <sq>J'ai un amant ! un amant !</sq> se délectant à cette idée comme à celle d'une autre puberté qui lui serait survenue</q>. (Victor Hugo, Les Misérables; Gustave Flaubert, Madame Bovary)</p>
                 </paragraphs>
 
                 <paragraphs xml:lang="de-DE">
@@ -10738,7 +10738,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <cd>&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</cd>
                     as the first line of your source file. (You <em>may</em> be able to accurately cut-and-paste this version here.  But if the copy has non-standard characters in it, go back to the top of this source file for a copy.)</p></li>
 
-                    <li><p>Alan Wood’s <url href="http://www.alanwood.net/unicode/unicode_samples.html" visual="www.alanwood.net/unicode/unicode_samples.html">Unicode Resources</url> has a plethora of samples of various groups of Unicode characters.  If you, or your readers, are <q>missing</q> characters in a web browser, this is a good place to start testing the local setup.</p></li>
+                    <li><p>Alan Wood's <url href="http://www.alanwood.net/unicode/unicode_samples.html" visual="www.alanwood.net/unicode/unicode_samples.html">Unicode Resources</url> has a plethora of samples of various groups of Unicode characters.  If you, or your readers, are <q>missing</q> characters in a web browser, this is a good place to start testing the local setup.</p></li>
                 </ul></p>
             </paragraphs>
 

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -995,7 +995,7 @@ TEST_CASE( "Test the add function" ) {
 
             for aline in ccfile:
                 values = aline.split()
-                print('In', values[0], 'the average temp. was', values[1], '°C and CO2 emmisions were', values[2], 'gigatons.')
+                print('In', values[0], 'the average temp. was', values[1], '&#x00B0;C and CO2 emmisions were', values[2], 'gigatons.')
 
             ccfile.close()
             </code>
@@ -1122,7 +1122,7 @@ TEST_CASE( "Test the add function" ) {
 
             for aline in ccfile:
                 values = aline.split()
-                print('In', values[0], 'the average temp. was', values[1], '°C and CO2 emmisions were', values[2], 'gigatons.')
+                print('In', values[0], 'the average temp. was', values[1], '&#x00B0;C and CO2 emmisions were', values[2], 'gigatons.')
 
             ccfile.close()
             </code>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -529,9 +529,28 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Note: a single text node can have many problems, -->
 <!-- we catch such a node and then test for problems  -->
 <xsl:template match="text()[contains(., '&#x00B0;') or contains(., '&#x00D7;') or contains(., '&#x200B;') or contains(., '&#x2013;') or contains(., '&#x2014;') or contains(., '&#x2018;') or contains(., '&#x2019;') or contains(., '&#x201C;') or contains(., '&#x201D;')]">
-    <!-- These characters do process properly in math mode -->
-    <!-- and can be useful in \text{} then, so we allow them there -->
-    <xsl:if test="not(parent::m or parent::me or parent::men or parent::mrow)">
+    <!-- A zero-width space is always worth reporting: the advice is to    -->
+    <!-- delete it, which an author can act on anywhere, and an invisible  -->
+    <!-- character does more damage in code or in a LaTeX fragment than in -->
+    <!-- prose.  So it is tested outside the guard below.                  -->
+    <xsl:if test="contains(., '&#x200B;')">
+        <xsl:apply-templates select="." mode="messaging">
+            <xsl:with-param name="severity" select="'warn'"/>
+            <xsl:with-param name="message-id" select="'unicode-zero-width-space'"/>
+            <xsl:with-param name="message">
+                <xsl:text>A run of text contains a Unicode character for zero-width character (U+200B, decimal 8203).&#xa;</xsl:text>
+                <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
+                <xsl:text>It is unnecessary and likely to cause errors.  It should be removed.</xsl:text>
+            </xsl:with-param>
+        </xsl:apply-templates>
+    </xsl:if>
+    <!-- The remaining advice is to replace the character with a PreTeXt    -->
+    <!-- element, so it is withheld where no element could go.  Math is     -->
+    <!-- LaTeX, where these characters process properly and are useful in   -->
+    <!-- \text{}.  The elements of &TEXT-ONLY-FILTER; take text and nothing -->
+    <!-- else.  A text-only element has no element children, so testing the -->
+    <!-- parent reaches every such run of text.                             -->
+    <xsl:if test="not(parent::m or parent::md or parent::mrow) and not(parent::*[&TEXT-ONLY-FILTER;])">
         <!-- Unicode Character 'DEGREE SIGN' (U+00B0) decimal: 176 -->
         <xsl:if test="contains(., '&#x00B0;')">
             <xsl:apply-templates select="." mode="messaging">
@@ -540,7 +559,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for a degree symbol (U+00B0, decimal 176).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>The symbol will behave better as the empty element "&lt;degree/&gt;"</xsl:text>
+                    <xsl:text>Where the markup is allowed, the symbol will behave better as the empty element "&lt;degree/&gt;"</xsl:text>
                 </xsl:with-param>
             </xsl:apply-templates>
         </xsl:if>
@@ -552,19 +571,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for a multiplication sign (U+00D7, decimal 215).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>The symbol will behave better as the empty element "&lt;times/&gt;"</xsl:text>
-                </xsl:with-param>
-            </xsl:apply-templates>
-        </xsl:if>
-        <!-- Unicode Character 'ZERO WIDTH SPACE' (U+200B) decimal: 8203 -->
-        <xsl:if test="contains(., '&#x200B;')">
-            <xsl:apply-templates select="." mode="messaging">
-                <xsl:with-param name="severity" select="'warn'"/>
-                <xsl:with-param name="message-id" select="'unicode-zero-width-space'"/>
-                <xsl:with-param name="message">
-                    <xsl:text>A run of text contains a Unicode character for zero-width character (U+200B, decimal 8203).&#xa;</xsl:text>
-                    <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>It is unnecessary and likely to cause errors.  It should be removed.</xsl:text>
+                    <xsl:text>Where the markup is allowed, the symbol will behave better as the empty element "&lt;times/&gt;"</xsl:text>
                 </xsl:with-param>
             </xsl:apply-templates>
         </xsl:if>
@@ -576,7 +583,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for an en-dash (U+2013, decimal 8211).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>The en-dash will behave better as the empty element "&lt;ndash/&gt;".&#xa;</xsl:text>
+                    <xsl:text>Where the markup is allowed, the en-dash will behave better as the empty element "&lt;ndash/&gt;".&#xa;</xsl:text>
                     <xsl:text>Understand the difference between an en-dash and an em-dash before editing.&#xa;</xsl:text>
                     <xsl:text>An en-dash is used for a range, such as the years 2013-22.</xsl:text>
                 </xsl:with-param>
@@ -590,7 +597,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains a Unicode character for an em-dash (U+2014, decimal 8212).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>The em-dash will behave better as the empty element "&lt;mdash/&gt;".&#xa;</xsl:text>
+                    <xsl:text>Where the markup is allowed, the em-dash will behave better as the empty element "&lt;mdash/&gt;".&#xa;</xsl:text>
                     <xsl:text>Understand the difference between an en-dash and an em-dash before editing.&#xa;</xsl:text>
                     <xsl:text>An em-dash is used for a pause in a sentence, and should not be authored with a space on either side.</xsl:text>
                 </xsl:with-param>
@@ -606,7 +613,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <xsl:text>A run of text contains Unicode characters for single quotation marks (U+2018, decimal 8216; U+2019, decimal 8217).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
                     <xsl:text>A U+2019 in isolation could be an apostrophe.  Replace it with the keyboard version: U+0027.&#xa;</xsl:text>
-                    <xsl:text>A matching pair U+2018, U+2019 should be replaced by the "&lt;sq&gt;" element enclosing content.&#xa;</xsl:text>
+                    <xsl:text>Where the markup is allowed, a matching pair U+2018, U+2019 should be replaced by the "&lt;sq&gt;" element enclosing content.&#xa;</xsl:text>
                     <xsl:text>In rare cases, U+2018 might be replaced by the empty element "&lt;lsq/&gt;".&#xa;</xsl:text>
                     <xsl:text>In rare cases, U+2019 might be replaced by the empty element "&lt;rsq/&gt;".</xsl:text>
                 </xsl:with-param>
@@ -621,7 +628,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:with-param name="message">
                     <xsl:text>A run of text contains Unicode characters for double quotation marks (U+201C, decimal 8220; U+201D, decimal 8221).&#xa;</xsl:text>
                     <xsl:text>Likely this was introduced in a conversion of source material authored in a word-processor.&#xa;</xsl:text>
-                    <xsl:text>A matching pair U+201C, U+201D should be replaced by the "&lt;q&gt;" element enclosing content.&#xa;</xsl:text>
+                    <xsl:text>Where the markup is allowed, a matching pair U+201C, U+201D should be replaced by the "&lt;q&gt;" element enclosing content.&#xa;</xsl:text>
                     <xsl:text>In rare cases, U+201C might be replaced by the empty element "&lt;lq/&gt;".&#xa;</xsl:text>
                     <xsl:text>In rare cases, U+201D might be replaced by the empty element "&lt;rq/&gt;".</xsl:text>
                 </xsl:with-param>

--- a/xsl/entities.ent
+++ b/xsl/entities.ent
@@ -174,6 +174,17 @@
 <!ENTITY DISCUSSION-LIKE "context|discussion|opinion|status|suggestion">
 <!ENTITY DISCUSSION-FILTER "self::context or self::discussion or self::opinion or self::status or self::suggestion">
 
+<!-- Elements the schema gives text-only content: no PreTeXt markup is   -->
+<!-- permitted inside them, whether because they are verbatim (code, a   -->
+<!-- graphics language, a LaTeX fragment) or because the element is a    -->
+<!-- plain string (a "shortdescription", a bibliography field).  Advice  -->
+<!-- to replace a stray character with an element cannot be followed in  -->
+<!-- these, so the validation-plus stylesheet withholds it there.        -->
+<!-- Every name below is text-only in EVERY declaration in the schema.   -->
+<!-- Deliberately absent: "author", "editor", "page" and "year", each of -->
+<!-- which is text in one context and markup in another.                 -->
+<!ENTITY TEXT-ONLY-FILTER "self::DOI or self::ISBN or self::ISSN or self::URL or self::asymptote or self::asymptote-preamble or self::attr or self::blurb or self::c or self::cd or self::cline or self::code or self::document-id or self::dropping-particle or self::edition or self::email or self::family or self::genre or self::genus or self::given or self::holder or self::initialism or self::input or self::issue or self::kbd or self::latex-image or self::latex-image-preamble or self::literal or self::macro-file or self::macros or self::mag or self::mermaid or self::non-dropping-particle or self::number or self::number-of-pages or self::output or self::page-first or self::pages or self::pf or self::pg-code or self::plaintitle or self::postamble or self::pre or self::preamble or self::publisher or self::rename or self::sageplot or self::series or self::shortdescription or self::species or self::static-ordering or self::stdin or self::suffix or self::tag or self::tage or self::volume">
+
 <!-- When context is an inline "exercise", then this condition is      -->
 <!-- true. We are positive, so as new locations of "exercise"          -->
 <!-- are added, then this need not change                              -->


### PR DESCRIPTION
Addresses false positives reported by Will Haynes on `pretext-dev`: the validation-plus checks for word-processor characters fired inside content where their advice cannot be followed. The example given was an en-dash in a copyright notice, inside a LaTeX comment, inside a `latex-image`. [thread](https://groups.google.com/d/msgid/pretext-dev/1e8da4b3-7622-47d4-ae14-6e71048fb14an%40googlegroups.com)

One template checks nine characters and issues six messages. Five say "replace this with a PreTeXt element", which is impossible where the schema permits no markup: verbatim code, LaTeX and graphics fragments, a `shortdescription`, a bibliography field. Those five are now withheld there, and their wording is tempered to "Where the markup is allowed, ...", since the same message is still seen where markup *is* available.

The sixth stays universal. A zero-width space is reported everywhere, because deleting it is advice an author can act on anywhere, and an invisible character does more harm in code than in prose.

`&TEXT-ONLY-FILTER;` in `xsl/entities.ent` names the 56 elements whose content is text in *every* declaration in `pretext.rnc`. Bibliography and CSL fields are included deliberately: they are prime territory for a paste from elsewhere, and a quotation mark has no business in a publisher's name. `author`, `editor`, `page` and `year` are excluded, being text in one context and markup in another.

The math guard was also wrong. It read `not(parent::m or parent::me or parent::men or parent::mrow)`; `me` and `men` are gone from the schema, while `md` was missing although its single-line form holds text directly. Now `m`, `md`, `mrow`.

Sample article warnings go 21 to 9, sample book 2 to 0. No other check changes. What is silenced is character and font testing, which is what nearly all of it was.

Two further commits fix what remained, both small author errors of exactly the kind the check exists to catch.

The sample article had seven U+2019 used as apostrophes, on three lines: `l'ignorance`, `J'ai un amant` and `d'une autre puberte` in the French quotation paragraph, twice over, and `Alan Wood's`. They become the keyboard apostrophe.

The sample book had a degree sign inside a Python string in an ActiveCode program. There the character is what the program prints, so it stays a degree sign, but it is now written `&#x00B0;` so the source file is 7-bit. The assembled tree is byte-identical.

Three sites are deliberately left alone, all of them tests rather than mistakes: the `&#x00B0;` and `&#x00D7;` cells of the Latin-1 character tables, the same range echoed through a console listing, and a quotation mark inside `\text{}` in math.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
