### PR TITLE
A "figure" may hold a single "p"

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -4339,6 +4339,8 @@
 
         <p>An <tag>image</tag> is likely the most frequent content in a <tag>figure</tag>.  But you may also place a <tag>video</tag>, <tag>audio</tag>, <tag>sidebyside</tag>, or <tag>sbsgroup</tag>.  Once completely implemented, an <tag>interactive</tag> is another possibility.  (See  <xref ref="topic-sidebyside"/> for more about the side-by-side construction.)</p>
 
+        <p>A <tag>figure</tag> may instead hold a single <tag>p</tag>.  This serves content that is honestly a captioned, numbered display, just built from text.  Displayed mathematics is the archetype: the addition table of a finite ring, authored as an <tag>md</tag> array, is no less a figure than a plot would be.  The humanities have the same need, for example the transcription of an inscription on a monument, a statue, or a coin.  It is a single paragraph by design<mdash/>a figure is a display, and is not meant to hold running prose that belongs to your narrative.</p>
+
         <p>A special situation is when a <tag>figure</tag> is a panel of a <tag>sidebyside</tag>, which is itself inside a <tag>figure</tag>.  Then the interior figure is <term>subnumbered</term>.  For example, the exterior figure might be Figure 4.12, and if a panel of the <tag>sidebyside</tag> is the second interior figure it will be Figure 4.12(b).  For example,<cd>
             <cline>&lt;figure&gt;</cline>
             <cline>    &lt;caption&gt;Salamanders at different life stages&lt;/caption&gt;</cline>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5016,6 +5016,33 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <p>In the early stages of a writing project, it may be best not to track provisional image files built with <c>pretext</c> under version control, and just regenerate them periodically (see the <c>-r</c> option for <c>pretext</c>).  As a project matures, then it makes sense to put stable files under version control for collaborators and others.  In every case, managing graphics files (and other aspects of production), is much more pleasurable with a script (shell, Makefile, etc.)</p>
             </subsection>
 
+            <subsection xml:id="paragraph-figures" label="paragraph-figures">
+                <title>Paragraphs as Figures</title>
+                <idx><h>figure</h><h>holding a paragraph</h></idx>
+
+                <p>A <tag>figure</tag> usually holds an image or similar planar media, but it may instead hold a single paragraph.  This serves content that is honestly a captioned, numbered display, just built from text.  Displayed mathematics is the archetype: the addition table of a finite ring is no less a figure than a plot would be.</p>
+
+                <figure xml:id="figure-z5-addition">
+                    <caption>Addition table for <m>{\mathbb Z}_5</m></caption>
+                    <p><md>\begin{array}{c|ccccc}
+                    + &amp; 0 &amp; 1 &amp; 2 &amp; 3 &amp; 4 \\
+                    \hline
+                    0 &amp; 0 &amp; 1 &amp; 2 &amp; 3 &amp; 4 \\
+                    1 &amp; 1 &amp; 2 &amp; 3 &amp; 4 &amp; 0 \\
+                    2 &amp; 2 &amp; 3 &amp; 4 &amp; 0 &amp; 1 \\
+                    3 &amp; 3 &amp; 4 &amp; 0 &amp; 1 &amp; 2 \\
+                    4 &amp; 4 &amp; 0 &amp; 1 &amp; 2 &amp; 3
+                    \end{array}</md></p>
+                </figure>
+
+                <p>The humanities have the same need.  The transcription of an inscription on a monument, a statue, or a coin is display material bound to its caption, not a paragraph of the surrounding argument.</p>
+
+                <figure xml:id="figure-pantheon-inscription">
+                    <caption>Inscription on the architrave of the Pantheon, Rome</caption>
+                    <p><foreign xml:lang="la">M·AGRIPPA·L·F·COS·TERTIVM·FECIT</foreign>, <q>Marcus Agrippa, son of Lucius, three times consul, built this.</q></p>
+                </figure>
+            </subsection>
+
             <subsection>
                 <title>Accessibility</title>
                 <p>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -878,7 +878,8 @@
                         Audio |
                         SideBySide |
                         SideBySideGroup |
-                        MuseScore
+                        MuseScore |
+                        Paragraph
                     )
                 } |
                 # the one route to a numbered, titled "tabular"

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -2469,6 +2469,7 @@
           <ref name="SideBySide"/>
           <ref name="SideBySideGroup"/>
           <ref name="MuseScore"/>
+          <ref name="Paragraph"/>
         </choice>
       </element>
       <!-- the one route to a numbered, titled "tabular" -->

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1669,6 +1669,8 @@
 
         <p>These are containers that all carry titles (mandatory and optional), captions for two, and numbers.  They need to be filled with other (atomic) items, which we generally call <term>planar</term> due to their two-dimensional and rigid characteristics.  These have also called <term>captioned items</term> in the code, even if not all allow a caption.  The option for a lanscape orientation is only relevant for print.</p>
 
+        <p>A <c>figure</c> may also hold a single paragraph.  A captioned, numbered display of mathematics (a multiplication table as an <c>md</c> array, say), or the transcription of an inscription, is honestly a figure, and one paragraph is a display, not a container.</p>
+
         <p>A <c>tabular</c> never takes a number directly.  Bare, it may sit between paragraphs as unnumbered, uncaptioned content; the <c>table</c> wrapper is the one route to a number and a title.  In particular, a <c>tabular</c> is not a child of a <c>figure</c>.</p>
         <!-- 2021-12-29: should add interactive to figure, once ready -->
 
@@ -1689,7 +1691,8 @@
                         Audio |
                         SideBySide |
                         SideBySideGroup |
-                        MuseScore
+                        MuseScore |
+                        Paragraph
                     )
                 } |
                 # the one route to a numbered, titled "tabular"


### PR DESCRIPTION
A `figure` may now hold a single `p`, in the base schema.  This serves
content that is honestly a captioned, numbered display, just built from
text.  Displayed mathematics is the archetype, and the practice is as
old as the sample book: its AATA chapters set Cayley tables as `md`
arrays inside figures, which validated nowhere until now — those five
figures become legal, dropping the sample book's complaint count by ten
under both schemas.  The humanities have the same need, for example the
transcription of an inscription on a monument, a statue, or a coin.

It is deliberately a *single* paragraph: a figure demands a caption and
takes a number, which reads absurd wrapped around running prose, and one
paragraph is a display, not a container.  That is the brake against a
`figure/p` becoming a generic captioned text box.

No conversion changes were needed anywhere — HTML, LaTeX, and XSL-FO
all process a paragraph child of a figure generically, as the sample
book has quietly demonstrated for years.

The commits:

- 3d478875 (Schema) `Paragraph` joins the base figure content choice,
  with the rationale in the literate prose.  Regeneration is idempotent;
  source and derived files travel in the one commit.

- 113d991b (Sample article) A new "Paragraphs as Figures" subsection in
  the Graphics section, with the two use cases: an addition table for
  the integers modulo 5 as an `md` array (caption below, in the AATA
  manner), and the inscription on the architrave of the Pantheon with
  its translation.

- 904a33de (Guide) The figures topic documents the capability, the two
  use cases, and why it is a single paragraph by design.

Testing: the sample article holds its development-schema baseline
(eleven complaints, all from the deliberately-retained old-style
fill-in exercise) with nothing new from the additions; both new figures
verified rendering in HTML, in the xelatex PDF (caption below the
array, sequential figure numbers), and in the XSL-FO PDF; the Guide
validates at its known two-error baseline.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
