### PR TITLE
Gaurd addKnowls against born-hidden-knowl elements missing a summary

### DIFF
--- a/js/dist/knowl.js
+++ b/js/dist/knowl.js
@@ -10,6 +10,9 @@ function addKnowls(target) {
   for (const bhk of bornHiddens) {
     const summary = bhk.querySelector(":scope > summary");
     const contents = bhk.querySelector(":scope > summary + *");
+    if (!summary || !contents) {
+      continue;
+    }
     new SlideRevealer(summary, contents, bhk);
   }
 }

--- a/js/dist/pretext-core.js
+++ b/js/dist/pretext-core.js
@@ -40,6 +40,9 @@
         for (const bhk of bornHiddens) {
           const summary = bhk.querySelector(":scope > summary");
           const contents = bhk.querySelector(":scope > summary + *");
+          if (!summary || !contents) {
+            continue;
+          }
           new SlideRevealer(summary, contents, bhk);
         }
       }
@@ -1872,7 +1875,7 @@
     existingSections.forEach((sec) => ptxContent.removeChild(sec));
     ptxContent.appendChild(printableSection);
   }
-  function rewriteSolutions() {
+  async function rewriteSolutions() {
     var born_hidden_knowls = document.querySelectorAll(".printout details");
     born_hidden_knowls.forEach(function(detail) {
       const summary = detail.querySelector("summary");
@@ -1889,6 +1892,9 @@
       div.appendChild(body);
       detail.parentNode.replaceChild(div, detail);
     });
+    if (typeof MathJax !== "undefined" && MathJax.typesetPromise) {
+      await MathJax.typesetPromise();
+    }
   }
   function toPixels(value) {
     if (typeof value === "number") return value;
@@ -1926,7 +1932,7 @@
         bottom: toPixels(marginList[2] || "0.75in"),
         left: toPixels(marginList[3] || "0.75in")
       };
-      rewriteSolutions();
+      await rewriteSolutions();
       let paperSize = getPaperSize();
       if (paperSize) {
         const radio = document.querySelector(`input[name="papersize"][value="${paperSize}"]`);

--- a/js/knowl.js
+++ b/js/knowl.js
@@ -10,11 +10,16 @@ function addKnowls(target) {
   for (const xref of xrefs) {
     LinkKnowl.initializeXrefKnowl(xref);
   }
-
+ 
   const bornHiddens = target.querySelectorAll(".born-hidden-knowl");
   for (const bhk of bornHiddens) {
     const summary = bhk.querySelector(":scope > summary");
     const contents = bhk.querySelector(":scope > summary + *");
+    if (!summary || !contents) {
+      // Skip elements that carry the class but aren't an actual
+      // <details>/<summary> knowl (e.g. a print-layout clone).
+      continue;
+    }
     new SlideRevealer(summary, contents, bhk);
   }
 }

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1052,7 +1052,7 @@ async function loadPrintout(printableSectionID) {
 }
 
 // Function to redo solutions details to divs with summary as title
-function rewriteSolutions() {
+async function rewriteSolutions() {
     var born_hidden_knowls = document.querySelectorAll('.printout details');
     born_hidden_knowls.forEach(function(detail) {
         const summary = detail.querySelector('summary');
@@ -1069,6 +1069,9 @@ function rewriteSolutions() {
         div.appendChild(body);
         detail.parentNode.replaceChild(div, detail);
     });
+    if (typeof MathJax !== "undefined" && MathJax.typesetPromise) {
+        await MathJax.typesetPromise();
+    }
 }
 
 // Utility to convert various CSS length units to pixels
@@ -1119,7 +1122,7 @@ window.addEventListener("DOMContentLoaded", async function(event) {
         }
 
         // Transform all solutions details elements to divs with the summary as a title
-        rewriteSolutions();
+        await rewriteSolutions();
 
         // Get the papersize from localStorage or set it based on user's geographic region.  This will always return a value (defaulting to 'letter' if all else fails).
         let paperSize = getPaperSize();


### PR DESCRIPTION
First PR attempt here; hopefully everything goes smoothly! 

While preparing print-preview handouts for my course, I ran into a JavaScript bug in PreTeXt's built-in print-preview feature that causes solution content to occasionally (in Safari, almost always) render as raw, un-typeset LaTeX source.

Print-preview mode converts each solution's details/summary into a plain div (in rewriteSolutions(), pretext_add_on.js) but leaves the born-hidden-knowl class on it. addKnowls() (knowl.js) then matches these divs, finds no summary child, and throws inside new SlideRevealer(), aborting the load handler.

Separately, rewriteSolutions() never calls MathJax on the newly-created solution content, and pagination (createPrintoutPages()/adjustPrintoutPages()) measures element heights immediately after. Since solution math is normally typeset lazily on knowl-open (never triggered by print preview), whether it renders becomes a pure race against MathJax's own unrelated auto-typeset pass — reproducible almost every time in Safari, intermittently in Chrome.

This PR: (1) guards addKnowls() to skip elements missing a summary/contents pair instead of throwing, and (2) makes rewriteSolutions() async, awaits MathJax.typesetPromise() before returning, and awaits it at the call site — so pagination always runs after solution math is fully typeset.

Tested via repeated fresh reloads (cache-busted) of a live print-preview page in both Chrome and Safari; no console errors and no unrendered LaTeX after the fix.