### PR TITLE
Embedded page reading controls

### DIFF
--- a/css/components/page-parts/_embed.scss
+++ b/css/components/page-parts/_embed.scss
@@ -1,0 +1,133 @@
+// Styles for a page loaded with the "embed" URL parameter, as an instructor's
+// LMS iframe loads it.  pretext-embed.js hides the masthead, footers and
+// sidebar outright; the navbar is the one page part it keeps, because the
+// reading controls live inside it and those are worth keeping.  Everything
+// here restyles that surviving navbar into a small floating cluster.
+//
+// Included via _navbar.scss so every theme with a navbar gets it.  The rules
+// only bite when JavaScript has put .ptx-embedded on the body.
+
+$nav-height: 36px !default;
+
+// The cluster's inset from the top-right corner of the iframe, and the corner
+// rounding of the cluster itself.  Both are deliberately independent of the
+// theme's button radius: navbar buttons are square-cornered in most themes
+// because they sit in a full-width bar with nothing to round against, which
+// stops being true the moment the bar becomes a floating object.
+$embed-controls-inset: 0.75rem !default;
+$embed-controls-radius: 5px !default;
+
+body.pretext.ptx-embedded {
+  // The navbar reserves space for itself at the foot of the page below the
+  // breakpoint, and read-aloud reserves a second row on top of that.  Neither
+  // reservation means anything once the bar is floating at the top, and both
+  // would show as dead space under the last line of content.
+  //
+  // The read-aloud rule is `body.pretext:has(.ptx-read-aloud-player:not([hidden]))`,
+  // which is (0,3,1) — `:has()` takes the specificity of its heaviest argument.
+  // Matching the same `:has()` here and adding .ptx-embedded is what clears it;
+  // a plain `body.pretext.ptx-embedded` is only (0,2,1) and would silently lose.
+  padding-bottom: 0;
+
+  &:has(.ptx-read-aloud-player:not([hidden])) {
+    padding-bottom: 0;
+  }
+
+  // -------------------------------------------------------------------------
+  // The navbar becomes the cluster
+
+  .ptx-navbar {
+    // Fixed rather than sticky or absolute: the embed code hands out a fixed
+    // 1000px-tall iframe, so a long page scrolls *inside* the frame and an
+    // in-flow cluster would scroll out of reach.  Fixed keeps the controls in
+    // the corner for the whole page.  In an auto-resized iframe (the LTI
+    // resizer grows the frame to fit its content) there is no inner scroll to
+    // outrun, and fixed and absolute come to the same thing.
+    position: fixed;
+    top: $embed-controls-inset;
+    right: $embed-controls-inset;
+    left: auto;
+    bottom: auto;
+    width: auto;
+    height: auto;
+    // Never wider than the frame, however narrow the LMS column is.  With the
+    // min-width floors released below, the buttons ellipsize or squeeze rather
+    // than spilling past the left edge.
+    max-width: calc(100% - 2 * #{$embed-controls-inset});
+    margin: 0;
+    background: transparent;
+    border: 0;
+    // Over the content, under the modal dialogs these buttons open.
+    z-index: 1200;
+
+    .ptx-navbar-contents {
+      // The full-page navbar centers itself in a max-width column and stretches
+      // to fill the row.  A floating cluster wants neither: it shrink-wraps its
+      // buttons and hugs the right edge.
+      max-width: none;
+      width: auto;
+      margin: 0;
+      flex: 0 0 auto;
+      justify-content: flex-end;
+      min-width: 0;
+    }
+
+    // Navigation is the reader's own; an embedded page is one page of a course
+    // shell that supplies its own.  That leaves the reading controls, which is
+    // the whole reason the navbar survives here.
+    .ptx-navbar-contents > *:not(.nav-other-controls) {
+      display: none;
+    }
+
+    // The share button hands out embed code for the current URL.  Inside an
+    // already-embedded page that URL still carries "embed", so it would offer
+    // an iframe of an iframe.
+    .ptx-embed-button {
+      display: none;
+    }
+
+    // -----------------------------------------------------------------------
+    // The cluster itself
+
+    .nav-other-controls {
+      height: $nav-height;
+      max-width: 100%;
+      min-width: 0;
+      background: var(--navbar-background);
+      border: 1px solid var(--page-border-color);
+      border-radius: $embed-controls-radius;
+      box-shadow: 1px 1px 3px var(--dialog-shadow-color);
+      // The buttons are square and butt against the border; without this the
+      // corners of the first and last one square off the rounding.
+      overflow: hidden;
+    }
+
+    // Below the breakpoint the player normally lifts onto its own row above the
+    // navbar (`bottom: 100%`), which is right when the navbar is pinned to the
+    // foot of the page and wrong here — the cluster is at the *top*, so that
+    // row would land off-screen above it.  It can stay in the row instead: the
+    // cluster holds two or three buttons rather than the six a full navbar
+    // carries, so the player has room that it does not have on a real page.
+    .ptx-read-aloud-player {
+      position: static;
+      height: auto;
+      background: none;
+      border-top: 0;
+      justify-content: flex-end;
+      min-width: 0;
+    }
+
+    // We remove the theme controls from reader controls entirely, because it is the instructor's choice that matters in an LMS iframe.,
+
+    .ptx-readability-options-group-theme {
+      display: none;
+    }
+
+    // What squeezing there is should land on the player's own controls, which
+    // are icons and stay legible at any width, rather than on the buttons that
+    // opened it.
+    .nav-other-controls > .button {
+      flex-shrink: 0;
+    }
+  }
+}

--- a/css/components/page-parts/_navbar.scss
+++ b/css/components/page-parts/_navbar.scss
@@ -37,6 +37,13 @@ $center-content: true !default;
   $navbar-breakpoint: $navbar-breakpoint
 );
 
+// Restyles this navbar into a floating control cluster when the page is loaded
+// with the "embed" URL parameter.  Its rules out-specify the ones below rather
+// than relying on source order, so its position here does not matter.
+@use 'components/page-parts/embed' with (
+  $nav-height: $nav-height
+);
+
 .ptx-navbar {
   position: sticky;
   top: 0;

--- a/js/src/pretext-embed.js
+++ b/js/src/pretext-embed.js
@@ -1,3 +1,5 @@
+import {applyThemeChoice } from "./readability-options.js";
+
 // Share button and embed in LMS code
 window.addEventListener("DOMContentLoaded", function(event) {
     const shareButton = document.getElementById("ptx-embed-button");
@@ -53,28 +55,43 @@ window.addEventListener("DOMContentLoaded", function(event) {
     }
 });
 
-// Hide everything except the content when the URL has "embed" in it
+// The embed URL carries the instructor's choice: plain "embed" asks for light,
+// "embed=dark" for dark, so the frame can be made to match the LMS page around
+// it.  We always enforce this theme and remove the choices from the reader.
+function applyEmbedTheme(embedValue) {
+    const instructorTheme = (embedValue === "dark") ? "dark" : "light";
+    applyThemeChoice(instructorTheme);
+}
+
+// Strip the page down to its content when the URL has "embed" in it, as an
+// instructor's LMS iframe loads it.
 window.addEventListener("DOMContentLoaded", function(event) {
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has("embed")) {
-        // Set dark mode based on value of param
-        if (urlParams.get("embed") === "dark") {
-            setDarkMode(true);
-        } else {
-            setDarkMode(false);
-        }
-        const elemsToHide = [
-            "ptx-navbar",
-            "ptx-masthead",
-            "ptx-page-footer",
-            "ptx-sidebar",
-            "ptx-content-footer"
-        ];
-        for (let id of elemsToHide) {
-            const elem = document.getElementById(id);
-            if (elem) {
-                elem.classList.add("hidden");
-            }
+    if (!urlParams.has("embed")) {
+        return;
+    }
+
+    // Hands the page to _embed.scss, which restyles the navbar below into a
+    // floating cluster in the top-right corner.
+    document.body.classList.add("ptx-embedded");
+
+    // "ptx-navbar" is deliberately absent from this list.  Hiding it used to be
+    // how the table of contents, search and prev/next buttons were dropped, but
+    // it took the reading settings and the read-aloud player down with them --
+    // those live in the same bar, and they are the controls an embedded reader
+    // most needs.  _embed.scss hides the navigation and keeps the rest.
+    const elemsToHide = [
+        "ptx-masthead",
+        "ptx-page-footer",
+        "ptx-sidebar",
+        "ptx-content-footer"
+    ];
+    for (let id of elemsToHide) {
+        const elem = document.getElementById(id);
+        if (elem) {
+            elem.classList.add("hidden");
         }
     }
+
+    applyEmbedTheme(urlParams.get("embed"));
 });

--- a/js/src/readability-options.js
+++ b/js/src/readability-options.js
@@ -323,3 +323,9 @@ applyFontSize(getSavedFontSize());
 // and from other modules (e.g. mermaid, embed code). Expose them globally.
 window.isDarkMode = isDarkMode;
 window.setDarkMode = setDarkMode;
+
+// Module exports for other files in the same bundle.  Preferred over the
+// window globals above, which exist for reaching code we do not bundle;
+// pretext-embed.js needs to know whether the reader has chosen a theme of
+// their own before it applies the one the embed URL asks for.
+export { applyThemeChoice };


### PR DESCRIPTION
When an instructor embeds a pretext page in their LMS (or using any iframe) we offer the `?embed` query parameter that hides navigation, masthead, and footer.  This works well, but now that we have reading controls and read-aloud for pages, those new conveniences are lost inside the LMS.

This PR moves just the "other" navigation controls (the two above, and also the embedded calculator if it is used) to a floating and hopefully unobtrusive group of buttons in the top-right of the page.