### PR TITLE
A "tabular" is bare, or within a "table"

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -6403,74 +6403,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <p>Note that tables may be constructed using the <url href="http://www.latex-tables.com/" visual="www.latex-tables.com"><latex/> Complex Table Editor</url> tool online at <c>latex-tables.com</c>and then exported in <pretext/> syntax.</p>
 
-            <p>Tables can be used and abused many ways.  We describe long division of polynomials by using vertical and horizontal borders on individual entries of a <tag>tabular</tag>.  The division lines are slightly thicker than the subtraction lines.  This is a good example of the typical abuse of tables for horizontal and vertical layout.  At least we have called it a <q>Figure,</q> not a <q>Table</q>.</p>
-
-            <figure>
-                <caption>Polynomial Long Division</caption>
-                <tabular halign="right">
-                    <row>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell bottom="medium"></cell>
-                        <cell bottom="medium"></cell>
-                        <cell bottom="medium"><m>x</m></cell>
-                        <cell bottom="medium"><m>-</m></cell>
-                        <cell bottom="medium"><m>5</m></cell>
-                    </row>
-                    <row>
-                        <cell><m>x</m></cell>
-                        <cell><m>+</m></cell>
-                        <cell right="medium"><m>2</m></cell>
-                        <cell><m>x^2</m></cell>
-                        <cell><m>-</m></cell>
-                        <cell><m>3x</m></cell>
-                        <cell><m>-</m></cell>
-                        <cell><m>8</m></cell>
-                    </row>
-                    <row>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell bottom="minor"><m>x^2</m></cell>
-                        <cell bottom="minor"><m>+</m></cell>
-                        <cell bottom="minor"><m>2x</m></cell>
-                        <cell bottom="minor"></cell>
-                        <cell bottom="minor"></cell>
-                    </row>
-                    <row>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell><m>-5x</m></cell>
-                        <cell><m>-</m></cell>
-                        <cell><m>8</m></cell>
-                    </row>
-                    <row>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell bottom="minor"><m>-5x</m></cell>
-                        <cell bottom="minor"><m>-</m></cell>
-                        <cell bottom="minor"><m>10</m></cell>
-                   </row>
-                    <row>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell></cell>
-                        <cell><m>2</m></cell>
-                    </row>
-                </tabular>
-            </figure>
-
             <p>An example of aligning table cells' contents horizontally. See the source for comments.</p>
 
 
@@ -6894,6 +6826,71 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </row>
                 </tabular>
             </table>
+
+            <p>Long division of polynomials, described with vertical and horizontal borders on individual entries of a <tag>tabular</tag>.  The division lines are slightly thicker than the subtraction lines.  This is an ill-advised torture test of the <tag>tabular</tag> machinery<mdash/>the typical abuse of tables for horizontal and vertical layout<mdash/>so do not take it as a model, but do notice what the machinery can do.  It is also a <em>bare</em> <tag>tabular</tag>, sitting between paragraphs with no wrapper at all, and so with no number and no caption.  A <tag>tabular</tag> is either bare, like this one, or wrapped in a <tag>table</tag> when it deserves a number and a title.</p>
+
+            <tabular halign="right">
+                <row>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell bottom="medium"></cell>
+                    <cell bottom="medium"></cell>
+                    <cell bottom="medium"><m>x</m></cell>
+                    <cell bottom="medium"><m>-</m></cell>
+                    <cell bottom="medium"><m>5</m></cell>
+                </row>
+                <row>
+                    <cell><m>x</m></cell>
+                    <cell><m>+</m></cell>
+                    <cell right="medium"><m>2</m></cell>
+                    <cell><m>x^2</m></cell>
+                    <cell><m>-</m></cell>
+                    <cell><m>3x</m></cell>
+                    <cell><m>-</m></cell>
+                    <cell><m>8</m></cell>
+                </row>
+                <row>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell bottom="minor"><m>x^2</m></cell>
+                    <cell bottom="minor"><m>+</m></cell>
+                    <cell bottom="minor"><m>2x</m></cell>
+                    <cell bottom="minor"></cell>
+                    <cell bottom="minor"></cell>
+                </row>
+                <row>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell><m>-5x</m></cell>
+                    <cell><m>-</m></cell>
+                    <cell><m>8</m></cell>
+                </row>
+                <row>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell bottom="minor"><m>-5x</m></cell>
+                    <cell bottom="minor"><m>-</m></cell>
+                    <cell bottom="minor"><m>10</m></cell>
+               </row>
+                <row>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell></cell>
+                    <cell><m>2</m></cell>
+                </row>
+            </tabular>
 
             <p>And now a <tag>sidebyside</tag> with a <tag>table</tag> and a <tag>tabular</tag> to check that width is scaled appropriately. See <xref ref="section-side-by-side" text="global">Section</xref> to learn about <tag>sidebyside</tag>s.</p>
 

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -162,12 +162,6 @@
                 element reasoning {ProofLike} |
                 element explanation {ProofLike}
 
-            Figure |=
-                element figure {
-                    MetaDataCaption,
-                    Tabular
-                }
-
             Solutions |=
                 element solutions {
                     MetaDataAltTitleOptional,

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -351,12 +351,6 @@
       </element>
     </choice>
   </define>
-  <define name="Figure" combine="choice">
-    <element name="figure">
-      <ref name="MetaDataCaption"/>
-      <ref name="Tabular"/>
-    </element>
-  </define>
   <define name="Solutions" combine="choice">
     <element name="solutions">
       <ref name="MetaDataAltTitleOptional"/>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -881,6 +881,7 @@
                         MuseScore
                     )
                 } |
+                # the one route to a numbered, titled "tabular"
                 element table {
                     MetaDataAltTitle,
                     Landscape?,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2471,6 +2471,7 @@
           <ref name="MuseScore"/>
         </choice>
       </element>
+      <!-- the one route to a numbered, titled "tabular" -->
       <element name="table">
         <ref name="MetaDataAltTitle"/>
         <optional>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1668,6 +1668,8 @@
         <title>Figures, Tables, Listings and Named Lists</title>
 
         <p>These are containers that all carry titles (mandatory and optional), captions for two, and numbers.  They need to be filled with other (atomic) items, which we generally call <term>planar</term> due to their two-dimensional and rigid characteristics.  These have also called <term>captioned items</term> in the code, even if not all allow a caption.  The option for a lanscape orientation is only relevant for print.</p>
+
+        <p>A <c>tabular</c> never takes a number directly.  Bare, it may sit between paragraphs as unnumbered, uncaptioned content; the <c>table</c> wrapper is the one route to a number and a title.  In particular, a <c>tabular</c> is not a child of a <c>figure</c>.</p>
         <!-- 2021-12-29: should add interactive to figure, once ready -->
 
         <fragment xml:id="table-figure">
@@ -1690,6 +1692,7 @@
                         MuseScore
                     )
                 } |
+                # the one route to a numbered, titled "tabular"
                 element table {
                     MetaDataAltTitle,
                     Landscape?,
@@ -1789,24 +1792,6 @@
                     TableColumn*,
                     TableRow+
                 }
-            </code>
-        </fragment>
-    </section>
-
-    <section>
-        <title>Figure (experimental)</title>
-        <p>
-            We add tabular as a valid child of a figure.
-        </p>
-        <fragment xml:id="figure-dev">
-            <title>Figure (experimental)</title>
-            <code>
-            Figure |=
-                element figure {
-                    MetaDataCaption,
-                    Tabular
-                }
-
             </code>
         </fragment>
     </section>
@@ -3925,7 +3910,6 @@
             <fragref ref="interactive" />
             <fragref ref="frontmatter-dev"/>
             <fragref ref="proof-like"/>
-            <fragref ref="figure-dev"/>
             <fragref ref="solutions-dev"/>
             <fragref ref="reference-dev"/>
             <fragref ref="exercise-dev"/>


### PR DESCRIPTION
The sample article's "Polynomial Long Division" was the lone
`figure/tabular` in the corpus, and the development schema's allowance
for the construct was the lone artifact suggesting we like it.  Both are
gone, in favor of stating the principle plainly: a `tabular` never takes
a number directly.  Bare, it may sit between paragraphs as unnumbered,
uncaptioned content; wrapping it in a `table` is the one route to a
number and a title.

Provenance, for the record.  `figure/tabular` was never in the base
schema.  It entered with the commit that initiated the development
schema (`b25e8bcb`, 2023-04-02, PR #1915), whose entire rationale was
one line — "We add tabular as a valid child of a figure" — evidently
accommodating the existing sample rather than endorsing a design, and it
sat in the experimental overlay for over two years without promotion.
The one sample it accommodated introduces itself as "a good example of
the typical abuse of tables for horizontal and vertical layout."  And
the community's working model has always been the other thing: in a
pretext-support discussion of these containers
(https://groups.google.com/g/pretext-support/c/xqmQLgxpUwk), Alex Jordan
laid out the two parallel systems in words: the captioned, numbered kind
puts an image inside a figure and a tabular inside a table; the
uncaptioned kind is a lone image, or a lone tabular, standing as the
single panel of a sidebyside.  A tabular directly inside a figure
appears in neither system, and the Guide states flatly that a `tabular`
is the only allowed content of a `table`.

The commits:

- ee927b0f (Sample article) The long-division demonstration is now a
  bare `tabular` between paragraphs — no wrapper, no number, no
  caption — relocated deeper into "Table Calisthenics" to sit just after
  the "Table Torture Test", and reframed honestly: an ill-advised
  torture test of the `tabular` machinery ("do not take it as a model,
  but do notice what the machinery can do"), closing with the principle
  above.  A bare `tabular` is fully legal; the schema has always placed
  `tabular` among ordinary block content.

- c554b421 (Schema) The development overlay's experimental
  figure-holding-`tabular` extension is withdrawn, along with its
  literate-program section.  The base schema's literate prose now states
  the principle, and a comment lands directly on the `table` element in
  the generated `pretext.rnc`: "the one route to a numbered, titled
  tabular".  Regeneration is idempotent; source and derived files travel
  in the one commit.

Testing: the sample article holds its development-schema baseline
(eleven complaints, all from the deliberately-retained old-style
fill-in exercise) with no `tabular` complaints anywhere; the relocated
bare `tabular` renders in HTML and LaTeX at its new position; and a
full before/after HTML build differs only in the move itself, build
timestamps, and two cross-reference knowls whose table numbers slide
down by one, since the former figure no longer consumes a number.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
