### PR TITLE
Messages: a missing translation is a warning, not a bug

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3207,7 +3207,7 @@ Book (with parts), "section" at level 3
             <xsl:text>[</xsl:text>
             <xsl:value-of select="$str-id" />
             <xsl:text>]</xsl:text>
-            <xsl:message>PTX:BUG:     could not translate string with id "<xsl:value-of select="$str-id"/>" into language for code "<xsl:value-of select="$lang"/>"</xsl:message>
+            <xsl:message>PTX:WARNING: could not translate string with id "<xsl:value-of select="$str-id"/>" into language for code "<xsl:value-of select="$lang"/>"</xsl:message>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -3838,7 +3838,7 @@ Book (with parts), "section" at level 3
                 <xsl:text>has been encountered without a @label attribute.  For reasons of backward-compatibility &#xa;</xsl:text>
                 <xsl:text>we have used the value of an @xml:id.  This may not be what you want, and as of 2024-02-15 &#xa;</xsl:text>
                 <xsl:text>is no longer best practice.  You can copy the @xml:id value exactly into a new @label &#xa;</xsl:text>
-                <xsl:text>attribute and this warning will stop AND your project's entries in any Runestone database &#xa;</xsl:text>
+                <xsl:text>attribute and this message will stop AND your project's entries in any Runestone database &#xa;</xsl:text>
                 <xsl:text>will be preserved and function exactly as before.&#xa;</xsl:text>
                 <xsl:text>[You may get more than one message about this instance.]&#xa;</xsl:text>
             </xsl:message>


### PR DESCRIPTION
Two corrections to my own work in PR #3046, "messages and severities". Both commits are mine, written with Claude Fable 5, both dated 2026-07-16.

`b0e8f23f`, "XSL: a message reporting an internal defect is `PTX:BUG`", reclassified the failed-localization message, which had been `PTX:WARNING` since 2022. That was wrong. The developer Guide defines a bug as "An internal PreTeXt defect — not the author's fault. Please report it." A string nobody has translated yet is neither, so the message was asking authors to report something that is not a defect. It goes back to `PTX:WARNING`.

Valerio Monti reported this on `pretext-dev` from Italian and French builds, but it is not language-specific. Every localization file carries the full `en-US` string list with the untranslated entries commented out, so 40 strings in Italian, 57 in French and 115 of 210 in German all reach this message. The sample article built as `it-IT` emits 1187 of them.

`8a8ce256`, "XSL: a message reporting a substituted default is `PTX:FALLBACK`", correctly reclassified the Runestone message about a component with no `@label`, but left its text telling the author that supplying one would stop "this warning". It now says "this message".

Testing: with the sample article as `xml:lang="it-IT"`, all 1187 report as `PTX:WARNING`; English output is unaffected, the message being unreachable for `en-US`. Removing the `@label` from an `activecode` `program` in the sample book and building against the Runestone Academy publication trips the Runestone message and shows the corrected sentence.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
