### PR TITLE
Nine small fixes from the issue backlog

### DIFF
--- a/css/targets/revealjs/reveal.scss
+++ b/css/targets/revealjs/reveal.scss
@@ -92,6 +92,14 @@ ul {
   position: relative;
 }
 
+// images in containers grow to fit the container, whose inline
+// style carries an authored width, so image/@width is honored
+// (mirrors the rule in components/elements/_media.scss)
+.image-box img,
+img.contained {
+  width: 100%;
+}
+
 iframe.asymptote,
 .video-box .video,
 .video-box .video-poster {

--- a/doc/guide/publisher/conversions.xml
+++ b/doc/guide/publisher/conversions.xml
@@ -24,7 +24,7 @@
 
         <p>We isolate these publisher decisions in a file we call a <term>publication file</term>.  Generally, use of this file will change <em>how</em> words look, or are arranged, on the page, but will not change the author's words <em>themselves</em>.  some software might call this a <q>configuration file</q>, but we think it is very important to indicate its role in the publication process.</p>
 
-        <p>In tnis section, we describe how to create and employ this file.  Details on actual options can be found throughout this guide, with terse comprehensive reference material in <xref ref="publication-file-reference"/>.</p>
+        <p>In this section, we describe how to create and employ this file.  Details on actual options can be found throughout this guide, with terse comprehensive reference material in <xref ref="publication-file-reference"/>.</p>
 
         <p>Create a separate <init>XML</init> file the same way you always would.  Include the usual <init>XML</init> declaration as the first line.  Now, instead of the overall element being <tag>pretext</tag>, use <tag>publication</tag>.  That's it.  Various elements within <tag>publication</tag> will be used to specify options, typically attributes.  Name the file something that reminds you of its purpose, such as <c>pod.xml</c> for a print-on-demand version.  Avoid using spaces in the filename, even if your operating system encourages it.</p>
 

--- a/doc/guide/publisher/web-hosting.xml
+++ b/doc/guide/publisher/web-hosting.xml
@@ -28,7 +28,7 @@
     <p>If you are hosting at your institution, that is a great outcome.  There is no cost to you, and everybody is happy.  Lobby for a great <init>URL</init>, like <c>platypus.mammal-institute.org</c> and the rest should take care of itself.  The rest of this section is about the second situation.</p>
 
     <p>To arrange hosting yourself,<ol>
-        <li>Purchase a domain name, it should not be a real big annual expense.  Choose something professional, rather than just your name (though your name does have a natural appeal).  And maybe something general enough that you can host your next book under that same domain name.  The idea here is to <em>own</em> the domain name, so your book can move anywhere, but that domain name will always point to the book.  This name should be <em>owned and controlled by you</em>, not your institution, not GitHub, not <c>5GBFree.com</c>.</li>
+        <li>Purchase a domain name; a typical registration runs a few dollars a month.  Choose something professional, rather than just your name (though your name does have a natural appeal).  And maybe something general enough that you can host your next book under that same domain name.  The idea here is to <em>own</em> the domain name, so your book can move anywhere, but that domain name will always point to the book.  This name should be <em>owned and controlled by you</em>, not your institution, not GitHub, not <c>5GBFree.com</c>.</li>
 
         <li>
             <p>Sign up for, and perhaps pay for, a hosting service that lets you point your domain name at the site.<ul>
@@ -36,7 +36,7 @@
                 <li>Mitch Keller likes the <q>Swift</q> plan at <url href="https://www.a2hosting.com/web-hosting" visual="www.a2hosting.com/web-hosting">A2 Hosting</url> at about $60 annually.  (2017-07-05)</li>
             </ul></p>
         </li>
-    </ol>Now you are set, and control distribution of your scholarly publication.  If you are bothered by the thought of having expenses while you make your work freely available to the world, then consider generating some modest income.  For example, sell Google ads against your pages.  (Why should <em>this</em> disturb anybody?  I don't get it.)  Or roll a small royalty into the print-on-demand version, see <xref ref="print-on-demand" />.</p>
+    </ol>Note the combination the two steps make possible: a project hosted at no cost on GitHub Pages, reached through a domain name you own, is complete control of your project's address for the price of the registration alone.  Now you are set, and control distribution of your scholarly publication.  If you are bothered by the thought of having expenses while you make your work freely available to the world, then consider generating some modest income.  For example, sell Google ads against your pages.  (Why should <em>this</em> disturb anybody?  I don't get it.)  Or roll a small royalty into the print-on-demand version, see <xref ref="print-on-demand" />.</p>
 
     <p>There are a few practical details to think about.  Eventually others will link to your book, and you will also release updates.  First, think about creating a simple high-level directory that will be stable, short, easy to type, and easy to remember.  Controlling your domain name (above) is the first step.  Then consider that you may also distribute a <init>PDF</init> version, and you may someday write a second book.  So, for example, your <init>URL</init> might look like:</p>
 

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -704,7 +704,7 @@ def main():
                 'cannot make Asymptote diagrams in "{}" format'.format(args.format)
             )
     elif args.component == "sageplot":
-        if args.format in ["pdf", "svg", "png", "html", "all"]:
+        if args.format in ["pdf", "svg", "png", "eps", "html", "all"]:
             ptx.sage_conversion(
                 xml_source,
                 publication_file,

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -218,10 +218,12 @@
             PersonName = element personname {TextSimple}
             Affiliation =
                 element affiliation {
+                    Position? &
                     Department? &
                     Institution? &
                     Location?
                 }
+            Position = element position {TextSimple | ShortLine+}
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
             Support = element support {TextParagraph}
@@ -249,7 +251,7 @@
                     attribute xml:id {text}?,
                     PersonName,
                     (
-                        (Department? & Institution? & Location?) |
+                        (Position? & Department? & Institution? & Location?) |
                         Affiliation+
                     )?,
                     Email?,
@@ -260,7 +262,7 @@
                 element editor {
                     PersonName,
                     (
-                        (Department? & Institution? & Location?) |
+                        (Position? & Department? & Institution? & Location?) |
                         Affiliation+
                     )?,
                     Email?
@@ -661,6 +663,8 @@
                     attribute line-numbers {"yes"|"no"}?,
                     attribute linker-args {text}?,
                     attribute timelimit {text}?,
+                    attribute pck {text}?,
+                    attribute scene {text}?,
                     (
                         text
                     |

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -722,6 +722,9 @@
     <element name="affiliation">
       <interleave>
         <optional>
+          <ref name="Position"/>
+        </optional>
+        <optional>
           <ref name="Department"/>
         </optional>
         <optional>
@@ -731,6 +734,16 @@
           <ref name="Location"/>
         </optional>
       </interleave>
+    </element>
+  </define>
+  <define name="Position">
+    <element name="position">
+      <choice>
+        <ref name="TextSimple"/>
+        <oneOrMore>
+          <ref name="ShortLine"/>
+        </oneOrMore>
+      </choice>
     </element>
   </define>
   <define name="Department">
@@ -830,6 +843,9 @@
         <choice>
           <interleave>
             <optional>
+              <ref name="Position"/>
+            </optional>
+            <optional>
               <ref name="Department"/>
             </optional>
             <optional>
@@ -861,6 +877,9 @@
       <optional>
         <choice>
           <interleave>
+            <optional>
+              <ref name="Position"/>
+            </optional>
             <optional>
               <ref name="Department"/>
             </optional>
@@ -1842,6 +1861,12 @@
       </optional>
       <optional>
         <attribute name="timelimit"/>
+      </optional>
+      <optional>
+        <attribute name="pck"/>
+      </optional>
+      <optional>
+        <attribute name="scene"/>
       </optional>
       <choice>
         <text/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3391,10 +3391,12 @@
             PersonName = element personname {TextSimple}
             Affiliation =
                 element affiliation {
+                    Position? &amp;
                     Department? &amp;
                     Institution? &amp;
                     Location?
                 }
+            Position = element position {TextSimple | ShortLine+}
             Department = element department {TextSimple | ShortLine+}
             Institution = element institution {TextSimple | ShortLine+}
             Support = element support {TextParagraph}
@@ -3422,7 +3424,7 @@
                     attribute xml:id {text}?,
                     PersonName,
                     (
-                        (Department? &amp; Institution? &amp; Location?) |
+                        (Position? &amp; Department? &amp; Institution? &amp; Location?) |
                         Affiliation+
                     )?,
                     Email?,
@@ -3433,7 +3435,7 @@
                 element editor {
                     PersonName,
                     (
-                        (Department? &amp; Institution? &amp; Location?) |
+                        (Position? &amp; Department? &amp; Institution? &amp; Location?) |
                         Affiliation+
                     )?,
                     Email?

--- a/xsl/extract-sageplot.xsl
+++ b/xsl/extract-sageplot.xsl
@@ -122,9 +122,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:call-template>
     </xsl:variable>
     <!-- NB: 2D PNG is not preferable, but needed for EPUB sent to Kindle -->
+    <!-- NB: 2D EPS serves journals requiring it; Sage's matplotlib        -->
+    <!-- machinery saves any 2D plot by the requested file extension       -->
     <xsl:variable name="b-legal-combination" select="($variant = '2d' and $sageplot.fileformat = 'pdf')
                                                  or  ($variant = '2d' and $sageplot.fileformat = 'svg')
                                                  or  ($variant = '2d' and $sageplot.fileformat = 'png')
+                                                 or  ($variant = '2d' and $sageplot.fileformat = 'eps')
                                                  or  ($variant = '3d' and $sageplot.fileformat = 'png')
                                                  or  ($variant = '3d' and $sageplot.fileformat = 'html')"/>
     <!-- Only certain combinations are supported and only certain       -->

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3138,14 +3138,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:copy>
         <!-- Include "personname" first -->
         <xsl:apply-templates select="personname|@*" mode="repair"/>
-        <!-- If there are bare deparmtment/institution/address, wrap them in affailiation -->
-        <xsl:if test="department or institution or location">
+        <!-- If there are bare position/department/institution/address, wrap them in affiliation -->
+        <xsl:if test="position or department or institution or location">
             <affiliation>
-                <xsl:apply-templates select="department|institution|location" mode="repair"/>
+                <xsl:apply-templates select="position|department|institution|location" mode="repair"/>
             </affiliation>
         </xsl:if>
         <!-- Include all additional elements as they are -->
-        <xsl:apply-templates select="*[not(self::personname or self::department or self::institution or self::location)]" mode="repair"/>
+        <xsl:apply-templates select="*[not(self::personname or self::position or self::department or self::institution or self::location)]" mode="repair"/>
     </xsl:copy>
 </xsl:template>
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9026,18 +9026,32 @@ Book (with parts), "section" at level 3
                 <!-- content override of type-prefix -->
                 <xsl:when test="$b-has-content">
                     <xsl:copy-of select="$custom-text" />
-                    <xsl:apply-templates select="." mode="xref-text-separator"/>
-                    <xsl:apply-templates select="$target" mode="xref-number">
-                        <xsl:with-param name="xref" select="." />
-                    </xsl:apply-templates>
+                    <xsl:variable name="the-number">
+                        <xsl:apply-templates select="$target" mode="xref-number">
+                            <xsl:with-param name="xref" select="." />
+                        </xsl:apply-templates>
+                    </xsl:variable>
+                    <!-- an unnumbered target ("paragraphs", squelched  -->
+                    <!-- numbering) contributes no separator, either    -->
+                    <xsl:if test="not($the-number = '')">
+                        <xsl:apply-templates select="." mode="xref-text-separator"/>
+                    </xsl:if>
+                    <xsl:copy-of select="$the-number"/>
                 </xsl:when>
                 <!-- usual, default case -->
                 <xsl:otherwise>
                     <xsl:apply-templates select="$target" mode="type-name" />
-                    <xsl:apply-templates select="." mode="xref-text-separator"/>
-                    <xsl:apply-templates select="$target" mode="xref-number">
-                        <xsl:with-param name="xref" select="." />
-                    </xsl:apply-templates>
+                    <xsl:variable name="the-number">
+                        <xsl:apply-templates select="$target" mode="xref-number">
+                            <xsl:with-param name="xref" select="." />
+                        </xsl:apply-templates>
+                    </xsl:variable>
+                    <!-- an unnumbered target ("paragraphs", squelched  -->
+                    <!-- numbering) contributes no separator, either    -->
+                    <xsl:if test="not($the-number = '')">
+                        <xsl:apply-templates select="." mode="xref-text-separator"/>
+                    </xsl:if>
+                    <xsl:copy-of select="$the-number"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
@@ -9046,14 +9060,28 @@ Book (with parts), "section" at level 3
                 <!-- content override of type-prefix -->
                 <xsl:when test="$b-has-content">
                     <xsl:copy-of select="$custom-text" />
-                    <xsl:apply-templates select="." mode="xref-text-separator"/>
-                    <xsl:apply-templates select="$target" mode="serial-number" />
+                    <xsl:variable name="the-number">
+                        <xsl:apply-templates select="$target" mode="serial-number" />
+                    </xsl:variable>
+                    <!-- an unnumbered target ("paragraphs", squelched  -->
+                    <!-- numbering) contributes no separator, either    -->
+                    <xsl:if test="not($the-number = '')">
+                        <xsl:apply-templates select="." mode="xref-text-separator"/>
+                    </xsl:if>
+                    <xsl:copy-of select="$the-number"/>
                 </xsl:when>
                 <!-- usual, default case -->
                 <xsl:otherwise>
                     <xsl:apply-templates select="$target" mode="type-name" />
-                    <xsl:apply-templates select="." mode="xref-text-separator"/>
-                    <xsl:apply-templates select="$target" mode="serial-number" />
+                    <xsl:variable name="the-number">
+                        <xsl:apply-templates select="$target" mode="serial-number" />
+                    </xsl:variable>
+                    <!-- an unnumbered target ("paragraphs", squelched  -->
+                    <!-- numbering) contributes no separator, either    -->
+                    <xsl:if test="not($the-number = '')">
+                        <xsl:apply-templates select="." mode="xref-text-separator"/>
+                    </xsl:if>
+                    <xsl:copy-of select="$the-number"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
@@ -9068,19 +9096,26 @@ Book (with parts), "section" at level 3
                     <xsl:apply-templates select="$target" mode="type-name" />
                 </xsl:otherwise>
             </xsl:choose>
-            <xsl:apply-templates select="." mode="xref-text-separator"/>
             <!-- only difference in behavior is global/local number -->
-            <xsl:choose>
-                <xsl:when test="$text-style = 'type-global-title'">
-                    <xsl:apply-templates select="$target" mode="xref-number">
-                        <xsl:with-param name="xref" select="." />
-                    </xsl:apply-templates>
-                </xsl:when>
-                <xsl:when test="$text-style = 'type-local-title'">
-                    <xsl:apply-templates select="$target" mode="serial-number"/>
-                </xsl:when>
-                <xsl:otherwise/>
-            </xsl:choose>
+            <xsl:variable name="the-number">
+                <xsl:choose>
+                    <xsl:when test="$text-style = 'type-global-title'">
+                        <xsl:apply-templates select="$target" mode="xref-number">
+                            <xsl:with-param name="xref" select="." />
+                        </xsl:apply-templates>
+                    </xsl:when>
+                    <xsl:when test="$text-style = 'type-local-title'">
+                        <xsl:apply-templates select="$target" mode="serial-number"/>
+                    </xsl:when>
+                    <xsl:otherwise/>
+                </xsl:choose>
+            </xsl:variable>
+            <!-- an unnumbered target ("paragraphs", squelched  -->
+            <!-- numbering) contributes no separator, either    -->
+            <xsl:if test="not($the-number = '')">
+                <xsl:apply-templates select="." mode="xref-text-separator"/>
+            </xsl:if>
+            <xsl:copy-of select="$the-number"/>
             <xsl:variable name="the-title">
                 <xsl:apply-templates select="$target" mode="title-xref"/>
             </xsl:variable>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -498,11 +498,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="affiliation">
-    <xsl:apply-templates select="department|institution|location"/>
+    <xsl:apply-templates select="position|department|institution|location"/>
 </xsl:template>
 
 <!-- each is a line, or authored "line"s, of the address block -->
-<xsl:template match="department|institution|location">
+<xsl:template match="position|department|institution|location">
     <xsl:choose>
         <xsl:when test="line">
             <xsl:apply-templates select="line"/>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1431,24 +1431,32 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:apply-templates select="." mode="exercise-heading"/>
             <xsl:text> </xsl:text>
         </xsl:variable>
+        <!-- The component switches must pass as genuine booleans: a   -->
+        <!-- with-param carrying *content* is a result tree fragment,   -->
+        <!-- and any fragment, even one whose text is "false", is true  -->
+        <!-- in the boolean tests downstream.  So: compute the strings, -->
+        <!-- pass comparisons.                                          -->
+        <xsl:variable name="has-hint">
+            <xsl:apply-templates select="." mode="b-main-text-component">
+                <xsl:with-param name="component" select="'hint'"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="has-answer">
+            <xsl:apply-templates select="." mode="b-main-text-component">
+                <xsl:with-param name="component" select="'answer'"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="has-solution">
+            <xsl:apply-templates select="." mode="b-main-text-component">
+                <xsl:with-param name="component" select="'solution'"/>
+            </xsl:apply-templates>
+        </xsl:variable>
         <xsl:apply-templates select="." mode="exercise-components">
             <xsl:with-param name="b-original" select="true()"/>
             <xsl:with-param name="b-has-statement" select="true()"/>
-            <xsl:with-param name="b-has-hint">
-                <xsl:apply-templates select="." mode="b-main-text-component">
-                    <xsl:with-param name="component" select="'hint'"/>
-                </xsl:apply-templates>
-            </xsl:with-param>
-            <xsl:with-param name="b-has-answer">
-                <xsl:apply-templates select="." mode="b-main-text-component">
-                    <xsl:with-param name="component" select="'answer'"/>
-                </xsl:apply-templates>
-            </xsl:with-param>
-            <xsl:with-param name="b-has-solution">
-                <xsl:apply-templates select="." mode="b-main-text-component">
-                    <xsl:with-param name="component" select="'solution'"/>
-                </xsl:apply-templates>
-            </xsl:with-param>
+            <xsl:with-param name="b-has-hint" select="$has-hint = 'true'"/>
+            <xsl:with-param name="b-has-answer" select="$has-answer = 'true'"/>
+            <xsl:with-param name="b-has-solution" select="$has-solution = 'true'"/>
             <xsl:with-param name="run-in-heading" select="$heading"/>
         </xsl:apply-templates>
         <!-- writing space below, in a printout, when requested -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1177,6 +1177,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="affiliation">
+    <xsl:if test="position">
+        <xsl:apply-templates select="position" />
+        <xsl:if test="position/following-sibling::*">
+            <br />
+        </xsl:if>
+    </xsl:if>
     <xsl:if test="department">
         <xsl:apply-templates select="department" />
         <xsl:if test="department/following-sibling::*">
@@ -1198,11 +1204,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- Departments and Institutions are free-form, or sequences of lines -->
-<xsl:template match="department|institution|location">
+<xsl:template match="position|department|institution|location">
     <xsl:apply-templates/>
 </xsl:template>
 
-<xsl:template match="department[line]|institution[line]|location[line]">
+<xsl:template match="position[line]|department[line]|institution[line]|location[line]">
     <xsl:apply-templates select="line" />
 </xsl:template>
 

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -3354,6 +3354,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Preprocessor always puts Department, Institution, and Location         -->
 <!-- inside Affiliation. This just adds line breaks between them as needed. -->
 <xsl:template match="affiliation">
+    <xsl:if test="position">
+        <xsl:text>\\&#xa;</xsl:text>
+        <xsl:apply-templates select="position" />
+    </xsl:if>
     <xsl:if test="department">
         <xsl:text>\\&#xa;</xsl:text>
         <xsl:apply-templates select="department" />
@@ -3378,11 +3382,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Departments, Institutions, and Addresses are free-form, or sequences of lines  -->
 <!-- Line breaks are inserted above, due to \and, etc, so do not end last line here -->
-<xsl:template match="department|institution|location">
+<xsl:template match="position|department|institution|location">
     <xsl:apply-templates/>
 </xsl:template>
 
-<xsl:template match="department[line]|institution[line]|location[line]">
+<xsl:template match="position[line]|department[line]|institution[line]|location[line]">
     <xsl:apply-templates select="line" />
 </xsl:template>
 

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -8759,6 +8759,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="xref-as-ref">
         <xsl:apply-templates select="$target" mode="xref-as-ref" />
     </xsl:variable>
+    <!-- Under the author's draft mode a forward reference, one     -->
+    <!-- preceding its target in document order, colors distinctly, -->
+    <!-- so material moved out of logical order announces itself.   -->
+    <!-- The count-union membership test reads document order.      -->
+    <xsl:variable name="b-draft-forward-reference" select="$b-latex-draft-mode and not(ancestor::title|ancestor::subtitle) and (count(current()|$target/preceding::*) = count($target/preceding::*))"/>
+    <xsl:if test="$b-draft-forward-reference">
+        <xsl:text>{\hypersetup{linkcolor=green}</xsl:text>
+    </xsl:if>
     <xsl:choose>
         <!-- inactive in titles, just text               -->
         <!-- With protection against incorrect, sloppy   -->
@@ -8805,6 +8813,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>}</xsl:text>
         </xsl:otherwise>
     </xsl:choose>
+    <xsl:if test="$b-draft-forward-reference">
+        <xsl:text>}</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <xsl:template match="xref|&PROOF-LIKE;" mode="latex-page-number">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1536,6 +1536,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- unexpected-value-for-option-hidelinkshyperref-is-ignored -->
         <!-- https://tex.stackexchange.com/a/503001                   -->
         <xsl:text>\hypersetup{hidelinks}&#xa;</xsl:text>
+        <xsl:text>%% A print PDF needs no internal anchors, nor links to them:&#xa;</xsl:text>
+        <xsl:text>%% both dissolve to their content, which preserves spacing&#xa;</xsl:text>
+        <xsl:text>\renewcommand{\hypertarget}[2]{#2}&#xa;</xsl:text>
+        <xsl:text>\renewcommand{\hyperlink}[2]{#2}&#xa;</xsl:text>
     </xsl:if>
     <!-- Hyperref gives names to destinations for links that look like      -->
     <!-- "section*.5.2" which you can guess is the second section of        -->


### PR DESCRIPTION
A head-down pass over the backlog: nine issues whose resolutions are small and self-contained, one commit per concern.  Every change is election-gated or fires only on constructs the test corpus lacks, so unelected sample-article builds are byte-identical to master in LaTeX and HTML apart from timestamps.

* `a2e04e76` — **Guide typo** ("tnis") in the publication file overview.  Closes #2023.
* `7aa9c429` — **Hosting advice**: the web-hosting chapter now names the cost scale of a domain registration and states the pairing plainly — a project hosted free on GitHub Pages, reached through a domain you own, is complete address control for the registration price.  Closes #1514.
* `2b7cf890` — **Print PDFs carry no internal link anchors**: under the print election, `\hypertarget` and `\hyperlink` dissolve to their content via two preamble redefinitions, removing the manual anchor layer (311 link annotations in a sample-article print PDF) that a printer-ready file has no use for.  Page breaks can shift slightly; print and electronic pagination already differ (landscape material rotates only in print).  Closes #1076.
* `b501874e` — **Draft mode colors forward references green**: a cross-reference that precedes its target in document order announces itself, which is exactly the rearrangement hazard draft mode exists to expose.  Backward references and non-draft builds are untouched.  Closes #1460.
* `efdc5b01` — **No stray space in an `xref` to an unnumbered target**: the non-breaking separator between a type name and a number now emits only when the target actually has a number, so a reference to a `paragraphs` reads "Paragraphs", not "Paragraphs ".  Closes #381.
* `d5a8fd8a` — **Slide images honor `@width`**: the authored width always reached the reveal.js markup, but `pretext-reveal.css` lacked the rule letting an image fill its width-carrying container; the rule is added to the SCSS source, mirrored from the HTML theme.  `css/dist` regeneration is left to the maintainer, as usual.  Closes #1888.
* `eec5222e` — **EPS Sage plots**: `eps` joins the supported 2D formats for the `sageplot` component — Sage saves by file extension, so the plumbing needed only permission.  Verified against Sage 10.8: the sample article's six 2D plots produce conforming EPS.  Closes #1417.
* `05adcfda`, `19d6cb4c` — **An author's `position`** (schema, then rendering): a `position` element — "Professor of Mathematics" — joins `author`, `editor`, and `affiliation`, modeled exactly like `department`, and renders as the leading affiliation line in HTML, LaTeX, and XSL-FO title pages.  Closes #913.
* `6d36adff` — **XSL-FO honors exercise-component visibility switches**: the FO conversion passed its hint/answer/solution flags as parameter *content*, making them result tree fragments — and a fragment whose text is "false" is still boolean-true downstream, so solutions always rendered.  The flags now pass as genuine booleans.  With divisional solutions switched off they disappear from the main text while a backmatter solutions division is unaffected.  Closes #2926.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
