### PR TITLE
Assembly: short-circuit "assembly-id-only" once, at the pass it stops after

### DIFF
--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -658,21 +658,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- them it is the identity, so we skip the full-tree copy.  NB: a         -->
 <!-- new template in the mode must be reflected in this test.               -->
 <xsl:variable name="b-has-dynamic-markup" select="boolean($assembly-label//setup | $assembly-label//numcmp | $assembly-label//strcmp | $assembly-label//jscmp | $assembly-label//mathcmp | $assembly-label//logic | $assembly-label//fillin[@ansobj] | $assembly-label//eval[@obj])"/>
+<!-- "assembly-id-only" emits $assembly-label, so every pass below is   -->
+<!-- discarded in that mode.  $post-label is empty then, and each later -->
+<!-- pass takes its input from $post-label, so each one copies nothing  -->
+<!-- and opens no file.  The test is written once, here, instead of     -->
+<!-- being repeated in every pass: libxslt computes a global variable   -->
+<!-- even when nothing uses the result, so a pass is not skipped just   -->
+<!-- by leaving its variable unread.                                    -->
+<xsl:variable name="post-label" select="$assembly-label[not($b-assembly-id-only)]"/>
 <xsl:variable name="dynamic-rtf">
     <xsl:if test="$b-has-dynamic-markup">
-        <xsl:apply-templates select="$assembly-label" mode="dynamic-substitution"/>
+        <xsl:apply-templates select="$post-label" mode="dynamic-substitution"/>
     </xsl:if>
 </xsl:variable>
-<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)[$b-has-dynamic-markup] | $assembly-label[not($b-has-dynamic-markup)]"/>
+<xsl:variable name="dynamic" select="exsl:node-set($dynamic-rtf)[$b-has-dynamic-markup] | $post-label[not($b-has-dynamic-markup)]"/>
 
 <xsl:variable name="representations-rtf">
-    <xsl:choose>
-        <!-- short-circuit to stop after adding @pi:assembly-id -->
-        <xsl:when test="$b-assembly-id-only"/>
-        <xsl:otherwise>
-            <xsl:apply-templates select="$dynamic" mode="representations"/>
-        </xsl:otherwise>
-    </xsl:choose>
+    <xsl:apply-templates select="$dynamic" mode="representations"/>
 </xsl:variable>
 <xsl:variable name="representations" select="exsl:node-set($representations-rtf)"/>
 


### PR DESCRIPTION
Closes the same defect as #3140, by moving the existing short-circuit rather than adding a second one.

`assembly-id-only` emits `$assembly-label`, which is pass 6 of the pipeline, so passes 7 through 14 are discarded in that mode. The short-circuit for it was written at pass 8, inside `$representations-rtf`. That stops passes 8 and later, and leaves pass 7, `dynamic-substitution`, to test the same condition separately. It did not, and since that pass opens the dynamic substitutions file, the omission was fatal rather than merely wasteful: generating WeBWorK representations for a document that also has fill-in-the-blank exercises failed outright, because substitutions it had no use for had not been generated yet.

The test now happens once, immediately after pass 6:

```xml
<xsl:variable name="post-label" select="$assembly-label[not($b-assembly-id-only)]"/>
```

Passes 7 and later take their input from `$post-label`, which is empty in that mode, so each copies nothing and opens no file. The `<xsl:choose>` in `$representations-rtf` can no longer be reached and is removed. Two tests become one, and a pass added between 6 and 8 later gets the behaviour without having to repeat the test.

It is written once here rather than in each pass because libxslt computes a global variable even when nothing uses the result — in `assembly-id-only` nothing referred to `$dynamic` at all, and `$dynamic-rtf` was computed regardless.

**Testing.** Sample article, which carries the fill-in-the-blank markup, with the publication file's `generated` directory pointed at an empty directory so the substitutions file is absent:

| | `assembly-id-only` | normal |
|---|---|---|
| before | fails, no output | fails, no output |
| after | succeeds | fails, no output |

The normal-build failure is correct and deliberately kept: that build does need the file.

With the real publication file the assembled tree is byte-identical to master in both modes — 3,323,516 bytes normally and 2,598,774 for `assembly-id-only`. The only change in behaviour is that a discarded pass no longer opens a file it has no use for.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
