### PR TITLE
Beamer theme elected in the publication file

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1177,6 +1177,27 @@
         </subsection>
     </section>
 
+    <section xml:id="publication-file-beamer" label="publication-file-beamer">
+        <title>Beamer Slideshow Options</title>
+        <idx>Beamer slideshow publisher options</idx>
+        <idx><h>publisher options</h><h>Beamer slideshow</h></idx>
+
+        <introduction>
+            <p>See <xref ref="publisher-beamer"/> for a more general overview of this conversion.</p>
+        </introduction>
+
+        <subsection xml:id="beamer-appearance-options" label="beamer-appearance-options">
+            <title>Beamer Appearance</title>
+            <idx><h>publisher options</h><h>Beamer appearance</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/beamer/appearance</cline>
+            </cd>element can have the following attribute:<ul>
+                <li><attr>theme</attr>: the name of a Beamer theme, as it would appear in a <c>\usetheme</c> command, such as <c>Singapore</c> or <c>Madrid</c>.  The default is <c>Boadilla</c>.  Any theme your <latex/> installation provides may be named, including a locally-installed custom theme.  A name the <latex/> installation cannot find stops the build with an error repeating the name; capitalization is the first thing to check.  See <xref ref="publisher-beamer"/>.</li>
+            </ul></p>
+        </subsection>
+    </section>
+
     <section xml:id="publication-file-epub">
         <title>EPUB Options</title>
         <idx>EPUB publisher options</idx>

--- a/doc/guide/publisher/slides.xml
+++ b/doc/guide/publisher/slides.xml
@@ -143,6 +143,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             Of course, you should then run e.g. <c>pdflatex slides.tex</c> to produce a PDF.
         </p>
         <p>
+            Beamer has a large collection of themes, which set colors, navigation aids, and the overall look of every frame.
+            Elect one with the <attr>theme</attr> attribute of the <tag>appearance</tag> element within the <tag>beamer</tag> element of the publication file, exactly as you would name it in a <c>\usetheme</c> command (<xref ref="beamer-appearance-options"/>).
+            Absent a choice, the <c>Boadilla</c> theme is used.
+            A theme name your <latex/> installation does not provide stops the build early, with an error message that repeats the name and suggests the likely repairs.
+            Theme names are case-sensitive<mdash/>it is <c>Singapore</c>, never <c>singapore</c><mdash/>so check capitalization before anything else.
+        </p>
+        <p>
             Beamer's own habit is to center a frame's content vertically.
             A <pretext/> slideshow instead places content at the top of every frame by default, in agreement with the Reveal.js conversion.
             For the classic centered look<mdash/>title page, section pages, and every slide<mdash/>set a document-wide default of <c>middle</c> with the <attr>valign</attr> attribute described in <xref ref="topic-slides"/>.

--- a/examples/sample-slideshow/publication.xml
+++ b/examples/sample-slideshow/publication.xml
@@ -49,4 +49,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <navigation mode="default"/>
     </revealjs>
 
+    <beamer>
+        <!-- theme="Boadilla" is the default -->
+        <appearance theme="Singapore"/>
+    </beamer>
+
 </publication>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -12,6 +12,7 @@
                     Pdf? &
                     Html? &
                     Revealjs? &
+                    Beamer? &
                     Epub? &
                     Jupyter? &
                     Braille? &
@@ -433,6 +434,16 @@
                 element resources {
                     attribute host { "local" | "cdn" | "embedded" }?,
                     attribute math { "online" | "embedded" }?
+                }
+
+            Beamer =
+                element beamer {
+                    AppearanceBeamer?
+                }
+
+            AppearanceBeamer =
+                element appearance {
+                    attribute theme { text }
                 }
 
             Epub =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -28,6 +28,9 @@
           <ref name="Revealjs"/>
         </optional>
         <optional>
+          <ref name="Beamer"/>
+        </optional>
+        <optional>
           <ref name="Epub"/>
         </optional>
         <optional>
@@ -1349,6 +1352,18 @@
           </choice>
         </attribute>
       </optional>
+    </element>
+  </define>
+  <define name="Beamer">
+    <element name="beamer">
+      <optional>
+        <ref name="AppearanceBeamer"/>
+      </optional>
+    </element>
+  </define>
+  <define name="AppearanceBeamer">
+    <element name="appearance">
+      <attribute name="theme"/>
     </element>
   </define>
   <define name="Epub">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -123,6 +123,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     Pdf? &amp;
                     Html? &amp;
                     Revealjs? &amp;
+                    Beamer? &amp;
                     Epub? &amp;
                     Jupyter? &amp;
                     Braille? &amp;
@@ -655,6 +656,29 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </section>
 
     <section>
+        <title>Beamer Options</title>
+
+        <p>
+            These options control the Beamer <latex/> slides presentation.
+        </p>
+
+        <fragment xml:id="beamer">
+            <title>Beamer Options</title>
+            <code>
+            Beamer =
+                element beamer {
+                    AppearanceBeamer?
+                }
+
+            AppearanceBeamer =
+                element appearance {
+                    attribute theme { text }
+                }
+            </code>
+        </fragment>
+    </section>
+
+    <section>
         <title>EPUB Options</title>
 
         <p>
@@ -806,6 +830,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <fragref ref="pdf" />
             <fragref ref="html" />
             <fragref ref="revealjs" />
+            <fragref ref="beamer" />
             <fragref ref="epub" />
             <fragref ref="jupyter" />
             <fragref ref="braille" />

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -49,10 +49,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <xsl:output method="text" indent="no" encoding="UTF-8"/>
 
-<!-- The Beamer theme, an author/publisher choice.  A string parameter -->
-<!-- until slideshow options mature in the publisher file.             -->
-<xsl:param name="beamer.theme" select="'Boadilla'"/>
-
 <!-- Blocks on slides never carry a LaTeX \label, so cross-reference -->
 <!-- numbers are hard-coded rather than realized through \ref        -->
 <xsl:variable name="b-latex-hardcode-numbers" select="true()"/>
@@ -488,8 +484,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="$latex.preamble.early" />
         <xsl:text>&#xa;</xsl:text>
     </xsl:if>
+    <!-- A theme name unknown to the installation would surface as    -->
+    <!-- a cryptic missing-file error, so test for the theme's file   -->
+    <!-- first and die early with advice.  "\usetheme{X}" loads       -->
+    <!-- "beamerthemeX.sty", and "\IfFileExists" performs the same    -->
+    <!-- search, so a theme local to the document is also honored.    -->
+    <xsl:text>\IfFileExists{beamertheme</xsl:text>
+    <xsl:value-of select="$beamer-theme"/>
+    <xsl:text>.sty}{}{\errmessage{The Beamer theme "</xsl:text>
+    <xsl:value-of select="$beamer-theme"/>
+    <xsl:text>" is not part of this TeX installation.  Theme names are case-sensitive, so check capitalization first.  Install the theme, or remove the theme entry of the publication file to accept the default theme}}&#xa;</xsl:text>
     <xsl:text>\usetheme{</xsl:text>
-    <xsl:value-of select="$beamer.theme"/>
+    <xsl:value-of select="$beamer-theme"/>
     <xsl:text>}&#xa;</xsl:text>
     <xsl:text>\usefonttheme[onlymath]{serif}&#xa;</xsl:text>
     <xsl:text>%% quash navigation symbols&#xa;</xsl:text>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3444,6 +3444,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:variable>
 
+<!-- ######################## -->
+<!-- Beamer Slideshow Options -->
+<!-- ######################## -->
+
+<!-- Beamer Theme -->
+
+<xsl:variable name="beamer-theme">
+    <xsl:apply-templates select="$publisher-attribute-options/beamer/appearance/pi:pub-attribute[@name='theme']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
 
 <!-- ########################################### -->
 <!-- Set Values/Defaults for Publisher Variables -->
@@ -3692,6 +3702,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <pi:pub-attribute name="math" default="online" options="embedded"/>
         </resources>
     </revealjs>
+    <beamer>
+        <appearance>
+            <pi:pub-attribute name="theme" default="Boadilla" freeform="yes"/>
+        </appearance>
+    </beamer>
 </pi:publisher>
 
 <!-- global variable for pi:publisher tree above -->


### PR DESCRIPTION
A Beamer slideshow's theme becomes a publication file choice:

```xml
<beamer>
    <appearance theme="Singapore"/>
</beamer>
```

The shape mirrors the Reveal.js options, so future Beamer appearance choices (color themes, fonts) have a natural home.  The value is the name exactly as it would appear in a `\usetheme` command; absent an entry, the `Boadilla` theme is used, as before.  The `beamer.theme` string parameter, which appeared with the conversion's rework last month and was never documented, is retired in favor of the publication entry.

A theme name the LaTeX installation does not provide would surface as a cryptic missing-file complaint deep in the log, followed by the build dying without a PDF.  The preamble now tests for the theme's file first — the same lookup `\usetheme` performs, so a theme local to the document still passes — and a bad name stops the run early with an error that repeats the name, points out that theme names are case-sensitive, and offers the repairs (fix the spelling, install the theme, or remove the entry to accept the default).

The publication schema gains the new element.  The sample slideshow's publication file elects `Singapore`, in the spirit of its non-default choices.  The Guide documents the entry twice: a reference entry among the publication file's Beamer options, and a conversational paragraph where the Beamer conversion is discussed, each pointing at the other, with the failure scenario described in both places.

Testing: the sample slideshow's publication file validates against the regenerated schema, and the regeneration is idempotent; builds with the entry present, absent, and bogus behave as described (`Singapore` look confirmed visually, default falls back to `Boadilla`, the bogus name dies with the new message); a Reveal.js build with the entry present is warning-free, so the other slideshow conversion is undisturbed; the Guide validates and builds with no new warnings.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
