### PR TITLE
Jupyter/RevealJS: add css for tablenotes

### DIFF
--- a/css/targets/revealjs/reveal.scss
+++ b/css/targets/revealjs/reveal.scss
@@ -170,3 +170,15 @@ pre[class*="language-"] {
 dfn {
   font-weight: bold;
 }
+
+.reveal .tablenotes {
+  margin: 0.5em auto;
+  width: fit-content;
+  display: block;
+  font-size: 80%;
+  list-style: none;
+}
+
+.reveal .tablenote sup i {
+  color: var(--r-link-color);
+}

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -313,13 +313,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <col/>
                         <col/>
                         <row bottom="minor">
-                            <cell>Format</cell>
+                            <cell>Format<tn>A table note.</tn></cell>
                             <cell>Engine</cell>
                             <cell>Output</cell>
                         </row>
                         <row>
                             <cell>reveal.js</cell>
-                            <cell>browser</cell>
+                            <cell>browser<tn>Another table note, of a differing length.</tn></cell>
                             <cell><init>HTML</init></cell>
                         </row>
                         <row>

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -353,6 +353,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>.mathbook-content td.r {text-align: right;}&#xa;</xsl:text>
             <xsl:text>.mathbook-content table tr.header-vertical th {writing-mode: vertical-rl; padding-left: 2em;}&#xa;</xsl:text>
             <xsl:text>.mathbook-content .sbspanel img {max-width: 100%;}&#xa;</xsl:text>
+            <xsl:text>.mathbook-content .tablenotes {list-style: none; padding-left: 0;}&#xa;</xsl:text>
             <xsl:text>&lt;/style&gt;</xsl:text>
             <xsl:call-template name="end-string" />
         </xsl:with-param>


### PR DESCRIPTION
For https://github.com/PreTeXtBook/pretext/issues/3121#issuecomment-5198029461

Untested for Jupyter. Had to add sample to the reveal slide show.