### PR TITLE
HTML: the WeBWorK wrapper id reads "@assembly-id", which has no "pi" prefix

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -11254,19 +11254,22 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-answer"/>
     <xsl:param name="b-has-solution"/>
 
-    <!-- For Runestone, the WW problem is handled in isolation, -->
-    <!-- yet capturing and storing student work/results needs   -->
-    <!-- to be associated with the parent/enclosing "exercise"  -->
-    <!-- (or PROJECT-LIKE).  So in this case (only) we place    -->
-    <!-- an id value on the  div.exercise-wrapper that is       -->
-    <!-- derived from the parent.  Otherwise, we use the        -->
-    <!-- parent @pi:assembly-id with a "-ww-inner" suffix.      -->
-    <!-- The suffix ensures the inner wrapper's DOM id is       -->
-    <!-- distinct from the enclosing "exercise" article's       -->
-    <!-- id (which also holds the @pi:assembly-id value).       -->
-    <!-- Without the suffix, JavaScript (handleWW) would        -->
-    <!-- look up the inner id with getElementById and find      -->
-    <!-- the outer "exercise" article instead.                  -->
+    <!-- For Runestone, the WW problem is handled in isolation,   -->
+    <!-- yet capturing and storing student work/results needs     -->
+    <!-- to be associated with the parent/enclosing "exercise"    -->
+    <!-- (or PROJECT-LIKE).  So in this case (only) we place      -->
+    <!-- an id value on the  div.exercise-wrapper that is         -->
+    <!-- derived from the parent.  Otherwise, we use the          -->
+    <!-- @assembly-id of this "webwork-reps" with a "-ww-inner"   -->
+    <!-- suffix.  That attribute is NOT the assembly stamp and    -->
+    <!-- carries no "pi" prefix: it is written by webwork.py into -->
+    <!-- the generated representation file, naming it for the     -->
+    <!-- exercise it belongs to.  The suffix ensures the inner    -->
+    <!-- wrapper's DOM id is distinct from the enclosing          -->
+    <!-- "exercise" article's id, which holds the same value.     -->
+    <!-- Without the suffix, JavaScript (handleWW) would          -->
+    <!-- look up the inner id with getElementById and find        -->
+    <!-- the outer "exercise" article instead.                    -->
     <xsl:variable name="inner-id">
         <xsl:choose>
             <xsl:when test="$b-host-runestone">
@@ -11274,7 +11277,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:text>-ww-rs</xsl:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="concat(@pi:assembly-id, '-ww-inner')"/>
+                <xsl:value-of select="concat(@assembly-id, '-ww-inner')"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -11422,7 +11425,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:variable>
     <!-- build the iframe -->
     <!-- mimicking Mike Gage's blog post -->
-    <iframe name="{concat(@pi:assembly-id, '-ww-inner')}" width="{$design-width}" src="{$the-url}" data-seed="{static/@seed}"/>
+    <iframe name="{concat(@assembly-id, '-ww-inner')}" width="{$design-width}" src="{$the-url}" data-seed="{static/@seed}"/>
     <script>
         <xsl:text>iFrameResize({log:true,inPageLinks:true,resizeFrom:'child',checkOrigin:["</xsl:text>
         <xsl:value-of select="$webwork-server" />


### PR DESCRIPTION
Reported by Alex Jordan on `pretext-dev`: every WeBWorK exercise on a page received the same wrapper id, `-ww-inner`, so activating one exercise moved focus to the first one instead.

`66302f4a`, "Assembly: identifier stamps move to the `pi` namespace", renamed `@assembly-id` to `@pi:assembly-id` across nine stylesheets. Eight of them read the attribute from a source element that carries the assembly stamp, so the rename was correct. Two reads in `pretext-html.xsl` sit inside `<xsl:template match="webwork-reps">`, and `webwork-reps` has no such stamp. Its `@assembly-id` is written by `webwork.py` into the generated representation file, naming it for the exercise it belongs to:

```xml
<webwork-reps version="2" … xml:id="extracted-options-subset" assembly-id="options-subset">
```

`@pi:assembly-id` therefore matched nothing, `concat()` returned the suffix alone, and every exercise got the same id. XSLT reports nothing when an attribute name matches nothing, so this stood from 2026-07-26 with no message in any build.

Both reads go back to the unprefixed name — the wrapper `div` and, two hundred lines later, the `iframe` `name`, which has the same fault. The comment now records why this attribute is not in the `pi` namespace, so a later namespace sweep has a reason to leave it alone.

**Testing.** WeBWorK sample chapter, HTML:

| | wrapper divs | distinct ids | duplicate ids in the build |
|---|---|---|---|
| before | 76 | 1 | 62, across 11 pages |
| after | 76 | 76 | 0 |

Parsing the built pages confirms the property the `-ww-inner` suffix exists for: each `X-ww-inner` div is nested inside the element with id `X`, so `handleWW` looking up the inner id with `getElementById` finds the wrapper rather than the enclosing exercise.

The iframe is unexercised by that document's configuration, so its fix is by inspection.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
