### PR TITLE
Missing-font warning and keyword whitespace, from issue triage

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -6490,7 +6490,7 @@ Book (with parts), "section" at level 3
     <xsl:if test="@primary='no' or @secondary='yes'">
         <xsl:text>Secondary </xsl:text>
     </xsl:if>
-    <xsl:value-of select="."/>
+    <xsl:value-of select="normalize-space(.)"/>
     <xsl:choose>
         <xsl:when test="following-sibling::keyword[1][@primary='no' or @secondary='yes']">
             <xsl:text>; </xsl:text>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -9587,7 +9587,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:value-of select="$font-name"/>
     <xsl:text>}{}{\GenericError{}{The font "</xsl:text>
     <xsl:value-of select="$font-name"/>
-    <xsl:text>" requested by PreTeXt output processed by the  xelatex  executable is not available.  Either a file cannot be located in default locations via a filename, or a font is not known by its name as part of your system.}{Consult the PreTeXt Guide for help with LaTeX fonts, or perhaps try using  pdflatex  as a test.}{}}&#xa;</xsl:text>
+    <xsl:text>" requested by PreTeXt output processed by the  xelatex  executable is not available.  Either a file cannot be located in default locations via a filename, or a font is not known by its name as part of your system.}{Perhaps try using  pdflatex  as a test.}{}}&#xa;</xsl:text>
 </xsl:template>
 
 <!-- Miscellaneous -->


### PR DESCRIPTION
Two small author-facing fixes surfaced while working the issue backlog.

The `xelatex` missing-font warning ended by steering readers to the PreTeXt Guide.  In practice (#1781) that pointer sent people, via search, to pages that cannot solve what is usually a system-packaging problem — a TeX installation missing a font package like `texlive-fonts-extra` — so the consultation clause is removed, leaving the factual report and the try-`pdflatex` suggestion.  The longer-term answer to font pain is architectural: the XSL-FO conversion route selects and embeds fonts under the converter's control.

Separately, a stray-whitespace point from #2419: each `keyword` now passes through `normalize-space`, so an author's incidental padding never reaches the comma-separated keyword lists.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
