### PR TITLE
Assembly: ensure dynamic-subs is not required for assembly-id-only

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -658,8 +658,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- them it is the identity, so we skip the full-tree copy.  NB: a         -->
 <!-- new template in the mode must be reflected in this test.               -->
 <xsl:variable name="b-has-dynamic-markup" select="boolean($assembly-label//setup | $assembly-label//numcmp | $assembly-label//strcmp | $assembly-label//jscmp | $assembly-label//mathcmp | $assembly-label//logic | $assembly-label//fillin[@ansobj] | $assembly-label//eval[@obj])"/>
+<!-- libxslt evaluates global variables eagerly, so this pass would run     -->
+<!-- even for $b-assembly-id-only, which stops at $assembly-label and       -->
+<!-- discards everything after it.  Reading the substitutions file for      -->
+<!-- a discarded tree is a hard error when it has not been generated,       -->
+<!-- so the short-circuit belongs here and not with $representations.       -->
 <xsl:variable name="dynamic-rtf">
-    <xsl:if test="$b-has-dynamic-markup">
+    <xsl:if test="$b-has-dynamic-markup and not($b-assembly-id-only)">
         <xsl:apply-templates select="$assembly-label" mode="dynamic-substitution"/>
     </xsl:if>
 </xsl:variable>


### PR DESCRIPTION
The recent-ish update to webwork generation (in individual files) required a second later report from assembly to give the assembly-ids before trying to read in other xml files, such as dynamic substitutions.  I thought I had this sorted correctly, but must have missed a case, because trying to build a document that has both webwork and FITB can't generate webwork, since the assembly-id-only bailout still requires the dynamic substitutions.  

This PR fixes that.