### PR TITLE
Runestone constructs: harmonize sample book, development schema, and code

### DIFF
--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -58,7 +58,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </listing>
 
-        <p>Instead of specifying <attr>language</attr> on each program, a default can be specified at <c>docinfo/programs/@language</c>. That value will be used for any program that lacks a <attr>language</attr> attribute. This sample does not specify it's own <attr>language</attr> and is relying on the default set in this book.</p>
+        <p>Instead of specifying <attr>language</attr> on each program, a default can be specified at <c>docinfo/defaults/programs/@language</c>. That value will be used for any program that lacks a <attr>language</attr> attribute. This sample does not specify it's own <attr>language</attr> and is relying on the default set in this book.</p>
 
         <listing>
             <title>Python program, relying on default programs language</title>
@@ -103,7 +103,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </listing>
 
-        <p>Otherwise they are rendered as text with syntax coloring. Either way, if a <attr>language</attr> is not specified, <c>docinfo/programs/@language</c> will be checked to determine what language to assume the code is written in.
+        <p>Otherwise they are rendered as text with syntax coloring. Either way, if a <attr>language</attr> is not specified, <c>docinfo/defaults/programs/@language</c> will be checked to determine what language to assume the code is written in.
         </p>
 
         <listing xml:id="program-activecode-python2">
@@ -363,9 +363,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </listing>
 
-        <p>Some languages, like Java or C++, are only interactive when run on a Runestone server where the code can be compiled and run. Those languages can specify <attr>compiler-args</attr> and <attr>linker-args</attr> or <attr>interpreter-args</attr> as appropriate to the language. Default values for those options can be set in <tag>docinfo/programs</tag> - any defaults set there will be used for any program that lacks the corresponding attribute.</p>
+        <p>Some languages, like Java or C++, are only interactive when run on a Runestone server where the code can be compiled and run. Those languages can specify <attr>compiler-args</attr> and <attr>linker-args</attr> or <attr>interpreter-args</attr> as appropriate to the language. Default values for those options can be set in <tag>docinfo/defaults/programs</tag> - any defaults set there will be used for any program that lacks the corresponding attribute.</p>
 
-        <p>It may be convenient to set <attr>compiler-args</attr> and <attr>linker-args</attr> at the book level in <tag>docinfo/programs</tag>. Values specified in that location will be used for any <tag>program</tag> that does not override the values by specifying its own attributes.</p>
+        <p>It may be convenient to set <attr>compiler-args</attr> and <attr>linker-args</attr> at the book level in <tag>docinfo/defaults/programs</tag>. Values specified in that location will be used for any <tag>program</tag> that does not override the values by specifying its own attributes.</p>
 
         <listing>
             <title>A C++ program with compiler-args and stdin</title>
@@ -507,7 +507,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </program>
         </listing>
 
-        <p>The following Python program is in a <tag>listing</tag> since we will want to reference it shortly.  The program does not do very much, it just defines four variables whose values are lists of statistics.  It should run, and there will be no syntax errors, but it is a bit boring since there is no output. Note that it does not have an <attr>language</attr> and is relying on the default one specified in <tag>docinfo/programs</tag></p>
+        <p>The following Python program is in a <tag>listing</tag> since we will want to reference it shortly.  The program does not do very much, it just defines four variables whose values are lists of statistics.  It should run, and there will be no syntax errors, but it is a bit boring since there is no output. Note that it does not have an <attr>language</attr> and is relying on the default one specified in <tag>docinfo/defaults/programs</tag></p>
 
         <listing xml:id="listing-python-included">
             <title>A Python program that defines some statistics</title>

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -365,9 +365,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>Some languages, like Java or C++, are only interactive when run on a Runestone server where the code can be compiled and run. Those languages can specify <attr>compiler-args</attr> and <attr>linker-args</attr> or <attr>interpreter-args</attr> as appropriate to the language. Default values for those options can be set in <tag>docinfo/programs</tag> - any defaults set there will be used for any program that lacks the corresponding attribute.</p>
 
+        <p>It may be convenient to set <attr>compiler-args</attr> and <attr>linker-args</attr> at the book level in <tag>docinfo/programs</tag>. Values specified in that location will be used for any <tag>program</tag> that does not override the values by specifying its own attributes.</p>
+
         <listing>
             <title>A C++ program with compiler-args and stdin</title>
-            <p>It may be convenient to set <attr>compiler-args</attr> and <attr>linker-args</attr> at the book level in <tag>docinfo/programs</tag>. Values specified in that location will be used for any <tag>program</tag> that does not override the values by specifying its own attributes.</p>
             <program interactive="activecode" label="hello-world-cpp" language="cpp" compiler-args="-std=c++17,-Wall,-g" linker-args="-g,-s">
                 <code>
                     #include &lt;iostream&gt;
@@ -747,7 +748,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
         <exercise label="program-codelens-cpp-questions">
             <title>A C++ program as CodeLens exercise</title>
-            <statement>Run the codelens and answer the questions it asks.</statement>
+            <statement>
+                <p>Run the codelens and answer the questions it asks.</p>
+            </statement>
             <program interactive="codelens" language="cpp">
                 <code><![CDATA[
                   int foo() {
@@ -4475,7 +4478,7 @@ TEST_CASE( "Test the add function" ) {
             <title>Fill-In, New Markup Strings</title>
             <statement>
                 <p>The word I'm thinking about is hinted at by the image.</p>
-                <p><image source="cartoon-magic.jpg" width="50%"/></p>
+                <image source="cartoon-magic.jpg" width="50%"/>
                 <p>What word am I thinking about? <fillin width="5" answer="magic"/> (Interactive feedback explores a variety of options: Try what happens if you mix the case, or type in a number, or include more than the word, or try <q>pizzazz</q>.")</p>
             </statement>
             <evaluation>
@@ -5590,8 +5593,10 @@ TEST_CASE( "Test the add function" ) {
                     </p>
                 </statement>
             </exercise>
+            <conclusion>
+                <p>And a final paragraph, now as a <tag>conclusion</tag> of the <tag>exercises</tag>, and a chance to say there is a trailing <tag>exercise</tag> outside the <tag>exercisegroup</tag>.</p>
+            </conclusion>
         </exercises>
-        <p>And a final paragraph in the section, and a chance to say there is a trailing <tag>exercise</tag> outside the <tag>exercisegroup</tag>.</p>
     </section>
 
     <worksheet groupwork="yes" groupsize="2" xml:id="worksheet-groupwork" label="worksheet-groupwork">
@@ -5984,16 +5989,19 @@ TEST_CASE( "Test the add function" ) {
     <figure xml:id="show-eval-visualization1">
         <caption>Show-Eval Visualization</caption>
         <interactive label="show-eval-visualization" platform="javascript" source="https://runestone.academy/cdn/runestone/showEval-0.10.0.js" width="100%" >
-            <slate surface="html">
-                <style>
+            <!-- The one namespace declaration on the "slate" marks all -->
+            <!-- the content as foreign, and satisfies validation; only  -->
+            <!-- local names survive into the output page                -->
+            <slate surface="html" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                <xhtml:style>
                     .showEval { font-family: monospace; font-size: 1.5em; }
                     .showEval span { vertical-align: text-top; }
-                </style>
-                <button id="nextStep">Next Step</button>
-                <button id="reset">Reset</button>
-                <div class='showEval'>eggs = ['dogs', 'cats', 'moose']</div>
-                <div id="showeval"></div>
-                <script>
+                </xhtml:style>
+                <xhtml:button id="nextStep">Next Step</xhtml:button>
+                <xhtml:button id="reset">Reset</xhtml:button>
+                <xhtml:div class='showEval'>eggs = ['dogs', 'cats', 'moose']</xhtml:div>
+                <xhtml:div id="showeval"></xhtml:div>
+                <xhtml:script>
                     document.addEventListener("DOMContentLoaded", function() {
                         console.log("Document loaded");
                         // for each step, put the part to replaced in the first set of {{ }}, and the replacement text in the following {{ }}
@@ -6003,7 +6011,7 @@ TEST_CASE( "Test the add function" ) {
                         "'DOGSCATSMOOSE'.join({{eggs}}{{['dogs', 'cats', 'moose']}})",
                         "{{'DOGSCATSMOOSE'.join(['dogs', 'cats', 'moose'])}}{{'dogsDOGSCATSMOOSEcatsDOGSCATSMOOSEmoose'}}"];
                         s = new SHOWEVAL.ShowEval(document.querySelector('#showeval'), steps, false); });
-                </script>
+                </xhtml:script>
             </slate>
         </interactive>
         </figure>

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -621,6 +621,41 @@
                 StatementExercise,
                 Program,
                 Hint*, Answer*, Solution*
+            # LEGACY fill-in ("fillin-basic" to the assembly classifier):
+            # empty "var" marks in the statement pair positionally with
+            # the "var" elements of the "setup", each holding conditions
+            # tried in order (a numeric interval via @number/@tolerance,
+            # or a @string regular expression), with optional feedback.
+            # The machinery is fully implemented, interactive and
+            # static, so the form is admitted here.  It will NEVER move
+            # to the stable schema: its only future is retirement in
+            # favor of the dynamic fill-in above.
+            FillInLegacy =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                element setup {
+                    element var {
+                        attribute case {"insensitive"}?,
+                        element condition {
+                            (
+                                (attribute number {text},
+                                 attribute tolerance {text}?)
+                            |
+                                attribute string {text}
+                            ),
+                            Feedback?
+                        }+
+                    }+
+                },
+                Hint*, Answer*, Solution*
+            # the empty mark in a statement, sized by @width
+            VarMark =
+                element var {
+                    attribute width {xsd:integer}?,
+                    empty
+                }
+            TextParagraphItem |= VarMark
             # A select exercise poses one of several existing questions
             # (variants), located by their @label values; @grade says
             # how the graded variant is chosen: at random, by A/B
@@ -646,6 +681,7 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
+                    FillInLegacy |
                     Areas |
                     CodingExercise |
                     Select
@@ -684,6 +720,7 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
+                    FillInLegacy |
                     Areas |
                     CodingExercise
                     )

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -198,13 +198,15 @@
                 StatementExercise,
                 element choices {
                     attribute randomize {"yes"|"no"}?,
+                    attribute multiple-correct {"yes"|"no"}?,
+                    attribute cols {xsd:integer}?,
                     Choice+
                 },
                 Hint*, Answer*, Solution*
             Choice =
                 element choice {
                     attribute correct {"yes"|"no"}?,
-                    ((mixed {BlockText?})
+                    ((mixed {BlockText*})
                     | (StatementExercise, Feedback?))
                 }
             Parsons =
@@ -557,11 +559,13 @@
                 }
             BlockStatement |= Datafile
 
-            # Query (poll/survey) element
+            # Query (poll/survey) element; results are private to the
+            # instructor unless @visibility says otherwise
             Query =
                 element query {
                     LabelID?,
                     attribute scale {xsd:integer}?,
+                    attribute visibility {"instructor"|"all"}?,
                     StatementExercise,
                     element choices {
                         Choice+

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -209,48 +209,75 @@
                     ((mixed {BlockText*})
                     | (StatementExercise, Feedback?))
                 }
+            # A horizontal SQL Parsons may name a grading database and
+            # carry raw unit tests; a horizontal layout may permit the
+            # reuse of blocks, where a source block carries an @xml:id
+            # (and no @order) and each use references it with @ref
             Parsons =
                     MetaDataTitleOptional,
                     attribute number {text}?,
                     attribute language {text}?,
                     attribute adaptive {"yes"|"no"}?,
                     attribute indentation {text}?,
+                    attribute database {text}?,
                     StatementExercise,
                     element blocks {
                         attribute layout {"horizontal"}?,
                         attribute randomize {"yes"|"no"}?,
-                        ( BlockOrdered+ | BlockUnordered+ )
+                        attribute reuse {"yes"|"no"}?,
+                        attribute numbered {"left"|"right"|"no"}?,
+                        ( (BlockOrdered | BlockSource)+ | BlockUnordered+ )
                     },
+                    element tests {text}?,
                     Hint*, Answer*, Solution*,
-                    (
-                        element preamble {
-                            attribute indent {text}?,
-                            text
-                        }?,
-                        Program,
-                        element postamble {
-                            attribute indent {text}?,
-                            text
-                        }?
-                    )?
+                    (ParsonsProgramPreamble?, Program, ParsonsProgramPostamble?)?
+            # Fixed code surrounding a runnable Parsons solution.  These
+            # patterns stand apart so the element names can be revisited
+            # on their own: the plain "preamble" and "postamble" within
+            # a "program" are close cousins, and some later decision may
+            # unify them.
+            ParsonsProgramPreamble =
+                element program-preamble {
+                    attribute indent {text}?,
+                    text
+                }
+            ParsonsProgramPostamble =
+                element program-postamble {
+                    attribute indent {text}?,
+                    text
+                }
+            # Horizontal blocks hold short inline bursts (code via "c",
+            # mathematics, text); vertical blocks hold code lines or
+            # natural-language blocks
             BlockBody =
                 ((
                     attribute correct {"yes"|"no"}?,
-                    mixed {BlockText?, CodeLine?}+
+                    mixed {BlockText?, CodeLine?, Verbatim?, MathInline?}+
                 ) |
                 (
                     element choice {
                         attribute correct {"yes"|"no"}?,
-                        mixed {BlockText?, CodeLine?}+
+                        mixed {BlockText?, CodeLine?, Verbatim?, MathInline?}+
                     }+
                 ))
             BlockOrdered =
                 element block {
                     attribute order {xsd:integer},
+                    attribute name {text}?,
+                    attribute depends {text}?,
+                    attribute ref {text}?,
+                    BlockBody
+                }
+            BlockSource =
+                element block {
+                    UniqueID,
+                    attribute name {text}?,
                     BlockBody
                 }
             BlockUnordered =
                 element block {
+                    attribute name {text}?,
+                    attribute depends {text}?,
                     BlockBody
                 }
             Matching =

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -639,6 +639,8 @@
                     attribute rows {xsd:integer}?,
                     attribute cols {xsd:integer}?,
                     attribute editable {"yes"|"no"}?,
+                    # a non-editable datafile can start hidden
+                    attribute hide {"yes"|"no"}?,
                     (
                         element pre {
                             attribute source {text}?,

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -739,6 +739,24 @@
                     Select
                     )
                 }
+            # STRICTLY EXPERIMENTAL, matching the sample's own alert:
+            # a dual exercise pairs a "dynamic" realization (typically
+            # an embedded interactive) with a "static" stand-in, and
+            # the assembly chooses one per output
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    element dynamic {
+                        StatementExercise
+                    },
+                    element static {
+                        (
+                            (StatementExercise, Hint*, Answer*, Solution*)
+                        |
+                            (IntroductionStatement?, Task+, ConclusionStatement?)
+                        )
+                    }
+                }
             # STACK assessment exercise type
             Exercise |=
                 element exercise {

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -613,5 +613,22 @@
                 FreeResponse |
                 FillInBlank |
                 Areas
+            # The assembly classifies "task" alongside "exercise" and the
+            # project-like blocks, and every interactive form is
+            # implemented within a "task", so the same union applies
+            Task |=
+                element task {
+                    attribute workspace {text}?,
+                    (
+                    TrueFalse |
+                    MultipleChoice |
+                    Parsons |
+                    Matching |
+                    FreeResponse |
+                    FillInBlank |
+                    Areas |
+                    CodingExercise
+                    )
+                }
 
                 }

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -302,15 +302,20 @@
                         TextLong
                     }+
                 })
+            # Premises and the response arrive in any order; a match
+            # with premises and no response, or a response and no
+            # premises, is a distractor
             Match =
                 element match {
                     element premise {
                         attribute order {xsd:integer}?,
                         TextLong
-                    }+,
+                    }*
+                    &
                     element response {
+                        attribute order {xsd:integer}?,
                         TextLong
-                    }
+                    }?
                 }
             FreeResponse =
                 MetaDataTitleOptional,

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -140,6 +140,40 @@
                 ConclusionDivision?
             }
 
+            # Hosted on Runestone, an "exercises" division can be a
+            # timed exam (@time-limit in minutes; results, feedback,
+            # the visible timer, and pausing each default on), or can
+            # collect group-work submissions (@groupwork, group size
+            # capped by @groupsize); a "worksheet" can do the latter
+            Exercises |= element exercises {
+                (
+                    (attribute time-limit {xsd:integer},
+                     attribute results {"yes"|"no"}?,
+                     attribute timer {"yes"|"no"}?,
+                     attribute feedback {"yes"|"no"}?,
+                     attribute pause {"yes"|"no"}?)
+                |
+                    (attribute groupwork {"yes"|"no"},
+                     attribute groupsize {xsd:integer}?)
+                ),
+                MetaDataAltTitleOptional,
+                IntroductionDivision?,
+                (Exercise | ExerciseGroup)+,
+                ConclusionDivision?
+            }
+            Worksheet |= element worksheet {
+                attribute groupwork {"yes"|"no"},
+                attribute groupsize {xsd:integer}?,
+                PrintoutAttributes,
+                attribute courseid {text}?,
+                attribute series {text}?,
+                attribute seriescode {text}?,
+                MetaDataAltTitleOptional,
+                (Objectives? & IntroductionDivision?),
+                (Page+ | PrintoutBlock+),
+                (Outcomes? & ConclusionDivision?)
+            }
+
             ShortLicense_X =
                 element shortlicense {
                     TextLong &

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -373,15 +373,23 @@
                     Component?,
                     TextParagraphAreas
                 }
+            # The areas come in three forms: paragraphs of prose, lines
+            # of code (@language names the language), or a tabular with
+            # clickable cells.  Trailing components in any order.
             Areas =
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
                 element areas {
-                  ParagraphAreas+
+                  attribute language {text}?,
+                  (ParagraphAreas | ClineAreas | Tabular)+
                 },
-                Feedback?,
-                Hint*, Answer*, Solution*
+                (Feedback? & Hint* & Answer* & Solution*)
+            ClineAreas =
+                element cline { mixed {Area*} }
+            # within the development schema, any tabular cell may hold
+            # a clickable area
+            TableCellText |= mixed { (TextLongContent | TableNote | Area)* }
 
             # General feedback element
             Feedback =

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -77,13 +77,7 @@
                           Paragraph |
                           Tabular |
                           SideBySideNoNumber |
-                          SlateInput |
-                          AnyXhtml |
-                          element xhtml:button {
-                            attribute type { text },
-                            attribute id { text },
-                            text*
-                          }? |
+                          AnyXHTML |
                           text*
                         )*
                       )
@@ -99,20 +93,17 @@
                   text*
                 )
 
-              SlateInput =
-                element input {
-                  attribute type {text}?,
-                  attribute value {text}?,
-                  attribute onkeypress {text}?,
-                  attribute onclick {text}?,
-                  attribute style {text}?
-                }
-
-              # A slate with surface="html" embeds an arbitrary XHTML fragment.
-              AnyXhtml =
+              # A slate with surface="html" embeds an arbitrary XHTML
+              # fragment, and the XHTML namespace is the author's
+              # declaration that the content is foreign: anything
+              # un-namespaced still gets the schema's full scrutiny.
+              # Declare it once, as a prefix on the "slate" itself;
+              # the conversion keeps only local names, so the output
+              # page carries plain HTML tags, free of namespaces.
+              AnyXHTML =
                 element xhtml:* {
                   (attribute * { text })*,
-                  mixed { AnyXhtml* }
+                  mixed { AnyXHTML* }
                 }
 
             # add Interactives where used

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -391,9 +391,17 @@
             # a clickable area
             TableCellText |= mixed { (TextLongContent | TableNote | Area)* }
 
-            # General feedback element
+            # General feedback element; a short burst of marked-up text
+            # is as welcome as a sequence of blocks
             Feedback =
                 element feedback {
+                    MetaDataTitleOptional,
+                    (BlockSolution+ | TextLong)
+                }
+            # A dynamic exercise's automatic solution can be declined
+            Solution |=
+                element solution {
+                    attribute include-automatic {"yes"|"no"},
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
@@ -441,10 +449,13 @@
                     attribute reduce {"yes"}?,
                     text
                 }
-            # A formula; the content model follows @mode
+            # A formula; the content model follows @mode.  Outside a
+            # "de-object" there is no enclosing context, so the
+            # expression may declare its own with @context.
             DEExpression =
                 element de-expression {
                     attribute reduce {"yes"}?,
+                    attribute context {"number" | "formula"}?,
                     (
                         (attribute mode {"formula"}?, text) |
                         (attribute mode {"substitution"}, DEFormula, DEVariableValued) |
@@ -516,10 +527,15 @@
             # none, the provided answer or answer object is the default
             # comparison.  A test holds a single numcmp or strcmp, OR any
             # number of jscmp/mathcmp/logic combined with an implied AND.
+            # A bare "eval" or a bare constructor within a test is
+            # shorthand for a comparison with the submission; the
+            # assembly substitutes the full form
             FITBTest =
                 element test {
                     attribute correct {"yes"|"no"}?,
-                    (FITBNumcmp | FITBStrcmp | (FITBJscmp | FITBMathcmp | FITBLogic)+),
+                    (FITBNumcmp | FITBStrcmp |
+                     (FITBJscmp | FITBMathcmp | FITBLogic |
+                      Eval | DENumber | DEExpression | DEEvaluate)+),
                     Feedback?
                 }
             FITBComparison =

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -621,6 +621,19 @@
                 StatementExercise,
                 Program,
                 Hint*, Answer*, Solution*
+            # A select exercise poses one of several existing questions
+            # (variants), located by their @label values; @grade says
+            # how the graded variant is chosen: at random, by A/B
+            # experiment group, always the first listed (the others
+            # remain viewable), or any one the reader selects
+            Select =
+                MetaDataTitleOptional,
+                element select {
+                    attribute grade {"random"|"ab-experiment"|"first"|"any"}?,
+                    attribute questions {text},
+                    attribute experiment-name {text}?,
+                    empty
+                }
             # Include all exercise types in exercise and activity
             Exercise |=
                 element exercise {
@@ -634,7 +647,8 @@
                     FreeResponse |
                     FillInBlank |
                     Areas |
-                    CodingExercise
+                    CodingExercise |
+                    Select
                     )
                 }
             # STACK assessment exercise type

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -930,6 +930,11 @@
       <ref name="TextParagraphAreas"/>
     </element>
   </define>
+  <!--
+    The areas come in three forms: paragraphs of prose, lines
+    of code (@language names the language), or a tabular with
+    clickable cells.  Trailing components in any order.
+  -->
   <define name="Areas">
     <ref name="MetaDataTitleOptional"/>
     <optional>
@@ -937,22 +942,55 @@
     </optional>
     <ref name="StatementExercise"/>
     <element name="areas">
+      <optional>
+        <attribute name="language"/>
+      </optional>
       <oneOrMore>
-        <ref name="ParagraphAreas"/>
+        <choice>
+          <ref name="ParagraphAreas"/>
+          <ref name="ClineAreas"/>
+          <ref name="Tabular"/>
+        </choice>
       </oneOrMore>
     </element>
-    <optional>
-      <ref name="Feedback"/>
-    </optional>
-    <zeroOrMore>
-      <ref name="Hint"/>
-    </zeroOrMore>
-    <zeroOrMore>
-      <ref name="Answer"/>
-    </zeroOrMore>
-    <zeroOrMore>
-      <ref name="Solution"/>
-    </zeroOrMore>
+    <interleave>
+      <optional>
+        <ref name="Feedback"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="Hint"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="Solution"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <define name="ClineAreas">
+    <element name="cline">
+      <mixed>
+        <zeroOrMore>
+          <ref name="Area"/>
+        </zeroOrMore>
+      </mixed>
+    </element>
+  </define>
+  <!--
+    within the development schema, any tabular cell may hold
+    a clickable area
+  -->
+  <define name="TableCellText" combine="choice">
+    <mixed>
+      <zeroOrMore>
+        <choice>
+          <ref name="TextLongContent"/>
+          <ref name="TableNote"/>
+          <ref name="Area"/>
+        </choice>
+      </zeroOrMore>
+    </mixed>
   </define>
   <!-- General feedback element -->
   <define name="Feedback">

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -297,6 +297,132 @@
       </optional>
     </element>
   </define>
+  <!--
+    Hosted on Runestone, an "exercises" division can be a
+    timed exam (@time-limit in minutes; results, feedback,
+    the visible timer, and pausing each default on), or can
+    collect group-work submissions (@groupwork, group size
+    capped by @groupsize); a "worksheet" can do the latter
+  -->
+  <define name="Exercises" combine="choice">
+    <element name="exercises">
+      <choice>
+        <group>
+          <attribute name="time-limit">
+            <data type="integer"/>
+          </attribute>
+          <optional>
+            <attribute name="results">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="timer">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="feedback">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="pause">
+              <choice>
+                <value>yes</value>
+                <value>no</value>
+              </choice>
+            </attribute>
+          </optional>
+        </group>
+        <group>
+          <attribute name="groupwork">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+          <optional>
+            <attribute name="groupsize">
+              <data type="integer"/>
+            </attribute>
+          </optional>
+        </group>
+      </choice>
+      <ref name="MetaDataAltTitleOptional"/>
+      <optional>
+        <ref name="IntroductionDivision"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="Exercise"/>
+          <ref name="ExerciseGroup"/>
+        </choice>
+      </oneOrMore>
+      <optional>
+        <ref name="ConclusionDivision"/>
+      </optional>
+    </element>
+  </define>
+  <define name="Worksheet" combine="choice">
+    <element name="worksheet">
+      <attribute name="groupwork">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="groupsize">
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <ref name="PrintoutAttributes"/>
+      <optional>
+        <attribute name="courseid"/>
+      </optional>
+      <optional>
+        <attribute name="series"/>
+      </optional>
+      <optional>
+        <attribute name="seriescode"/>
+      </optional>
+      <ref name="MetaDataAltTitleOptional"/>
+      <interleave>
+        <optional>
+          <ref name="Objectives"/>
+        </optional>
+        <optional>
+          <ref name="IntroductionDivision"/>
+        </optional>
+      </interleave>
+      <choice>
+        <oneOrMore>
+          <ref name="Page"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="PrintoutBlock"/>
+        </oneOrMore>
+      </choice>
+      <interleave>
+        <optional>
+          <ref name="Outcomes"/>
+        </optional>
+        <optional>
+          <ref name="ConclusionDivision"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
   <define name="ShortLicense_X">
     <element name="shortlicense">
       <interleave>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1445,4 +1445,26 @@
       <ref name="Areas"/>
     </choice>
   </define>
+  <!--
+    The assembly classifies "task" alongside "exercise" and the
+    project-like blocks, and every interactive form is
+    implemented within a "task", so the same union applies
+  -->
+  <define name="Task" combine="choice">
+    <element name="task">
+      <optional>
+        <attribute name="workspace"/>
+      </optional>
+      <choice>
+        <ref name="TrueFalse"/>
+        <ref name="MultipleChoice"/>
+        <ref name="Parsons"/>
+        <ref name="Matching"/>
+        <ref name="FreeResponse"/>
+        <ref name="FillInBlank"/>
+        <ref name="Areas"/>
+        <ref name="CodingExercise"/>
+      </choice>
+    </element>
+  </define>
 </grammar>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -767,21 +767,35 @@
       </element>
     </choice>
   </define>
+  <!--
+    Premises and the response arrive in any order; a match
+    with premises and no response, or a response and no
+    premises, is a distractor
+  -->
   <define name="Match">
     <element name="match">
-      <oneOrMore>
-        <element name="premise">
-          <optional>
-            <attribute name="order">
-              <data type="integer"/>
-            </attribute>
-          </optional>
-          <ref name="TextLong"/>
-        </element>
-      </oneOrMore>
-      <element name="response">
-        <ref name="TextLong"/>
-      </element>
+      <interleave>
+        <zeroOrMore>
+          <element name="premise">
+            <optional>
+              <attribute name="order">
+                <data type="integer"/>
+              </attribute>
+            </optional>
+            <ref name="TextLong"/>
+          </element>
+        </zeroOrMore>
+        <optional>
+          <element name="response">
+            <optional>
+              <attribute name="order">
+                <data type="integer"/>
+              </attribute>
+            </optional>
+            <ref name="TextLong"/>
+          </element>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="FreeResponse">

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -446,6 +446,19 @@
           </choice>
         </attribute>
       </optional>
+      <optional>
+        <attribute name="multiple-correct">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="cols">
+          <data type="integer"/>
+        </attribute>
+      </optional>
       <oneOrMore>
         <ref name="Choice"/>
       </oneOrMore>
@@ -472,9 +485,9 @@
       </optional>
       <choice>
         <mixed>
-          <optional>
+          <zeroOrMore>
             <ref name="BlockText"/>
-          </optional>
+          </zeroOrMore>
         </mixed>
         <group>
           <ref name="StatementExercise"/>
@@ -1349,7 +1362,10 @@
   <define name="BlockStatement" combine="choice">
     <ref name="Datafile"/>
   </define>
-  <!-- Query (poll/survey) element -->
+  <!--
+    Query (poll/survey) element; results are private to the
+    instructor unless @visibility says otherwise
+  -->
   <define name="Query">
     <element name="query">
       <optional>
@@ -1358,6 +1374,14 @@
       <optional>
         <attribute name="scale">
           <data type="integer"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="visibility">
+          <choice>
+            <value>instructor</value>
+            <value>all</value>
+          </choice>
         </attribute>
       </optional>
       <ref name="StatementExercise"/>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -498,6 +498,12 @@
       </choice>
     </element>
   </define>
+  <!--
+    A horizontal SQL Parsons may name a grading database and
+    carry raw unit tests; a horizontal layout may permit the
+    reuse of blocks, where a source block carries an @xml:id
+    (and no @order) and each use references it with @ref
+  -->
   <define name="Parsons">
     <ref name="MetaDataTitleOptional"/>
     <optional>
@@ -517,6 +523,9 @@
     <optional>
       <attribute name="indentation"/>
     </optional>
+    <optional>
+      <attribute name="database"/>
+    </optional>
     <ref name="StatementExercise"/>
     <element name="blocks">
       <optional>
@@ -532,15 +541,40 @@
           </choice>
         </attribute>
       </optional>
+      <optional>
+        <attribute name="reuse">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="numbered">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
       <choice>
         <oneOrMore>
-          <ref name="BlockOrdered"/>
+          <choice>
+            <ref name="BlockOrdered"/>
+            <ref name="BlockSource"/>
+          </choice>
         </oneOrMore>
         <oneOrMore>
           <ref name="BlockUnordered"/>
         </oneOrMore>
       </choice>
     </element>
+    <optional>
+      <element name="tests">
+        <text/>
+      </element>
+    </optional>
     <zeroOrMore>
       <ref name="Hint"/>
     </zeroOrMore>
@@ -552,24 +586,42 @@
     </zeroOrMore>
     <optional>
       <optional>
-        <element name="preamble">
-          <optional>
-            <attribute name="indent"/>
-          </optional>
-          <text/>
-        </element>
+        <ref name="ParsonsProgramPreamble"/>
       </optional>
       <ref name="Program"/>
       <optional>
-        <element name="postamble">
-          <optional>
-            <attribute name="indent"/>
-          </optional>
-          <text/>
-        </element>
+        <ref name="ParsonsProgramPostamble"/>
       </optional>
     </optional>
   </define>
+  <!--
+    Fixed code surrounding a runnable Parsons solution.  These
+    patterns stand apart so the element names can be revisited
+    on their own: the plain "preamble" and "postamble" within
+    a "program" are close cousins, and some later decision may
+    unify them.
+  -->
+  <define name="ParsonsProgramPreamble">
+    <element name="program-preamble">
+      <optional>
+        <attribute name="indent"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="ParsonsProgramPostamble">
+    <element name="program-postamble">
+      <optional>
+        <attribute name="indent"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <!--
+    Horizontal blocks hold short inline bursts (code via "c",
+    mathematics, text); vertical blocks hold code lines or
+    natural-language blocks
+  -->
   <define name="BlockBody">
     <choice>
       <group>
@@ -588,6 +640,12 @@
             </optional>
             <optional>
               <ref name="CodeLine"/>
+            </optional>
+            <optional>
+              <ref name="Verbatim"/>
+            </optional>
+            <optional>
+              <ref name="MathInline"/>
             </optional>
           </mixed>
         </oneOrMore>
@@ -610,6 +668,12 @@
               <optional>
                 <ref name="CodeLine"/>
               </optional>
+              <optional>
+                <ref name="Verbatim"/>
+              </optional>
+              <optional>
+                <ref name="MathInline"/>
+              </optional>
             </mixed>
           </oneOrMore>
         </element>
@@ -621,11 +685,35 @@
       <attribute name="order">
         <data type="integer"/>
       </attribute>
+      <optional>
+        <attribute name="name"/>
+      </optional>
+      <optional>
+        <attribute name="depends"/>
+      </optional>
+      <optional>
+        <attribute name="ref"/>
+      </optional>
+      <ref name="BlockBody"/>
+    </element>
+  </define>
+  <define name="BlockSource">
+    <element name="block">
+      <ref name="UniqueID"/>
+      <optional>
+        <attribute name="name"/>
+      </optional>
       <ref name="BlockBody"/>
     </element>
   </define>
   <define name="BlockUnordered">
     <element name="block">
+      <optional>
+        <attribute name="name"/>
+      </optional>
+      <optional>
+        <attribute name="depends"/>
+      </optional>
       <ref name="BlockBody"/>
     </element>
   </define>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1654,6 +1654,15 @@
           </choice>
         </attribute>
       </optional>
+      <optional>
+        <!-- a non-editable datafile can start hidden -->
+        <attribute name="hide">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
       <choice>
         <element name="pre">
           <optional>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -992,9 +992,30 @@
       </zeroOrMore>
     </mixed>
   </define>
-  <!-- General feedback element -->
+  <!--
+    General feedback element; a short burst of marked-up text
+    is as welcome as a sequence of blocks
+  -->
   <define name="Feedback">
     <element name="feedback">
+      <ref name="MetaDataTitleOptional"/>
+      <choice>
+        <oneOrMore>
+          <ref name="BlockSolution"/>
+        </oneOrMore>
+        <ref name="TextLong"/>
+      </choice>
+    </element>
+  </define>
+  <!-- A dynamic exercise's automatic solution can be declined -->
+  <define name="Solution" combine="choice">
+    <element name="solution">
+      <attribute name="include-automatic">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
       <ref name="MetaDataTitleOptional"/>
       <oneOrMore>
         <ref name="BlockSolution"/>
@@ -1108,12 +1129,24 @@
       <text/>
     </element>
   </define>
-  <!-- A formula; the content model follows @mode -->
+  <!--
+    A formula; the content model follows @mode.  Outside a
+    "de-object" there is no enclosing context, so the
+    expression may declare its own with @context.
+  -->
   <define name="DEExpression">
     <element name="de-expression">
       <optional>
         <attribute name="reduce">
           <value>yes</value>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="context">
+          <choice>
+            <value>number</value>
+            <value>formula</value>
+          </choice>
         </attribute>
       </optional>
       <choice>
@@ -1265,6 +1298,9 @@
     none, the provided answer or answer object is the default
     comparison.  A test holds a single numcmp or strcmp, OR any
     number of jscmp/mathcmp/logic combined with an implied AND.
+    A bare "eval" or a bare constructor within a test is
+    shorthand for a comparison with the submission; the
+    assembly substitutes the full form
   -->
   <define name="FITBTest">
     <element name="test">
@@ -1284,6 +1320,10 @@
             <ref name="FITBJscmp"/>
             <ref name="FITBMathcmp"/>
             <ref name="FITBLogic"/>
+            <ref name="Eval"/>
+            <ref name="DENumber"/>
+            <ref name="DEExpression"/>
+            <ref name="DEEvaluate"/>
           </choice>
         </oneOrMore>
       </choice>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1558,6 +1558,33 @@
       <ref name="Solution"/>
     </zeroOrMore>
   </define>
+  <!--
+    A select exercise poses one of several existing questions
+    (variants), located by their @label values; @grade says
+    how the graded variant is chosen: at random, by A/B
+    experiment group, always the first listed (the others
+    remain viewable), or any one the reader selects
+  -->
+  <define name="Select">
+    <ref name="MetaDataTitleOptional"/>
+    <element name="select">
+      <optional>
+        <attribute name="grade">
+          <choice>
+            <value>random</value>
+            <value>ab-experiment</value>
+            <value>first</value>
+            <value>any</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="questions"/>
+      <optional>
+        <attribute name="experiment-name"/>
+      </optional>
+      <empty/>
+    </element>
+  </define>
   <!-- Include all exercise types in exercise and activity -->
   <define name="Exercise" combine="choice">
     <element name="exercise">
@@ -1574,6 +1601,7 @@
         <ref name="FillInBlank"/>
         <ref name="Areas"/>
         <ref name="CodingExercise"/>
+        <ref name="Select"/>
       </choice>
     </element>
   </define>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1849,6 +1849,47 @@
       </choice>
     </element>
   </define>
+  <!--
+    STRICTLY EXPERIMENTAL, matching the sample's own alert:
+    a dual exercise pairs a "dynamic" realization (typically
+    an embedded interactive) with a "static" stand-in, and
+    the assembly chooses one per output
+  -->
+  <define name="Exercise" combine="choice">
+    <element name="exercise">
+      <ref name="MetaDataTitleOptional"/>
+      <element name="dynamic">
+        <ref name="StatementExercise"/>
+      </element>
+      <element name="static">
+        <choice>
+          <group>
+            <ref name="StatementExercise"/>
+            <zeroOrMore>
+              <ref name="Hint"/>
+            </zeroOrMore>
+            <zeroOrMore>
+              <ref name="Answer"/>
+            </zeroOrMore>
+            <zeroOrMore>
+              <ref name="Solution"/>
+            </zeroOrMore>
+          </group>
+          <group>
+            <optional>
+              <ref name="IntroductionStatement"/>
+            </optional>
+            <oneOrMore>
+              <ref name="Task"/>
+            </oneOrMore>
+            <optional>
+              <ref name="ConclusionStatement"/>
+            </optional>
+          </group>
+        </choice>
+      </element>
+    </element>
+  </define>
   <!-- STACK assessment exercise type -->
   <define name="Exercise" combine="choice">
     <element name="exercise">

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <include href="pretext.rng"/>
   <define name="Interactive">
     <element name="interactive">
@@ -166,17 +166,7 @@
               <ref name="Paragraph"/>
               <ref name="Tabular"/>
               <ref name="SideBySideNoNumber"/>
-              <ref name="SlateInput"/>
-              <ref name="AnyXhtml"/>
-              <optional>
-                <element name="xhtml:button">
-                  <attribute name="type"/>
-                  <attribute name="id"/>
-                  <zeroOrMore>
-                    <text/>
-                  </zeroOrMore>
-                </element>
-              </optional>
+              <ref name="AnyXHTML"/>
               <zeroOrMore>
                 <text/>
               </zeroOrMore>
@@ -213,27 +203,16 @@
       </zeroOrMore>
     </choice>
   </define>
-  <define name="SlateInput">
-    <element name="input">
-      <optional>
-        <attribute name="type"/>
-      </optional>
-      <optional>
-        <attribute name="value"/>
-      </optional>
-      <optional>
-        <attribute name="onkeypress"/>
-      </optional>
-      <optional>
-        <attribute name="onclick"/>
-      </optional>
-      <optional>
-        <attribute name="style"/>
-      </optional>
-    </element>
-  </define>
-  <!-- A slate with surface="html" embeds an arbitrary XHTML fragment. -->
-  <define name="AnyXhtml">
+  <!--
+    A slate with surface="html" embeds an arbitrary XHTML
+    fragment, and the XHTML namespace is the author's
+    declaration that the content is foreign: anything
+    un-namespaced still gets the schema's full scrutiny.
+    Declare it once, as a prefix on the "slate" itself;
+    the conversion keeps only local names, so the output
+    page carries plain HTML tags, free of namespaces.
+  -->
+  <define name="AnyXHTML">
     <element>
       <nsName ns="http://www.w3.org/1999/xhtml"/>
       <zeroOrMore>
@@ -243,7 +222,7 @@
       </zeroOrMore>
       <mixed>
         <zeroOrMore>
-          <ref name="AnyXhtml"/>
+          <ref name="AnyXHTML"/>
         </zeroOrMore>
       </mixed>
     </element>

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -1559,6 +1559,74 @@
     </zeroOrMore>
   </define>
   <!--
+    LEGACY fill-in ("fillin-basic" to the assembly classifier):
+    empty "var" marks in the statement pair positionally with
+    the "var" elements of the "setup", each holding conditions
+    tried in order (a numeric interval via @number/@tolerance,
+    or a @string regular expression), with optional feedback.
+    The machinery is fully implemented, interactive and
+    static, so the form is admitted here.  It will NEVER move
+    to the stable schema: its only future is retirement in
+    favor of the dynamic fill-in above.
+  -->
+  <define name="FillInLegacy">
+    <ref name="MetaDataTitleOptional"/>
+    <optional>
+      <attribute name="number"/>
+    </optional>
+    <ref name="StatementExercise"/>
+    <element name="setup">
+      <oneOrMore>
+        <element name="var">
+          <optional>
+            <attribute name="case">
+              <value>insensitive</value>
+            </attribute>
+          </optional>
+          <oneOrMore>
+            <element name="condition">
+              <choice>
+                <group>
+                  <attribute name="number"/>
+                  <optional>
+                    <attribute name="tolerance"/>
+                  </optional>
+                </group>
+                <attribute name="string"/>
+              </choice>
+              <optional>
+                <ref name="Feedback"/>
+              </optional>
+            </element>
+          </oneOrMore>
+        </element>
+      </oneOrMore>
+    </element>
+    <zeroOrMore>
+      <ref name="Hint"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Answer"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="Solution"/>
+    </zeroOrMore>
+  </define>
+  <!-- the empty mark in a statement, sized by @width -->
+  <define name="VarMark">
+    <element name="var">
+      <optional>
+        <attribute name="width">
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="TextParagraphItem" combine="choice">
+    <ref name="VarMark"/>
+  </define>
+  <!--
     A select exercise poses one of several existing questions
     (variants), located by their @label values; @grade says
     how the graded variant is chosen: at random, by A/B
@@ -1599,6 +1667,7 @@
         <ref name="Matching"/>
         <ref name="FreeResponse"/>
         <ref name="FillInBlank"/>
+        <ref name="FillInLegacy"/>
         <ref name="Areas"/>
         <ref name="CodingExercise"/>
         <ref name="Select"/>
@@ -1654,6 +1723,7 @@
         <ref name="Matching"/>
         <ref name="FreeResponse"/>
         <ref name="FillInBlank"/>
+        <ref name="FillInLegacy"/>
         <ref name="Areas"/>
         <ref name="CodingExercise"/>
       </choice>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -1172,6 +1172,8 @@
                     attribute preview {"default" | "generic" | text}?,
                     (AttributesSourceFile | AttributesNetwork | AttributesYouTube |
                      AttributesYouTubePlaylist | AttributesVimeo),
+                    # names the video, as in a Runestone manifest
+                    Title?,
                     Track*
                 }
             Audio =

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -623,6 +623,8 @@
                 element stdin {
                     text
                 }
+            # A checkpoint's prompt and feedback are short bursts of
+            # marked-up text, not sequences of blocks
             CodelensCheckpoint =
                 element checkpoint {
                     attribute line {text},
@@ -631,8 +633,8 @@
                     |
                         attribute answer-variable {text}
                     ),
-                    element prompt {BlockText+},
-                    element feedback {BlockText+}?
+                    element prompt {TextLong},
+                    element feedback {TextLong}?
                 }
             Program =
                 element program {
@@ -646,10 +648,12 @@
                     attribute codelens {"yes"|"no"}?,
                     attribute codetailor {"all"|"incorrect"}?,
                     attribute codetailor-fallback {text}?,
-                    attribute starting-step {"yes"|"no"}?,
+                    # the codelens trace step (1-based) to open on
+                    attribute starting-step {xsd:integer}?,
                     attribute compiler-args {text}?,
                     attribute extra-compiler-args {text}?,
                     attribute database {text}?,
+                    attribute datafile {text}?,
                     attribute add-files {text}?,
                     attribute compile-also {text}?,
                     attribute download {"yes"|"no"}?,

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1712,6 +1712,10 @@
       <text/>
     </element>
   </define>
+  <!--
+    A checkpoint's prompt and feedback are short bursts of
+    marked-up text, not sequences of blocks
+  -->
   <define name="CodelensCheckpoint">
     <element name="checkpoint">
       <attribute name="line"/>
@@ -1720,15 +1724,11 @@
         <attribute name="answer-variable"/>
       </choice>
       <element name="prompt">
-        <oneOrMore>
-          <ref name="BlockText"/>
-        </oneOrMore>
+        <ref name="TextLong"/>
       </element>
       <optional>
         <element name="feedback">
-          <oneOrMore>
-            <ref name="BlockText"/>
-          </oneOrMore>
+          <ref name="TextLong"/>
         </element>
       </optional>
     </element>
@@ -1786,11 +1786,9 @@
         <attribute name="codetailor-fallback"/>
       </optional>
       <optional>
+        <!-- the codelens trace step (1-based) to open on -->
         <attribute name="starting-step">
-          <choice>
-            <value>yes</value>
-            <value>no</value>
-          </choice>
+          <data type="integer"/>
         </attribute>
       </optional>
       <optional>
@@ -1801,6 +1799,9 @@
       </optional>
       <optional>
         <attribute name="database"/>
+      </optional>
+      <optional>
+        <attribute name="datafile"/>
       </optional>
       <optional>
         <attribute name="add-files"/>

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -3136,6 +3136,10 @@
         <ref name="AttributesYouTubePlaylist"/>
         <ref name="AttributesVimeo"/>
       </choice>
+      <optional>
+        <!-- names the video, as in a Runestone manifest -->
+        <ref name="Title"/>
+      </optional>
       <zeroOrMore>
         <ref name="Track"/>
       </zeroOrMore>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2776,6 +2776,23 @@
                 FreeResponse |
                 FillInBlank |
                 Areas
+            # The assembly classifies "task" alongside "exercise" and the
+            # project-like blocks, and every interactive form is
+            # implemented within a "task", so the same union applies
+            Task |=
+                element task {
+                    attribute workspace {text}?,
+                    (
+                    TrueFalse |
+                    MultipleChoice |
+                    Parsons |
+                    Matching |
+                    FreeResponse |
+                    FillInBlank |
+                    Areas |
+                    CodingExercise
+                    )
+                }
             </code>
         </fragment>
     </section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2249,6 +2249,8 @@
                     attribute preview {"default" | "generic" | text}?,
                     (AttributesSourceFile | AttributesNetwork | AttributesYouTube |
                      AttributesYouTubePlaylist | AttributesVimeo),
+                    # names the video, as in a Runestone manifest
+                    Title?,
                     Track*
                 }
             Audio =
@@ -2806,6 +2808,8 @@
                     attribute rows {xsd:integer}?,
                     attribute cols {xsd:integer}?,
                     attribute editable {"yes"|"no"}?,
+                    # a non-editable datafile can start hidden
+                    attribute hide {"yes"|"no"}?,
                     (
                         element pre {
                             attribute source {text}?,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2186,6 +2186,40 @@
                 ),
                 ConclusionDivision?
             }
+
+            # Hosted on Runestone, an "exercises" division can be a
+            # timed exam (@time-limit in minutes; results, feedback,
+            # the visible timer, and pausing each default on), or can
+            # collect group-work submissions (@groupwork, group size
+            # capped by @groupsize); a "worksheet" can do the latter
+            Exercises |= element exercises {
+                (
+                    (attribute time-limit {xsd:integer},
+                     attribute results {"yes"|"no"}?,
+                     attribute timer {"yes"|"no"}?,
+                     attribute feedback {"yes"|"no"}?,
+                     attribute pause {"yes"|"no"}?)
+                |
+                    (attribute groupwork {"yes"|"no"},
+                     attribute groupsize {xsd:integer}?)
+                ),
+                MetaDataAltTitleOptional,
+                IntroductionDivision?,
+                (Exercise | ExerciseGroup)+,
+                ConclusionDivision?
+            }
+            Worksheet |= element worksheet {
+                attribute groupwork {"yes"|"no"},
+                attribute groupsize {xsd:integer}?,
+                PrintoutAttributes,
+                attribute courseid {text}?,
+                attribute series {text}?,
+                attribute seriescode {text}?,
+                MetaDataAltTitleOptional,
+                (Objectives? &amp; IntroductionDivision?),
+                (Page+ | PrintoutBlock+),
+                (Outcomes? &amp; ConclusionDivision?)
+            }
             </code>
         </fragment>
     </section>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -1298,6 +1298,8 @@
                 element stdin {
                     text
                 }
+            # A checkpoint's prompt and feedback are short bursts of
+            # marked-up text, not sequences of blocks
             CodelensCheckpoint =
                 element checkpoint {
                     attribute line {text},
@@ -1306,8 +1308,8 @@
                     |
                         attribute answer-variable {text}
                     ),
-                    element prompt {BlockText+},
-                    element feedback {BlockText+}?
+                    element prompt {TextLong},
+                    element feedback {TextLong}?
                 }
             Program =
                 element program {
@@ -1321,10 +1323,12 @@
                     attribute codelens {"yes"|"no"}?,
                     attribute codetailor {"all"|"incorrect"}?,
                     attribute codetailor-fallback {text}?,
-                    attribute starting-step {"yes"|"no"}?,
+                    # the codelens trace step (1-based) to open on
+                    attribute starting-step {xsd:integer}?,
                     attribute compiler-args {text}?,
                     attribute extra-compiler-args {text}?,
                     attribute database {text}?,
+                    attribute datafile {text}?,
                     attribute add-files {text}?,
                     attribute compile-also {text}?,
                     attribute download {"yes"|"no"}?,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2788,6 +2788,19 @@
                 StatementExercise,
                 Program,
                 Hint*, Answer*, Solution*
+            # A select exercise poses one of several existing questions
+            # (variants), located by their @label values; @grade says
+            # how the graded variant is chosen: at random, by A/B
+            # experiment group, always the first listed (the others
+            # remain viewable), or any one the reader selects
+            Select =
+                MetaDataTitleOptional,
+                element select {
+                    attribute grade {"random"|"ab-experiment"|"first"|"any"}?,
+                    attribute questions {text},
+                    attribute experiment-name {text}?,
+                    empty
+                }
             # Include all exercise types in exercise and activity
             Exercise |=
                 element exercise {
@@ -2801,7 +2814,8 @@
                     FreeResponse |
                     FillInBlank |
                     Areas |
-                    CodingExercise
+                    CodingExercise |
+                    Select
                     )
                 }
             # STACK assessment exercise type

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2361,13 +2361,15 @@
                 StatementExercise,
                 element choices {
                     attribute randomize {"yes"|"no"}?,
+                    attribute multiple-correct {"yes"|"no"}?,
+                    attribute cols {xsd:integer}?,
                     Choice+
                 },
                 Hint*, Answer*, Solution*
             Choice =
                 element choice {
                     attribute correct {"yes"|"no"}?,
-                    ((mixed {BlockText?})
+                    ((mixed {BlockText*})
                     | (StatementExercise, Feedback?))
                 }
             Parsons =
@@ -2720,11 +2722,13 @@
                 }
             BlockStatement |= Datafile
 
-            # Query (poll/survey) element
+            # Query (poll/survey) element; results are private to the
+            # instructor unless @visibility says otherwise
             Query =
                 element query {
                     LabelID?,
                     attribute scale {xsd:integer}?,
+                    attribute visibility {"instructor"|"all"}?,
                     StatementExercise,
                     element choices {
                         Choice+

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2469,15 +2469,20 @@
                         TextLong
                     }+
                 })
+            # Premises and the response arrive in any order; a match
+            # with premises and no response, or a response and no
+            # premises, is a distractor
             Match =
                 element match {
                     element premise {
                         attribute order {xsd:integer}?,
                         TextLong
-                    }+,
+                    }*
+                    &amp;
                     element response {
+                        attribute order {xsd:integer}?,
                         TextLong
-                    }
+                    }?
                 }
             FreeResponse =
                 MetaDataTitleOptional,

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2376,48 +2376,75 @@
                     ((mixed {BlockText*})
                     | (StatementExercise, Feedback?))
                 }
+            # A horizontal SQL Parsons may name a grading database and
+            # carry raw unit tests; a horizontal layout may permit the
+            # reuse of blocks, where a source block carries an @xml:id
+            # (and no @order) and each use references it with @ref
             Parsons =
                     MetaDataTitleOptional,
                     attribute number {text}?,
                     attribute language {text}?,
                     attribute adaptive {"yes"|"no"}?,
                     attribute indentation {text}?,
+                    attribute database {text}?,
                     StatementExercise,
                     element blocks {
                         attribute layout {"horizontal"}?,
                         attribute randomize {"yes"|"no"}?,
-                        ( BlockOrdered+ | BlockUnordered+ )
+                        attribute reuse {"yes"|"no"}?,
+                        attribute numbered {"left"|"right"|"no"}?,
+                        ( (BlockOrdered | BlockSource)+ | BlockUnordered+ )
                     },
+                    element tests {text}?,
                     Hint*, Answer*, Solution*,
-                    (
-                        element preamble {
-                            attribute indent {text}?,
-                            text
-                        }?,
-                        Program,
-                        element postamble {
-                            attribute indent {text}?,
-                            text
-                        }?
-                    )?
+                    (ParsonsProgramPreamble?, Program, ParsonsProgramPostamble?)?
+            # Fixed code surrounding a runnable Parsons solution.  These
+            # patterns stand apart so the element names can be revisited
+            # on their own: the plain "preamble" and "postamble" within
+            # a "program" are close cousins, and some later decision may
+            # unify them.
+            ParsonsProgramPreamble =
+                element program-preamble {
+                    attribute indent {text}?,
+                    text
+                }
+            ParsonsProgramPostamble =
+                element program-postamble {
+                    attribute indent {text}?,
+                    text
+                }
+            # Horizontal blocks hold short inline bursts (code via "c",
+            # mathematics, text); vertical blocks hold code lines or
+            # natural-language blocks
             BlockBody =
                 ((
                     attribute correct {"yes"|"no"}?,
-                    mixed {BlockText?, CodeLine?}+
+                    mixed {BlockText?, CodeLine?, Verbatim?, MathInline?}+
                 ) |
                 (
                     element choice {
                         attribute correct {"yes"|"no"}?,
-                        mixed {BlockText?, CodeLine?}+
+                        mixed {BlockText?, CodeLine?, Verbatim?, MathInline?}+
                     }+
                 ))
             BlockOrdered =
                 element block {
                     attribute order {xsd:integer},
+                    attribute name {text}?,
+                    attribute depends {text}?,
+                    attribute ref {text}?,
+                    BlockBody
+                }
+            BlockSource =
+                element block {
+                    UniqueID,
+                    attribute name {text}?,
                     BlockBody
                 }
             BlockUnordered =
                 element block {
+                    attribute name {text}?,
+                    attribute depends {text}?,
                     BlockBody
                 }
             Matching =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2908,6 +2908,24 @@
                     Select
                     )
                 }
+            # STRICTLY EXPERIMENTAL, matching the sample's own alert:
+            # a dual exercise pairs a "dynamic" realization (typically
+            # an embedded interactive) with a "static" stand-in, and
+            # the assembly chooses one per output
+            Exercise |=
+                element exercise {
+                    MetaDataTitleOptional,
+                    element dynamic {
+                        StatementExercise
+                    },
+                    element static {
+                        (
+                            (StatementExercise, Hint*, Answer*, Solution*)
+                        |
+                            (IntroductionStatement?, Task+, ConclusionStatement?)
+                        )
+                    }
+                }
             # STACK assessment exercise type
             Exercise |=
                 element exercise {

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2788,6 +2788,41 @@
                 StatementExercise,
                 Program,
                 Hint*, Answer*, Solution*
+            # LEGACY fill-in ("fillin-basic" to the assembly classifier):
+            # empty "var" marks in the statement pair positionally with
+            # the "var" elements of the "setup", each holding conditions
+            # tried in order (a numeric interval via @number/@tolerance,
+            # or a @string regular expression), with optional feedback.
+            # The machinery is fully implemented, interactive and
+            # static, so the form is admitted here.  It will NEVER move
+            # to the stable schema: its only future is retirement in
+            # favor of the dynamic fill-in above.
+            FillInLegacy =
+                MetaDataTitleOptional,
+                attribute number {text}?,
+                StatementExercise,
+                element setup {
+                    element var {
+                        attribute case {"insensitive"}?,
+                        element condition {
+                            (
+                                (attribute number {text},
+                                 attribute tolerance {text}?)
+                            |
+                                attribute string {text}
+                            ),
+                            Feedback?
+                        }+
+                    }+
+                },
+                Hint*, Answer*, Solution*
+            # the empty mark in a statement, sized by @width
+            VarMark =
+                element var {
+                    attribute width {xsd:integer}?,
+                    empty
+                }
+            TextParagraphItem |= VarMark
             # A select exercise poses one of several existing questions
             # (variants), located by their @label values; @grade says
             # how the graded variant is chosen: at random, by A/B
@@ -2813,6 +2848,7 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
+                    FillInLegacy |
                     Areas |
                     CodingExercise |
                     Select
@@ -2851,6 +2887,7 @@
                     Matching |
                     FreeResponse |
                     FillInBlank |
+                    FillInLegacy |
                     Areas |
                     CodingExercise
                     )

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2558,9 +2558,17 @@
             # a clickable area
             TableCellText |= mixed { (TextLongContent | TableNote | Area)* }
 
-            # General feedback element
+            # General feedback element; a short burst of marked-up text
+            # is as welcome as a sequence of blocks
             Feedback =
                 element feedback {
+                    MetaDataTitleOptional,
+                    (BlockSolution+ | TextLong)
+                }
+            # A dynamic exercise's automatic solution can be declined
+            Solution |=
+                element solution {
+                    attribute include-automatic {"yes"|"no"},
                     MetaDataTitleOptional,
                     BlockSolution+
                 }
@@ -2608,10 +2616,13 @@
                     attribute reduce {"yes"}?,
                     text
                 }
-            # A formula; the content model follows @mode
+            # A formula; the content model follows @mode.  Outside a
+            # "de-object" there is no enclosing context, so the
+            # expression may declare its own with @context.
             DEExpression =
                 element de-expression {
                     attribute reduce {"yes"}?,
+                    attribute context {"number" | "formula"}?,
                     (
                         (attribute mode {"formula"}?, text) |
                         (attribute mode {"substitution"}, DEFormula, DEVariableValued) |
@@ -2683,10 +2694,15 @@
             # none, the provided answer or answer object is the default
             # comparison.  A test holds a single numcmp or strcmp, OR any
             # number of jscmp/mathcmp/logic combined with an implied AND.
+            # A bare "eval" or a bare constructor within a test is
+            # shorthand for a comparison with the submission; the
+            # assembly substitutes the full form
             FITBTest =
                 element test {
                     attribute correct {"yes"|"no"}?,
-                    (FITBNumcmp | FITBStrcmp | (FITBJscmp | FITBMathcmp | FITBLogic)+),
+                    (FITBNumcmp | FITBStrcmp |
+                     (FITBJscmp | FITBMathcmp | FITBLogic |
+                      Eval | DENumber | DEExpression | DEEvaluate)+),
                     Feedback?
                 }
             FITBComparison =

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2124,13 +2124,7 @@
                           Paragraph |
                           Tabular |
                           SideBySideNoNumber |
-                          SlateInput |
-                          AnyXhtml |
-                          element xhtml:button {
-                            attribute type { text },
-                            attribute id { text },
-                            text*
-                          }? |
+                          AnyXHTML |
                           text*
                         )*
                       )
@@ -2146,20 +2140,17 @@
                   text*
                 )
 
-              SlateInput =
-                element input {
-                  attribute type {text}?,
-                  attribute value {text}?,
-                  attribute onkeypress {text}?,
-                  attribute onclick {text}?,
-                  attribute style {text}?
-                }
-
-              # A slate with surface="html" embeds an arbitrary XHTML fragment.
-              AnyXhtml =
+              # A slate with surface="html" embeds an arbitrary XHTML
+              # fragment, and the XHTML namespace is the author's
+              # declaration that the content is foreign: anything
+              # un-namespaced still gets the schema's full scrutiny.
+              # Declare it once, as a prefix on the "slate" itself;
+              # the conversion keeps only local names, so the output
+              # page carries plain HTML tags, free of namespaces.
+              AnyXHTML =
                 element xhtml:* {
                   (attribute * { text })*,
-                  mixed { AnyXhtml* }
+                  mixed { AnyXHTML* }
                 }
 
             # add Interactives where used

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -2540,15 +2540,23 @@
                     Component?,
                     TextParagraphAreas
                 }
+            # The areas come in three forms: paragraphs of prose, lines
+            # of code (@language names the language), or a tabular with
+            # clickable cells.  Trailing components in any order.
             Areas =
                 MetaDataTitleOptional,
                 attribute number {text}?,
                 StatementExercise,
                 element areas {
-                  ParagraphAreas+
+                  attribute language {text}?,
+                  (ParagraphAreas | ClineAreas | Tabular)+
                 },
-                Feedback?,
-                Hint*, Answer*, Solution*
+                (Feedback? &amp; Hint* &amp; Answer* &amp; Solution*)
+            ClineAreas =
+                element cline { mixed {Area*} }
+            # within the development schema, any tabular cell may hold
+            # a clickable area
+            TableCellText |= mixed { (TextLongContent | TableNote | Area)* }
 
             # General feedback element
             Feedback =

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10468,30 +10468,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <!-- HTML Code                                                  -->
-<!-- Simply create deep-copy of HTML elements                   -->
 <!-- TODO: should this be a div, with width and height?         -->
-<!-- Authored HTML goes into the page verbatim.  But a plain    -->
-<!-- "xsl:copy-of" materializes every namespace in scope at the -->
-<!-- source location as a declaration on the copy: the source   -->
-<!-- file's own declarations (such as XInclude) and any         -->
-<!-- namespace employed by the assembly machinery.  So instead  -->
-<!-- we rebuild each element, which carries along only the      -->
-<!-- namespaces actually in use.                                -->
+<!-- Authored HTML goes into the page, which is the content's   -->
+<!-- only destination, and an HTML parser has no notion of      -->
+<!-- namespaces.  So the copy keeps just the local name of each -->
+<!-- element: an author declares the XHTML namespace once (say, -->
+<!-- a prefix on the "slate") to satisfy validation, and the    -->
+<!-- output carries plain HTML tags with no declarations at     -->
+<!-- all.  (This utility may serve other embedded-markup        -->
+<!-- copying; nothing about it is specific to a "slate".)       -->
 <xsl:template match="slate[@surface = 'html']">
-    <xsl:apply-templates select="*" mode="copy-authored-html"/>
+    <xsl:apply-templates select="*" mode="copy-authored-xml"/>
 </xsl:template>
 
 <!-- Attributes in the internal namespace are the assembly's     -->
 <!-- identification stamps, not the author's work, so they stay  -->
 <!-- out of the copy.                                            -->
-<xsl:template match="*" mode="copy-authored-html">
-    <xsl:element name="{name()}" namespace="{namespace-uri()}">
+<xsl:template match="*" mode="copy-authored-xml">
+    <xsl:element name="{local-name()}">
         <xsl:copy-of select="@*[namespace-uri(.) != 'http://pretextbook.org/2020/pretext/internal']"/>
-        <xsl:apply-templates select="node()" mode="copy-authored-html"/>
+        <xsl:apply-templates select="node()" mode="copy-authored-xml"/>
     </xsl:element>
 </xsl:template>
 
-<xsl:template match="text()|comment()|processing-instruction()" mode="copy-authored-html">
+<xsl:template match="text()|comment()|processing-instruction()" mode="copy-authored-xml">
     <xsl:copy/>
 </xsl:template>
 


### PR DESCRIPTION
The sample book's Runestone chapters produced 217 errors against the
development schema.  A three-way audit — what the samples author, what
the XSL actually reads (the interactive builders, the static
representations, and the assembly's classifier, which stamps
`exercise`, the project-like blocks, and `task` alike), and what the
schema models — showed nearly all of it was the schema trailing the
implemented feature set, with a handful of genuine sample defects.
This branch closes the gap from all three sides.  After it: the sample
book validates with exactly one error (a `@reduce` placement question
parked for #3047 or the FITB maintainer), and the sample article's
count drops from eleven to zero.

The commits:

- 72bfa845 (HTML) Authored slate markup is copied by *local name*
  only.  An HTML page is this content's sole destination, and HTML
  parsers have no notion of namespaces — so the XHTML namespace
  becomes purely a source-side validation marker, declared once (a
  prefix on the `slate`), with plain HTML tags in the output.  The
  mode (`copy-authored-xml`) is not slate-specific and could serve
  other embedded markup.

- 9a8a2994 (Sample book) Four conformance repairs (a bare-text
  statement, a `p` wrapping an image, a stray `p` inside a `listing`,
  a trailing paragraph now a proper `conclusion`), and the show-eval
  demonstration declares `xmlns:xhtml` once on its `slate`, authoring
  `xhtml:button` and kin.

- afcf71c5 (Schema) A `task` hosts the same interactive forms as an
  `exercise` — the classifier always treated them alike.

- 6459c40f (Schema) `choices/@multiple-correct`, `choices/@cols`, a
  choice holding several blocks, and `query/@visibility`.

- 9cc3f82a (Schema) Codelens `checkpoint` prompts and feedback are
  marked-up text, not block sequences; `program/@starting-step` is the
  integer the trace extractor arithmetics on, not a yes/no; and
  `program/@datafile` joins its long attribute list.

- 00cfcdc5 (Schema) Parsons, both layouts: `@database`, `blocks/@reuse`
  and `@numbered`, `block/@name` and `@depends` (partial-order
  grading), the `@ref`/`@xml:id` block-reuse pair, inline content for
  horizontal blocks, exercise-level `tests` — and the model's
  `preamble`/`postamble` become the `program-preamble` and
  `program-postamble` the code and samples have always used, standing
  as their own named patterns so a future unification with a
  program's interior preamble/postamble stays a contained decision.

- b2c67fa1 (Schema) A `match` holds premises and a response in either
  order, and either side alone is a distractor.

- c3859d48 (Schema) Clickable areas in their three authored forms —
  paragraphs, `cline` code (with `@language`), and `tabular` cells —
  freely interleaved, trailing components in any order.

- 83e9cf80 (Schema) The `select` exercise, whole: `@questions` lists
  the variant questions, `@grade` says how the graded variant is
  chosen (random, A/B experiment, first-with-others-viewable, or the
  reader's pick), `@experiment-name` for the A/B case.

- 8c8e6bb8 (Schema) The legacy fill-in (`setup`/`var`/`condition`),
  fully modeled — the machinery is completely implemented, interactive
  and static — with the literate source stating plainly that this form
  will NEVER move to the stable schema; its only future is retirement.

- 45602a46 (Schema) Dynamic fill-in growth: a bare `eval` or
  constructor as a test's comparison shorthand (the assembly
  substitutes the full form), `de-expression/@context`, text-level
  `feedback`, `solution/@include-automatic`.

- 4628eb34 (Schema) Timed exams (`@time-limit` with the `results`,
  `timer`, `feedback`, `pause` toggles) and group work
  (`@groupwork`/`@groupsize`) on their hosting divisions.

- d7ce0f3b (Schema) `datafile/@hide`; a `video` may carry a `title`,
  which the Runestone manifest consumes.

- 8079c507 (Schema) The dual (dynamic-plus-static) exercise, modeled
  minimally and marked experimental, matching the sample's own alert.

- 5f6a6bda (Schema) Slate housekeeping: the no-namespace `input` and a
  redundant `xhtml:button` special case are gone; the wildcard's
  comment explains the namespace-as-foreign-marker principle and the
  declare-once idiom.

- a3b15553 (Sample book) Five stale prose references to
  `docinfo/programs` now read `docinfo/defaults/programs`, the
  location the code prefers, the schema models, and the book itself
  uses.

Nearly all modeling deliberately lives in the development overlay; the
base schema changes are confined to the `program` element, the video
title, and one tabular-cell extension.  Under the stable schema the
book's count falls 322 to 289 — the Runestone frontier remains
development-schema territory by design.

Testing: every schema regeneration is idempotent; the Guide holds its
two-error baseline; a full before/after HTML build of the sample book
differs in exactly the pages the source repairs touch, each verified
intended (including the show-eval page, whose buttons now arrive as
plain HTML tags with no namespace residue); and the sample article's
slate output sheds its now-pointless `xmlns` attributes while
rendering identically.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
