### PR TITLE
A "headnote" for every list-like division

### DIFF
--- a/css/components/_spacing.scss
+++ b/css/components/_spacing.scss
@@ -45,7 +45,7 @@ $line-height: 1.35 !default;
 
 @layer spacing {
   // selectors for items that are expected to contain sequences of items
-  $containers: "section, article, .knowl__content, .introduction, .conclusion";
+  $containers: "section, article, .knowl__content, .introduction, .conclusion, .headnote";
 
   // inter-item spacing high level containers
   :is(#{$containers}) > *:not(:first-child) {

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -1447,7 +1447,7 @@
 
             <p>A <tag>glossary</tag> division may be placed inside any main matter division, and at most once in the <tag>backmatter</tag>.   In either event, the <pubtitle>Chicago Manual of Style</pubtitle> <xref ref="cmos" detail="1.87"/> indicates that it should be placed right before a <tag>references</tag>.</p>
 
-            <p>After a <tag>title</tag>, index entries, and other metadata, a <tag>glossary</tag> division may begin with an optional <tag>headnote</tag>, which can use paragraphs to explain anything unusual about the construction of a particular glossary.</p>
+            <p>After a <tag>title</tag>, index entries, and other metadata, a <tag>glossary</tag> division may begin with an optional <tag>headnote</tag>, which can use paragraphs to explain anything unusual about the construction of a particular glossary.  The same element serves the other list-like divisions: a <tag>references</tag>, an <tag>index</tag>, and an <tag>appendix</tag> that is exactly a <tag>notation-list</tag>.</p>
 
             <p>The remainder of a glossary is a sequence of items to explain.  Typically these are words, phrases, initialisms, or acronyms.  Each item is a <q>glossary item</q>, enclosed in a shorthand <tag>gi</tag> element.  The element must lead with a <tag>title</tag>, which is the term being explained.  <pretext/> will provide a period after each defined word, so there should not be any punctuation in your source at this location.  The term should not have any markup, <em>unless</em> the markup is used in every occurence of the term in the text.  Similarly, a term is capitalized only if it is capitalized routinely in the text.</p>
 
@@ -5092,6 +5092,7 @@
 
               <p>An index may start with a <term>headnote</term> giving advice about using the index.
                 Typically a headnote is not necessary unless the index has some unusual features.
+                Author one with a <tag>headnote</tag> element, holding paragraphs, placed just before the <tag>index-list</tag>.
               </p>
             </paragraphs>
 

--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -230,7 +230,7 @@
             <li>Locators for smaller units are knowls.</li>
             <li><q>Page ranges</q> use the initial location.</li>
             <li>No running heads (yet).</li>
-            <li>A <term>headnote</term> can be accomplished with an <tag>introduction</tag>.</li>
+            <li>A <tag>headnote</tag> renders between the heading and the entries.</li>
         </ul>Some of these choices would be easy to adjust or extend as the result of a feature request.</p>
 
         <p>Also, there can be significant differences between how <pretext/> implements the index for <init>HTML</init> and how the <c>imakeidx</c> package creates an index for <latex/>.  See <xref ref="latex-index-style"/> and <xref ref="indexing-guide"/>.</p>

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -18143,6 +18143,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <index label="the-index">
                 <title>Index</title>
+                <headnote>
+                    <p>An index may begin with a <tag>headnote</tag> like this one.  Indexing advice holds that a headnote is only necessary when the index has some unusual feature a reader should know in advance<mdash/>perhaps how symbols are ordered, or that persons and topics are interfiled.  This index has no such feature; this headnote is a demonstration.</p>
+                </headnote>
                 <index-list/>
             </index>
 

--- a/examples/showcase/source/pretext-showcase.ptx
+++ b/examples/showcase/source/pretext-showcase.ptx
@@ -73,10 +73,12 @@
       <index>
         <title>Index</title>
 
+        <headnote>
           <p>
             Entries are alphabetized word-by-word, not letter-by-letter.
             Topics indexed are <pretext/> features, not any actual content.
           </p>
+        </headnote>
 
         <index-list />
       </index>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -147,6 +147,11 @@
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionCompanion?)
                         )
+                    |
+                        (
+                            HeadNote?,
+                            NotationList
+                        )
                     )
                 }
             BookAppendix =
@@ -169,11 +174,17 @@
                              Solutions | References | Glossary)*,
                             (Outcomes? & ConclusionCompanion?)
                         )
+                    |
+                        (
+                            HeadNote?,
+                            NotationList
+                        )
                     )
                 }
             IndexDivision =
                 element index {
                     MetaDataAltTitleOptional,
+                    HeadNote?,
                     IndexList
                 }
 
@@ -406,6 +417,7 @@
                 element references {
                     MetaDataAltTitleOptional,
                     IntroductionDivision?,
+                    HeadNote?,
                     BibliographyItem+,
                     ConclusionDivision?
                 }

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -531,6 +531,12 @@
             </optional>
           </interleave>
         </group>
+        <group>
+          <optional>
+            <ref name="HeadNote"/>
+          </optional>
+          <ref name="NotationList"/>
+        </group>
       </choice>
     </element>
   </define>
@@ -612,12 +618,21 @@
             </optional>
           </interleave>
         </group>
+        <group>
+          <optional>
+            <ref name="HeadNote"/>
+          </optional>
+          <ref name="NotationList"/>
+        </group>
       </choice>
     </element>
   </define>
   <define name="IndexDivision">
     <element name="index">
       <ref name="MetaDataAltTitleOptional"/>
+      <optional>
+        <ref name="HeadNote"/>
+      </optional>
       <ref name="IndexList"/>
     </element>
   </define>
@@ -1207,6 +1222,9 @@
       <ref name="MetaDataAltTitleOptional"/>
       <optional>
         <ref name="IntroductionDivision"/>
+      </optional>
+      <optional>
+        <ref name="HeadNote"/>
       </optional>
       <oneOrMore>
         <ref name="BibliographyItem"/>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -258,6 +258,11 @@
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionCompanion?)
                         )
+                    |
+                        (
+                            HeadNote?,
+                            NotationList
+                        )
                     )
                 }
             BookAppendix =
@@ -280,11 +285,17 @@
                              Solutions | References | Glossary)*,
                             (Outcomes? &amp; ConclusionCompanion?)
                         )
+                    |
+                        (
+                            HeadNote?,
+                            NotationList
+                        )
                     )
                 }
             IndexDivision =
                 element index {
                     MetaDataAltTitleOptional,
+                    HeadNote?,
                     IndexList
                 }
             </code>
@@ -368,6 +379,7 @@
                 element references {
                     MetaDataAltTitleOptional,
                     IntroductionDivision?,
+                    HeadNote?,
                     BibliographyItem+,
                     ConclusionDivision?
                 }
@@ -1033,7 +1045,7 @@
 
         <p>The <c>introduction</c> and <c>conclusion</c> containers can be used in a variety of other structured elements.  They come in four levels, according to what they can contain, and are meant to be consonant with their surroundings.  As children of a division, they may carry a <c>title</c>, which in turn allows them to be cross-referenced by that text.</p>
 
-        <p>A <tag>headnote</tag> is like an <tag>introduction</tag>, but does not have a symmetric concluding element, and is typically meant for specialized divisions, such as a <tag>glossary</tag>.</p>
+        <p>A <tag>headnote</tag> is like an <tag>introduction</tag>, but does not have a symmetric concluding element, and is meant for divisions whose content is essentially one list: a <tag>glossary</tag>, a <tag>references</tag>, an <tag>index</tag>, or an <tag>appendix</tag> that is exactly a notation list.  It is a light prefatory note, only necessary when something about the list is unusual and deserves a reader's advance attention.</p>
 
         <fragment xml:id="introduction-conclusion-headnote">
             <title>Introductions, conclusions, headnotes</title>

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6125,10 +6125,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:element>
 </xsl:template>
 
-<!-- A "headnote" prefaces the content of a "glossary".  Below -->
-<!-- is modeled on block introductions (just above), but with  -->
-<!-- no "title" and with a provisional recycled CSS class.     -->
-<xsl:template match="glossary/headnote">
+<!-- A "headnote" prefaces the list of a list-like division: a -->
+<!-- "glossary", a "references", an "index", an "appendix"     -->
+<!-- that is a notation list.  Below is modeled on block       -->
+<!-- introductions (just above), but with no "title".          -->
+<xsl:template match="glossary/headnote|references/headnote|index/headnote|appendix/headnote">
     <xsl:param name="b-original" select="true()" />
     <section class="headnote">
         <xsl:if test="$b-original">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1979,6 +1979,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:for-each select="$introduction-reps">
         <xsl:apply-templates select="." mode="environment"/>
     </xsl:for-each>
+    <!-- HEADNOTE (prefatory note of a list-like division) -->
+    <xsl:variable name="headnote-reps" select="($document-root//headnote)[1]"/>
+    <xsl:if test="$headnote-reps">
+        <xsl:text>%%&#xa;</xsl:text>
+        <xsl:text>%% xparse environment for headnotes of list-like divisions&#xa;</xsl:text>
+        <xsl:text>%%&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:for-each select="$headnote-reps">
+        <xsl:apply-templates select="." mode="environment"/>
+    </xsl:for-each>
     <!-- MISCELLANEOUS -->
     <!-- "paragraphs" are partly like a division, -->
     <!-- but we include it here as a one-off      -->
@@ -2371,6 +2381,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>{}</xsl:text>
         </xsl:when>
     </xsl:choose>
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<!-- A "headnote" is the prefatory note of a list-like division -->
+<!-- (a glossary, a references, an index, an appendix that is a -->
+<!-- notation list).  It functions just like an "introduction", -->
+<!-- though a headnote never carries a title of its own.        -->
+<xsl:template match="headnote" mode="environment">
+    <xsl:text>%% headnote: prefatory note of a list-like division&#xa;</xsl:text>
+    <xsl:text>\NewDocumentEnvironment{headnote}{m}&#xa;</xsl:text>
+    <xsl:text>{\notblank{#1}{\noindent\textbf{#1}\space}{}}</xsl:text>
+    <xsl:text>{\par\medskip}</xsl:text>
     <xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
@@ -3581,13 +3603,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- infrastructure and not so hard-coded as it is here.     -->
             <xsl:text>\newpage%&#xa;</xsl:text>
             <xsl:apply-templates select="." mode="latex-division-heading"/>
+            <xsl:apply-templates select="headnote"/>
             <xsl:apply-templates select="index-list"/>
             <xsl:apply-templates select="." mode="latex-division-footing"/>
         </xsl:when>
         <xsl:when test="$index-maker = 'latex'">
+            <xsl:apply-templates select="headnote" mode="index-prologue"/>
             <xsl:apply-templates select="index-list"/>
         </xsl:when>
     </xsl:choose>
+</xsl:template>
+
+<!-- The \printindex of the  imakeidx  package makes the division  -->
+<!-- heading itself, so a headnote cannot simply precede it.  The  -->
+<!-- package's \indexprologue stores the note, and \printindex     -->
+<!-- sets it after the heading and before the entries.             -->
+<xsl:template match="index/headnote" mode="index-prologue">
+    <xsl:text>\indexprologue{%&#xa;</xsl:text>
+    <xsl:apply-templates select="."/>
+    <xsl:text>}%&#xa;</xsl:text>
 </xsl:template>
 
 <!-- TEMPORARY (2024-08-11) (migrate to publisher)  -->
@@ -4119,9 +4153,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="type-name"/>
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
-    <!-- For references we open a list to hold "biblio" -->
-    <!-- unless we need to wait for an "introduction"   -->
-    <xsl:if test="self::references and not(introduction)">
+    <!-- For references we open a list to hold "biblio"  -->
+    <!-- unless we need to wait for an "introduction" or -->
+    <!-- a "headnote"                                    -->
+    <xsl:if test="self::references and not(introduction) and not(headnote)">
         <xsl:call-template name="open-reference-list"/>
     </xsl:if>
 </xsl:template>
@@ -4196,9 +4231,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
     <xsl:text>\end{introduction}%&#xa;</xsl:text>
-    <!-- We have not opened the list of references yet    -->
-    <!-- when it has an "introduction".  Now is the time. -->
-    <xsl:if test="parent::references">
+    <!-- We have not opened the list of references yet when  -->
+    <!-- it has an "introduction".  Now is the time, unless  -->
+    <!-- a "headnote" follows and defers the list once more. -->
+    <xsl:if test="parent::references and not(following-sibling::headnote)">
         <xsl:call-template name="open-reference-list"/>
     </xsl:if>
 </xsl:template>
@@ -9174,12 +9210,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
-<!-- TEMPORARILY: render a glossary "headnote" as an "introduction" -->
-<xsl:template match="glossary/headnote">
-    <xsl:text>%% this should be a new (isomorphic) "headnote" environment&#xa;</xsl:text>
-    <xsl:text>\begin{introduction}{}%&#xa;</xsl:text>
+<!-- A "headnote" prefaces the list of a list-like division; the -->
+<!-- index is special (see the "index-prologue" mode nearby its  -->
+<!-- division template), the other hosts render it in place      -->
+<xsl:template match="glossary/headnote|references/headnote|index/headnote|appendix/headnote">
+    <xsl:text>\begin{headnote}{}%&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
-    <xsl:text>\end{introduction}%&#xa;</xsl:text>
+    <xsl:text>\end{headnote}%&#xa;</xsl:text>
+    <!-- We have not opened the list of references yet when -->
+    <!-- a "headnote" intervenes.  Now is the time.         -->
+    <xsl:if test="parent::references">
+        <xsl:call-template name="open-reference-list"/>
+    </xsl:if>
 </xsl:template>
 
 <!-- Defined Terms, in a Glossary -->
@@ -9289,14 +9331,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and \bibitem seems comfortable there, so our source -->
 <!-- is nearly compatible with the usual usage           -->
 
-<!-- We open and close a single "referencelist" environment,    -->
-<!-- which we create in the preamble.  It opens right after     -->
-<!-- a "references" division, or after optional "introduction". -->
-<!-- It closes right before the "references" division closes,   -->
-<!-- or right before the "conclusion" begins.  The templates    -->
-<!-- below ensure consistency, and help with overrides.  You    -->
-<!-- can search on them to see the two pairs of scenarios       -->
-<!-- just described.                                            -->
+<!-- We open and close a single "referencelist" environment,      -->
+<!-- which we create in the preamble.  It opens right after a     -->
+<!-- "references" division, or after an optional "introduction"   -->
+<!-- or "headnote" (whichever comes last).  It closes right       -->
+<!-- before the "references" division closes, or right before the -->
+<!-- "conclusion" begins.  The templates below ensure             -->
+<!-- consistency, and help with overrides.  You can search on     -->
+<!-- them to see the pairs of scenarios just described.           -->
 
 <xsl:template name="open-reference-list">
     <xsl:text>%% If this is a top-level references&#xa;</xsl:text>


### PR DESCRIPTION
Closes #1048.  Closes #1251.

A `headnote` is the light prefatory note of a division whose content is
essentially one list.  A `glossary` has had the element since 2021; it
now serves the other three hosts: a `references`, an `index`, and an
`appendix` that is exactly a notation list.  Following the Guide's own
indexing advice (cited in #1048), a headnote is only necessary when
something about the list is unusual and deserves the reader's advance
attention.

Two deliberate scope choices.  A `solutions` division is excluded: it
already admits an `introduction`, and migrating it to a headnote would
be its own deprecation decision.  And `references` gains the headnote
*alongside* its existing optional `introduction` rather than replacing
it — the coexistence is transitional by intent, with a glossary-style
deprecation and repair of `references/introduction` anticipated as a
follow-up.

The commits:

- 0347003a (Schema) `index` becomes title, `headnote?`, `index-list`;
  `references` admits `headnote?` before its bibliography items; and
  both appendix models gain a third alternative — an appendix that is
  exactly `headnote?` plus `notation-list` (the #1251 shape).  The
  mixed placement of a `notation-list` among paragraphs stays legal.

- 1d475af5 (LaTeX) A real `headnote` environment, emitted only when a
  document has one, isomorphic to `introduction`, retiring the
  "TEMPORARILY render as an introduction" comment.  Two hosts needed
  care: the index headnote rides `imakeidx`'s `\indexprologue`, since
  `\printindex` manufactures the division heading itself and the note
  belongs after it; and the `references` division's `referencelist`
  environment now defers its opening past a headnote, extending the
  same idiom its `introduction` already used.

- d74d5dda (HTML) The one headnote template's match widens to all four
  hosts (`<section class="headnote">`); the generic division machinery
  places it in document order.  EPUB and braille inherit.  XSL-FO
  needed nothing at all — its `headnote` template already flows any
  host's content.

- 1c264607 (CSS) `.headnote` joins the spacing containers beside
  `.introduction` and `.conclusion` — which is the entirety of the
  modern introduction styling.  (Source only; the `css/dist` rebuild
  is the maintainer's.)

- 4a43c7f7 (Showcase) The alphabetization advice — formerly a bare `p`
  and the showcase's only validation error — is now a `headnote`.
  The showcase validates clean under both schemas.

- 09d48628 (Sample article) The index gains a demonstration headnote
  whose prose carries the principle: only necessary for an unusual
  index, which this one is not.

- ae77e9c5 (Guide) The indexing-advice paragraph gains the authoring
  sentence; the glossary topic names the other hosts; and the stale
  publisher line "a headnote can be accomplished with an
  `introduction`" now reads "a `headnote` renders between the heading
  and the entries."

Testing: schema regeneration idempotent; the sample article and the
showcase both validate at zero development-schema errors on this
branch; the Guide holds its two-error baseline.  The emitted LaTeX
differs in exactly the environment definition, the two glossary
environment switches (identical typesetting), and the index prologue;
the compiled PDF shows heading, then note, then entries, with the
index built by makeindex.  The two hosts the corpus lacks — a
references headnote and a pure notation-list appendix — were exercised
by temporary edits, compiled clean, and verified rendering correctly
(the references case is what surfaced, and fixed, the referencelist
deferral).  HTML before/after differs only in the index page's new
section, the theme's two new spacing selectors, and timestamps.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
