### PR TITLE
Sample coverage: exercise what the schema defines

### DIFF
--- a/examples/sample-article/gen/trace/regression-codelens.js
+++ b/examples/sample-article/gen/trace/regression-codelens.js
@@ -1,0 +1,12 @@
+
+if (allTraceData === undefined) {
+    var allTraceData = {};
+}
+(function() { // IIFE to avoid variable collision
+    let codelensID = "rs-regression-codelens";  //fallback
+    let partnerCodelens = document.currentScript.parentElement.querySelector(".pytutorVisualizer");
+    if (partnerCodelens) {
+        codelensID = partnerCodelens.id;
+    }
+    allTraceData[codelensID] = {"code": "a = 5\nb = a + 2\nc = a * b\n", "trace": [{"line": 1, "event": "step_line", "func_name": "<module>", "globals": {}, "ordered_globals": [], "stack_to_render": [], "heap": {}, "stdout": ""}, {"line": 2, "event": "step_line", "func_name": "<module>", "globals": {"a": 5}, "ordered_globals": ["a"], "stack_to_render": [], "heap": {}, "stdout": ""}, {"line": 3, "event": "step_line", "func_name": "<module>", "globals": {"a": 5, "b": 7}, "ordered_globals": ["a", "b"], "stack_to_render": [], "heap": {}, "stdout": "", "question": {"text": "What value is assigned to <code class=\"code-inline tex2jax_ignore\">c</code>?", "correctText": "35", "feedback": "Multiply the current values of <code class=\"code-inline tex2jax_ignore\">a</code> and <code class=\"code-inline tex2jax_ignore\">b</code>."}}, {"line": 3, "event": "return", "func_name": "<module>", "globals": {"a": 5, "b": 7, "c": 35}, "ordered_globals": ["a", "b", "c"], "stack_to_render": [], "heap": {}, "stdout": ""}], "startingInstruction": 1};
+})();

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -10364,6 +10364,51 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         </evaluate>
                     </evaluation>
                 </exercise>
+
+                <exercise label="fillin-remaining-machinery">
+                    <title>Fill-In, Remaining Machinery</title>
+                    <statement>
+                        <p>Let <m>n = <eval obj="n"/></m>.  Enter either <m>n</m> or its negative: <fillin mode="number" name="plusminus" width="5"/>.</p>
+                    </statement>
+                    <setup seed="1234">
+                        <de-object name="n" context="number">
+                            <de-random distribution="discrete" min="2" max="5"/>
+                        </de-object>
+                        <postRenderScript>
+                            // a hook run after the exercise renders; deliberately inert
+                        </postRenderScript>
+                    </setup>
+                    <evaluation>
+                        <evaluate>
+                            <test correct="yes">
+                                <logic op="or">
+                                    <mathcmp>
+                                        <eval obj="n"/>
+                                    </mathcmp>
+                                    <mathcmp>
+                                        <de-evaluate reduce="yes">
+                                            <formula>
+                                                <de-expression mode="formula">{{n}}*x</de-expression>
+                                            </formula>
+                                            <variable name="x">
+                                                <de-number>-1</de-number>
+                                            </variable>
+                                        </de-evaluate>
+                                    </mathcmp>
+                                </logic>
+                            </test>
+                            <test>
+                                <de-expression context="number" mode="formula" reduce="yes">2*{{n}}</de-expression>
+                                <feedback>
+                                    <p>Twice the value is neither the value nor its negative.</p>
+                                </feedback>
+                            </test>
+                        </evaluate>
+                    </evaluation>
+                    <solution include-automatic="no">
+                        <p>Both <m><eval obj="n"/></m> and its negative are accepted; the automatic solution is declined in favor of this sentence.</p>
+                    </solution>
+                </exercise>
             </exercises>
         </section>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -17780,6 +17780,243 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </references>
         </section>
 
+        <section xml:id="section-runestone-components" label="section-runestone-components">
+            <title>Runestone Components</title>
+            <idx>Runestone components</idx>
+
+            <p>One of each interactive Runestone component, each with a moderately complicated set of attributes and features, so this article can serve as a regression test for the whole collection.  The final chapter of the sample book is the comprehensive tour, with many variants of each component; here one representative apiece suffices.  Fill-in exercises, in both the dynamic and the legacy styles, are exercised thoroughly at <xref ref="section-dynamic-exercises"/> and so are not repeated here.  Note that many of these components render, and function, in ordinary offline HTML; a Runestone server adds grading and persistence.</p>
+
+            <exercise xml:id="regression-truefalse" label="regression-truefalse">
+                <title>True/False, a True Statement</title>
+                <statement correct="yes">
+                    <p>The square of a real number is never negative.</p>
+                </statement>
+                <feedback>
+                    <p>Squaring preserves the sign of zero and erases the sign of everything else.</p>
+                </feedback>
+                <hint>
+                    <p>Consider the three cases: negative, zero, positive.</p>
+                </hint>
+            </exercise>
+
+            <exercise xml:id="regression-multiplechoice" label="regression-multiplechoice">
+                <title>Multiple Choice, Several Correct, Randomized</title>
+                <statement>
+                    <p>Which of the following are prime numbers?</p>
+                </statement>
+                <choices randomize="yes" multiple-correct="yes">
+                    <choice correct="yes">
+                        <statement>
+                            <p><m>2</m></p>
+                        </statement>
+                        <feedback>
+                            <p>The only even prime.</p>
+                        </feedback>
+                    </choice>
+                    <choice>
+                        <statement>
+                            <p><m>1</m></p>
+                        </statement>
+                        <feedback>
+                            <p>A unit, by convention not a prime.</p>
+                        </feedback>
+                    </choice>
+                    <choice correct="yes">
+                        <statement>
+                            <p><m>17</m></p>
+                        </statement>
+                        <feedback>
+                            <p>Indeed, no divisors but <m>1</m> and itself.</p>
+                        </feedback>
+                    </choice>
+                </choices>
+            </exercise>
+
+            <exercise label="regression-parsons" language="python" adaptive="yes" indentation="hide">
+                <title>Parsons, Vertical, Partial Ordering</title>
+                <statement>
+                    <p>Arrange the blocks to define a function and then call it.  There is more than one correct order, a paired distractor, and an unneeded block.</p>
+                </statement>
+                <blocks>
+                    <block order="3" name="define">
+                        <cline>def double(x):</cline>
+                        <cline>    return 2 * x</cline>
+                    </block>
+                    <block order="1" name="input" depends="define">
+                        <choice correct="yes">
+                            <cline>n = int(input())</cline>
+                        </choice>
+                        <choice>
+                            <cline>n = input()</cline>
+                        </choice>
+                    </block>
+                    <block order="2" depends="input">
+                        <cline>print(double(n))</cline>
+                    </block>
+                    <block order="4" correct="no">
+                        <cline>import antigravity</cline>
+                    </block>
+                </blocks>
+            </exercise>
+
+            <exercise label="regression-parsons-horizontal" language="natural">
+                <title>Parsons, Horizontal, Reused Blocks</title>
+                <statement>
+                    <p>Assemble a familiar proverb.  Two of the blocks are each used twice.</p>
+                </statement>
+                <blocks layout="horizontal" randomize="yes" reuse="yes">
+                    <block xml:id="regression-block-early">early</block>
+                    <block xml:id="regression-block-to">to</block>
+                    <block ref="regression-block-early" order="1"/>
+                    <block ref="regression-block-to" order="2"/>
+                    <block order="3">bed</block>
+                    <block order="4">and</block>
+                    <block ref="regression-block-early" order="5"/>
+                    <block ref="regression-block-to" order="6"/>
+                    <block order="7">rise</block>
+                </blocks>
+            </exercise>
+
+            <exercise label="regression-cardsort">
+                <title>Cardsort, with Distractors</title>
+                <statement>
+                    <p>Sort each function by its growth rate.  One category has no members, and one function fits no category.</p>
+                </statement>
+                <cardsort>
+                    <match>
+                        <response>Polynomial</response>
+                        <premise order="2"><m>n^2</m></premise>
+                        <premise order="4"><m>100 n^3</m></premise>
+                    </match>
+                    <match>
+                        <response>Exponential</response>
+                        <premise order="1"><m>2^n</m></premise>
+                    </match>
+                    <match>
+                        <response>Constant</response>
+                    </match>
+                    <match>
+                        <premise order="3"><m>n \log n</m></premise>
+                    </match>
+                </cardsort>
+            </exercise>
+
+            <exercise label="regression-matching">
+                <title>Matching, Premises with References</title>
+                <statement>
+                    <p>Match each derivative rule to its name.  One rule matches two names.</p>
+                </statement>
+                <matching>
+                    <premise ref="regression-response-product"><m>(fg)' = f'g + fg'</m></premise>
+                    <premise ref="regression-response-chain regression-response-composite"><m>(f \circ g)' = (f' \circ g) \cdot g'</m></premise>
+                    <response xml:id="regression-response-product" order="2">Product Rule</response>
+                    <response xml:id="regression-response-chain" order="1">Chain Rule</response>
+                    <response xml:id="regression-response-composite" order="3">Composite Rule</response>
+                </matching>
+            </exercise>
+
+            <exercise label="regression-clickablearea">
+                <title>Clickable Areas, Code</title>
+                <statement>
+                    <p>Click every line that mutates the list <c>data</c>.</p>
+                </statement>
+                <areas language="python">
+                    <cline>data = [3, 1, 2]</cline>
+                    <cline><area>data.sort()</area></cline>
+                    <cline><area correct="no">total = sum(data)</area></cline>
+                    <cline><area>data.append(total)</area></cline>
+                </areas>
+                <feedback>
+                    <p>Reading a list is not mutating it.</p>
+                </feedback>
+            </exercise>
+
+            <exercise label="regression-select">
+                <title>Select, an A/B Experiment</title>
+                <select grade="ab-experiment" experiment-name="sample-article-regression" questions="regression-truefalse regression-multiplechoice"/>
+            </exercise>
+
+            <exercise label="regression-shortanswer" attachment="yes">
+                <title>Short Answer, with Attachment</title>
+                <statement>
+                    <p>Describe, in a sentence or two, the difference between a sequence and a series.  Attach a photograph of your handwritten scratch work.</p>
+                </statement>
+                <response/>
+            </exercise>
+
+            <exercise label="regression-activecode">
+                <title>ActiveCode, Decorated</title>
+                <statement>
+                    <p>Run the program, then modify the highlighted line so it counts down instead.</p>
+                </statement>
+                <program label="regression-activecode-program" interactive="activecode" language="python" line-numbers="yes" highlight-lines="2" download="yes">
+                    <code>
+                    for i in range(5):
+                        print(i)
+                    </code>
+                </program>
+            </exercise>
+
+            <exercise label="regression-codelens">
+                <title>CodeLens, with a Checkpoint</title>
+                <statement>
+                    <p>Step the visualization and answer the question it poses.</p>
+                </statement>
+                <program label="regression-codelens-program" interactive="codelens" language="python" starting-step="2">
+                    <code>
+                    a = 5
+                    b = a + 2
+                    c = a * b
+                    </code>
+                    <checkpoint line="3" answer="35">
+                        <prompt>What value is assigned to <c>c</c>?</prompt>
+                        <feedback>Multiply the current values of <c>a</c> and <c>b</c>.</feedback>
+                    </checkpoint>
+                </program>
+            </exercise>
+
+            <query label="regression-query" visibility="all">
+                <statement>
+                    <p>Which topic in this article did you find most challenging?</p>
+                </statement>
+                <choices>
+                    <choice>
+                        <p>The Fundamental Theorem</p>
+                    </choice>
+                    <choice>
+                        <p>Displayed mathematics</p>
+                    </choice>
+                    <choice>
+                        <p>Table calisthenics</p>
+                    </choice>
+                </choices>
+            </query>
+
+            <datafile label="regression-datafile" xml:id="regression-datafile" filename="regression.csv" editable="no" hide="yes" rows="4" cols="30">
+                <pre>
+                x,y
+                1,1
+                2,4
+                3,9
+                </pre>
+            </datafile>
+
+            <exercise xml:id="regression-dual" label="regression-dual">
+                <title>A Dual Exercise (Experimental)</title>
+                <dynamic>
+                    <statement>
+                        <p>Work the embedded exercise.</p>
+                        <interactive label="regression-dual-interactive" iframe="https://opendsax.cs.vt.edu/OpenDSA/Exercises/List/AlistInsertPRO.html" width="100%"/>
+                    </statement>
+                </dynamic>
+                <static>
+                    <statement>
+                        <p>An exercise about array-based list insertion goes here, in an output with no interaction.</p>
+                    </statement>
+                </static>
+            </exercise>
+        </section>
+
         <exercises xml:id="exercises" label="exercises-top-level">
             <title>Exercises, Top-Level</title>
 

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2606,6 +2606,33 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                         <p>The proof of the theorem.</p>
                     </proof>
                 </theorem>
+                <theorem>
+                    <title>A title</title>
+                    <statement>
+                        <p>A theorem with an <tag>argument</tag>, a proof-like alternate.</p>
+                    </statement>
+                    <argument>
+                        <p>The argument for the theorem.</p>
+                    </argument>
+                </theorem>
+                <theorem>
+                    <title>A title</title>
+                    <statement>
+                        <p>A theorem with a <tag>reasoning</tag>, a proof-like alternate.</p>
+                    </statement>
+                    <reasoning>
+                        <p>The reasoning for the theorem.</p>
+                    </reasoning>
+                </theorem>
+                <theorem>
+                    <title>A title</title>
+                    <statement>
+                        <p>A theorem with an <tag>explanation</tag>, a proof-like alternate.</p>
+                    </statement>
+                    <explanation>
+                        <p>The explanation of the theorem.</p>
+                    </explanation>
+                </theorem>
                 <corollary>
                     <title>A title</title>
                     <p>A minimal <tag>corollary</tag>.</p>

--- a/examples/sample-book/rune.xml
+++ b/examples/sample-book/rune.xml
@@ -3504,14 +3504,14 @@ TEST_CASE( "Test the add function" ) {
             </blocks>
             <!-- note that the blank lines in pre and postabmbles are intentional to -->
             <!-- separate those from user code, but you might not always want them   -->
-            <program-preamble>
+            <program-preamble indent="4">
                 print("Using your code to isolate the red in the Golden Gate Bridge image.")
                 import image
 
             </program-preamble>
             <!-- the program is empty as its contents will be replaced by student code -->
             <program datafile="golden-gate.png" codelens="no"/>
-            <program-postamble>
+            <program-postamble indent="4">
 
                 img = image.Image("golden-gate.png")
                 win = image.ImageWin(img.getWidth(), img.getHeight())
@@ -4184,7 +4184,7 @@ TEST_CASE( "Test the add function" ) {
 
         <p>We begin with standalone queries, using the <tag>query</tag> element.  Runestone calls these <term>polls</term>.   We plan structures/blocks such as <tag>poll</tag>, <tag>survey</tag>, and <tag>questionnaire</tag>, that will be structured collections of <tag>query</tag>.</p>
 
-        <query label="stoplight-query">
+        <query label="stoplight-query" visibility="all">
             <statement>
                 <p>In my town, the stoplights have:</p>
             </statement>
@@ -4973,11 +4973,26 @@ TEST_CASE( "Test the add function" ) {
                 </hint>
             </task>
 
-            <task label="short-answer-task-in-exercises">
+            <task label="short-answer-task-in-exercises" attachment="yes">
                 <statement>
                     <p>Explain your reasoning in the previous question.</p>
                 </statement>
                 <response/>
+            </task>
+
+            <task label="parsons-task-in-exercises" language="python" adaptive="yes" indentation="hide">
+                <title>Parsons Problem, as a Task</title>
+                <statement>
+                    <p>A Parsons problem hosted by a <tag>task</tag>, carrying its language, adaptivity, and indentation attributes there.</p>
+                </statement>
+                <blocks>
+                    <block order="2">
+                        <cline>x = 3</cline>
+                    </block>
+                    <block order="1">
+                        <cline>print(x)</cline>
+                    </block>
+                </blocks>
             </task>
 
             <conclusion>
@@ -6017,7 +6032,7 @@ TEST_CASE( "Test the add function" ) {
         </figure>
     </section>
 
-    <exercises xml:id="chapter-exam" label="chapter-exam" time-limit="15" pause="yes">
+    <exercises xml:id="chapter-exam" label="chapter-exam" time-limit="15" pause="yes" results="no" timer="no" feedback="no">
         <title>Timed Chapter Exam</title>
 
         <introduction>

--- a/xsl/pretext-runestone-static.xsl
+++ b/xsl/pretext-runestone-static.xsl
@@ -644,15 +644,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- The flow variant serves natural-language blocks: the children  -->
 <!-- of a block are "p", whose contents join the running line, so   -->
 <!-- mathematics and other markup process normally.                 -->
+<!-- A natural-language block may wrap its content in a "p", or -->
+<!-- carry short inline content directly; the flow copy handles -->
+<!-- both shapes, following @ref to a reused source block first -->
 <xsl:template match="blocks/block" mode="static-horizontal-block-flow">
+    <xsl:variable name="the-block" select="id(@ref)|self::*[not(@ref)]"/>
     <xsl:choose>
-        <!-- follow @ref, copy paragraph contents -->
-        <xsl:when test="@ref">
-            <xsl:copy-of select="id(@ref)/p/node()"/>
+        <xsl:when test="$the-block/p">
+            <xsl:copy-of select="$the-block/p/node()"/>
         </xsl:when>
-        <!-- otherwise duplicate paragraph contents -->
         <xsl:otherwise>
-            <xsl:copy-of select="p/node()"/>
+            <xsl:copy-of select="$the-block/node()"/>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
The samples now validate nearly clean, so this branch runs the check in
reverse: what does the development schema define that the sample
article and sample book never exercise?  A small analysis tool (RELAX-NG
parsed with define/ref resolution, three passes: elements never used,
attributes never used, enumerated values never used) drove the work.
The score, before and after: unexercised elements five, now one
("address", which lives in letters and memos, outside these samples);
unexercised attributes fourteen, now two thin task variants; every
remaining enumerated-value miss is a default-equivalent value,
deliberately exempt.

The inversion also caught a real bug, fixed first so every commit
builds correctly:

- 48254011 (Runestone) The static form of a natural-language
  horizontal Parsons rendered blocks of bare text as empty bars: the
  flow copy selected only a block's "p" content, and short blocks are
  legitimately authored as bare inline text (the sample book's
  font-sample proverb had the same latent defect).  The copy now
  follows @ref to a reused source block, then takes the "p" content
  when there is one, and the node content otherwise.

- 0f2fcd45 (Sample book) The untested attributes land in the final
  chapter, keeping its author-facing spirit: the chapter exam turns
  off results, timer, and feedback; the runnable Parsons preambles
  carry @indent; a poll makes its results visible to all; the
  short-answer task requests an attachment; and a new Parsons hosted
  by a "task" carries its language, adaptivity, and indentation
  attributes at the task level.  All verified flowing into their
  data attributes in a Runestone-hosted build.

- a1fa0422 (Sample article) The three never-used proof-like
  alternates — "argument", "reasoning", "explanation" — demonstrated
  beside their "proof" sibling in the theorem gallery.

- 39f163fe (Sample article) One compact dynamic fill-in carrying
  everything that model defined but no sample used: a
  "postRenderScript" hook, "de-evaluate" with @reduce,
  "de-expression" with @context="number", disjunctive logic
  (@op="or"), and a hand-written solution declining the automatic one
  (@include-automatic="no").

- 1ed5fc07 (Sample article) A new section, "Runestone Components":
  one of each interactive component with a moderately complicated set
  of attributes, so the article serves as a regression tester for the
  whole collection while the sample book's final chapter remains the
  comprehensive tour.  True/false (a true statement, at last),
  multi-correct randomized multiple choice, an adaptive vertical
  Parsons with partial ordering and a paired distractor, a horizontal
  Parsons with genuinely reused blocks, a cardsort with both kinds of
  distractor, matching with a premise carrying two references,
  clickable code areas, an A/B-experiment select, short answer with
  attachment, decorated ActiveCode, CodeLens with a checkpoint and a
  starting step (its trace generated and committed), a public-results
  poll, a hidden datafile, and a minimal dual.  Verified in HTML
  (every data-component present; select and short answer correctly
  host-gated) and in the compiled PDF (all static forms, no errors).

No WeBWorK was added anywhere — the WeBWorK sample chapter is its own
home, and a survey of it is reported separately: it carries 57
development-schema errors of its own, its authored form="array" is
absent from the schema's enumeration (a gap in the reverse direction),
and the "@copy" mechanism plus "pg-macros" are never exercised — a
ready follow-up in the same spirit.

Testing: the sample article validates at zero development-schema
errors and the sample book holds its single sanctioned residue; the
new section renders interactively in HTML and statically in a clean
xelatex PDF; the Runestone-hosted build of the book confirms the
gated attributes.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
