### PR TITLE
Bibliographic info: test residue, and "support" as the schema says

### DIFF
--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -79,10 +79,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <url href="http://abstract.pugetsound.edu" visual="abstract.pugetsound.edu"/>
         </website>
 
-        <website>
-            <url href="http://abstract.pugetsound.edu" visual="abstract.pugetsound.edu">Some text to test bug report</url>
-        </website>
-
         <copyright>
             <year>1997<ndash />2015</year>
             <holder>Thomas W. Judson, Robert A. Beezer</holder>

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -92,9 +92,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <keyword>samples</keyword>
         </keywords>
 
-        <support>
-        <p>This work has received assistance from numerous volunteer contributors.</p>
-        </support>
+        <support>This work has received assistance from numerous volunteer contributors.</support>
     </bibinfo>
 
     <titlepage>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -1225,10 +1225,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </xsl:template>
 
-<!-- General support (not for a particular author) -->
+<!-- General support (not for a particular author).  The schema -->
+<!-- says a "support" statement is text-level, mixed content    -->
 <xsl:template match="bibinfo/support">
     <div class="support">
-        <xsl:apply-templates select="*"/>
+        <xsl:apply-templates select="node()"/>
     </div>
 </xsl:template>
 

--- a/xsl/pretext-latex.xsl
+++ b/xsl/pretext-latex.xsl
@@ -1017,12 +1017,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%% end:   copyright-page&#xa;</xsl:text>
 </xsl:template>
 
-<!-- Only for a book with a colophon, we put the statement of support at the bottom of the colophon -->
+<!-- Only for a book with a colophon, we put the statement of support -->
+<!-- at the bottom of the colophon.  The schema says a "support"      -->
+<!-- statement is text-level, mixed content                           -->
 <xsl:template match="bibinfo/support" mode="copyright-page">
     <xsl:text>%% Funding/Support statement:</xsl:text>
     <xsl:text>\par\medskip&#xa;</xsl:text>
     <xsl:text>\noindent{}</xsl:text>
-    <xsl:apply-templates select="*" />
+    <xsl:apply-templates select="node()"/>
     <xsl:text>\par&#xa;</xsl:text>
     <xsl:text>\vspace*{\stretch{1}}&#xa;</xsl:text>
 </xsl:template>


### PR DESCRIPTION
Two small repairs in the sample book's bibliographic information,
surfaced by a schema survey — and the second one uncovered a real
rendering defect, fixed here as well.

- efbf8a7e (Sample book) The duplicated `website` is removed.  The
  schema allows one; the second entered as a rider in commit `0a52bc3d`
  (PR #2300), marked "Some text to test bug report", and has outlived
  its test.

- 14b7cde5 (HTML), ee28aa89 (LaTeX) The schema says a `support`
  statement is text-level, mixed content — and the sample article
  authors all four of its `support` elements that way.  But the two
  book-colophon templates rendered only *element* children, so the
  schema-valid form produced an empty `div` in HTML (visible today in
  the sample article's front colophon) and nothing on the LaTeX
  copyright page.  Both now render the node content as authored.

- 993026cf (Sample book) With the conversions honoring the schema, the
  book's lone nonconforming `support` — a statement wrapped in `p` —
  becomes bare text, matching the sample article's practice.

Testing: before/after HTML builds of the sample book differ in exactly
the removed website credit (plus one shifted auto-id) and the support
statement's new text-level shape; the statement appears in the book's
HTML colophon and LaTeX copyright page, and the sample article's
previously-empty support `div` now carries its sentence.  The book's
development-schema complaint count drops by exactly the two targeted
errors.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
