### PR TITLE
A "references" preface is a "headnote", nothing more

### DIFF
--- a/examples/errors/sample-errors-and-warnings.xml
+++ b/examples/errors/sample-errors-and-warnings.xml
@@ -1280,6 +1280,22 @@ m \begin{bmatrix}2 \\ 5\end{bmatrix} = \begin{bmatrix}3 \\ 7\end{bmatrix}
 
 
         <backmatter>
+            <!-- 2026-08-06: both companions deprecated, each provokes -->
+            <!-- a warning; repair converts the "introduction" to a    -->
+            <!-- "headnote" (discarding its "title") and drops the     -->
+            <!-- "conclusion" entirely                                 -->
+            <references>
+                <title>Deprecated References Companions</title>
+                <introduction>
+                    <title>A Discarded Title</title>
+                    <p>This preface survives repair as a headnote, but its title is discarded.</p>
+                </introduction>
+                <biblio type="raw" xml:id="biblio-deprecated-companions">An Author, <title>A Fine Book</title>, A Publisher, 2026.</biblio>
+                <conclusion>
+                    <p>This conclusion is discarded entirely by the repair.</p>
+                </conclusion>
+            </references>
+
             <!-- need an index to provoke error warnings above -->
             <index>
                 <title>Index</title>

--- a/examples/numbering/main.ptx
+++ b/examples/numbering/main.ptx
@@ -433,22 +433,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- specialized: references -->
                 <references xml:id="rfs-chB">
                     <title>Chapter B References</title>
-                    <introduction>
+                    <headnote>
                         <p>Introduction to chapter B references<fn xml:id="fn-rfs-chB">A footnote in a references introduction.</fn>.</p>
                         <p><md><mrow xml:id="eq-intro-1-rfs-chB" number="yes">BB_1 = CC_1</mrow></md></p>
                         <p><md><mrow xml:id="eq-intro-2-rfs-chB" number="yes">BB_2 = CC_2</mrow></md></p>
-                    </introduction>
+                    </headnote>
                     <biblio xml:id="bib-1-chB" type="raw">
                         <title>First reference in chapter B.</title>
                     </biblio>
                     <biblio xml:id="bib-2-chB" type="raw">
                         <title>Second reference in chapter B.</title>
                     </biblio>
-                    <conclusion>
-                        <p>End of chapter B references.</p>
-                        <p><md><mrow xml:id="eq-concl-1-rfs-chB" number="yes">DD_1 = EE_1</mrow></md></p>
-                        <p><md><mrow xml:id="eq-concl-2-rfs-chB" number="yes">DD_2 = EE_2</mrow></md></p>
-                    </conclusion>
                 </references>
 
                 <!-- specialized: glossary -->
@@ -587,19 +582,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
                     <references xml:id="rfs-chC-sB">
                         <title>Section B References</title>
-                        <introduction>
+                        <headnote>
                             <p>Introduction to section B references.</p>
                             <p><md><mrow xml:id="eq-intro-1-rfs-chC-sB" number="yes">NN_1 = OO_1</mrow></md></p>
                             <p><md><mrow xml:id="eq-intro-2-rfs-chC-sB" number="yes">NN_2 = OO_2</mrow></md></p>
-                        </introduction>
+                        </headnote>
                         <biblio xml:id="bib-1-chC-sB" type="raw">
                             <title>A reference.</title>
                         </biblio>
-                        <conclusion>
-                            <p>End of section B references.</p>
-                            <p><md><mrow xml:id="eq-concl-1-rfs-chC-sB" number="yes">PP_1 = QQ_1</mrow></md></p>
-                            <p><md><mrow xml:id="eq-concl-2-rfs-chC-sB" number="yes">PP_2 = QQ_2</mrow></md></p>
-                        </conclusion>
                     </references>
 
                     <glossary xml:id="gls-chC-sB">
@@ -1148,22 +1138,17 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <!-- but its biblio entries are numbered within it.              -->
             <references xml:id="refs-bm">
                 <title>Bibliography</title>
-                <introduction>
+                <headnote>
                     <p>Introduction to the backmatter references.</p>
                     <p><md><mrow xml:id="eq-intro-1-refs-bm" number="yes">ZZZ_1 = AAAA_1</mrow></md></p>
                     <p><md><mrow xml:id="eq-intro-2-refs-bm" number="yes">ZZZ_2 = AAAA_2</mrow></md></p>
-                </introduction>
+                </headnote>
                 <biblio xml:id="bib-1-bm" type="raw">
                     <title>First backmatter reference.</title>
                 </biblio>
                 <biblio xml:id="bib-2-bm" type="raw">
                     <title>Second backmatter reference.</title>
                 </biblio>
-                <conclusion>
-                    <p>End of backmatter references.</p>
-                    <p><md><mrow xml:id="eq-concl-1-refs-bm" number="yes">BBBB_1 = CCCC_1</mrow></md></p>
-                    <p><md><mrow xml:id="eq-concl-2-refs-bm" number="yes">BBBB_2 = CCCC_2</mrow></md></p>
-                </conclusion>
             </references>
 
             <index xml:id="the-index">

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5417,9 +5417,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <title>References</title>
                 <idx><h>references</h><h>within a section</h></idx>
 
-                <introduction>
-                    <p>These items are here to test basic formatting of references.</p>
-                </introduction>
+                <headnote>
+                    <p>These items are here to test basic formatting of references.  Did you see that the entry for <xref ref="biblio-beezer-fcla"/> has a short annotation?  So you can make annotated bibliographies easily.</p>
+                </headnote>
 
                 <biblio type="raw" xml:id="biblio-strang-article">Gilbert Strang, <title>The Fundamental Theorem of Linear Algebra</title>, <journal>The American Mathematical Monthly</journal> November 1993, <volume>100</volume> <number>9</number>, 848<ndash/>855.</biblio>
 
@@ -5450,10 +5450,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <biblio type="raw" xml:id="biblio-rosswell-fictional">Alexander Rosswell, <title>Diffeomorphisms of Penciled Fiber Bundles</title>, <journal>Mathematicians of America</journal> <year>2020</year>, <volume>2</volume> <number>6</number>, 884<ndash/>888.</biblio>
 
                 <biblio type="raw" xml:id="biblio-rosswell-fictional-two"><ibid/>, <title>Diffeomorphisms of Penciled Fiber Bundles, Part 2</title>, <journal>Mathematicians of America</journal> <year>2021</year>, <volume>3</volume> <number>4</number>, 102<ndash/>103.</biblio>
-
-                <conclusion>
-                    <p>This is a conclusion, which has not been used very much in this sample.  Did you see that the entry for <xref ref="biblio-beezer-fcla"/> has a short annotation?  So you can make annotated bibliographies easily.</p>
-                </conclusion>
             </references>
 
         </section>
@@ -17086,9 +17082,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <references>
                 <title>More Reading</title>
 
-                <introduction>
+                <headnote>
                     <p>Left intentionally blank, just checking sectioning.</p>
-                </introduction>
+                </headnote>
 
                 <biblio type="raw" xml:id="biblio-lay-article-repeat2">David C. Lay, <title>Subspaces and Echelon Forms</title>. <journal>The College Mathematics Journal</journal>, January 1993, <volume>24</volume> <number>1</number>, 57<ndash/>62.</biblio>
 
@@ -17400,9 +17396,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <references>
                 <title>More Reading</title>
 
-                <introduction>
+                <headnote>
                     <p>Left intentionally blank, just checking sectioning.</p>
-                </introduction>
+                </headnote>
 
                 <biblio type="raw" xml:id="biblio-lay-article-repeat1">David C. Lay, <title>Subspaces and Echelon Forms</title>. <journal>The College Mathematics Journal</journal>, January 1993, <volume>24</volume> <number>1</number>, 57<ndash/>62.</biblio>
 
@@ -17426,9 +17422,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <references xml:id="references-raw" label="references-raw">
                 <title>Raw Entries</title>
-                <introduction>
+                <headnote>
                     <p>The twelve references as <c>type="raw"</c> entries.</p>
-                </introduction>
+                </headnote>
 
                 <biblio xml:id="raw-judson" type="raw">Thomas W. Judson, <title>Abstract Algebra: Theory and Applications</title>, Orthogonal Publishing, Ann Arbor, MI, 2022.</biblio>
 
@@ -17457,9 +17453,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <references xml:id="references-bibtex" label="references-bibtex">
                 <title>BibTeX-Style Entries</title>
-                <introduction>
+                <headnote>
                     <p>The twelve references as <c>type="bibtex"</c> entries.</p>
-                </introduction>
+                </headnote>
 
                 <biblio xml:id="bibtex-judson" type="bibtex">
                     <author>Thomas W. Judson</author>
@@ -17564,9 +17560,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             <references xml:id="references-csl" label="references-csl">
                 <title>CSL-Style Entries</title>
-                <introduction>
+                <headnote>
                     <p>The twelve references as CSL-style entries.</p>
-                </introduction>
+                </headnote>
 
                 <biblio xml:id="csl-judson" type="book">
                     <author>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -413,13 +413,13 @@
                     IntroductionDivision?,
                     ConclusionDivision?
                 }
+            # A "references" is a list-like division: its one preface
+            # is a "headnote", and it has no "conclusion"
             References =
                 element references {
                     MetaDataAltTitleOptional,
-                    IntroductionDivision?,
                     HeadNote?,
-                    BibliographyItem+,
-                    ConclusionDivision?
+                    BibliographyItem+
                 }
             Glossary =
                 element glossary {

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1217,21 +1217,19 @@
       </optional>
     </element>
   </define>
+  <!--
+    A "references" is a list-like division: its one preface
+    is a "headnote", and it has no "conclusion"
+  -->
   <define name="References">
     <element name="references">
       <ref name="MetaDataAltTitleOptional"/>
-      <optional>
-        <ref name="IntroductionDivision"/>
-      </optional>
       <optional>
         <ref name="HeadNote"/>
       </optional>
       <oneOrMore>
         <ref name="BibliographyItem"/>
       </oneOrMore>
-      <optional>
-        <ref name="ConclusionDivision"/>
-      </optional>
     </element>
   </define>
   <define name="Glossary">

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -4105,7 +4105,6 @@
             <fragref ref="frontmatter-dev"/>
             <fragref ref="proof-like"/>
             <fragref ref="solutions-dev"/>
-            <fragref ref="reference-dev"/>
             <fragref ref="exercise-dev"/>
             <code>
                 }

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -375,13 +375,13 @@
                     IntroductionDivision?,
                     ConclusionDivision?
                 }
+            # A "references" is a list-like division: its one preface
+            # is a "headnote", and it has no "conclusion"
             References =
                 element references {
                     MetaDataAltTitleOptional,
-                    IntroductionDivision?,
                     HeadNote?,
-                    BibliographyItem+,
-                    ConclusionDivision?
+                    BibliographyItem+
                 }
             Glossary =
                 element glossary {

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3548,6 +3548,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- never summary pages (the situation that demands the heading)    -->
 <xsl:template match="introduction[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title|conclusion[parent::article or parent::chapter or parent::appendix or parent::section or parent::subsection]/title" mode="repair"/>
 
+<!-- 2026-08-06  a "references" preface is a "headnote" -->
+
+<!-- The "introduction" becomes a "headnote", which never carries a  -->
+<!-- "title", so any title is discarded; the deprecation warning     -->
+<!-- says so plainly                                                 -->
+<xsl:template match="references/introduction" mode="repair">
+    <headnote>
+        <xsl:apply-templates select="node()[not(self::title)]|@*" mode="repair"/>
+    </headnote>
+</xsl:template>
+
+<!-- A "references" has no "conclusion": the element is dropped -->
+<!-- whole, and the deprecation warning says so plainly         -->
+<xsl:template match="references/conclusion" mode="repair"/>
+
 <!-- ########## -->
 <!-- Enrichment -->
 <!-- ########## -->

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -2834,7 +2834,7 @@ Book (with parts), "section" at level 3
     <xsl:value-of select="true()"/>
 </xsl:template>
 <!-- Introductions and Conclusions -->
-<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction|glossary/introduction|references/introduction|article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion|glossary/conclusion|references/conclusion" mode="title-wants-punctuation">
+<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction|article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion" mode="title-wants-punctuation">
     <xsl:value-of select="true()"/>
 </xsl:template>
 <xsl:template match="*" mode="title-wants-punctuation">

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11987,6 +11987,20 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'a footnote (&quot;fn&quot;) within a &quot;tabular&quot; cell is now a table note, the &quot;tn&quot; element, lettered and placed at the bottom of the table.  We will honor your intent, but please convert to &quot;tn&quot;.  Note that a table note is not part of the numbering of true footnotes, and is not a target for a cross-reference.'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- 2026-08-06  references "introduction" is now a "headnote" -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//references/introduction&quot;" />
+        <xsl:with-param name="date-string" select="'2026-08-06'" />
+        <xsl:with-param name="message" select="'a &quot;references&quot; &quot;introduction&quot; is now a &quot;headnote&quot;.  We will attempt to fix your source, but a &quot;title&quot; on such an &quot;introduction&quot; is discarded entirely: its text will not appear in any output.  Please convert to a &quot;headnote&quot; yourself'"/>
+    </xsl:call-template>
+    <!--  -->
+    <!-- 2026-08-06  references "conclusion" is obsolete -->
+    <xsl:call-template name="deprecation-message">
+        <xsl:with-param name="occurrences" select="&quot;$document-root//references/conclusion&quot;" />
+        <xsl:with-param name="date-string" select="'2026-08-06'" />
+        <xsl:with-param name="message" select="'a &quot;references&quot; division no longer has a &quot;conclusion&quot;.  The element is discarded entirely: its content will not appear in any output.  Please relocate the content, perhaps following the &quot;references&quot;'"/>
+    </xsl:call-template>
+    <!--  -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/pretext-latex-classic.xsl
+++ b/xsl/pretext-latex-classic.xsl
@@ -683,7 +683,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Introductions and Conclusions -->
 <!-- Introductions and conclusions are just their contents at their position. -->
-<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|reading-questions/introduction|references/introduction">
+<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|reading-questions/introduction">
     <xsl:text>% Introduction&#xa;</xsl:text>
     <!-- an authored @xml:id suggests a cross-reference target -->
     <xsl:if test="@xml:id">
@@ -694,7 +694,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>% end of introduction&#xa;</xsl:text>
 </xsl:template>
 
-<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|reading-questions/conclusion|references/conclusion">
+<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|reading-questions/conclusion">
     <xsl:text>% Conclusion&#xa;</xsl:text>
     <!-- an authored @xml:id suggests a cross-reference target -->
     <xsl:if test="@xml:id">

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -1969,8 +1969,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:for-each>
     <!-- INTRODUCTION, CONCLUSION (divisional) -->
     <xsl:variable name="introduction-reps" select="
-        ($root/article/introduction|$document-root//chapter/introduction|$document-root//section/introduction|$document-root//subsection/introduction|$document-root//appendix/introduction|$document-root//exercises/introduction|$document-root//solutions/introduction|$document-root//worksheet/introduction|$document-root//handout/introduction|$document-root//reading-questions/introduction|$document-root//glossary/introduction|$document-root//references/introduction)[1]|
-        ($root/article/conclusion|$document-root//chapter/conclusion|$document-root//section/conclusion|$document-root//subsection/conclusion|$document-root//appendix/conclusion|$document-root//exercises/conclusion|$document-root//solutions/conclusion|$document-root//worksheet/conclusion|$document-root//handout/conclusion|$document-root//handout/conclusion|$document-root//reading-questions/conclusion|$document-root//glossary/conclusion|$document-root//references/conclusion)[1]"/>
+        ($root/article/introduction|$document-root//chapter/introduction|$document-root//section/introduction|$document-root//subsection/introduction|$document-root//appendix/introduction|$document-root//exercises/introduction|$document-root//solutions/introduction|$document-root//worksheet/introduction|$document-root//handout/introduction|$document-root//reading-questions/introduction)[1]|
+        ($root/article/conclusion|$document-root//chapter/conclusion|$document-root//section/conclusion|$document-root//subsection/conclusion|$document-root//appendix/conclusion|$document-root//exercises/conclusion|$document-root//solutions/conclusion|$document-root//worksheet/conclusion|$document-root//handout/conclusion|$document-root//reading-questions/conclusion)[1]"/>
     <xsl:if test="$introduction-reps">
         <xsl:text>%%&#xa;</xsl:text>
         <xsl:text>%% xparse environments for introductions and conclusions of divisions&#xa;</xsl:text>
@@ -4153,10 +4153,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="type-name"/>
         <xsl:text>}&#xa;</xsl:text>
     </xsl:if>
-    <!-- For references we open a list to hold "biblio"  -->
-    <!-- unless we need to wait for an "introduction" or -->
-    <!-- a "headnote"                                    -->
-    <xsl:if test="self::references and not(introduction) and not(headnote)">
+    <!-- For references we open a list to hold "biblio" -->
+    <!-- unless we need to wait for a "headnote"         -->
+    <xsl:if test="self::references and not(headnote)">
         <xsl:call-template name="open-reference-list"/>
     </xsl:if>
 </xsl:template>
@@ -4196,9 +4195,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Footings are straightforward -->
 <xsl:template match="part|chapter|appendix|section|subsection|subsubsection|acknowledgement|foreword|preface|exercises|solutions|reading-questions|glossary|references|index|worksheet|handout" mode="latex-division-footing">
-    <!-- For references we close a list holding "biblio"    -->
-    <!-- unless we already added it before the "conclusion" -->
-    <xsl:if test="self::references and not(conclusion)">
+    <!-- For references we close a list holding "biblio" -->
+    <xsl:if test="self::references">
         <xsl:call-template name="close-reference-list"/>
     </xsl:if>
 
@@ -4219,7 +4217,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Title optional (and discouraged), in argument    -->
 <!-- typically just a few paragraphs                  -->
 <!-- NB: a glossary has a "headnote" (elsewhere) and does not have a "conclusion" -->
-<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction|references/introduction">
+<xsl:template match="article/introduction|chapter/introduction|section/introduction|subsection/introduction|appendix/introduction|exercises/introduction|solutions/introduction|worksheet/introduction|handout/introduction|reading-questions/introduction">
     <xsl:text>\begin{introduction}</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:apply-templates select="." mode="title-full" />
@@ -4231,20 +4229,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>%&#xa;</xsl:text>
     <xsl:apply-templates select="*"/>
     <xsl:text>\end{introduction}%&#xa;</xsl:text>
-    <!-- We have not opened the list of references yet when  -->
-    <!-- it has an "introduction".  Now is the time, unless  -->
-    <!-- a "headnote" follows and defers the list once more. -->
-    <xsl:if test="parent::references and not(following-sibling::headnote)">
-        <xsl:call-template name="open-reference-list"/>
-    </xsl:if>
 </xsl:template>
 
-<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion|references/conclusion">
-    <!-- We will not close the list of references when -->
-    <!-- it has an "introduction".  Now is the time.   -->
-    <xsl:if test="parent::references">
-        <xsl:call-template name="close-reference-list"/>
-    </xsl:if>
+<xsl:template match="article/conclusion|chapter/conclusion|section/conclusion|subsection/conclusion|appendix/conclusion|exercises/conclusion|solutions/conclusion|worksheet/conclusion|handout/conclusion|reading-questions/conclusion">
     <xsl:text>\begin{conclusion}</xsl:text>
     <xsl:text>{</xsl:text>
     <xsl:apply-templates select="." mode="title-full" />
@@ -9331,14 +9318,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and \bibitem seems comfortable there, so our source -->
 <!-- is nearly compatible with the usual usage           -->
 
-<!-- We open and close a single "referencelist" environment,      -->
-<!-- which we create in the preamble.  It opens right after a     -->
-<!-- "references" division, or after an optional "introduction"   -->
-<!-- or "headnote" (whichever comes last).  It closes right       -->
-<!-- before the "references" division closes, or right before the -->
-<!-- "conclusion" begins.  The templates below ensure             -->
-<!-- consistency, and help with overrides.  You can search on     -->
-<!-- them to see the pairs of scenarios just described.           -->
+<!-- We open and close a single "referencelist" environment,   -->
+<!-- which we create in the preamble.  It opens right after a  -->
+<!-- "references" division, or after an optional "headnote",   -->
+<!-- and closes right before the division does.  The templates -->
+<!-- below ensure consistency, and help with overrides.        -->
 
 <xsl:template name="open-reference-list">
     <xsl:text>%% If this is a top-level references&#xa;</xsl:text>


### PR DESCRIPTION
PR #3129 gave every list-like division a `headnote` and said the
coexistence with a references `introduction` was transitional by
intent.  This is the transition.  A `references` division is now
exactly a title, an optional `headnote`, and its `biblio` items: the
`introduction` and `conclusion` companions are gone from the schema,
repaired away by the assembly, and their handling is retired from the
conversions.

Fair warning, stated just as plainly in the deprecation messages
themselves: the repair discards content.  An old `introduction`
becomes a `headnote`, but any `title` it carried is discarded
entirely — its text will not appear in any output.  An old
`conclusion` is discarded whole — its content will not appear in any
output, and the message advises relocating it.  The 2021 glossary
change is the pattern throughout (deprecation message plus silent
repair, schema removal in the same stroke), applied here with a
harder edge.

The commits:

- 34fd0e02 (Schema) The `references` model drops both companions; the
  literate prose states the principle: a references is a list-like
  division, its one preface is a headnote, and it has no conclusion.

- 314a2c7f (Schema) Clean-house bonus: the development-schema assembly
  carried a dangling fragment reference (`reference-dev`, a `url`
  experiment removed in PR #2211) that the literate machinery has
  silently ignored since 2024.  Removing it changes no derived file —
  the proof it was dead.

- 320875ec (Repair) The assembly rewrites `references/introduction` as
  a `headnote`, copying everything except a `title`, and drops
  `references/conclusion` entirely; two blunt deprecation messages
  announce the discards.

- 520673c6 (LaTeX) With the repaired forms impossible on the internal
  tree, every handler is unreachable and retired: the references
  alternatives leave the companion match lists (modern and classic),
  the environment-representatives lists, and the title-punctuation
  list; the `referencelist` deferral collapses to
  heading-or-headnote.  Riding along: the glossary companion entries
  dead since the 2021 repair, and a duplicated `handout/conclusion`.

- 5b9089f8 (Samples) Nine live conversions — six references prefaces
  in the sample article and three in the numbering document (whose
  equations-in-the-preface coverage survives inside the headnote).
  The article's one references `conclusion` folds its
  annotated-bibliography remark into the adjacent headnote; the
  numbering document's three conclusions are deleted, their equations
  having tested a construct that no longer exists, with nothing
  cross-referencing them and no other equation number moving.

- 54963093 (Errors) A tripwire in the deliberately-invalid document —
  a references with a titled introduction and a conclusion — so both
  warnings keep living coverage.

Testing: the sample article and the numbering document both validate
at zero development-schema errors; regeneration is idempotent, and a
regeneration pass after rebasing produces no diff.  A temporary edit
provoking both deprecated forms shows each message firing exactly
once, the surviving prose inside the headnote environment, the
discarded title and conclusion nowhere in the output, and the
reference list opening after the headnote.  Before/after LaTeX for
both documents differs in exactly the environment switches, the fold,
and the removed conclusions.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
