### PR TITLE
Tablenotes css

### DIFF
--- a/css/components/elements/_tables.scss
+++ b/css/components/elements/_tables.scss
@@ -114,6 +114,17 @@
   margin-right: auto;
 }
 
+.tablenotes {
+  margin: 0.5em 0 0;
+  padding-left: 0;
+  list-style: none;
+  font-size: 80%;
+
+  .tablenote {
+    margin-top: 0;
+  }
+}
+
 // More specific types of tables
 
 table.notation-list {

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -2753,14 +2753,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- specific notes at 3.80).  Adjacency is the presentation: a note   -->
 <!-- sits just below its table, so there is no knowl.                  -->
 <xsl:template match="tabular//tn">
+    <xsl:variable name="note-number">
+        <xsl:apply-templates select="." mode="number"/>
+    </xsl:variable>
     <sup class="tablenote-mark">
+        <xsl:apply-templates select="." mode="html-id-attribute"/>
         <a>
             <xsl:attribute name="href">
                 <xsl:text>#</xsl:text>
-                <xsl:apply-templates select="." mode="unique-id"/>
+                <xsl:apply-templates select="." mode="html-id"/>
+                <xsl:text>-note</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="aria-label">
+                <xsl:text>Go to table note </xsl:text>
+                <xsl:value-of select="$note-number"/>
             </xsl:attribute>
             <i>
-                <xsl:apply-templates select="." mode="number"/>
+                <xsl:value-of select="$note-number"/>
             </i>
         </a>
     </sup>
@@ -8166,22 +8175,38 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- to tables: CMoS 18th ed., 3.77-3.81; specific notes at       -->
     <!-- 3.80).  Disjoint from true footnote numbering.               -->
     <xsl:if test=".//tn">
-        <!-- each note is a plain "div" (not a "p"): one tight -->
-        <!-- line per note, free of paragraph margins          -->
-        <div class="tablenotes">
+        <!-- each note is a list item (not a "p"): one tight -->
+        <!-- line per note, free of paragraph margins        -->
+        <ol class="tablenotes" aria-label="Table notes">
             <xsl:for-each select=".//tn">
-                <div class="tablenote">
-                    <xsl:apply-templates select="." mode="html-id-attribute"/>
+                <xsl:variable name="note-number">
+                    <xsl:apply-templates select="." mode="number"/>
+                </xsl:variable>
+                <li class="tablenote">
+                    <xsl:attribute name="id">
+                        <xsl:apply-templates select="." mode="html-id"/>
+                        <xsl:text>-note</xsl:text>
+                    </xsl:attribute>
                     <sup>
-                        <i>
-                            <xsl:apply-templates select="." mode="number"/>
-                        </i>
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:text>#</xsl:text>
+                                <xsl:apply-templates select="." mode="html-id"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="aria-label">
+                                <xsl:text>Back to table note reference </xsl:text>
+                                <xsl:value-of select="$note-number"/>
+                            </xsl:attribute>
+                            <i>
+                                <xsl:value-of select="$note-number"/>
+                            </i>
+                        </a>
                     </sup>
                     <xsl:text> </xsl:text>
                     <xsl:apply-templates/>
-                </div>
+                </li>
             </xsl:for-each>
-        </div>
+        </ol>
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
Changes discussed on -dev

One additional change - I turned the tablenotes into a list (instead of a div). Semantically it is more accurate and improves keyboard/screen reader navigation. (Leaving the table into the list will announce "List - table notes" and allow easy skipping past it.)

----------------

This pull request updates the way table notes are rendered in HTML output, improving both accessibility and semantic structure. The changes include switching from `div` elements to semantic lists for table notes, adding ARIA labels for better accessibility, and updating CSS for the new structure.

**Accessibility and HTML structure improvements:**

* Table notes are now rendered as an ordered list (`<ol class="tablenotes">`) with each note as a list item (`<li class="tablenote">`), replacing the previous use of `div` elements. This improves semantic HTML and screen reader support.
* ARIA labels have been added to the table notes list and note references to improve accessibility for users with assistive technologies. [[1]](diffhunk://#diff-d6cc23bab210bdd0e195069306f6a2bc727005926cc003aa3cbe7b790713519fL8169-R8209) [[2]](diffhunk://#diff-d6cc23bab210bdd0e195069306f6a2bc727005926cc003aa3cbe7b790713519fR2756-R2772)
* Table note references now use more descriptive `href` and `aria-label` attributes and improved ID generation for better navigation and accessibility. [[1]](diffhunk://#diff-d6cc23bab210bdd0e195069306f6a2bc727005926cc003aa3cbe7b790713519fR2756-R2772) [[2]](diffhunk://#diff-d6cc23bab210bdd0e195069306f6a2bc727005926cc003aa3cbe7b790713519fL8169-R8209)

**Styling updates:**

* New CSS rules for `.tablenotes` and `.tablenote` are added to style the ordered list and its items, ensuring the new structure is displayed correctly.