### PR TITLE
strawman attempt at a static-first runestone multiplechoice interactive

### DIFF
--- a/js/dist/pretext-core.js
+++ b/js/dist/pretext-core.js
@@ -2069,6 +2069,9 @@
       });
       section.appendChild(list);
       container.replaceChildren(section);
+      if (window.runestoneComponents) {
+        window.runestoneComponents.renderOneComponent(container);
+      }
     });
   }
   async function loadPrintout(printableSectionID) {

--- a/js/dist/pretext-core.js
+++ b/js/dist/pretext-core.js
@@ -2020,6 +2020,57 @@
     ev.stopPropagation();
     window.location.assign(link.href);
   });
+  function hydrateMultipleChoice() {
+    document.querySelectorAll('[data-hydrate="multiplechoice"]').forEach((container) => {
+      const id = container.id;
+      const statement = container.querySelector(":scope > .exercise-statement");
+      const choices = container.querySelectorAll(":scope > ol.runestone-static-choices > li");
+      if (!id || !statement || choices.length === 0) return;
+      const section = document.createElement("div");
+      section.className = "runestone multiplechoice_section";
+      section.appendChild(statement);
+      const list = document.createElement("ul");
+      list.id = id;
+      list.className = "exercise-interactives";
+      list.dataset.component = "multiplechoice";
+      if (container.dataset.multipleanswers) {
+        list.dataset.multipleanswers = container.dataset.multipleanswers;
+      }
+      if ("random" in container.dataset) {
+        list.dataset.random = "";
+      }
+      choices.forEach((choice, index) => {
+        const letter = String.fromCharCode("a".charCodeAt(0) + index);
+        const choiceId = `${id}_opt_${letter}`;
+        const feedback = choice.querySelector(":scope > .choice-feedback");
+        const answerItem = document.createElement("li");
+        answerItem.id = choiceId;
+        answerItem.dataset.component = "answer";
+        if ("correct" in choice.dataset) {
+          answerItem.dataset.correct = "";
+        }
+        while (choice.firstChild) {
+          if (choice.firstChild === feedback) {
+            choice.removeChild(feedback);
+            continue;
+          }
+          answerItem.appendChild(choice.firstChild);
+        }
+        list.appendChild(answerItem);
+        const feedbackItem = document.createElement("li");
+        feedbackItem.id = choiceId;
+        feedbackItem.dataset.component = "feedback";
+        if (feedback) {
+          while (feedback.firstChild) {
+            feedbackItem.appendChild(feedback.firstChild);
+          }
+        }
+        list.appendChild(feedbackItem);
+      });
+      section.appendChild(list);
+      container.replaceChildren(section);
+    });
+  }
   async function loadPrintout(printableSectionID) {
     const themeStylesheetLink = document.querySelector('link[rel="stylesheet"][href*="theme"]');
     const themeStylesheetHref = themeStylesheetLink ? themeStylesheetLink.getAttribute("href") : null;
@@ -2143,6 +2194,9 @@
   window.addEventListener("DOMContentLoaded", async function(event2) {
     const urlParams = new URLSearchParams(window.location.search);
     let pendingSettle = Promise.resolve();
+    if (!urlParams.has("printpreview")) {
+      hydrateMultipleChoice();
+    }
     if (urlParams.has("printpreview")) {
       const printableSectionID = urlParams.get("printpreview");
       await loadPrintout(printableSectionID);

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1342,20 +1342,19 @@ document.addEventListener("click", (ev) => {
 // and a hidden/visible .choice-feedback div per choice) so that the exercise
 // is always usable as-is: in print preview, or for a reader without JS. On a
 // normal page, this rebuilds -- in place, from that same static HTML -- the
-// data-component skeleton Runestone's own JS expects, and lets Runestone
-// enhance it into the interactive widget exactly as it does today.
+// data-component skeleton Runestone's own JS expects, then explicitly asks
+// Runestone to render it via window.runestoneComponents.renderOneComponent().
+// That's the same public entry point knowl.js's addKnowl() already relies on
+// for interactives injected into a knowl after page load: Runestone's own
+// automatic page-load scan only ever sees markup that was already present
+// when *it* ran (well before this DOMContentLoaded handler gets a turn), so
+// anything built afterward -- ours included -- needs this explicit call, or
+// it's never picked up.
 //
 // This mutates each container in place rather than hiding one version and
 // showing another, so there's no separate CSS toggle: skip this call (as the
 // printpreview DOMContentLoaded handler below does) and the static markup is
 // simply what's left on the page.
-//
-// Must run synchronously, before this module's DOMContentLoaded handler
-// hits its first `await`: the <head> loads this bundle before Runestone's
-// own script, so Runestone's component scan can only be deferred to some
-// later event (almost certainly DOMContentLoaded itself) -- same-event
-// listeners fire in registration order, so running this before any `await`
-// here guarantees it wins the race against Runestone's own listener.
 function hydrateMultipleChoice() {
     document.querySelectorAll('[data-hydrate="multiplechoice"]').forEach(container => {
         const id = container.id;
@@ -1411,6 +1410,10 @@ function hydrateMultipleChoice() {
 
         section.appendChild(list);
         container.replaceChildren(section);
+
+        if (window.runestoneComponents) {
+            window.runestoneComponents.renderOneComponent(container);
+        }
     });
 }
 
@@ -1620,9 +1623,7 @@ window.addEventListener("DOMContentLoaded", async function(event) {
     const urlParams = new URLSearchParams(window.location.search);
     let pendingSettle = Promise.resolve();
     // Print preview shows the static, plain-HTML exercise markup as-is; every
-    // other page hydrates it into the interactive Runestone widget. Must run
-    // here, synchronously, before this handler's first `await` below -- see
-    // hydrateMultipleChoice()'s docstring for why that ordering matters.
+    // other page hydrates it into the interactive Runestone widget.
     if (!urlParams.has("printpreview")) {
         hydrateMultipleChoice();
     }

--- a/js/pretext_add_on.js
+++ b/js/pretext_add_on.js
@@ -1337,6 +1337,83 @@ document.addEventListener("click", (ev) => {
     window.location.assign(link.href);
 });
 
+// PreTeXt emits multiple-choice exercises as static, readable HTML (a
+// statement plus a lettered <ol> of choices, annotated with @data-correct
+// and a hidden/visible .choice-feedback div per choice) so that the exercise
+// is always usable as-is: in print preview, or for a reader without JS. On a
+// normal page, this rebuilds -- in place, from that same static HTML -- the
+// data-component skeleton Runestone's own JS expects, and lets Runestone
+// enhance it into the interactive widget exactly as it does today.
+//
+// This mutates each container in place rather than hiding one version and
+// showing another, so there's no separate CSS toggle: skip this call (as the
+// printpreview DOMContentLoaded handler below does) and the static markup is
+// simply what's left on the page.
+//
+// Must run synchronously, before this module's DOMContentLoaded handler
+// hits its first `await`: the <head> loads this bundle before Runestone's
+// own script, so Runestone's component scan can only be deferred to some
+// later event (almost certainly DOMContentLoaded itself) -- same-event
+// listeners fire in registration order, so running this before any `await`
+// here guarantees it wins the race against Runestone's own listener.
+function hydrateMultipleChoice() {
+    document.querySelectorAll('[data-hydrate="multiplechoice"]').forEach(container => {
+        const id = container.id;
+        const statement = container.querySelector(':scope > .exercise-statement');
+        const choices = container.querySelectorAll(':scope > ol.runestone-static-choices > li');
+        if (!id || !statement || choices.length === 0) return;
+
+        const section = document.createElement('div');
+        section.className = 'runestone multiplechoice_section';
+        section.appendChild(statement);
+
+        const list = document.createElement('ul');
+        list.id = id;
+        list.className = 'exercise-interactives';
+        list.dataset.component = 'multiplechoice';
+        if (container.dataset.multipleanswers) {
+            list.dataset.multipleanswers = container.dataset.multipleanswers;
+        }
+        if ('random' in container.dataset) {
+            list.dataset.random = '';
+        }
+
+        choices.forEach((choice, index) => {
+            const letter = String.fromCharCode('a'.charCodeAt(0) + index);
+            const choiceId = `${id}_opt_${letter}`;
+            const feedback = choice.querySelector(':scope > .choice-feedback');
+
+            const answerItem = document.createElement('li');
+            answerItem.id = choiceId;
+            answerItem.dataset.component = 'answer';
+            if ('correct' in choice.dataset) {
+                answerItem.dataset.correct = '';
+            }
+            while (choice.firstChild) {
+                if (choice.firstChild === feedback) {
+                    choice.removeChild(feedback);
+                    continue;
+                }
+                answerItem.appendChild(choice.firstChild);
+            }
+            list.appendChild(answerItem);
+
+            const feedbackItem = document.createElement('li');
+            feedbackItem.id = choiceId;
+            feedbackItem.dataset.component = 'feedback';
+            if (feedback) {
+                while (feedback.firstChild) {
+                    feedbackItem.appendChild(feedback.firstChild);
+                }
+            }
+            list.appendChild(feedbackItem);
+        });
+
+        section.appendChild(list);
+        container.replaceChildren(section);
+    });
+}
+
 // Function to load the printout section and switch to print stylesheet.  This will run whenever a user clicks on a print preview link (which adds ?printpreview=sectionID to the URL).
 async function loadPrintout(printableSectionID) {
 
@@ -1542,6 +1619,13 @@ async function applySolutionVisibility(solutionType, hidden, {paperSize, margins
 window.addEventListener("DOMContentLoaded", async function(event) {
     const urlParams = new URLSearchParams(window.location.search);
     let pendingSettle = Promise.resolve();
+    // Print preview shows the static, plain-HTML exercise markup as-is; every
+    // other page hydrates it into the interactive Runestone widget. Must run
+    // here, synchronously, before this handler's first `await` below -- see
+    // hydrateMultipleChoice()'s docstring for why that ordering matters.
+    if (!urlParams.has("printpreview")) {
+        hydrateMultipleChoice();
+    }
     // We condition on the existence of the papersize radio buttons, which only appear in the printout print preview.
     if (urlParams.has("printpreview")) {
         const printableSectionID = urlParams.get("printpreview");

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -4665,7 +4665,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:param name="b-has-solution" />
 
     <xsl:if test="$b-has-statement">
-        <xsl:apply-templates select="." mode="runestone-to-interactive"/>
+        <xsl:apply-templates select="." mode="runestone-to-interactive">
+            <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+        </xsl:apply-templates>
     </xsl:if>
     <xsl:apply-templates select="." mode="solutions-div">
         <xsl:with-param name="b-original" select="$b-original"/>

--- a/xsl/pretext-runestone.xsl
+++ b/xsl/pretext-runestone.xsl
@@ -1049,76 +1049,72 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- Multiple Choice -->
 
+<!-- Static-first, JS-hydrated: this emits genuine, readable HTML (a       -->
+<!-- statement plus a lettered list of choices) that is fully usable as-is -->
+<!-- (print, no-JS).  It is annotated with just enough data (@data-correct, -->
+<!-- @data-hydrate, the multipleanswers/random flags) for client-side JS    -->
+<!-- (hydrateMultipleChoice() in pretext_add_on.js) to rebuild, in place,   -->
+<!-- the exact data-component skeleton Runestone's own JS expects, before  -->
+<!-- Runestone's script has a chance to scan the page.  If that JS never   -->
+<!-- runs (print preview, or JS disabled), this static markup is simply    -->
+<!-- what the reader sees.                                                  -->
 <xsl:template match="*[@pi:exercise-interactive = 'multiplechoice']" mode="runestone-to-interactive">
-    <div class="ptx-runestone-container">
-        <div class="runestone multiplechoice_section">
-            <!-- overall statement, not per-choice -->
-            <div class="exercise-statement">
-                <xsl:apply-templates select="statement"/>
-            </div>
-            <!-- ul can have multiple answer attribute -->
-            <ul data-component="multiplechoice" class="exercise-interactives">
-                <xsl:apply-templates select="." mode="runestone-id-attribute"/>
-                <xsl:variable name="ncorrect" select="count(choices/choice[@correct = 'yes'])"/>
-                <xsl:attribute name="data-multipleanswers">
-                    <xsl:choose>
-                        <xsl:when test="choices/@multiple-correct = 'yes'">
-                            <xsl:text>true</xsl:text>
-                        </xsl:when>
-                        <xsl:when test="choices/@multiple-correct = 'no'">
-                            <xsl:text>false</xsl:text>
-                        </xsl:when>
-                        <xsl:when test="$ncorrect > 1">
-                            <xsl:text>true</xsl:text>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:text>false</xsl:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:attribute>
-                <!-- bare attribute, iff requested -->
-                <xsl:if test="choices/@randomize = 'yes'">
-                    <xsl:attribute name="data-random"/>
-                </xsl:if>
-                <xsl:apply-templates select="choices/choice">
-                    <xsl:with-param name="the-id">
-                        <xsl:apply-templates select="." mode="runestone-id"/>
-                    </xsl:with-param>
-                </xsl:apply-templates>
-            </ul>
+    <xsl:param name="b-has-solution" select="false()"/>
+    <div class="ptx-runestone-container" data-hydrate="multiplechoice">
+        <xsl:apply-templates select="." mode="runestone-id-attribute"/>
+        <xsl:variable name="ncorrect" select="count(choices/choice[@correct = 'yes'])"/>
+        <xsl:attribute name="data-multipleanswers">
+            <xsl:choose>
+                <xsl:when test="choices/@multiple-correct = 'yes'">
+                    <xsl:text>true</xsl:text>
+                </xsl:when>
+                <xsl:when test="choices/@multiple-correct = 'no'">
+                    <xsl:text>false</xsl:text>
+                </xsl:when>
+                <xsl:when test="$ncorrect > 1">
+                    <xsl:text>true</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>false</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+        <!-- bare attribute, iff requested -->
+        <xsl:if test="choices/@randomize = 'yes'">
+            <xsl:attribute name="data-random"/>
+        </xsl:if>
+        <!-- overall statement, not per-choice -->
+        <div class="exercise-statement">
+            <xsl:apply-templates select="statement"/>
         </div>
+        <ol class="runestone-static-choices" type="A">
+            <xsl:apply-templates select="choices/choice">
+                <xsl:with-param name="b-has-solution" select="$b-has-solution"/>
+            </xsl:apply-templates>
+        </ol>
     </div>
 </xsl:template>
 
 <xsl:template match="choices/choice">
-    <xsl:param name="the-id"/>
+    <xsl:param name="b-has-solution" select="false()"/>
 
-    <!-- id for each "choice"                  -->
-    <!-- with common base, then a, b, c suffix -->
-    <!-- Used *twice* on adjacent "li"?        -->
-    <xsl:variable name="choice-id">
-        <xsl:value-of select="$the-id"/>
-        <xsl:text>_opt_</xsl:text>
-        <!-- will count preceding "choice" only -->
-        <xsl:number format="a"/>
-    </xsl:variable>
-    <li data-component="answer">
-        <xsl:attribute name="id">
-            <xsl:value-of select="$choice-id"/>
-        </xsl:attribute>
-        <!-- mark correct answers (empty attribute value) -->
+    <li>
+        <!-- mark correct answers, consumed by hydrateMultipleChoice() -->
         <xsl:if test="@correct = 'yes'">
-            <xsl:attribute name="data-correct"/>
+            <xsl:attribute name="data-correct">yes</xsl:attribute>
         </xsl:if>
         <!-- per-choice statement -->
         <xsl:apply-templates select="statement"/>
-    </li>
-    <li data-component="feedback">
-        <xsl:attribute name="id">
-            <xsl:value-of select="$choice-id"/>
-        </xsl:attribute>
-        <!-- per-choice explanation -->
-        <xsl:apply-templates select="feedback"/>
+        <!-- per-choice explanation: visible here only when solutions are   -->
+        <!-- visible in this exercise's context, matching every other       -->
+        <!-- exercise type; otherwise present but hidden, for JS to move    -->
+        <!-- into the hydrated widget's feedback reveal.                    -->
+        <div class="choice-feedback">
+            <xsl:if test="not($b-has-solution)">
+                <xsl:attribute name="hidden"/>
+            </xsl:if>
+            <xsl:apply-templates select="feedback"/>
+        </div>
     </li>
 </xsl:template>
 


### PR DESCRIPTION
WIP draft PR based upon discussions with @oscarlevin in mathtech discord.

Following is the LLM summary of this proposal. I will review and update before marking as ready to review by others. A known deficiency as of this edit: this only touches exercises with choices, but there are several other semantically-described `<exercise/>`s that should have improved print-ready HTML for use in worksheet/handout print previews.

# Static-first, JS-hydrated multiple-choice exercises

## Summary

A `<worksheet>` is meant to be printed, but a multiple-choice `<exercise>`
(one with a `<choices>` block) was rendered straight to a Runestone-JS-only
skeleton — a bare `<ul data-component="multiplechoice">` of answer/feedback
`<li>`s that only became a real question once Runestone's JS enhanced it at
runtime. Printing a worksheet goes through a client-side-only "print
preview" pass that swaps stylesheets and reflows content, but never touches
the DOM inside an exercise, and there's no XSLT-time "print mode" to branch
on, since screen and print share one DOM. The result: a printed worksheet
either showed nothing where the question belonged, or leaked the raw,
unstyled skeleton.

This PR reworks multiple-choice rendering, site-wide, into a **static-first,
progressively-enhanced** pattern:

- XSLT now always emits genuine, readable HTML — a statement plus a lettered
  list of choices — annotated with just enough data (`data-correct`, a
  `.choice-feedback` block) to rebuild the interactive widget later.
- On a normal page load, JS reads that static HTML, rebuilds the exact
  `data-component` skeleton Runestone expects, and explicitly hands it to
  Runestone via `window.runestoneComponents.renderOneComponent()` — the same
  entry point `knowl.js` already uses for interactives injected after page
  load, since Runestone's own automatic scan only ever sees markup that
  existed when *it* ran.
- On a print-preview page, or for any reader without JS, that hydration step
  never runs, so the plain static HTML is simply what's shown.

Worksheets get a working printed/no-JS fallback as the direct result of a
general fix, rather than a worksheet-specific special case — and every
multiple-choice exercise anywhere in a book now degrades gracefully without
JS, for free.

## Before / after

**Regular (interactive) view** — unchanged from a reader's perspective:
Runestone's full widget, radio buttons, and "Check Me" button.

<img width="600" height="235" alt="download" src="https://github.com/user-attachments/assets/9f2c976c-5f7f-48b3-9919-0c7469b9cc3e" />

**Print preview view** — previously a dead or broken skeleton; now a clean,
readable, lettered list:

<img width="672" height="110" alt="download" src="https://github.com/user-attachments/assets/f0746054-cdac-446d-a403-d7bd7e0fe11f" />

## How it works

| | Before | After |
|---|---|---|
| XSLT output | `<ul data-component="multiplechoice">` skeleton, unusable without JS | Real `<statement>` + lettered `<ol>` of choices, readable as-is |
| Interactivity | Runestone's automatic page-load scan enhanced the skeleton in place | JS rebuilds the skeleton from the static HTML, then explicitly calls `renderOneComponent()` |
| Print preview | No special handling — showed the broken skeleton | Hydration is skipped entirely; static HTML is what prints |
| No-JS fallback | Broken, unstyled skeleton with feedback text exposed | Same readable static HTML as print preview |

## Files changed

- **`xsl/pretext-runestone.xsl`** — the multiple-choice templates now
  hand-author static HTML (statement, lettered `<ol>` of choices,
  `data-correct`, a `.choice-feedback` block gated by the same
  `$b-has-solution` switch used everywhere else) instead of the
  JS-dependent skeleton.
- **`xsl/pretext-html.xsl`** — forwards the already-computed
  `$b-has-solution` flag into the template above.
- **`js/pretext_add_on.js`** (+ regenerated **`js/dist/pretext-core.js`**) —
  new `hydrateMultipleChoice()`, called from the existing `DOMContentLoaded`
  handler whenever the page isn't a print preview; rebuilds the interactive
  skeleton in place and hands it to Runestone via `renderOneComponent()`.

## Testing

Verified end-to-end against a real build (Saxon + the modified core, served
locally) with a headless-browser check:

- **Interactive page**: hydration runs, Runestone fully initializes the
  widget (`class="... runestone-component-ready"`), radio buttons render,
  MathJax typesets, and clicking an answer + "Check Me" correctly reveals
  the matching feedback ("✔️ Correct, 7 is prime.").
- **Print preview page** (`?printpreview=<id>`): hydration is skipped, no
  `data-component` anywhere, no radio buttons — just the plain lettered
  list.
- **JS disabled**: same plain, readable list as print preview — no blank or
  broken output.
- **Solution-visibility publisher switches** (`common/exercise-worksheet`,
  `exercise-divisional`, etc.) correctly gate whether `.choice-feedback`
  starts hidden, reusing the existing mechanism rather than inventing a new
  one.
- Zero console/page errors in either view.

## Scope

Multiple-choice (`choices`) only, matching the original ask. Other
Runestone interactivity types (`truefalse`, `parson`, `matching`, etc.) are
unchanged and out of scope for this PR.