### PR TITLE
Table notes: a "tn" element, lettered below the table

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -151,7 +151,7 @@
             <paragraphs>
                 <title><tag>fn</tag>, footnotes</title>
                 <idx>footnotes</idx>
-                <p>A footnote can be inserted in a paragraph and a mark will be left behind.  Where the content of the footnote goes depends on the capabilities of the output format.  Because a footnote allows you to begin a new piece of text <em>anywhere</em>, it can be difficult to handle technically.  For this reason it is banned from places like titles and its possible content is limited (for openers, no paragraphs).</p>
+                <p>A footnote can be inserted in a paragraph and a mark will be left behind.  Where the content of the footnote goes depends on the capabilities of the output format.  Because a footnote allows you to begin a new piece of text <em>anywhere</em>, it can be difficult to handle technically.  For this reason it is banned from places like titles and its possible content is limited (for openers, no paragraphs).  One place a footnote may not go is within a <tag>tabular</tag>: a note anchored in a table cell is a <term>table note</term>, the <tag>tn</tag> element, which is lettered and collects at the bottom of its table (<xref ref="topic-table-notes"/>).</p>
 
                 <p>A footnote is the farthest thing from structured writing that we can think of.  It can go anywhere.  Resist the temptation to use it, and your writing will improve.  We frequently entertain the thought of making footnotes impossible in <pretext />.  See the <tag>aside</tag> element for a possible alternative.</p>
             </paragraphs>
@@ -4326,6 +4326,14 @@
             <idx><h>cell</h><h>table</h></idx>
 
             <p>A given cell can span multiple columns, by providing the <attr>colspan</attr> attribute with a value that is a positive number, the cell will extend to occupy additional columns.</p>
+        </subsection>
+
+        <subsection xml:id="topic-table-notes" label="topic-table-notes">
+            <title>Table Notes</title>
+            <idx><h>table</h><h>note</h></idx>
+            <idx><h>note</h><h>table</h></idx>
+
+            <p>A note anchored in a table cell is a <term>table note</term>, the <tag>tn</tag> element, authored within the content of a <tag>cell</tag> (in a cell composed of paragraphs, a note follows any paragraph, and its mark lands at that paragraph's end).  Only a superscript letter appears at that location; the text of the note collects at the bottom of the table.  Letters run a, b, c, <ellipsis/> within each <tag>tabular</tag>, in the order the marks appear reading left-to-right and top-to-bottom, and they begin again with each table.  This follows the treatment of notes to tables in the <pubtitle>Chicago Manual of Style</pubtitle> (18th edition, Section 3.80), where the lettered marks are chosen deliberately: a table's notes are apparatus of the table, so they never join the numbering of true footnotes.  For the same reason a <tag>tn</tag> is not a target for a cross-reference, and takes no <attr>xml:id</attr> or <attr>label</attr>.  Do not author a <tag>fn</tag> footnote within a <tag>tabular</tag>; an existing one will be honored as a table note, with a warning to convert it.</p>
         </subsection>
 
         <subsection>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -6342,7 +6342,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <tabular>
                     <row>
                         <cell>Red</cell>
-                        <cell>Green<fn>Green can be a very sick looking color.</fn></cell>
+                        <cell>Green<tn>Green can be a very sick looking color.</tn></cell>
                         <cell>Yellow</cell>
                     </row>
                     <row>
@@ -14104,7 +14104,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
                 <tabular width="auto">
                     <row header="yes">
-                        <cell>State<fn>Only from the West Coast.</fn></cell>
+                        <cell>State<tn>Only from the West Coast.</tn></cell>
                         <cell>Population</cell>
                         <cell>Area (sq. mi.)</cell>
                         <cell>Statehood (Year)</cell>
@@ -14123,7 +14123,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </row>
                     <row>
                         <cell>California</cell>
-                        <cell>39,512,223<fn>Wow! That is as big as many countries.</fn></cell>
+                        <cell>39,512,223<tn>Wow! That is as big as many countries.</tn></cell>
                         <cell>163,696</cell>
                         <cell>1850</cell>
                     </row>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -6335,7 +6335,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>That was a Sage cell just now, which has nothing to do with tables.  But we needed someplace to test placement right after a division heading.  Carry on.</p>
 
-            <p>A very minimal table, hence with left-justified cells, no borders.  We do wrap the tabular element in a table element to get centering, numbering and a caption.  Footnotes inside cells are tested here.</p>
+            <p>A very minimal table, hence with left-justified cells, no borders.  We do wrap the tabular element in a table element to get centering, numbering and a caption.  A single table note (the <tag>tn</tag> element) is tested here.</p>
 
             <table>
                 <title>Some Colors</title>
@@ -6349,6 +6349,36 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <cell>Blue</cell>
                         <cell>White</cell>
                         <cell>Pink</cell>
+                    </row>
+                </tabular>
+            </table>
+
+            <p>Table notes get a thorough workout in the next table: one in a header cell, one in a cell spanning two columns, two in a single cell of two paragraphs (one note anchored at the end of each paragraph), and one anchored mid-text of an ordinary cell.  Letters accumulate in reading order, and begin again with each table.</p>
+
+            <table xml:id="table-note-gallery">
+                <title>Table Notes in Demanding Locations</title>
+                <tabular>
+                    <col width="40%"/>
+                    <col width="35%"/>
+                    <col width="25%"/>
+                    <row header="yes">
+                        <cell>Construction<tn>A header cell may carry a note.</tn></cell>
+                        <cell>Behavior</cell>
+                        <cell>Year</cell>
+                    </row>
+                    <row>
+                        <cell colspan="2"><p>A single cell of text long enough that it plainly runs across the boundary between the first and second columns.</p><tn>The mark trails the spanning content.</tn></cell>
+                        <cell>1971</cell>
+                    </row>
+                    <row>
+                        <cell>
+                            <p>A first paragraph, with a note anchored at its end.</p>
+                            <tn>Anchored after the first paragraph.</tn>
+                            <p>A second paragraph, with its own note.</p>
+                            <tn>Anchored after the second paragraph.</tn>
+                        </cell>
+                        <cell>A note<tn>Anchored mid-text, at the word <q>note</q>.</tn> amid running text</cell>
+                        <cell>2026</cell>
                     </row>
                 </tabular>
             </table>

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -365,6 +365,27 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates/>
 </xsl:template>
 
+<!-- A note anchored in a table cell is a "tn" table note, lettered   -->
+<!-- and placed at the bottom of the table (Notes to tables: CMoS     -->
+<!-- 18th ed., 3.77-3.81), never an "fn" footnote.  The schema        -->
+<!-- rejects an "fn" as direct cell content, but cannot reach one     -->
+<!-- inside a cell's paragraphs, since a paragraph's content is the   -->
+<!-- same everywhere.  This check reaches every depth of a "tabular". -->
+<xsl:template match="tabular//fn">
+    <xsl:apply-templates select="." mode="messaging">
+        <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'footnote-in-tabular'"/>
+        <xsl:with-param name="message">
+            <xsl:text>A footnote (&lt;fn&gt;) has no place within a &lt;tabular&gt;: a note anchored&#xa;</xsl:text>
+            <xsl:text>in a table belongs at the bottom of the table, not in the numbering of&#xa;</xsl:text>
+            <xsl:text>true footnotes.  Use a &lt;tn&gt; table note instead; it will be lettered&#xa;</xsl:text>
+            <xsl:text>a, b, c and placed below the table.  A build will honor this footnote&#xa;</xsl:text>
+            <xsl:text>as a table note in the meantime.</xsl:text>
+        </xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:apply-templates/>
+</xsl:template>
+
 <xsl:template match="title[m]">
     <xsl:if test="parent::chapter|appendix|preface|acknowledgement|biography|foreword|dedication|colophon|section|subsection|subsubsection|slide|exercises|worksheet|reading-questions|solutions|references|glossary|backmatter and not(following-sibling::shorttitle)">
         <xsl:apply-templates select="." mode="messaging">

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1072,9 +1072,15 @@
             AlignmentVertical =
                 attribute valign {"top" | "middle" | "bottom"}
 
-            # A table cell admits footnotes, authored as table notes; the
-            # rendering (below the table, keyed a, b, c) is a pending TODO.
-            TableCellText = mixed { (TextLongContent | Footnote)* }
+            # A table cell takes "tn" table notes, not "fn" footnotes.  A
+            # table note is lettered a, b, c per-tabular in reading order
+            # and is placed below the table, disjoint from the numbering
+            # of true footnotes.  Notes to tables: CMoS 18th ed.,
+            # 3.77-3.81; the specific (lettered) notes here are 3.80.
+            # A "tn" is not a cross-reference target, so takes no
+            # identification attributes.
+            TableNote = element tn {TextLong}
+            TableCellText = mixed { (TextLongContent | TableNote)* }
             TableCell =
                 element cell {
                     AlignmentHorizontal?,
@@ -1084,7 +1090,11 @@
                     (
                         TableCellText |
                         LongLine+ |
-                        Paragraph+
+                        # a paragraph's content is the same everywhere, so a
+                        # cell of paragraphs anchors a table note after any
+                        # of them; assembly relocates the note's mark to the
+                        # end of the paragraph it follows
+                        (Paragraph, TableNote*)+
                     )
                 }
             TableRow =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2848,15 +2848,25 @@
     </attribute>
   </define>
   <!--
-    A table cell admits footnotes, authored as table notes; the
-    rendering (below the table, keyed a, b, c) is a pending TODO.
+    A table cell takes "tn" table notes, not "fn" footnotes.  A
+    table note is lettered a, b, c per-tabular in reading order
+    and is placed below the table, disjoint from the numbering
+    of true footnotes.  Notes to tables: CMoS 18th ed.,
+    3.77-3.81; the specific (lettered) notes here are 3.80.
+    A "tn" is not a cross-reference target, so takes no
+    identification attributes.
   -->
+  <define name="TableNote">
+    <element name="tn">
+      <ref name="TextLong"/>
+    </element>
+  </define>
   <define name="TableCellText">
     <mixed>
       <zeroOrMore>
         <choice>
           <ref name="TextLongContent"/>
-          <ref name="Footnote"/>
+          <ref name="TableNote"/>
         </choice>
       </zeroOrMore>
     </mixed>
@@ -2881,7 +2891,18 @@
           <ref name="LongLine"/>
         </oneOrMore>
         <oneOrMore>
-          <ref name="Paragraph"/>
+          <!--
+            a paragraph's content is the same everywhere, so a
+            cell of paragraphs anchors a table note after any
+            of them; assembly relocates the note's mark to the
+            end of the paragraph it follows
+          -->
+          <group>
+            <ref name="Paragraph"/>
+            <zeroOrMore>
+              <ref name="TableNote"/>
+            </zeroOrMore>
+          </group>
         </oneOrMore>
       </choice>
     </element>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1730,9 +1730,15 @@
             AlignmentVertical =
                 attribute valign {"top" | "middle" | "bottom"}
 
-            # A table cell admits footnotes, authored as table notes; the
-            # rendering (below the table, keyed a, b, c) is a pending TODO.
-            TableCellText = mixed { (TextLongContent | Footnote)* }
+            # A table cell takes "tn" table notes, not "fn" footnotes.  A
+            # table note is lettered a, b, c per-tabular in reading order
+            # and is placed below the table, disjoint from the numbering
+            # of true footnotes.  Notes to tables: CMoS 18th ed.,
+            # 3.77-3.81; the specific (lettered) notes here are 3.80.
+            # A "tn" is not a cross-reference target, so takes no
+            # identification attributes.
+            TableNote = element tn {TextLong}
+            TableCellText = mixed { (TextLongContent | TableNote)* }
             TableCell =
                 element cell {
                     AlignmentHorizontal?,
@@ -1742,7 +1748,11 @@
                     (
                         TableCellText |
                         LongLine+ |
-                        Paragraph+
+                        # a paragraph's content is the same everywhere, so a
+                        # cell of paragraphs anchors a table note after any
+                        # of them; assembly relocates the note's mark to the
+                        # end of the paragraph it follows
+                        (Paragraph, TableNote*)+
                     )
                 }
             TableRow =

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2955,6 +2955,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:element>
 </xsl:template>
 
+<!-- 2026-07-31: a footnote within a "tabular" cell becomes a "tn" -->
+<!-- table note, lettered and placed at the bottom of the table    -->
+<!-- (Notes to tables: CMoS 18th ed., 3.77-3.81; specific notes    -->
+<!-- at 3.80).  Any identification attributes are orphaned: a      -->
+<!-- "tn" is not a cross-reference target.                         -->
+<xsl:template match="tabular//fn" mode="repair">
+    <tn>
+        <xsl:apply-templates select="node()" mode="repair"/>
+    </tn>
+</xsl:template>
+
 <!-- 2026-07-30: an "event" is bibliographic content, so it -->
 <!-- belongs in "bibinfo", already its home for slideshows. -->
 <!-- Suppressed at its origin within "docinfo"...           -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -2966,6 +2966,28 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </tn>
 </xsl:template>
 
+<!-- A "tn" authored as a block sibling of a cell's paragraphs is -->
+<!-- relocated to the tail of the paragraph it follows, where its -->
+<!-- mark belongs typographically; conversions then treat every   -->
+<!-- "tn" as inline.  A "tn" amid the mixed text of a cell is     -->
+<!-- already inline, and is untouched.                            -->
+<xsl:template match="cell[p]/tn" mode="repair"/>
+
+<xsl:template match="cell/p" mode="repair">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="repair"/>
+        <xsl:apply-templates select="following-sibling::tn[count(preceding-sibling::p[1] | current()) = 1]" mode="tn-relocate"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- A faithful copy, since the "repair" mode on the same   -->
+<!-- element is its suppression at the original location.   -->
+<xsl:template match="cell/tn" mode="tn-relocate">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="repair"/>
+    </xsl:copy>
+</xsl:template>
+
 <!-- 2026-07-30: an "event" is bibliographic content, so it -->
 <!-- belongs in "bibinfo", already its home for slideshows. -->
 <!-- Suppressed at its origin within "docinfo"...           -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11902,6 +11902,13 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'the document-wide style of cross-reference text is now a &quot;text&quot; attribute on an &quot;xrefs&quot; element within &quot;docinfo/defaults&quot;, replacing the &quot;cross-references&quot; element.  We will honor your intent, but please convert to the new form.'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2026-07-31  a footnote within a "tabular" cell becomes a "tn" table note -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//tabular//fn&quot;" />
+        <xsl:with-param name="date-string" select="'2026-07-31'" />
+        <xsl:with-param name="message" select="'a footnote (&quot;fn&quot;) within a &quot;tabular&quot; cell is now a table note, the &quot;tn&quot; element, lettered and placed at the bottom of the table.  We will honor your intent, but please convert to &quot;tn&quot;.  Note that a table note is not part of the numbering of true footnotes, and is not a target for a cross-reference.'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2468,6 +2468,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:template match="fn" mode="width-text"/>
 
+<!-- A table note's text sets below the table, so a cell is only -->
+<!-- as wide as its mark: one superscript letter, roughly one    -->
+<!-- character.                                                  -->
+<xsl:template match="tn" mode="width-text">
+    <xsl:text>a</xsl:text>
+</xsl:template>
+
 <!-- A cross-reference's displayed text is generated, never in    -->
 <!-- the source, so render it via the shared "xref-text" (driven  -->
 <!-- by the resolved text style) rather than measure an empty     -->
@@ -3192,42 +3199,65 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Figures and Caption -->
 <!-- ################### -->
 
-<!-- The FIGURE-LIKE blocks (a captioned "figure"; and "table",   -->
-<!-- "listing", "list", each titled) wrap their contents and      -->
-<!-- finish with a caption: a body-aligned paragraph led by a     -->
-<!-- bold run-in heading (the type name and number), so a long    -->
-<!-- caption sets as ordinary prose, not centered ragged lines.   -->
-<!-- All share one counter.  The "caption" element is consumed    -->
-<!-- here, so it is killed in the default mode, with the rest     -->
-<!-- of the metadata.                                             -->
+<!-- The FIGURE-LIKE blocks: a "figure" wraps its contents and    -->
+<!-- finishes with its caption below, while the titled blocks     -->
+<!-- ("table", "listing", "list") lead with their title above,    -->
+<!-- as the other conversions do.  Either way the heading is a    -->
+<!-- body-aligned paragraph led by a bold run-in (the type name   -->
+<!-- and number), so a long caption or title sets as ordinary     -->
+<!-- prose, not centered ragged lines.  All share one counter.    -->
+<!-- The "caption" element is consumed here, so it is killed in   -->
+<!-- the default mode, with the rest of the metadata.             -->
 <xsl:template match="&FIGURE-LIKE;">
     <xsl:apply-templates select="." mode="forced-pagebreak"/>
     <fo:block space-before="1em" space-after="1em">
         <xsl:apply-templates select="." mode="link-id-attribute"/>
+        <xsl:if test="not(self::figure)">
+            <xsl:apply-templates select="." mode="figure-like-heading"/>
+        </xsl:if>
         <xsl:apply-templates select="*"/>
-        <fo:block text-align="{$text-alignment}" space-before="0.5em" keep-with-previous.within-page="always">
-            <fo:inline font-weight="bold">
-                <xsl:apply-templates select="." mode="type-name"/>
-                <xsl:variable name="the-number">
-                    <xsl:apply-templates select="." mode="number"/>
-                </xsl:variable>
-                <xsl:if test="not($the-number = '')">
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="$the-number"/>
-                </xsl:if>
-                <xsl:text>.</xsl:text>
-            </fo:inline>
-            <xsl:text> </xsl:text>
-            <xsl:choose>
-                <xsl:when test="self::figure">
-                    <xsl:apply-templates select="caption/node()"/>
-                </xsl:when>
-                <!-- "table", "listing", "list" are titled -->
-                <xsl:otherwise>
-                    <xsl:apply-templates select="." mode="title-full"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </fo:block>
+        <xsl:if test="self::figure">
+            <xsl:apply-templates select="." mode="figure-like-heading"/>
+        </xsl:if>
+    </fo:block>
+</xsl:template>
+
+<!-- The caption of a "figure" (set below, held to its content), or -->
+<!-- the title of a "table"/"listing"/"list" (set above, held to    -->
+<!-- its content).                                                  -->
+<xsl:template match="&FIGURE-LIKE;" mode="figure-like-heading">
+    <fo:block text-align="{$text-alignment}">
+        <xsl:choose>
+            <xsl:when test="self::figure">
+                <xsl:attribute name="space-before">0.5em</xsl:attribute>
+                <xsl:attribute name="keep-with-previous.within-page">always</xsl:attribute>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:attribute name="space-after">0.5em</xsl:attribute>
+                <xsl:attribute name="keep-with-next.within-page">always</xsl:attribute>
+            </xsl:otherwise>
+        </xsl:choose>
+        <fo:inline font-weight="bold">
+            <xsl:apply-templates select="." mode="type-name"/>
+            <xsl:variable name="the-number">
+                <xsl:apply-templates select="." mode="number"/>
+            </xsl:variable>
+            <xsl:if test="not($the-number = '')">
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="$the-number"/>
+            </xsl:if>
+            <xsl:text>.</xsl:text>
+        </fo:inline>
+        <xsl:text> </xsl:text>
+        <xsl:choose>
+            <xsl:when test="self::figure">
+                <xsl:apply-templates select="caption/node()"/>
+            </xsl:when>
+            <!-- "table", "listing", "list" are titled -->
+            <xsl:otherwise>
+                <xsl:apply-templates select="." mode="title-full"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </fo:block>
 </xsl:template>
 

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -2346,6 +2346,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="row[not(@header = 'yes') and not(@header = 'vertical')]"/>
         </fo:table-body>
     </fo:table>
+    <!-- Table notes ("tn") collect just below the table, lettered in -->
+    <!-- reading order, which is document order of the marks (Notes   -->
+    <!-- to tables: CMoS 18th ed., 3.77-3.81; specific notes at       -->
+    <!-- 3.80).  Disjoint from true footnote numbering.               -->
+    <xsl:for-each select=".//tn">
+        <fo:block font-size="80%" text-align="{$text-alignment}" text-align-last="start" space-before="0.25em">
+            <fo:inline baseline-shift="35%" font-size="70%" font-style="italic">
+                <xsl:apply-templates select="." mode="number"/>
+            </fo:inline>
+            <xsl:text> </xsl:text>
+            <xsl:apply-templates/>
+        </fo:block>
+    </xsl:for-each>
 </xsl:template>
 
 <!-- An estimated width, in points, for each of a tabular's columns, -->
@@ -3624,6 +3637,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- text, and the body, marked again, collected at the bottom of -->
 <!-- the page above the separator rule defined in the entry       -->
 <!-- template.  The footnote number is the serial machinery's.    -->
+<!-- A table note ("tn") drops only its superscript letter mark at   -->
+<!-- the cell location; the note text collects below the table, in   -->
+<!-- the "tabular" template.  No footnote machinery is involved.     -->
+<xsl:template match="tabular//tn">
+    <fo:inline baseline-shift="35%" font-size="70%" font-style="italic">
+        <xsl:apply-templates select="." mode="number"/>
+    </fo:inline>
+</xsl:template>
+
 <xsl:template match="fn">
     <xsl:variable name="the-mark">
         <xsl:apply-templates select="." mode="serial-number"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2746,6 +2746,26 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Footnotes -->
 <!-- ######### -->
 
+<!-- A table note ("tn") drops only its superscript letter mark at the -->
+<!-- cell location, linked to the note text collected below the table  -->
+<!-- in the "tabular-inclusion" template.  Letters count per-tabular   -->
+<!-- in document order (Notes to tables: CMoS 18th ed., 3.77-3.81;     -->
+<!-- specific notes at 3.80).  Adjacency is the presentation: a note   -->
+<!-- sits just below its table, so there is no knowl.                  -->
+<xsl:template match="tabular//tn">
+    <sup class="tablenote-mark">
+        <a>
+            <xsl:attribute name="href">
+                <xsl:text>#</xsl:text>
+                <xsl:apply-templates select="." mode="unique-id"/>
+            </xsl:attribute>
+            <i>
+                <xsl:apply-templates select="." mode="number"/>
+            </i>
+        </a>
+    </sup>
+</xsl:template>
+
 <!-- Currently implemented as a details html element with no guardrails   -->
 <!-- on nested content. Other footnotes, block content, etc... will all   -->
 <!-- be rendered, but perhaps not well. Caveat emptor.                    -->
@@ -8141,6 +8161,28 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:with-param name="ambient-relative-width" select="$width" />
         </xsl:apply-templates>
     </table>
+    <!-- Table notes ("tn") collect just below the table, lettered in -->
+    <!-- reading order, which is document order of the marks (Notes   -->
+    <!-- to tables: CMoS 18th ed., 3.77-3.81; specific notes at       -->
+    <!-- 3.80).  Disjoint from true footnote numbering.               -->
+    <xsl:if test=".//tn">
+        <!-- each note is a plain "div" (not a "p"): one tight -->
+        <!-- line per note, free of paragraph margins          -->
+        <div class="tablenotes">
+            <xsl:for-each select=".//tn">
+                <div class="tablenote">
+                    <xsl:apply-templates select="." mode="html-id-attribute"/>
+                    <sup>
+                        <i>
+                            <xsl:apply-templates select="." mode="number"/>
+                        </i>
+                    </sup>
+                    <xsl:text> </xsl:text>
+                    <xsl:apply-templates/>
+                </div>
+            </xsl:for-each>
+        </div>
+    </xsl:if>
 </xsl:template>
 
 <!-- A row of table -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1012,6 +1012,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Tables -->
 <xsl:template name="tables">
+    <xsl:if test="$document-root//tabular[.//tn]">
+        <xsl:text>%% A box to measure a "tabular", so its table notes set to its width&#xa;</xsl:text>
+        <xsl:text>\newsavebox{\ptxtablenotebox}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:if test="$document-root//tabular">
         <xsl:text>%% For improved tables&#xa;</xsl:text>
         <xsl:text>\usepackage{array}&#xa;</xsl:text>
@@ -7615,6 +7619,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="ancestor::sidebyside">
         <xsl:text>{\centering%&#xa;</xsl:text>
     </xsl:if>
+    <!-- A tabular with table notes, other than a "longtable" (which  -->
+    <!-- cannot be boxed), is measured in a box so the notes can set   -->
+    <!-- to exactly the width of the table.                            -->
+    <xsl:variable name="b-has-table-notes" select="boolean(.//tn)"/>
+    <xsl:variable name="b-boxed-notes" select="$b-has-table-notes and not(@break = 'yes')"/>
+    <xsl:if test="$b-boxed-notes">
+        <xsl:text>\begin{lrbox}{\ptxtablenotebox}%&#xa;</xsl:text>
+    </xsl:if>
     <!-- Build latex column specification                         -->
     <!--   vertical borders (left side, right side, three widths) -->
     <!--   horizontal alignment (left, center, right)             -->
@@ -7724,21 +7736,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- reading order, which is document order of the marks      -->
     <!-- (Notes to tables: CMoS 18th ed., 3.77-3.81; specific     -->
     <!-- notes at 3.80).  Disjoint from true footnote numbering.  -->
-    <xsl:if test=".//tn">
-        <xsl:text>\par\smallskip%&#xa;</xsl:text>
-        <xsl:text>{\footnotesize%&#xa;</xsl:text>
-        <xsl:for-each select=".//tn">
-            <xsl:text>\textsuperscript{\textit{</xsl:text>
-            <xsl:apply-templates select="." mode="number"/>
-            <xsl:text>}}\,</xsl:text>
-            <xsl:apply-templates/>
-            <xsl:text>\par&#xa;</xsl:text>
-        </xsl:for-each>
-        <xsl:text>}%&#xa;</xsl:text>
-    </xsl:if>
+    <!-- The usual case sets the notes flush left in a "minipage" -->
+    <!-- of exactly the table's measured width; a "longtable"     -->
+    <!-- cannot be boxed, so its notes set at the text width.     -->
+    <xsl:choose>
+        <xsl:when test="$b-boxed-notes">
+            <xsl:text>\end{lrbox}%&#xa;</xsl:text>
+            <xsl:text>\begin{minipage}{\wd\ptxtablenotebox}&#xa;</xsl:text>
+            <xsl:text>\usebox{\ptxtablenotebox}\par&#xa;</xsl:text>
+            <xsl:text>\smallskip%&#xa;</xsl:text>
+            <xsl:text>{\footnotesize\raggedright%&#xa;</xsl:text>
+            <xsl:call-template name="latex-table-notes"/>
+            <xsl:text>}%&#xa;</xsl:text>
+            <xsl:text>\end{minipage}%&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="$b-has-table-notes">
+            <xsl:text>\par\smallskip%&#xa;</xsl:text>
+            <xsl:text>{\footnotesize\raggedright%&#xa;</xsl:text>
+            <xsl:call-template name="latex-table-notes"/>
+            <xsl:text>}%&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
     <xsl:if test="ancestor::sidebyside">
         <xsl:text>\par}&#xa;</xsl:text>
     </xsl:if>
+</xsl:template>
+
+<!-- Context is the "tabular"; one line per note -->
+<xsl:template name="latex-table-notes">
+    <xsl:for-each select=".//tn">
+        <xsl:text>\textsuperscript{\textit{</xsl:text>
+        <xsl:apply-templates select="." mode="number"/>
+        <xsl:text>}}\,</xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>\par&#xa;</xsl:text>
+    </xsl:for-each>
 </xsl:template>
 
 
@@ -7980,18 +8012,38 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <xsl:with-param name="align" select="$row-valign" />
                     </xsl:call-template>
                     <xsl:text>{</xsl:text>
+                    <!-- The paragraph sets to the combined width of every   -->
+                    <!-- column the cell spans, so a spanning cell occupies  -->
+                    <!-- its full span, not just its leftmost column.        -->
+                    <!-- A column with no @width silently contributes the    -->
+                    <!-- 20% default; some ill-formed WW exercises arrive    -->
+                    <!-- here, so a less-precise warning is given on the     -->
+                    <!-- author's source.                                    -->
+                    <xsl:variable name="spanned-widths-rtf">
+                        <xsl:for-each select="parent::row/parent::tabular/col[position() &gt;= number($left-column-number) and position() &lt;= number($right-column-number)]">
+                            <w>
+                                <xsl:choose>
+                                    <xsl:when test="@width">
+                                        <xsl:variable name="width">
+                                            <xsl:call-template name="normalize-percentage">
+                                                <xsl:with-param name="percentage" select="@width" />
+                                            </xsl:call-template>
+                                        </xsl:variable>
+                                        <xsl:value-of select="substring-before($width, '%') div 100" />
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:text>0.2</xsl:text>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </w>
+                        </xsl:for-each>
+                    </xsl:variable>
+                    <xsl:variable name="spanned-widths" select="exsl:node-set($spanned-widths-rtf)/w"/>
                     <xsl:choose>
-                        <xsl:when test="$left-col/@width">
-                            <xsl:variable name="width">
-                                <xsl:call-template name="normalize-percentage">
-                                    <xsl:with-param name="percentage" select="$left-col/@width" />
-                                </xsl:call-template>
-                            </xsl:variable>
-                            <xsl:value-of select="substring-before($width, '%') div 100" />
+                        <xsl:when test="$spanned-widths">
+                            <xsl:value-of select="sum($spanned-widths)"/>
                         </xsl:when>
-                        <!-- If there is no $left-col/@width, silently use 20% as default -->
-                        <!-- We get some ill-formed WW exercises here, so a less-precise  -->
-                        <!-- warning is given on the author's source.                     -->
+                        <!-- no "col" elements at all -->
                         <xsl:otherwise>
                             <xsl:text>0.2</xsl:text>
                         </xsl:otherwise>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -7720,7 +7720,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}&#xa;</xsl:text>
     <!-- finish grouping for tabular font -->
     <xsl:text>}%&#xa;</xsl:text>
-    <xsl:apply-templates select="." mode="pop-footnote-text"/>
+    <!-- Table notes ("tn") collect below the table, lettered in  -->
+    <!-- reading order, which is document order of the marks      -->
+    <!-- (Notes to tables: CMoS 18th ed., 3.77-3.81; specific     -->
+    <!-- notes at 3.80).  Disjoint from true footnote numbering.  -->
+    <xsl:if test=".//tn">
+        <xsl:text>\par\smallskip%&#xa;</xsl:text>
+        <xsl:text>{\footnotesize%&#xa;</xsl:text>
+        <xsl:for-each select=".//tn">
+            <xsl:text>\textsuperscript{\textit{</xsl:text>
+            <xsl:apply-templates select="." mode="number"/>
+            <xsl:text>}}\,</xsl:text>
+            <xsl:apply-templates/>
+            <xsl:text>\par&#xa;</xsl:text>
+        </xsl:for-each>
+        <xsl:text>}%&#xa;</xsl:text>
+    </xsl:if>
     <xsl:if test="ancestor::sidebyside">
         <xsl:text>\par}&#xa;</xsl:text>
     </xsl:if>
@@ -9011,9 +9026,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- matching  \footnotetext  since "biblio" is not yet a    -->
 <!-- tcolorbox and the "pop-footnote-text" template was not  -->
 <!-- present as part of processing  biblio/note.             -->
+<!-- A table note ("tn") drops only its superscript letter mark at  -->
+<!-- the cell location; the note text collects below the table, in  -->
+<!-- the "tabular-inclusion" template.  Letters count per-tabular   -->
+<!-- in document order.  No footnote machinery is involved, so a    -->
+<!-- "tn" never interacts with tcolorbox footnote management.       -->
+<xsl:template match="tabular//tn">
+    <xsl:text>\textsuperscript{\textit{</xsl:text>
+    <xsl:apply-templates select="." mode="number"/>
+    <xsl:text>}}</xsl:text>
+</xsl:template>
+
 <xsl:template match="fn">
     <xsl:choose>
-        <xsl:when test="ancestor::*[&ASIDE-FILTER; or &THEOREM-FILTER; or &AXIOM-FILTER;  or &DEFINITION-FILTER; or &REMARK-FILTER; or &COMPUTATION-FILTER; or &OPENPROBLEM-FILTER; or &EXAMPLE-FILTER; or &PROJECT-FILTER; or &GOAL-FILTER; or &FIGURE-FILTER; or self::tabular or self::list or self::sidebyside or self::gi or self::colophon/parent::backmatter or self::assemblage or self::exercise or (self::li and parent::dl) or self::proof[not(parent::*[&THEOREM-FILTER;])] or self::argument[not(parent::*[&THEOREM-FILTER;])] or self::justification[not(parent::*[&THEOREM-FILTER;])] or self::reasoning[not(parent::*[&THEOREM-FILTER;])] or self::explanation[not(parent::*[&THEOREM-FILTER;])]] and not(ancestor::note/parent::biblio)">
+        <!-- NB: "self::tabular" is not among these ancestors: a footnote -->
+        <!-- within a "tabular" cell is repaired into a "tn" table note   -->
+        <!-- during assembly, so never arrives here.                      -->
+        <xsl:when test="ancestor::*[&ASIDE-FILTER; or &THEOREM-FILTER; or &AXIOM-FILTER;  or &DEFINITION-FILTER; or &REMARK-FILTER; or &COMPUTATION-FILTER; or &OPENPROBLEM-FILTER; or &EXAMPLE-FILTER; or &PROJECT-FILTER; or &GOAL-FILTER; or &FIGURE-FILTER; or self::list or self::sidebyside or self::gi or self::colophon/parent::backmatter or self::assemblage or self::exercise or (self::li and parent::dl) or self::proof[not(parent::*[&THEOREM-FILTER;])] or self::argument[not(parent::*[&THEOREM-FILTER;])] or self::justification[not(parent::*[&THEOREM-FILTER;])] or self::reasoning[not(parent::*[&THEOREM-FILTER;])] or self::explanation[not(parent::*[&THEOREM-FILTER;])]] and not(ancestor::note/parent::biblio)">
             <!-- a footnote in the text of a caption will migrate to -->
             <!-- the auxiliary file for use in the "list of figures" -->
             <!-- and there is some confusion of braces and the use   -->
@@ -9053,8 +9082,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- NB: these templates could be improved with an entity          -->
 <!-- NB: "detached" proofs require a proliferation of              -->
 <!-- complicated constructions                                     -->
-<xsl:template match="&ASIDE-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&DEFINITION-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&OPENPROBLEM-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|&FIGURE-LIKE;|tabular|list|sidebyside|gi|&GOAL-LIKE;|backmatter/colophon|assemblage|exercise|dl/li|proof[not(parent::*[&THEOREM-FILTER;])]|argument[not(parent::*[&THEOREM-FILTER;])]|justification[not(parent::*[&THEOREM-FILTER;])]|reasoning[not(parent::*[&THEOREM-FILTER;])]|explanation[not(parent::*[&THEOREM-FILTER;])]" mode="pop-footnote-text">
-    <xsl:if test="count(ancestor::*[&ASIDE-FILTER; or &THEOREM-FILTER; or &AXIOM-FILTER;  or &DEFINITION-FILTER; or &REMARK-FILTER; or &COMPUTATION-FILTER; or &EXAMPLE-FILTER; or &PROJECT-FILTER; or &GOAL-FILTER; or &FIGURE-FILTER; or self::tabular or self::list or self::sidebyside or self::gi or self::colophon/parent::backmatter or self::assemblage or self::exercise or (self::li and parent::dl) or self::proof[not(parent::*[&THEOREM-FILTER;])] or self::argument[not(parent::*[&THEOREM-FILTER;])] or self::justification[not(parent::*[&THEOREM-FILTER;])] or self::reasoning[not(parent::*[&THEOREM-FILTER;])] or self::explanation[not(parent::*[&THEOREM-FILTER;])]]) = 0">
+<!-- NB: "tabular" appears nowhere here: a footnote within a "tabular"  -->
+<!-- cell is repaired into a "tn" table note during assembly, which     -->
+<!-- involves no footnote machinery at all.                             -->
+<xsl:template match="&ASIDE-LIKE;|&THEOREM-LIKE;|&AXIOM-LIKE;|&DEFINITION-LIKE;|&REMARK-LIKE;|&COMPUTATION-LIKE;|&OPENPROBLEM-LIKE;|&EXAMPLE-LIKE;|&PROJECT-LIKE;|&FIGURE-LIKE;|list|sidebyside|gi|&GOAL-LIKE;|backmatter/colophon|assemblage|exercise|dl/li|proof[not(parent::*[&THEOREM-FILTER;])]|argument[not(parent::*[&THEOREM-FILTER;])]|justification[not(parent::*[&THEOREM-FILTER;])]|reasoning[not(parent::*[&THEOREM-FILTER;])]|explanation[not(parent::*[&THEOREM-FILTER;])]" mode="pop-footnote-text">
+    <xsl:if test="count(ancestor::*[&ASIDE-FILTER; or &THEOREM-FILTER; or &AXIOM-FILTER;  or &DEFINITION-FILTER; or &REMARK-FILTER; or &COMPUTATION-FILTER; or &EXAMPLE-FILTER; or &PROJECT-FILTER; or &GOAL-FILTER; or &FIGURE-FILTER; or self::list or self::sidebyside or self::gi or self::colophon/parent::backmatter or self::assemblage or self::exercise or (self::li and parent::dl) or self::proof[not(parent::*[&THEOREM-FILTER;])] or self::argument[not(parent::*[&THEOREM-FILTER;])] or self::justification[not(parent::*[&THEOREM-FILTER;])] or self::reasoning[not(parent::*[&THEOREM-FILTER;])] or self::explanation[not(parent::*[&THEOREM-FILTER;])]]) = 0">
         <xsl:for-each select=".//fn">
             <xsl:text>\footnotetext[</xsl:text>
             <xsl:apply-templates select="." mode="serial-number"/>

--- a/xsl/pretext-numbers.xsl
+++ b/xsl/pretext-numbers.xsl
@@ -810,6 +810,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Full Numbers -->
 <!--              -->
 
+<!-- The "number" of a table note ("tn") is its letter: a, b, c,     -->
+<!-- assigned per-"tabular" in document order of the marks, which is -->
+<!-- reading order (Notes to tables: CMoS 18th ed., 3.77-3.81;       -->
+<!-- specific notes at 3.80).  One computation, consumed by every    -->
+<!-- conversion, and deliberately disjoint from the numbering of     -->
+<!-- true footnotes.                                                 -->
+<xsl:template match="tabular//tn" mode="number">
+    <xsl:number level="any" from="tabular" format="a"/>
+</xsl:template>
+
 <!-- Now trivial, the container structure plus the serial.  -->
 <!-- We condition on empty serial number in order to create -->
 <!-- empty full numbers.  This is where we add separator,   -->

--- a/xsl/pretext-text.xsl
+++ b/xsl/pretext-text.xsl
@@ -353,10 +353,27 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Modest: each row a line, cells separated by double spaces.   -->
 <!-- No column alignment (yet), spanning cells simply run in.     -->
+<!-- Table notes ("tn") collect just below the table, lettered    -->
+<!-- in reading order; letters keep them apart from the [1]-style -->
+<!-- marks of true footnotes.                                     -->
 <xsl:template match="tabular">
     <xsl:text>&#xa;</xsl:text>
     <xsl:apply-templates select="row"/>
+    <xsl:for-each select=".//tn">
+        <xsl:text>[</xsl:text>
+        <xsl:apply-templates select="." mode="number"/>
+        <xsl:text>] </xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>&#xa;</xsl:text>
+    </xsl:for-each>
     <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- The letter mark of a table note, at its cell location -->
+<xsl:template match="tabular//tn">
+    <xsl:text>[</xsl:text>
+    <xsl:apply-templates select="." mode="number"/>
+    <xsl:text>]</xsl:text>
 </xsl:template>
 
 <xsl:template match="row">


### PR DESCRIPTION
A note anchored in a table cell is now a first-class object: the `tn` element, authored as cell content (in a cell built of paragraphs, following any paragraph, anchoring at that paragraph's end).  Only a superscript lowercase letter appears in the cell; the text of the notes collects at the bottom of the table.  Letters run a, b, c, … in reading order and begin again with each `tabular`.  This is the treatment of notes to tables in the Chicago Manual of Style (18th edition, 3.77–3.81; specific notes at 3.80), where the lettered marks are deliberate: a table's notes are apparatus of the table, so they never join the numbering of true footnotes.  Accordingly a `tn` takes no `@xml:id` or `@label` and is not a cross-reference target.

Previously a footnote in a `tabular` cell consumed a genuine footnote number and its text landed at the bottom of the *page*, far from the table it annotates.  The schema removes `fn` from cell content in the same change, per the no-grace-period deprecation policy; an existing cell `fn` is honored — the assembly repair pass rewrites it as a `tn`, with a dated deprecation warning asking for conversion — so legacy documents build unchanged in source.  The visible consequence, to be announced: true footnote numbers close up wherever a cell footnote existed.

The letter comes from a single source of truth, one `mode="number"` template in the numbering stylesheet, consumed by every conversion.  LaTeX sets the notes hand-rolled — marks and a small flush-left block set to exactly the measured width of the table (a `longtable` cannot be measured this way and uses the text width) — never touching LaTeX's footnote machinery, so the fragile footnote dance inside `tcolorbox` environments does not apply to table notes and no package is added.  HTML places a compact notes list adjacent to the `tabular`, marks hyperlinked to notes with `aria-describedby` for assistive technology, and EPUB inherits this.  XSL-FO emits a plain block sequence after the table, and the text conversion letter-prefixed note lines below the rendered table.

Two corrections ride along, both surfaced by the new sample-article gallery: in XSL-FO, titled blocks (`table`, `listing`, `list`) now lead with their title above the content, with only a `figure` keeping its caption below; and in LaTeX, a paragraph cell spanning several columns now sets to the combined width of every column it spans, not just its leftmost.

The sample article converts its three existing cell footnotes and gains a gallery, "Table Notes in Demanding Locations": a note in a header cell, in a spanning paragraph cell, two in a single two-paragraph cell (one per paragraph), and one anchored mid-text — letters a–e in reading order.  Verified in `latex`/`pdf`, `html`, `text`, `pdf-fo`, and `epub-svg` builds of the sample article; the FO PDF remains PDF/UA-1 compliant under veraPDF and epubcheck reports no new issues; the deprecation warning fires on a cell `fn` and is silent otherwise; validation baselines are unchanged.  The Guide's tables topic documents authoring, lettering, and the `fn`-vs-`tn` distinction.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
