### PR TITLE
Numbering: block scopes follow the division structure model

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -15,7 +15,7 @@
     <title>Publication File Reference</title>
 
     <introduction>
-        <p>This chapter is reference material for the <term>publication file</term>, whose employment is described in <xref ref="publication-file"/>, where you can also find an explanation of the shorthand syntax used here to describe elements of this file.  Any path appearing as a value below is relative to your <em>main source file</em>, never to the publication file itself (<xref ref="publication-file-paths"/>).</p>
+        <p>This chapter is reference material for the <term>publication file</term>, whose employment is described in <xref ref="publication-file"/>, where you can also find an explanation of the shorthand syntax used here to describe elements of this file.  Any path appearing as a value below is relative to your <em>main source file</em>, never to the publication file itself (<xref ref="publication-file-paths" text="title"/>).</p>
     </introduction>
 
     <section xml:id="publication-file-common">
@@ -570,7 +570,7 @@
 
             <p>The<cd>
                 <cline>/publication/html/brandlogo</cline>
-            </cd>element places an image in the upper-left corner of every page's banner.  The <attr>source</attr> attribute (required) locates the image file, and an optional <attr>url</attr> attribute makes the image a link, such as to a project's landing page.  See <xref ref="online-banner-brandlogo"/> for a fuller discussion, including where the image file must reside.</p>
+            </cd>element places an image in the upper-left corner of every page's banner.  The <attr>source</attr> attribute (required) locates the image file, and an optional <attr>url</attr> attribute makes the image a link, such as to a project's landing page.  See <xref ref="online-banner-brandlogo" text="title"/> for a fuller discussion, including where the image file must reside.</p>
         </subsection>
 
         <subsection xml:id="online-banner">

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -4724,7 +4724,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="book|article|part|chapter|appendix|section|subsection|subsubsection" mode="is-structured-division">
     <xsl:variable name="has-traditional" select="boolean(&TRADITIONAL-DIVISION;)"/>
     <xsl:variable name="all-children" select="*"/>
-    <xsl:variable name="all-worksheet" select="title|shorttitle|plaintitle|idx|introduction|worksheet|handout|conclusion"/>
+    <xsl:variable name="all-worksheet" select="title|subtitle|shorttitle|plaintitle|idx|frontmatter|introduction|worksheet|handout|conclusion"/>
     <xsl:variable name="only-worksheets" select="count($all-children) = count($all-worksheet)"/>
 
     <xsl:value-of select="$has-traditional or $only-worksheets"/>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -4317,12 +4317,31 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="project-nodes"/>
     <xsl:param name="exercise-nodes"/>
     <xsl:param name="openproblem-nodes"/>
-    <!-- terminal: holds content directly, so it has no child divisions of  -->
-    <!-- any kind.  Specialized divisions ("worksheet", "handout", etc.)     -->
-    <!-- count here just like the traditional ones, else a division whose    -->
-    <!-- children are specialized divisions is wrongly deemed terminal and   -->
-    <!-- pools their blocks into one scope instead of one scope apiece.      -->
-    <xsl:variable name="b-terminal" select="not(part|chapter|appendix|section|subsection|subsubsection|preface|exercises|worksheet|handout|reading-questions|references|glossary|solutions)"/>
+    <!-- Terminal: this division's items pool into one flat scope  -->
+    <!-- here.  For a traditional division the authority is the    -->
+    <!-- two-model test "is-structured-division": an unstructured  -->
+    <!-- division (content, plus at most one of each specialized   -->
+    <!-- division) is terminal, its specialized divisions pooling  -->
+    <!-- into its scope; a structured division (traditional        -->
+    <!-- subdivisions, or only worksheets) recurses, and each      -->
+    <!-- worksheet then opens a scope apiece.  The test does not   -->
+    <!-- apply to "frontmatter", "backmatter", a "preface", or the -->
+    <!-- specialized divisions themselves, which keep the plain    -->
+    <!-- child-division inspection.                                -->
+    <xsl:variable name="terminal">
+        <xsl:choose>
+            <xsl:when test="self::book or self::article or self::part or self::chapter or self::appendix or self::section or self::subsection or self::subsubsection">
+                <xsl:variable name="is-structured">
+                    <xsl:apply-templates select="." mode="is-structured-division"/>
+                </xsl:variable>
+                <xsl:value-of select="$is-structured = 'false'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="not(part|chapter|appendix|section|subsection|subsubsection|preface|exercises|worksheet|handout|reading-questions|references|glossary|solutions)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="b-terminal" select="$terminal = 'true'"/>
     <xsl:variable name="b-open-eq"          select="not($eq-nodes)          and ($b-terminal or (@pi:level &gt;= $numbering-equations))"/>
     <xsl:variable name="b-open-fn"          select="not($fn-nodes)          and ($b-terminal or (@pi:level &gt;= $numbering-footnotes))"/>
     <xsl:variable name="b-open-blocks"      select="not($blocks-nodes)      and ($b-terminal or (@pi:level &gt;= $numbering-blocks))"/>


### PR DESCRIPTION
Building the Guide recently began emitting warnings and errors about cross-references that could not form their text.  Investigation found three independent causes, and fixing the main one properly led one step further.  (Bisection with Guide builds located each arrival precisely.)

Two errors were simply new Guide cross-references (July 30, August 5) pointing at `paragraphs`, which never hold a number, so the default text form cannot work.  Those two now elect `text="title"`.

The rest traced to PR #3050 (July 17), which taught the block-numbering scope walker that specialized divisions defeat terminality, so that a division of only worksheets gets a numbering scope per worksheet.  That was correct, but the test overshot: a chapter of ordinary content plus a single `worksheet` — the classic unstructured model, and exactly the shape of the Guide's chapter on worksheets — also stopped being terminal, and its chapter-level `listing` fell outside every scope: no number, and the Guide's PDF read "…is given in Listing ." with nothing after the word.  The walker now defers to `is-structured-division`, the code's own authority on the two division models, instead of keeping a private child list.  An unstructured division is terminal again (the Guide's listing is back to Listing 17.0.1, its worksheet back to numberless), while a structured division of only worksheets keeps its scope apiece.

Testing that deferral across the corpus exposed one more gap: the only-worksheets test compares a division's children against a list of metadata, and the list omitted `subtitle` and `frontmatter`, so the workbook article — front matter, an introduction, then six printouts — classified as unstructured.  With the list completed, that document is structured everywhere, which resolves a live inconsistency: on master its PDF pools block numbers continuously (Figure 0.1 through Example 0.12) while its HTML restarts per printout with zero-padded chains, colliding on duplicate numbers.  Now both conversions agree exactly: printouts numbered in document order (Worksheet 1, 2, Handout 3, …, replacing six numberless headings), blocks numbered within their printout (Figure 1.1, Theorem 2.1, Definition 3.1), every number unique, cross-references like "Worksheet Exercise 1.1" resolving cleanly.

Testing: an assembly-tree sweep of eighteen document/publication pairs (both sample books, parts both structural and decorative, the numbering test document, workbooks, WeBWorK chapter, and more) shows byte-identical numbering everywhere except the Guide and the workbook article, each changed exactly as described; a LaTeX sweep of eleven documents confirms the same at the rendered layer; the workbook's PDF and HTML were both built on both sides and every printed number compared; the Guide builds with zero cross-reference warnings; validation is unchanged throughout.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
