### PR TITLE
Appendix letters carry a period when composed with a title

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3223,6 +3223,19 @@ Book (with parts), "section" at level 3
     </xsl:apply-templates>
 </xsl:template>
 
+<!-- A bare appendix letter beside a title is ambiguous ("A Trip    -->
+<!-- Abroad"), so wherever the letter and title compose on one line -->
+<!-- a period follows the letter: "A. Trip Abroad".  A "solutions"  -->
+<!-- division in the back matter shares the letter sequence (see    -->
+<!-- "division-serial-number" in the assembly), so it is treated    -->
+<!-- identically.  Only the top-level letter: subdivision numbers   -->
+<!-- ("A.2") are already unambiguous.  Styling refinements are      -->
+<!-- anticipated.                                                   -->
+<xsl:template match="*" mode="division-number-separator"/>
+<xsl:template match="appendix|backmatter/solutions" mode="division-number-separator">
+    <xsl:text>.</xsl:text>
+</xsl:template>
+
 <!-- Most PreTeXt elements have names, and their localizations, indexed   -->
 <!-- by a "string-id" that is simply their local name.  However, others   -->
 <!-- ("exercise" is archetypical) have names that vary according to their -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -430,6 +430,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:variable>
             <xsl:if test="not($the-number = '')">
                 <xsl:value-of select="$the-number"/>
+                <xsl:apply-templates select="." mode="division-number-separator"/>
                 <xsl:text> </xsl:text>
             </xsl:if>
             <xsl:variable name="the-title">
@@ -731,6 +732,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="." mode="link-id-attribute"/>
                 <xsl:if test="not($the-number = '')">
                     <xsl:value-of select="$the-number"/>
+                    <xsl:apply-templates select="." mode="division-number-separator"/>
                     <xsl:text> </xsl:text>
                 </xsl:if>
                 <xsl:apply-templates select="." mode="title-full"/>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -563,6 +563,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:if test="not($num = '')">
                 <span class="codenumber">
                     <xsl:value-of select="$num" />
+                    <xsl:apply-templates select="." mode="division-number-separator"/>
                 </span>
                 <xsl:text> </xsl:text>
             </xsl:if>
@@ -984,6 +985,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:call-template name="space-styled"/>
     <span class="codenumber">
         <xsl:apply-templates select="." mode="number" />
+        <xsl:apply-templates select="." mode="division-number-separator"/>
     </span>
     <xsl:call-template name="space-styled"/>
     <span class="title">
@@ -13270,6 +13272,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:if test="not($the-number = '')">
                 <span class="codenumber">
                     <xsl:value-of select="$the-number" />
+                    <xsl:apply-templates select="." mode="division-number-separator"/>
                 </span>
                 <!-- separating space, only if needed -->
                 <xsl:text> </xsl:text>

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -369,6 +369,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>\AtBeginDocument{\setlength{\ptxnormalparindent}{\parindent}}&#xa;</xsl:text>
     <xsl:text>\AtBeginDocument{\setlength{\ptxnormalparskip}{\parskip}}&#xa;</xsl:text>
     <xsl:text>\newcommand{\ptxsetparstyle}{\setlength{\parindent}{\ptxnormalparindent}\setlength{\parskip}{\ptxnormalparskip}}</xsl:text>
+    <xsl:text>%% An appendix is numbered by a letter, and a bare letter beside a&#xa;</xsl:text>
+    <xsl:text>%% title is ambiguous ("A Trip Abroad"), so a letter composed with&#xa;</xsl:text>
+    <xsl:text>%% a title carries a period ("A. Trip Abroad").  These macros are&#xa;</xsl:text>
+    <xsl:text>%% seams in the division styles, empty until the appendices arrive&#xa;</xsl:text>
+    <xsl:text>%% (chapter-level for a book, section-level for an article, so a&#xa;</xsl:text>
+    <xsl:text>%% multi-part number like "E.1" never gains a period); see the&#xa;</xsl:text>
+    <xsl:text>%% uses at  \appendix&#xa;</xsl:text>
+    <xsl:text>\newcommand{\ptxappendixperiodchapter}{}&#xa;</xsl:text>
+    <xsl:text>\newcommand{\ptxappendixperiodsection}{}&#xa;</xsl:text>
     <xsl:text>%% Hyperref should be here, but likes to be loaded late&#xa;</xsl:text>
     <xsl:text>%%&#xa;</xsl:text>
     <xsl:text>%% Inline math delimiters, \(, \), need to be robust&#xa;</xsl:text>
@@ -3432,6 +3441,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="appendix|solutions">
         <xsl:text>%&#xa;</xsl:text>
         <xsl:text>\appendix%&#xa;</xsl:text>
+        <xsl:text>%% Appendix letters compose with titles, so take a period: in&#xa;</xsl:text>
+        <xsl:text>%% contents entries (scoped: the .toc file is read within a group)&#xa;</xsl:text>
+        <xsl:text>\addtocontents{toc}{\protect\renewcommand{\protect\ptxappendixperiodsection}{.}}%&#xa;</xsl:text>
+        <xsl:text>%% and in the hang-shape division headings from here on&#xa;</xsl:text>
+        <xsl:text>\renewcommand{\ptxappendixperiodsection}{.}%&#xa;</xsl:text>
         <xsl:text>%&#xa;</xsl:text>
         <xsl:text>%% A lineskip in table of contents as a transition to the appendices&#xa;</xsl:text>
         <xsl:text>\addtocontents{toc}{\vspace{\normalbaselineskip}}%&#xa;</xsl:text>
@@ -3451,6 +3465,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="appendix|solutions">
         <xsl:text>%&#xa;</xsl:text>
         <xsl:text>\appendix%&#xa;</xsl:text>
+        <xsl:text>%% Appendix letters compose with titles in contents entries, so&#xa;</xsl:text>
+        <xsl:text>%% take a period (scoped: the .toc file is read within a group;&#xa;</xsl:text>
+        <xsl:text>%% display-shape chapter headings do not compose, and stay bare)&#xa;</xsl:text>
+        <xsl:text>\addtocontents{toc}{\protect\renewcommand{\protect\ptxappendixperiodchapter}{.}}%&#xa;</xsl:text>
         <!-- When the equation counter is scoped to "part" (see the         -->
         <!-- equation-numbering template), the LaTeX book class's chapter   -->
         <!-- reset of "equation" has been removed, so \appendix no longer   -->

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -586,7 +586,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- section-level items in the back matter         -->
 <xsl:template name="titlesec-section-style">
     <xsl:text>\titleformat{\section}[hang]&#xa;</xsl:text>
-    <xsl:text>{\divisionfont\Large\bfseries}{\thesection}{1ex}{#1}&#xa;</xsl:text>
+    <xsl:text>{\divisionfont\Large\bfseries}{\thesection\ptxappendixperiodsection}{1ex}{#1}&#xa;</xsl:text>
     <xsl:text>[{\large\authorsptx}]&#xa;</xsl:text>
     <xsl:text>\titleformat{name=\section,numberless}[block]&#xa;</xsl:text>
     <xsl:text>{\divisionfont\Large\bfseries}{}{0pt}{#1}&#xa;</xsl:text>
@@ -656,16 +656,24 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template name="titletoc-chapter-style">
     <xsl:text>\titlecontents{chapter}%&#xa;</xsl:text>
     <xsl:text>[0pt]{\contentsmargin{0em}\addvspace{1pc}\contentsfont\bfseries}%&#xa;</xsl:text>
-    <xsl:text>{\large\thecontentslabel\enspace}{\large}%&#xa;</xsl:text>
+    <xsl:text>{\large\thecontentslabel\ptxappendixperiodchapter\enspace}{\large}%&#xa;</xsl:text>
     <xsl:text>{\hfill\bfseries\thecontentspage}%&#xa;</xsl:text>
     <xsl:text>[\addvspace{.5pc}]%&#xa;</xsl:text>
 </xsl:template>
 
 <!-- The indent, and space for the number/label are straight  -->
 <!-- from the  titletoc  documentation, which says they match -->
-<!-- the LaTeX  book  class                                   -->
+<!-- the LaTeX  book  class.  The top-level division of an    -->
+<!-- article is a section, so the  \dottedcontents  shorthand -->
+<!-- is expanded verbatim to the  \titlecontents  form it     -->
+<!-- abbreviates, exposing the label composition to carry the -->
+<!-- appendix-period seam                                     -->
 <xsl:template name="titletoc-section-style">
-    <xsl:text>\dottedcontents{section}[3.8em]{\contentsfont}{2.3em}{1pc}%&#xa;</xsl:text>
+    <xsl:text>\titlecontents{section}%&#xa;</xsl:text>
+    <xsl:text>[3.8em]{\contentsfont}%&#xa;</xsl:text>
+    <xsl:text>{\contentslabel[\thecontentslabel\ptxappendixperiodsection]{2.3em}}%&#xa;</xsl:text>
+    <xsl:text>{\hspace*{-2.3em}}%&#xa;</xsl:text>
+    <xsl:text>{\titlerule*[1pc]{.}\contentspage}%&#xa;</xsl:text>
 </xsl:template>
 
 <!-- The indent, and space for the number/label are straight  -->


### PR DESCRIPTION
Closes #914.

An appendix is numbered by a letter, and a bare letter beside a title is
ambiguous: the sample book's table of contents offers "A Notation" two
lines below the unnumbered chapter "A Short Note on Proofs", and the
sample article has "A Structured Appendix".  Wherever a heading, contents
entry, or navigation item composes the bare letter with the title on one
line, the letter now carries a period: "A. Notation".  This is the
default (and only) behavior — no publisher option.  A "solutions"
division in the back matter shares the appendix letter sequence, so it is
treated identically.

Deliberately narrow scope:

- Only the top-level letter: subdivision numbers ("E.1") are already
  unambiguous and stay bare in headings, contents, and bookmarks.
- The LaTeX book chapter heading is display-shape — "Appendix A" sits on
  its own line above the title — so it stays bare.  Running heads already
  read "APPENDIX A. TITLE"; that period predates this PR.
- PDF sidebar bookmarks in the LaTeX route keep the bare letter (hyperref
  composes them outside the new seams); the XSL-FO route's bookmarks do
  gain the period.
- HTML browser-tab titles and breadcrumbs are untouched.

Styling refinements are invited on this PR.  In HTML the period sits
inside the span — `<span class="codenumber">A.</span>` — so CSS can style
or suppress it.  In LaTeX the implementation is a pair of always-empty
seam macros (`\ptxappendixperiodchapter`, `\ptxappendixperiodsection`)
referenced in the default titlesec/titletoc division styles and flipped
at `\appendix`; a style that overrides those templates simply keeps bare
letters, with no errors.

The commits:

- 16c61604 (Common) The hook: `mode="division-number-separator"`, empty
  generically, a period for `appendix|backmatter/solutions` — exactly the
  node set the assembly letters.
- 5b207e17 (HTML) Applied at the three composition sites: division
  headings, the ToC sidebar, and summary-page navigation.  EPUB and
  braille inherit the heading composition.
- 8c7d40dd (XSL-FO) Applied in hang-shape division headings and PDF
  bookmarks.
- 46106273 (LaTeX) titletoc parses `\numberline` tokens rather than
  executing them, so the seams live in the label specifications: the
  chapter `\titlecontents` label, the section `\titleformat` label, and
  `\dottedcontents{section}` expanded verbatim to the `\titlecontents`
  form it abbreviates — whose `\contentslabel` already reserves exactly
  this slot for a dot (the `dotinlabels` package option).  Flips ride the
  `.toc` stream (read within a group, so they cannot leak into headings)
  plus, for an article's headings, the document stream.

Testing, all before/after at the merge base: HTML sample article — across
all 63 changed files the only content difference is the ten letters A.–J.
in codenumber spans.  EPUB — same result, with epubcheck unchanged at its
corpus baseline.  XSL-FO — full-text and bookmark dumps differ in exactly
the ten letters, subdivision bookmarks bare.  LaTeX — emitted .tex diffs
for both document classes are exactly the seam and flip lines; compiled
PDFs show the sample book ToC "A. Notation"–"G. …" with "E.1" bare and
display headings bare, article headings "A."–"E." with mainmatter bare,
and a ToC-enabled article correct at both levels.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
