### PR TITLE
Sample article: the index headnote points to the appendix on indices

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -18324,7 +18324,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </subsection>
             </appendix>
 
-            <appendix label="appendix-index">
+            <appendix xml:id="appendix-index" label="appendix-index">
                 <title>Index</title>
 
                 <p>There is an index manufactured at the end of the back matter.  So we are talking about it here, rather than within the index, which is an impossibility.  It contains some sample entries, and is not meant to be comprehensive.  Look at the source of this XML file, searching on <tag>idx</tag>, to see how they are written.  They may be placed inside of a a variety of structures, and their location greatly influences the cross-references produced in the HTML version of the index.</p>
@@ -18509,7 +18509,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <index label="the-index">
                 <title>Index</title>
                 <headnote>
-                    <p>An index may begin with a <tag>headnote</tag> like this one.  Indexing advice holds that a headnote is only necessary when the index has some unusual feature a reader should know in advance<mdash/>perhaps how symbols are ordered, or that persons and topics are interfiled.  This index has no such feature; this headnote is a demonstration.</p>
+                    <p>An index may begin with a <tag>headnote</tag> like this one.  Indexing advice holds that a headnote is only necessary when the index has some unusual feature a reader should know in advance<mdash/>perhaps how symbols are ordered, or that persons and topics are interfiled.  This index has no such feature; this headnote is a demonstration.  For a fuller discussion of this index, and of authoring index entries generally, see <xref ref="appendix-index"/>.</p>
                 </headnote>
                 <index-list/>
             </index>


### PR DESCRIPTION
The sample article's index has a demonstration `headnote`, and there is an appendix discussing the index in some detail.  The headnote now ends by pointing at that appendix, so a reader landing on the index finds the fuller discussion.  The appendix gains an `@xml:id` matching its existing `@label`, to serve as the target.

Testing: validation is unchanged, and the HTML output differs from master in exactly the one headnote paragraph, with the new cross-reference rendering as a live link.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
