### PR TITLE
The "slideshow" document type, validatable at last

### DIFF
--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -6294,37 +6294,16 @@
     <section xml:id="topic-slides">
         <title>Slides</title>
         <idx>slides</idx>
-        <p>
-Slideshows may be authored in <pretext/> by using the following tags.
-        <ul>
-          <li>
-<c>slideshow</c> replaces the usual <c>article</c> or <c>book</c> tag to
-let <pretext/> know you are authoring a set of slides. As usual, you may then
-define your <c>title</c>, <c>subtitle</c>, and <c>frontmatter</c>.
-          </li>
-          <li>
-Similar to articles, your content should be organized into several
-<c>section</c>s.
-          </li>
-          <li>
-And within each section, a <c>slide</c> represents a full screen of information.
-Within a slide, you may author <pretext/> content as usual, such as paragraphs
-(<c>p</c>), lists (<c>ul</c>), and so on.
-          </li>
-          <li>
-Several elements support setting the <attr>pause</attr> attribute to the
-value <c>yes</c> to allow stepping through
-parts of a slide (e.g. it inserts a Beamer <c>\pause</c>).
-          </li>
-        </ul>
-        </p>
-        <p>
-A minimal working example may be found in the
-<url href="https://github.com/PreTeXtBook/pretext/blob/dev/examples/sample-slideshow/sample-slideshow.xml" visual="examples/sample-slideshow/sample-slideshow.xml">
-  Examples folder of the PreTeXt repo on GitHub
-</url>.
-See publishing details for various outputs in <xref ref="publisher-slides"/>.
-        </p>
+        <idx>slideshow</idx>
+
+        <p>A <tag>slideshow</tag> is a document type of its own: the element replaces <tag>article</tag> or <tag>book</tag> at the top of your source, as a child of <tag>pretext</tag>.  A <tag>docinfo</tag> works exactly as for any other document type, and so does the bibliographic information: the show opens with a <tag>title</tag>, an optional <tag>subtitle</tag>, and an optional <tag>frontmatter</tag> whose <tag>bibinfo</tag> (authors, an <tag>event</tag> naming the conference or seminar, a date) feeds a title slide, with an optional <tag>abstract</tag> following.</p>
+
+        <p>The body of the show is a sequence of <tag>section</tag>, or, for a short talk, simply a sequence of <tag>slide</tag>.  A section here is lighter than its namesake in an article: a <tag>title</tag> and then its slides, nothing else.  Each conversion renders a section title as an interstitial title slide, so sections give a long talk its signposts.</p>
+
+        <p>A <tag>slide</tag> has a <tag>title</tag> and then holds content much as a division does: paragraphs, displayed mathematics, figures, images, theorems and their kin, programs and consoles, side-by-side layouts.  One convenience is particular to the genre: a list (<tag>ol</tag>, <tag>ul</tag>, or <tag>dl</tag>) may sit directly on a slide, bare, without the customary wrapping <tag>p</tag>.  This applies only at the top level of a slide (or subslide); a list nested within a list item still requires its paragraph, just as anywhere else.</p>
+
+        <p>Presentation is incremental, and two devices control it, identically in every conversion.  First, the <attr>pause</attr> attribute, with value <c>yes</c>, may be placed on a paragraph, a list, an image, or a side-by-side: that material is held back until the next advance of the show, and a paused list reveals its items one at a time.  Second, a <tag>subslide</tag> gathers several blocks that then appear together, all at once, after an advance<mdash/>while material <em>following</em> the subslide is visible from the outset.  The <attr>pause</attr> attribute means nothing outside a slideshow, and validation will tell you so.</p>
+
     </section>
 
     <section xml:id="topic-literate-programming">

--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -232,7 +232,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
                 <p>Here is an inline bit of code with surrounding text. <c>print("hello world")</c>. Here is a more text. And some more. And yet more. And a full program... with Prism support.</p>
                 <program language="python" line-numbers="yes">
-                    <title>A simple program</title>
                     <code>
                         def f(x):
                             return x**2

--- a/schema/pretext-validation-plus.xsl
+++ b/schema/pretext-validation-plus.xsl
@@ -480,6 +480,21 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- but we allow them (apparently) everywhere when writing the   -->
 <!-- official schema.  We indicate these situations here.         -->
 
+<!-- pausing is specific to slideshows -->
+<xsl:template match="*[@pause][not(ancestor::slideshow)]">
+    <xsl:apply-templates select="." mode="messaging">
+        <xsl:with-param name="severity" select="'error'"/>
+        <xsl:with-param name="message-id" select="'pause-outside-slideshow'"/>
+        <xsl:with-param name="message">
+            <xsl:text>The @pause attribute stages the incremental appearance&#xa;</xsl:text>
+            <xsl:text>of material in a &lt;slideshow&gt;, and has no meaning in any&#xa;</xsl:text>
+            <xsl:text>other document type.  It will be ignored.</xsl:text>
+        </xsl:with-param>
+    </xsl:apply-templates>
+    <!-- recurse further -->
+    <xsl:apply-templates/>
+</xsl:template>
+
 <!-- an image drawn by PG code is specific to WW -->
 <xsl:template match="image[@pg-name][not(ancestor::webwork)]">
     <xsl:apply-templates select="." mode="messaging">

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2,13 +2,13 @@
                     namespace pf = "https://prefigure.org"
                     grammar {
 
-            start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Printout | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
+            start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Printout | Slideshow | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
 
             PretextRoot =
                 element pretext {
                     XMLLang?,
                     DocInfo?,
-                    (Book | Article | Letter | Memorandum)
+                    (Book | Article | Letter | Memorandum | Slideshow)
                 }
 
             Article =
@@ -46,6 +46,29 @@
                 element letter {empty}
             Memorandum =
                 element memo {empty}
+
+            Slideshow =
+                element slideshow {
+                    MetaDataLinedSubtitle,
+                    ArticleFrontMatter?,
+                    (SlideshowSection+ | Slide+)
+                }
+            # a slideshow's "section" organizes slides, nothing more
+            SlideshowSection =
+                element section {
+                    MetaDataAltTitle,
+                    Slide+
+                }
+            Slide =
+                element slide {
+                    MetaDataAltTitle,
+                    (BlockDivision | List | Subslide)+
+                }
+            # a group of material appearing all at once, after a pause
+            Subslide =
+                element subslide {
+                    (BlockDivision | List)+
+                }
 
             Part =
                 element part {
@@ -711,17 +734,21 @@
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
+                    # pausing, within a slideshow: items appear one at a time
+                    attribute pause {"yes" | "no"}?,
                     ListItem+
                 } |
                 element ul {
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {"disc" | "circle" | "square" | ""}?,
+                    attribute pause {"yes" | "no"}?,
                     ListItem+
                 } |
                 element dl {
                     Component?,
                     attribute width {"narrow" | "medium" | "wide"}?,
+                    attribute pause {"yes" | "no"}?,
                     DefinitionListItem+
                 }
 
@@ -935,6 +962,8 @@
             SidebySideAttributes =
                 Component?,
                 attribute margins {text}?,
+                # pausing, within a slideshow
+                attribute pause {"yes" | "no"}?,
                 attribute landscape {"yes" | "no"}?,
                 (attribute width {text} | attribute widths {text})?,
                 (
@@ -1012,6 +1041,8 @@
                     Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     attribute rotate {text}?,
                     attribute archive {text}?,
                     attribute source {text},
@@ -1038,6 +1069,8 @@
                     Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     attribute archive {text}?,
                     (
                       attribute decorative {"yes"} |
@@ -1721,6 +1754,8 @@
                     LabelID?,
                     Component?,
                     attribute workspace {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     TextParagraph
                 }
             ParagraphLined =

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -10,6 +10,7 @@
       <ref name="Subsection"/>
       <ref name="Subsubsection"/>
       <ref name="Printout"/>
+      <ref name="Slideshow"/>
       <ref name="Paragraphs"/>
       <ref name="ReadingQuestions"/>
       <ref name="Exercises"/>
@@ -43,6 +44,7 @@
         <ref name="Article"/>
         <ref name="Letter"/>
         <ref name="Memorandum"/>
+        <ref name="Slideshow"/>
       </choice>
     </element>
   </define>
@@ -160,6 +162,54 @@
   <define name="Memorandum">
     <element name="memo">
       <empty/>
+    </element>
+  </define>
+  <define name="Slideshow">
+    <element name="slideshow">
+      <ref name="MetaDataLinedSubtitle"/>
+      <optional>
+        <ref name="ArticleFrontMatter"/>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <ref name="SlideshowSection"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="Slide"/>
+        </oneOrMore>
+      </choice>
+    </element>
+  </define>
+  <!-- a slideshow's "section" organizes slides, nothing more -->
+  <define name="SlideshowSection">
+    <element name="section">
+      <ref name="MetaDataAltTitle"/>
+      <oneOrMore>
+        <ref name="Slide"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Slide">
+    <element name="slide">
+      <ref name="MetaDataAltTitle"/>
+      <oneOrMore>
+        <choice>
+          <ref name="BlockDivision"/>
+          <ref name="List"/>
+          <ref name="Subslide"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!-- a group of material appearing all at once, after a pause -->
+  <define name="Subslide">
+    <element name="subslide">
+      <oneOrMore>
+        <choice>
+          <ref name="BlockDivision"/>
+          <ref name="List"/>
+        </choice>
+      </oneOrMore>
     </element>
   </define>
   <define name="Part">
@@ -1952,6 +2002,15 @@
         <optional>
           <attribute name="marker"/>
         </optional>
+        <optional>
+          <!-- pausing, within a slideshow: items appear one at a time -->
+          <attribute name="pause">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
         <oneOrMore>
           <ref name="ListItem"/>
         </oneOrMore>
@@ -1981,6 +2040,14 @@
             </choice>
           </attribute>
         </optional>
+        <optional>
+          <attribute name="pause">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
+            </choice>
+          </attribute>
+        </optional>
         <oneOrMore>
           <ref name="ListItem"/>
         </oneOrMore>
@@ -1995,6 +2062,14 @@
               <value>narrow</value>
               <value>medium</value>
               <value>wide</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="pause">
+            <choice>
+              <value>yes</value>
+              <value>no</value>
             </choice>
           </attribute>
         </optional>
@@ -2545,6 +2620,15 @@
       <attribute name="margins"/>
     </optional>
     <optional>
+      <!-- pausing, within a slideshow -->
+      <attribute name="pause">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
       <attribute name="landscape">
         <choice>
           <value>yes</value>
@@ -2710,6 +2794,15 @@
         <attribute name="margins"/>
       </optional>
       <optional>
+        <!-- pausing, within a slideshow -->
+        <attribute name="pause">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
         <attribute name="rotate"/>
       </optional>
       <optional>
@@ -2762,6 +2855,15 @@
       </optional>
       <optional>
         <attribute name="margins"/>
+      </optional>
+      <optional>
+        <!-- pausing, within a slideshow -->
+        <attribute name="pause">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
       </optional>
       <optional>
         <attribute name="archive"/>
@@ -4497,6 +4599,15 @@
       </optional>
       <optional>
         <attribute name="workspace"/>
+      </optional>
+      <optional>
+        <!-- pausing, within a slideshow -->
+        <attribute name="pause">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
       </optional>
       <ref name="TextParagraph"/>
     </element>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -76,7 +76,7 @@
         <fragment xml:id="start-elements">
             <title>Start elements</title>
             <code>
-            start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Printout | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
+            start = PretextRoot | DocInfo | Part | Chapter | Section | Subsection | Subsubsection | Printout | Slideshow | Paragraphs | ReadingQuestions | Exercises | Subexercises |  Solutions | BookFrontMatter | ArticleFrontMatter | BookBackMatter | ArticleBackMatter | Preface | Acknowledgement | ArticleAppendix | BookAppendix | IndexDivision | References | Glossary | Figure | WebWork
             </code>
         </fragment>
     </section>
@@ -93,7 +93,7 @@
                 element pretext {
                     XMLLang?,
                     DocInfo?,
-                    (Book | Article | Letter | Memorandum)
+                    (Book | Article | Letter | Memorandum | Slideshow)
                 }
             </code>
         </fragment>
@@ -142,6 +142,40 @@
                 element letter {empty}
             Memorandum =
                 element memo {empty}
+            </code>
+        </fragment>
+    </section>
+
+    <section>
+        <title>Slideshows</title>
+
+        <p>A <tag>slideshow</tag> is a document type of its own, a peer of <tag>book</tag> and <tag>article</tag>, whose <tag>docinfo</tag> and <tag>bibinfo</tag> are just as for the other types (its front matter has the shape of an article's).  The show is a sequence of <tag>section</tag>, each a titled sequence of <tag>slide</tag>, or is simply a sequence of <tag>slide</tag>.  A slide holds division-style content, with two conveniences particular to the genre.  A list (<tag>ol</tag>, <tag>ul</tag>, <tag>dl</tag>) may stand bare, outside any <tag>p</tag>, at the top level of a slide or subslide<mdash/>a nested list still requires its paragraph.  And presentation is incremental: a <attr>pause</attr> attribute on a paragraph, list, image, or side-by-side holds that material (list items one at a time) for the next advance of the show, while a <tag>subslide</tag> holds a group of material, all at once, the same way.  The <attr>pause</attr> attribute appears throughout the grammar for this purpose; the validation-plus stylesheet confines it to a slideshow.</p>
+
+        <fragment xml:id="slideshow">
+            <title>Slideshows</title>
+            <code>
+            Slideshow =
+                element slideshow {
+                    MetaDataLinedSubtitle,
+                    ArticleFrontMatter?,
+                    (SlideshowSection+ | Slide+)
+                }
+            # a slideshow's "section" organizes slides, nothing more
+            SlideshowSection =
+                element section {
+                    MetaDataAltTitle,
+                    Slide+
+                }
+            Slide =
+                element slide {
+                    MetaDataAltTitle,
+                    (BlockDivision | List | Subslide)+
+                }
+            # a group of material appearing all at once, after a pause
+            Subslide =
+                element subslide {
+                    (BlockDivision | List)+
+                }
             </code>
         </fragment>
     </section>
@@ -549,6 +583,8 @@
                     LabelID?,
                     Component?,
                     attribute workspace {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     TextParagraph
                 }
             ParagraphLined =
@@ -1399,17 +1435,21 @@
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {text}?,
+                    # pausing, within a slideshow: items appear one at a time
+                    attribute pause {"yes" | "no"}?,
                     ListItem+
                 } |
                 element ul {
                     Component?,
                     attribute cols {"2"|"3"|"4"|"5"|"6"}?,
                     attribute marker {"disc" | "circle" | "square" | ""}?,
+                    attribute pause {"yes" | "no"}?,
                     ListItem+
                 } |
                 element dl {
                     Component?,
                     attribute width {"narrow" | "medium" | "wide"}?,
+                    attribute pause {"yes" | "no"}?,
                     DefinitionListItem+
                 }
             </code>
@@ -1852,6 +1892,8 @@
             SidebySideAttributes =
                 Component?,
                 attribute margins {text}?,
+                # pausing, within a slideshow
+                attribute pause {"yes" | "no"}?,
                 attribute landscape {"yes" | "no"}?,
                 (attribute width {text} | attribute widths {text})?,
                 (
@@ -1944,6 +1986,8 @@
                     Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     attribute rotate {text}?,
                     attribute archive {text}?,
                     attribute source {text},
@@ -1970,6 +2014,8 @@
                     Component?,
                     attribute width {text}?,
                     attribute margins {text}?,
+                    # pausing, within a slideshow
+                    attribute pause {"yes" | "no"}?,
                     attribute archive {text}?,
                     (
                       attribute decorative {"yes"} |
@@ -4053,6 +4099,7 @@
             <fragref ref="start-elements" />
             <fragref ref="gross-structure" />
             <fragref ref="document-types" />
+            <fragref ref="slideshow" />
             <fragref ref="divisions" />
             <fragref ref="frontmatter" />
             <fragref ref="backmatter" />


### PR DESCRIPTION
Closes #1431.

A `slideshow` has been authorable, and convertible to reveal.js and
Beamer, since 2019 — and has never had a schema.  It was the last
document type that could not be validated at all.  Now it can: the
sample slideshow validates with zero errors, under both schemas, for
the first time in its existence.

The grammar.  A `slideshow` is a peer of `book` and `article` in the
root, with `docinfo` and bibliographic information exactly as for the
other types (its front matter *is* an article's: `bibinfo`,
`titlepage`, optional `abstract`).  The show is a sequence of
`section` — here a lighter creature than an article's: a title and its
slides, nothing more, rendered by every conversion as an interstitial
title slide — or simply a sequence of `slide`.  A slide holds
division-style content, with one convenience particular to the genre:
a list (`ol`, `ul`, `dl`) may stand bare at the top level of a slide
or subslide, outside any `p`; a nested list still requires its
paragraph, as anywhere else.

Two devices the sample and both conversions have always used are
modeled alongside: a `subslide`, gathering blocks that appear together
after an advance of the show (with following material visible from the
outset), and the `pause` attribute (`yes` or `no`) on a paragraph, a
list, an image, or a side-by-side, holding material for the next
advance — a paused list revealing its items one at a time.  Since
`pause` rides base-schema productions, the validation-plus stylesheet
confines it: used outside a slideshow it draws an error, with the
usual file/path/line report.

The commits:

- 28190cd1 (Schema) Everything above: the `Slideshow`, section, slide,
  and subslide productions; root and standalone-validation membership;
  `@pause` on its seven host productions; the validation-plus rule.

- 0fa40b2b (Sample slideshow) The one spec-versus-sample disagreement,
  resolved by evidence: a bare `program` carried a `title` that no
  conversion consumes and the built show provably does not render.
  Dead markup, removed.

- a1cddf7b (Guide) The slides topic, rewritten from a bulleted sketch
  into conversion-agnostic prose: the document type and its front
  matter, sections as signposts, slide content and the bare-list
  convenience, and the two incremental-presentation devices described
  by their behavior, not by any conversion's mechanism.

Testing: the sample slideshow validates at zero errors under both the
stable and development schemas; the full corpus is unaffected by the
base-schema additions (sample article at zero, sample book at its one
parked residue); a temporary `@pause` planted in the sample article
draws the validation-plus error with correct context, and is gone;
both conversions build the sample — reveal.js HTML and a complete
Beamer PDF; schema regeneration is idempotent, and a regeneration
pass after rebasing produces no diff.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
