### PR TITLE
Validation: allow for multiple opts

### DIFF
--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -44,7 +44,27 @@
                 <cline>jing = java -jar /usr/share/java/jing.jar</cline>
             </cd>Anything after the executable name is passed along as options, as for other configured executables.</p>
 
-            <p>Three other methods may be elected with the <c>-M</c> switch.  <c>-M local-dev</c> is identical, but checks against the development schema (<c>pretext-dev.rng</c>), which additionally describes new and experimental parts of the vocabulary.  <c>-M server</c> bundles your source files and ships them to a validation server for processing, so no <c>jing</c> installation is necessary at all.  <c>-M terse</c> produces the machine-readable report described in <xref ref="validation-terse"/>.</p>
+            <p>The <c>-M</c> switch may be used to elect any combination of three independent validation choices: where to run the validation; whether to use the production or development schema, and how to format the output.
+                <ul>
+                    <li>
+                        <p>
+                           The choices for where to run are <c>local</c> (default) and <c>server</c>. They correspond say where the <acro>RELAX-NG</acro> check runs: locally with your configured <c>jing</c> program, or by bundling your source files and shipping them to a validation server so no <c>jing</c> installation is necessary.  
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            For schema, the options are <c>production</c> (default) and <c>dev</c>. They correspond to which schema is used: the production schema (<c>pretext.rng</c>) or the development schema (<c>pretext-dev.rng</c>), which additionally describes new and experimental parts of the vocabulary.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            For format, you can specify <c>verbose</c> (default) or <c>terse</c>. They correspond to the format of the report: the author-oriented report or the machine-readable report described in <xref ref="validation-terse"/>.
+                        </p>
+                    </li>
+                </ul>
+            </p>
+
+            <p>For example, <c>-M dev terse</c> checks against the development schema and writes a terse report while still running <c>jing</c> locally.  The order is immaterial, so <c>-M terse dev</c> is equivalent.  Likewise, <c>-M server dev terse</c> asks the validation server to check against the development schema and return a terse report.  The former single value <c>local-dev</c> remains available as an alias for <c>local dev</c>.</p>
 
             <p>Incidentally, the <c>lxml</c> library the script relies on has <acro>RELAX-NG</acro> validation built in, and you might wonder why it is not employed for this purpose.  It cannot process the <c>externalRef</c> construction the schema uses (for PreFigure diagrams), and even given a reduced schema it reports only a small fraction of the problems <c>jing</c> finds, with messages that suggest an arbitrary alternative rather than describe the error.</p>
         </subsection>
@@ -52,7 +72,7 @@
         <subsection xml:id="validation-terse">
             <title>Validation for Programs</title>
 
-            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The <c>terse</c> method serves exactly this purpose: the report is one line per message, five tab-separated fields<mdash/>file, path, line, check, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.  Unlike that report, every element of a path carries its count, so a program may consume paths uniformly.  Sorting on the <c>check</c> field clusters occurrences of the same problem.)  Elect it with <c>-V -M terse</c> at the command line, or call the library directly, as in the following complete driver, which prints the report on standard output and is simple enough to serve as a model.<listing>
+            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The <c>terse</c> reporting option serves exactly this purpose: the report is one line per message, five tab-separated fields<mdash/>file, path, line, check, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.  Unlike that report, every element of a path carries its count, so a program may consume paths uniformly.  Sorting on the <c>check</c> field clusters occurrences of the same problem.)  Elect it with <c>-V -M terse</c> at the command line, perhaps combined with <c>dev</c> or <c>server</c>, or call the library directly, as in the following complete driver, which prints the report on standard output and is simple enough to serve as a model.<listing>
                 <title>A driver for machine-readable validation</title>
                 <program language="python">
                     <code>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -5447,21 +5447,89 @@ def pdf_fo(xml, pub_file, stringparams, out_file, dest_dir):
 PI_SOURCE_URI = "{http://pretextbook.org/2020/pretext/internal}source-uri"
 
 
+def _validation_method_tokens(method):
+    """Normalize validation method input into individual option tokens."""
+    if not method:
+        return []
+    if isinstance(method, str):
+        values = [method]
+    else:
+        values = method
+    tokens = []
+    aliases = {
+        "local-dev": ["local", "dev"],
+    }
+    for value in values:
+        if not value:
+            continue
+        for raw_token in str(value).replace(",", " ").split():
+            token = raw_token.lower()
+            tokens.extend(aliases.get(token, [token]))
+    return tokens
+
+
+def _validation_method_settings(method):
+    """Return the three independent validation settings, with defaults."""
+    settings = {
+        "location": "local",
+        "schema": "production",
+        "report": "verbose",
+    }
+    choices = {
+        "local": ("location", "local"),
+        "server": ("location", "server"),
+        "production": ("schema", "production"),
+        "dev": ("schema", "dev"),
+        "verbose": ("report", "verbose"),
+        "terse": ("report", "terse"),
+    }
+    assigned = {}
+    invalid = []
+    for token in _validation_method_tokens(method):
+        if token not in choices:
+            invalid.append(token)
+            continue
+        category, value = choices[token]
+        previous = assigned.get(category)
+        if previous is not None and settings[category] != value:
+            log.warning(
+                'validation method "{}" replaces earlier "{}" for {}; using "{}"'.format(
+                    token, previous, category, value
+                )
+            )
+        settings[category] = value
+        assigned[category] = token
+    if invalid:
+        log.warning(
+            'ignoring unrecognized validation method value(s): "{}"'.format(
+                " ".join(invalid)
+            )
+        )
+    return settings
+
+
+def validation_method(method):
+    """Return a canonical validation method string from -M tokens."""
+    settings = _validation_method_settings(method)
+    return "{location} {schema} {report}".format(**settings)
+
+
 def validate(xml_source, pub_file, stringparams, out_file, dest_dir, method):
     """Validate source against the RELAX-NG schema, locally or via a server"""
 
-    # "local" validates against the production schema and "local-dev"
-    # against the development schema, each with a report meant for an
-    # author.  "terse" is the production schema with machine-readable
-    # output, one tab-separated message per line, meant for a program.
-    # "server" is "local" with the "jing" run delegated to a remote
-    # service; the consolidated report is identical.
-    if method == "local-dev":
+    # Three independent choices govern validation:
+    #   "local" or "server"       where the RELAX-NG check runs
+    #   "production" or "dev"     which schema is used
+    #   "verbose" or "terse"      author report or tab-separated output
+    # Defaults are "local production verbose"; legacy single values such
+    # as "local-dev", "server", and "terse" are accepted by the normalizer.
+    validation_settings = _validation_method_settings(method)
+    if validation_settings["schema"] == "dev":
         schema_file = "pretext-dev.rng"
     else:
         schema_file = "pretext.rng"
-    terse = method == "terse"
-    server = method == "server"
+    terse = validation_settings["report"] == "terse"
+    server = validation_settings["location"] == "server"
     # to ensure provided stringparams aren't mutated unintentionally
     stringparams = stringparams.copy()
 

--- a/pretext/pretext
+++ b/pretext/pretext
@@ -181,26 +181,56 @@ def string_parameters_as_dict(pairs):
     return params
 
 
+def method_argument_tokens(method):
+    """Normalize the -M argument into a list of method tokens."""
+    if not (method):
+        return []
+    if isinstance(method, str):
+        values = [method]
+    else:
+        values = method
+    tokens = []
+    for value in values:
+        if value:
+            tokens.extend(str(value).replace(",", " ").split())
+    return tokens
+
+
+def single_method_argument(method, purpose):
+    """Return one method token for uses of -M that accept only one value."""
+    tokens = method_argument_tokens(method)
+    if len(tokens) > 1:
+        log.warning(
+            'multiple method values supplied for {}; using "{}" and ignoring "{}"'.format(
+                purpose, tokens[0], " ".join(tokens[1:])
+            )
+        )
+    return tokens[0] if tokens else ""
+
+
+def all_validation_method_tokens(method):
+    """Whether every supplied -M token is a recognized validation token."""
+    validation_tokens = {
+        "local",
+        "server",
+        "production",
+        "dev",
+        "verbose",
+        "terse",
+        "local-dev",
+    }
+    tokens = method_argument_tokens(method)
+    return bool(tokens) and all(token.lower() in validation_tokens for token in tokens)
+
+
 def sanitize_method(method, component, format, validate):
     """Returns a string appropriate for the component and format, else None"""
     if validate:
-        # unset by command-line, use default
-        if not (method):
-            return "local"
-        # set, but illegal
-        elif not (method in ["local", "local-dev", "server", "terse"]):
-            msg = "\n".join(
-                [
-                    'the method given for validation ("{}") is not "local", "local-dev", "server", or "terse",',
-                    '              so using the default method instead ("local")',
-                ]
-            )
-            log.warning(msg.format(method))
-            return "local"
-        # set correctly
-        else:
-            return method
-    elif component == "asy":
+        return ptx.validation_method(method)
+    method = single_method_argument(
+        method, 'component "{}" and format "{}"'.format(component, format)
+    )
+    if component == "asy":
         # unset by command-line, use default
         if not (method):
             return "server"
@@ -482,10 +512,10 @@ def get_cli_arguments():
     parser.add_argument(
         "-M",
         "--method",
-        help="method to use for a component/format (values and defaults vary)",
-        action="store",
+        help="method value(s) to use for a component/format (values and defaults vary)",
+        nargs="*",
         dest="method",
-        default="",
+        default=[],
     )
     # default to an empty string, which signals root to XSL stylesheet
     parser.add_argument(
@@ -541,12 +571,12 @@ def get_cli_arguments():
         dest="tgz",
     )
     validate_info = [
-        ("local", 'employs an installed "jing" program (default)'),
-        ("local-dev", 'as "local", but checks against the development schema'),
-        ("server", "a round-trip to a validation server"),
-        ("terse", "machine-readable, one tab-separated message per line"),
+        ("local, server", 'employ an installed "jing" program (default), or a validation server'),
+        ("production, dev", "check against the production schema (default), or development schema"),
+        ("verbose, terse", "write an author report (default), or one tab-separated message per line"),
+        ("local-dev", 'legacy alias for "local dev"'),
     ]
-    validate_help = "validate source, methods are:\n" + "\n".join(
+    validate_help = "validate source; -M may combine values in any order:\n" + "\n".join(
         ["  {} - {}".format(info[0], info[1]) for info in validate_info]
     )
     parser.add_argument(
@@ -557,10 +587,17 @@ def get_cli_arguments():
         dest="validate",
     )
     parser.add_argument(
-        "xml_file", help="PreTeXt source file with content", action="store"
+        "xml_file", help="PreTeXt source file with content", action="store", nargs="?"
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.xml_file is None and args.method:
+        if args.validate and all_validation_method_tokens(args.method):
+            parser.error("the following arguments are required: xml_file")
+        args.xml_file = args.method.pop()
+    if args.xml_file is None:
+        parser.error("the following arguments are required: xml_file")
+    return args
 
 
 ############################################


### PR DESCRIPTION
This makes the -M flag accept multiple values to specify the three concepts: where to run; which schema to use; how to format the output.

So you might specify:

... -V -M dev terse
or
... -V -M server dev verbose

local-dev is kept as an alias for "local dev"