### PR TITLE
Seven fixes from the issue backlog

### DIFF
--- a/doc/guide/publisher/conversions.xml
+++ b/doc/guide/publisher/conversions.xml
@@ -28,6 +28,13 @@
 
         <p>Create a separate <init>XML</init> file the same way you always would.  Include the usual <init>XML</init> declaration as the first line.  Now, instead of the overall element being <tag>pretext</tag>, use <tag>publication</tag>.  That's it.  Various elements within <tag>publication</tag> will be used to specify options, typically attributes.  Name the file something that reminds you of its purpose, such as <c>pod.xml</c> for a print-on-demand version.  Avoid using spaces in the filename, even if your operating system encourages it.</p>
 
+        <paragraphs xml:id="publication-file-paths">
+            <title>Paths in a publication file</title>
+            <idx><h>publication file</h><h>paths within</h></idx>
+
+            <p>Every path inside a publication file<mdash/>a generated-files directory, a file of private solutions, a cover image<mdash/>is interpreted <em>relative to the main source file</em> of your project, the one holding the <tag>pretext</tag> element.  Not relative to the publication file itself, and not relative to the directory where you run a conversion.  This is deliberate: the publication file can live anywhere, be renamed, or be swapped for another, and its entries still locate the same files.  When a path seems to be ignored, or a file cannot be found, check it against the location of your main source file first.</p>
+        </paragraphs>
+
         <p>Entries that control aspects of the output are often attributes of various elements, but may also be the content of elements.  When you read the reference material in <xref ref="publication-file-reference"/> be aware that we use a sort of shorthand to describe these entries, modeled on a specification called XPath.  For example, if we say to set<cd>
             <cline>/publication/foo/bar/@bazz</cline>
         </cd>to possible values of <c>yes</c>, <c>no</c>, or <c>maybe</c> then the following will be the guts of a legitimate publication file that would somehow adjust your output in some way.  In particular, note that the <q>at sign</q>, <c>@</c>, indicates an attribute of the preceding element.</p>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -15,7 +15,7 @@
     <title>Publication File Reference</title>
 
     <introduction>
-        <p>This chapter is reference material for the <term>publication file</term>, whose employment is described in <xref ref="publication-file"/>, where you can also find an explanation of the shorthand syntax used here to describe elements of this file.</p>
+        <p>This chapter is reference material for the <term>publication file</term>, whose employment is described in <xref ref="publication-file"/>, where you can also find an explanation of the shorthand syntax used here to describe elements of this file.  Any path appearing as a value below is relative to your <em>main source file</em>, never to the publication file itself (<xref ref="publication-file-paths"/>).</p>
     </introduction>
 
     <section xml:id="publication-file-common">

--- a/doc/guide/publisher/web-hosting.xml
+++ b/doc/guide/publisher/web-hosting.xml
@@ -38,6 +38,8 @@
         </li>
     </ol>Note the combination the two steps make possible: a project hosted at no cost on GitHub Pages, reached through a domain name you own, is complete control of your project's address for the price of the registration alone.  Now you are set, and control distribution of your scholarly publication.  If you are bothered by the thought of having expenses while you make your work freely available to the world, then consider generating some modest income.  For example, sell Google ads against your pages.  (Why should <em>this</em> disturb anybody?  I don't get it.)  Or roll a small royalty into the print-on-demand version, see <xref ref="print-on-demand" />.</p>
 
+    <p>Wherever the project lands, state its official home <em>inside</em> the project itself: a sentence in the preface or the colophon giving the address of the free, official <init>HTML</init> version.  Copies of openly-licensed projects circulate<mdash/>some unauthorized, some merely stale<mdash/>and a reader holding any copy should be one sentence away from the canonical, current version.</p>
+
     <p>There are a few practical details to think about.  Eventually others will link to your book, and you will also release updates.  First, think about creating a simple high-level directory that will be stable, short, easy to type, and easy to remember.  Controlling your domain name (above) is the first step.  Then consider that you may also distribute a <init>PDF</init> version, and you may someday write a second book.  So, for example, your <init>URL</init> might look like:</p>
 
     <pre>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -1768,6 +1768,10 @@ def youtube_thumbnail(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
         # read lines, but only lines that are comma delimited
         thumbs = [t.strip() for t in id_file.readlines() if "," in t]
 
+    # A failed download (a video gone missing, a network hiccup) is
+    # reported and the remainder still downloads; the whole run only
+    # errors afterward, naming every failure.
+    failed_thumbnails = []
     for thumb in thumbs:
         thumb_pair = thumb.split(",")
         url = "http://i.ytimg.com/vi/{}/default.jpg".format(thumb_pair[0])
@@ -1775,14 +1779,32 @@ def youtube_thumbnail(xml_source, pub_file, stringparams, xmlid_root, dest_dir):
         log.info("downloading {} as {}...".format(url, path))
         # http://stackoverflow.com/questions/13137817/how-to-download-image-using-requests/13137873
         # removed some settings wrapper from around the URL, otherwise verbatim
-        r = requests.get(url, stream=True, timeout=10)
+        try:
+            r = requests.get(url, stream=True, timeout=10)
+        except requests.exceptions.RequestException as e:
+            failed_thumbnails.append(url)
+            log.warning("the download of {} failed: {}".format(url, e))
+            continue
         if r.status_code == 200:
             with open(path, "wb") as f:
                 r.raw.decode_content = True
                 shutil.copyfileobj(r.raw, f)
         else:
-            msg = "PTX:ERROR: download returned a bad status code ({}), perhaps try {} manually?"
-            raise OSError(msg.format(r.status_code, url))
+            failed_thumbnails.append(url)
+            log.warning(
+                "the download of {} returned a bad status code ({})".format(
+                    url, r.status_code
+                )
+            )
+    if failed_thumbnails:
+        msg = "\n".join(
+            [
+                "{} YouTube thumbnail(s) failed to download.",
+                "Perhaps a video has gone missing; try the address(es) manually:",
+            ]
+        ).format(len(failed_thumbnails))
+        url_list = "\n  " + "\n  ".join(failed_thumbnails)
+        raise OSError(msg + url_list)
     log.info("YouTube thumbnail download complete")
 
 

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -9081,7 +9081,18 @@ Book (with parts), "section" at level 3
                     <xsl:if test="not($the-number = '')">
                         <xsl:apply-templates select="." mode="xref-text-separator"/>
                     </xsl:if>
-                    <xsl:copy-of select="$the-number"/>
+                    <!-- a task's local serial reads as its rendered  -->
+                    <!-- label: "Task (a)", not "Task a"              -->
+                    <xsl:choose>
+                        <xsl:when test="$target/self::task">
+                            <xsl:text>(</xsl:text>
+                            <xsl:copy-of select="$the-number"/>
+                            <xsl:text>)</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:copy-of select="$the-number"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:when>
                 <!-- usual, default case -->
                 <xsl:otherwise>
@@ -9094,7 +9105,18 @@ Book (with parts), "section" at level 3
                     <xsl:if test="not($the-number = '')">
                         <xsl:apply-templates select="." mode="xref-text-separator"/>
                     </xsl:if>
-                    <xsl:copy-of select="$the-number"/>
+                    <!-- a task's local serial reads as its rendered  -->
+                    <!-- label: "Task (a)", not "Task a"              -->
+                    <xsl:choose>
+                        <xsl:when test="$target/self::task">
+                            <xsl:text>(</xsl:text>
+                            <xsl:copy-of select="$the-number"/>
+                            <xsl:text>)</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:copy-of select="$the-number"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9145,8 +9145,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </code>
 </xsl:template>
 
+<!-- A copy button serves a block of code; within a "tabular"  -->
+<!-- cell the content is short and the floating button crowds  -->
+<!-- the cell, so there we decline to provide one.             -->
 <xsl:template name="insert-clipboardable-class">
-    <xsl:text> clipboardable</xsl:text>
+    <xsl:if test="not(ancestor::tabular)">
+        <xsl:text> clipboardable</xsl:text>
+    </xsl:if>
 </xsl:template>
 
 <!-- 100% analogue of LaTeX's verbatim            -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1761,11 +1761,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- https://stackoverflow.com/questions/538293/find-common-parent-using-xpath -->
             <xsl:variable name="nearest-common-ancestor"
                           select="./ancestor::*[count(. | $link/ancestor::*) = count($link/ancestor::*)] [1]"/>
-            <xsl:variable name="nearest-ancestor-level">
-                <xsl:apply-templates select="$nearest-common-ancestor" mode="enclosing-level"/>
-            </xsl:variable>
-            <!-- remove not(), replace operator with <, then radically different behavior -->
-            <xsl:value-of select="not($nearest-ancestor-level >= $chunk-level)"/>
+            <xsl:choose>
+                <!-- A division's "introduction" or "conclusion" renders on   -->
+                <!-- its division's page, whole, whatever the chunk level.    -->
+                <!-- So a link and target together inside one companion are   -->
+                <!-- always on one page, though the companion's level would   -->
+                <!-- say otherwise.  Deliberately a containment test, not     -->
+                <!-- level arithmetic: the levels of these companions are     -->
+                <!-- slated for rework.                                       -->
+                <xsl:when test="$nearest-common-ancestor/ancestor-or-self::introduction[parent::*[&STRUCTURAL-FILTER;]] or $nearest-common-ancestor/ancestor-or-self::conclusion[parent::*[&STRUCTURAL-FILTER;]]">
+                    <xsl:value-of select="false()"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:variable name="nearest-ancestor-level">
+                        <xsl:apply-templates select="$nearest-common-ancestor" mode="enclosing-level"/>
+                    </xsl:variable>
+                    <!-- remove not(), replace operator with <, then radically different behavior -->
+                    <xsl:value-of select="not($nearest-ancestor-level >= $chunk-level)"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -545,6 +545,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Parson (Horizontal) -->
 
 <xsl:template match="*[@pi:exercise-interactive = 'parson-horizontal']" mode="runestone-to-static">
+    <!-- Natural-language blocks (mathematics included) must stay in  -->
+    <!-- the normal flow, where markup is processed; only genuine     -->
+    <!-- program code belongs in a verbatim code display.  This       -->
+    <!-- mirrors the vertical Parsons template above.                 -->
+    <xsl:variable name="language">
+        <xsl:apply-templates select="." mode="get-programming-language"/>
+    </xsl:variable>
+    <xsl:variable name="b-natural" select="($language = '') or ($language = 'natural')"/>
     <xsl:attribute name="language">
         <xsl:apply-templates select="." mode="active-language"/>
     </xsl:attribute>
@@ -552,20 +560,31 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Statement -->
     <statement>
         <xsl:copy-of select="statement/node()"/>
-        <!-- programming language version -->
         <p>
-            <cd>
-                <cline>
-                    <!-- hard to tell which is last once sorted, -->
-                    <!-- so we just mark front *and* end         -->
+            <!-- hard to tell which is last once sorted, -->
+            <!-- so we just mark front *and* end         -->
+            <xsl:choose>
+                <xsl:when test="$b-natural">
                     <xsl:text> | </xsl:text>
                     <xsl:for-each select="blocks/block[@order]">
                         <xsl:sort select="@order"/>
-                        <xsl:apply-templates select="." mode="static-horizontal-block"/>
+                        <xsl:apply-templates select="." mode="static-horizontal-block-flow"/>
                         <xsl:text> | </xsl:text>
                     </xsl:for-each>
-                </cline>
-            </cd>
+                </xsl:when>
+                <xsl:otherwise>
+                    <cd>
+                        <cline>
+                            <xsl:text> | </xsl:text>
+                            <xsl:for-each select="blocks/block[@order]">
+                                <xsl:sort select="@order"/>
+                                <xsl:apply-templates select="." mode="static-horizontal-block"/>
+                                <xsl:text> | </xsl:text>
+                            </xsl:for-each>
+                        </cline>
+                    </cd>
+                </xsl:otherwise>
+            </xsl:choose>
         </p>
     </statement>
     <!-- We provide a complete solution below, -->
@@ -577,22 +596,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <!-- versions on authored ones.                                   -->
     <xsl:copy-of select="solution"/>
     <solution>
-        <!-- programming language version -->
         <!-- filter out distractors for the solution -->
         <xsl:variable name="the-blocks" select="blocks/block[not(@correct = 'no')]"/>
         <p>
-            <cd>
-                <cline>
+            <xsl:choose>
+                <xsl:when test="$b-natural">
                     <!-- authored in order, but need to follow @ref -->
                     <xsl:for-each select="$the-blocks">
-                        <xsl:apply-templates select="." mode="static-horizontal-block"/>
-                        <!-- context shift should handle distractors at the end -->
+                        <xsl:apply-templates select="." mode="static-horizontal-block-flow"/>
                         <xsl:if test="following-sibling::block">
                             <xsl:text> </xsl:text>
                         </xsl:if>
                     </xsl:for-each>
-                </cline>
-            </cd>
+                </xsl:when>
+                <xsl:otherwise>
+                    <cd>
+                        <cline>
+                            <!-- authored in order, but need to follow @ref -->
+                            <xsl:for-each select="$the-blocks">
+                                <xsl:apply-templates select="." mode="static-horizontal-block"/>
+                                <!-- context shift should handle distractors at the end -->
+                                <xsl:if test="following-sibling::block">
+                                    <xsl:text> </xsl:text>
+                                </xsl:if>
+                            </xsl:for-each>
+                        </cline>
+                    </cd>
+                </xsl:otherwise>
+            </xsl:choose>
         </p>
     </solution>
 </xsl:template>
@@ -606,6 +637,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <!-- otherwisr duplicate children -->
         <xsl:otherwise>
             <xsl:copy-of select="node()"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- The flow variant serves natural-language blocks: the children  -->
+<!-- of a block are "p", whose contents join the running line, so   -->
+<!-- mathematics and other markup process normally.                 -->
+<xsl:template match="blocks/block" mode="static-horizontal-block-flow">
+    <xsl:choose>
+        <!-- follow @ref, copy paragraph contents -->
+        <xsl:when test="@ref">
+            <xsl:copy-of select="id(@ref)/p/node()"/>
+        </xsl:when>
+        <!-- otherwise duplicate paragraph contents -->
+        <xsl:otherwise>
+            <xsl:copy-of select="p/node()"/>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
Second harvest from the issue backlog: seven fixes, each with its issue.
Close notes will follow individually on the issues after merge.  (An
eighth fix, for #745, was set aside: it assumed the Sage doctest
extraction and the HTML build chunk at the same level, which they need
not; a note recording the difficulty goes to that issue instead.)

- faabc05f (Guide, #1485) Every path inside a publication file is
  interpreted relative to the project's main source file — never the
  publication file itself, never the working directory.  Now stated
  hit-you-over-the-head style, twice: a titled, indexed subsection where
  the publication file is introduced, and a cross-linked sentence
  opening the reference chapter.

- d7b93ddc (Guide, #1515) The web-hosting chapter now advises stating
  the official home *inside* the project — a sentence in the preface or
  colophon giving the address of the free, official HTML version — so a
  reader holding any circulating copy is one sentence from the canonical
  one.

- 1cbb4f37 (Script, #1690) A failed YouTube thumbnail download (request
  failure or bad status code) warns and continues; the run errors once,
  after the loop, naming every failed address.  One missing video costs
  one thumbnail, not the batch.

- f5b91ad5 (Common, #690) A type-local cross reference to a task renders
  its serial as the label the reader sees where the task was born:
  "Task (a)", not "Task a".  In the common composition, so every
  conversion agrees.

- 4e529cae (HTML, #2622) Code inside a "tabular" cell no longer receives
  a copy button: the button serves a block of code, and in a short cell
  it crowds the content it serves.

- 9430a293 (HTML, #2729) A cross reference whose link and target share a
  division's "introduction" or "conclusion" is recognized as on-page, so
  knowled="cross-page" leaves it un-knowled.  Deliberately a containment
  test, not level arithmetic — these companions' levels are slated for
  rework, and containment survives it.

- 58e05842 (Runestone, #2883) The static rendering of horizontal Parsons
  exercises gains the natural-language branch the vertical layout has
  always had: blocks whose language is "natural" (or unset) stay in the
  normal flow — markup processed, mathematics included — in statement
  and solution both; genuine program code keeps its verbatim display.

Testing: each fix was exercised against a document that trips it, and
before/after identity gates on the sample article show timestamps only
for content the branch does not touch.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
