### PR TITLE
HTML: the MathJax module specifier is relative only for a local build

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -13958,7 +13958,16 @@ TODO:
 <xsl:template name="mathjax">
     <!-- MathJax 4 configuration via JavaScript module -->
     <script type="module">
-        <xsl:text>import { startMathJax } from './</xsl:text>
+        <!-- A module specifier is either an absolute URL or a relative      -->
+        <!-- reference beginning "/", "./", or "../" - a bare path will not  -->
+        <!-- resolve.  So a local build, where "html.js.dir" is relative,    -->
+        <!-- needs the "./", while a CDN build, where the prefix has already -->
+        <!-- made it absolute, must not have it: the "./" would make the     -->
+        <!-- whole URL relative to the page.                                 -->
+        <xsl:text>import { startMathJax } from '</xsl:text>
+        <xsl:if test="$cdn-prefix = ''">
+            <xsl:text>./</xsl:text>
+        </xsl:if>
         <xsl:value-of select="$html.js.dir"/>
         <xsl:text>/mathjax_startup.js';&#xa;</xsl:text>
         <xsl:text>startMathJax({&#xa;</xsl:text>


### PR DESCRIPTION
The `mathjax` template hard-codes a `./` before `$html.js.dir` when writing the module import for the MathJax startup script.  That prefix is correct for a local build, where `$html.js.dir` is the relative `_static/pretext/js/dist`, and wrong for a CDN build, where `$cdn-prefix` has already made it absolute.  In the CDN case the browser sees a relative reference and resolves it against the page:

```
import { startMathJax } from './https://cdn.jsdelivr.net/gh/PreTeXtBook/html-static@latest/dist/_static/pretext/js/dist/mathjax_startup.js';

→ https://example.org/book/https:/cdn.jsdelivr.net/.../mathjax_startup.js
→ TypeError: Failed to fetch dynamically imported module
```

`startMathJax` never runs.  This affects every build with `<html><resources host="cdn"/></html>` and every portable build, since `@portable` forces `$b-cdn-resources`.

## Why nobody noticed

Mathematics still typesets.  MathJax itself loads from its own CDN in a separate `<script>`, so it comes up with stock defaults, and author macros still work because they reach MathJax as `\newcommand` in the page body via `configmacros`, not through `startMathJax`.  What is lost is everything that needs a *loaded extension*.  Comparing `window.MathJax.config` between two builds of the sample article, before this change:

| | `resources host="local"` | `resources host="cdn"` |
|---|---|---|
| `loader.load` | `input/asciimath`, `[tex]/amscd`, `[tex]/color` | `[]` |
| `tex.packages` | … `configmacros`, `amscd`, `color`, `knowl` | … `configmacros` (ends there) |

So knowls inside mathematics, `\begin{CD}` commutative diagrams, `\color`, and AsciiMath input have all been quietly unavailable in CDN and portable output — along with the rest of the `startMathJax` arguments (`lang`, `hasWebworkReps`, `hasSage`, the accessibility setup).  No console error is visible to an author who is not looking for one.

## The change

```xml
<xsl:text>import { startMathJax } from '</xsl:text>
<xsl:if test="$cdn-prefix = ''">
    <xsl:text>./</xsl:text>
</xsl:if>
<xsl:value-of select="$html.js.dir"/>
```

The `./` cannot simply be deleted: a module specifier must be an absolute URL or begin with `/`, `./`, or `../`, so a *bare* `_static/pretext/js/dist/…` is rejected outright by the browser.  The prefix is required locally and forbidden remotely, hence the condition.

I tested `$cdn-prefix = ''` rather than `not($b-cdn-resources)` on purpose.  The prefix being empty is precisely what makes the path relative, and the comment at `$html.css.dir` notes a publisher could point these locations elsewhere, so the prefix is the more durable test.  Happy to switch to the boolean if the house idiom is preferred.

## Verification

Sample article, three configurations:

| publication | specifier emitted |
|---|---|
| default | `./_static/pretext/js/dist/mathjax_startup.js` |
| `<resources host="cdn"/>` | `https://cdn.jsdelivr.net/…/mathjax_startup.js` |
| `<platform portable="yes"/>` | `https://cdn.jsdelivr.net/…/mathjax_startup.js` |

The local build is byte-identical to `master` apart from build timestamps — zero differences in the emitted script.

Loaded both builds in Chrome over `http://localhost`, so specifiers resolve as they would on a real site.  After the change the CDN build matches the local one exactly: the import resolves, `loader.load` is `input/asciimath`, `[tex]/amscd`, `[tex]/color`, `tex.packages` regains `amscd`, `color` and `knowl`, and all 47 math containers render with no errors in both.

This is the only `import` statement in `xsl/`.  The other two `type="module"` scripts are the mermaid header, which uses absolute CDN URLs directly, and author-supplied `interactive` script content; neither has the problem.

Introduced in `bba4f3f3` (2026-04-04, the MathJax 4 switch).  The MathJax 3 configuration it replaced used `$html.js.dir` bare in `loader.paths.pretext`, which was correct in both modes.

Closes #3156

*Claude Opus 5 (1M context), acting as a coding assistant for Rob Beezer*
