### PR TITLE
Script: request offscreen Asymptote rendering only where it exists

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -453,31 +453,57 @@ def asymptote_conversion(
             outformats = [outformat]
         else:
             outformats = []
+        # The version does not vary with the output format, so we ask for it
+        # once rather than once per format, and any advisory about a version
+        # we cannot read is then issued just once as well.
+        asy_executable_cmd = []
+        asyversion = ""
+        rendering_option = []
+        if outformats and (method == "local"):
+            asy_executable_cmd = common.get_executable_cmd("asy")
+            proc = subprocess.Popen(
+                [asy_executable_cmd[0], "--version"], stderr=subprocess.PIPE
+            )
+            # bytes -> ASCII, strip final newline
+            asyversion = proc.stderr.read().decode("ascii")[:-1]
+            version_numbers = asymptote_version_numbers(asyversion)
+            if version_numbers is None:
+                msg = [
+                    "the version of Asymptote could not be determined, so a current version",
+                    "             is assumed and offscreen rendering requested.  If no images are built,",
+                    "             and your Asymptote lies between 2.66 and 3.11, that is the explanation.",
+                    "             A version query replied:",
+                    "             {}".format(asyversion),
+                ]
+                log.warning("\n".join(msg))
+                version_numbers = (3, 13)
+            # "-offscreen" has come and gone: Asymptote introduced it at 2.11,
+            # dropped it at 2.66, and restored it at 3.12.  (Checked against
+            # every release from 1.67 to 3.13.)  A version lacking the option
+            # does not say so.  Its parser reads "-offscreen" as "-o ffscreen",
+            # so every image is written to a file of that name, and Asymptote
+            # exits successfully and silently: only the missing file betrays
+            # it.  "-iconify" is understood by every release, and so serves
+            # wherever offscreen rendering cannot be asked for.
+            if ((2, 11) <= version_numbers < (2, 66)) or ((3, 12) <= version_numbers):
+                rendering_option = ["-offscreen"]
+            else:
+                rendering_option = ["-iconify"]
         for outform in outformats:
             # initialize variables for each method
             asy_cli = []
             alberta = ""
-            asyversion = ""
             # setup, depending on the method
             if method == "local":
-                asy_executable_cmd = common.get_executable_cmd("asy")
-                # perhaps replace following stock advisory
-                # with a real version check.  Perhaps see:
-                # https://stackoverflow.com/questions/11887762/how-do-i-compare-version-numbers-in-python
-                proc = subprocess.Popen(
-                    [asy_executable_cmd[0], "--version"], stderr=subprocess.PIPE
-                )
-                # bytes -> ASCII, strip final newline
-                asyversion = proc.stderr.read().decode("ascii")[:-1]
                 # build command line to suit
                 # 2021-12-10, Michael Doob: "-noprc" is default for the server,
                 # and newer CLI versions.  Retain for explicit use locally when
                 # perhaps an older version is being employed
                 asy_cli = asy_executable_cmd + ["-f", outform, "-noV"]
                 if outform in ["pdf", "eps"]:
-                    asy_cli += ["-noprc", "-offscreen", "-tex", "xelatex", "-batchMask"]
+                    asy_cli += ["-noprc"] + rendering_option + ["-tex", "xelatex", "-batchMask"]
                 elif outform in ["svg", "png"]:
-                    asy_cli += ["-render=4", "-tex", "xelatex", "-offscreen"]
+                    asy_cli += ["-render=4", "-tex", "xelatex"] + rendering_option
             if method == "server":
                 alberta = "http://asymptote.ualberta.ca:10007?f={}".format(outform)
             # loop over .asy files, doing conversions
@@ -486,6 +512,17 @@ def asymptote_conversion(
                     ext_converter(asydiagram, outform, method, asy_cli, asyversion, alberta, dest_dir)
                 else:
                     individual_asymptote_conversion(asydiagram, outform, method, asy_cli, asyversion, alberta, dest_dir)
+
+def asymptote_version_numbers(version_banner):
+    """Asymptote's version as a tuple of integers, or None if not discernable"""
+    # Asked for "--version", Asymptote replies on standard error with a
+    # banner whose first line reads, for example,
+    #     Asymptote version 3.12 [(C) 2004 Andy Hammerlindl, ...
+    # Integers, and not the string, so that 3.9 precedes 3.11
+    version_match = re.search(r"Asymptote version ([0-9]+(?:\.[0-9]+)*)", version_banner)
+    if not version_match:
+        return None
+    return tuple(int(number) for number in version_match.group(1).split("."))
 
 def individual_asymptote_conversion(asydiagram, outform, method, asy_cli, asyversion, alberta, dest_dir):
     try:
@@ -518,8 +555,8 @@ def individual_asymptote_conversion(asydiagram, outform, method, asy_cli, asyver
         ]
         if method == "local":
             msg += [
-                "             Or your local copy of Asymtote may precede version 2.66 that we expect.",
-                "             In this case, not every image can be built in every possible format.",
+                "             Or your local copy of Asymptote may be too old to build this format,",
+                "             since not every version can produce every format.",
                 "",
                 "             Your Asymptote reports its version within the following:",
                 "             {}".format(asyversion),


### PR DESCRIPTION
Reported by Sean Fitzpatrick on pretext-dev.  Asymptote images silently fail to build on many installations: no image appears, and nothing says why.

`-offscreen` replaced the deprecated `-iconify` in `a839ccdc`, which enabled image generation in GitHub Codespaces.  But Asymptote parses single-dash long options with `getopt_long_only`, which falls back to short options when a long one is unknown.  On a version that does not have `-offscreen`, the flag is read as `-o ffscreen`: every image is written to a file named `ffscreen`, the expected file never appears, and Asymptote **exits successfully and prints nothing**.  Only the missing file betrays it, and because every image writes to that same name, a document's diagrams also overwrite one another.

## The option comes and goes

`-offscreen` was not introduced recently — it was introduced, removed, and restored.  I read `settings.cc` for **every numbered release from 1.67 to 3.13, 147 of them**, and checked which options each registers:

```
+-----------------------------+------------+
| Asymptote version           | option     |
+-----------------------------+------------+
| 1.67 (2009) - 2.10 (2011)   | -iconify   |
| 2.11 (2011) - 2.65 (2020)   | -offscreen |
| 2.66 (2020) - 3.11 (2026)   | -iconify   |
| 3.12 (2026) and later       | -offscreen |
| version unreadable          | -offscreen |
+-----------------------------+------------+
```

`-iconify` is registered by **all 147 releases without exception**, so it is always available where offscreen rendering cannot be requested.

Two details worth having on record.  The Asymptote release notes mention offscreen rendering at 2.11, but between 2.66 and 3.11 the only trace of the word in `settings.cc` is a feature-banner string, `"OpenGL 3D OSMesa offscreen rendering"` — so searching the banner is misleading.  And **3.12 is barely ten weeks old** (2026-06-02), with 3.11 from May, so until installations catch up this affects nearly everyone building Asymptote locally, not a rare configuration.

## The change

The version is read once per run rather than once per output format, parsed into a tuple of integers so that 3.9 precedes 3.11, and the option chosen from the table above.  An unreadable version is treated as 3.13 and therefore asks for offscreen rendering: a window opening for every image is disruptive, and on Windows especially so, which is what prompted the move to `-offscreen` in the first place.  That case also emits a warning naming the one band, 2.66 to 3.11, in which the assumption could be wrong.

This also retires the standing `# perhaps replace following stock advisory with a real version check` comment, which is now done.

## The failure advice

The message shown when an image does not appear said:

```
Or your local copy of Asymtote may precede version 2.66 that we expect.
In this case, not every image can be built in every possible format.
```

It now reads:

```
Or your local copy of Asymptote may be too old to build this format,
since not every version can produce every format.
```

`Asymtote` was a typo, the only occurrence in the repository.  The expectation of 2.66 appears nowhere else as a stated minimum, and naming it was actively misleading, since 2.66 is precisely where `-offscreen` support ended.  The two sentences also said the same thing twice.

## Verification

The decision was checked against the source scan itself: all 147 release numbers run through it, compared to what each release's `settings.cc` actually registers — **zero disagreements**.

End to end through the build script, with stubbed versions at every boundary:

```
1.90 -> -iconify     2.11 -> -offscreen     2.65 -> -offscreen
2.66 -> -iconify     3.11 -> -iconify       3.12 -> -offscreen
empty or unparseable -> -offscreen, with one warning
```

The option lands in the same position the previous code used, so for a current Asymptote the command line is byte-identical to before:

```
svg  ... -render=4 -tex xelatex -offscreen
pdf  ... -noprc -offscreen -tex xelatex -batchMask
```

On @rbeezer's machine, whose Asymptote is 2.85, a one-diagram document builds `asy-triangle.svg`, where master produces no file at all and warns that the output "was not built".  With five output formats and an unreadable version, the advisory appears once rather than five times.

Closes #3161

*Claude Opus 5 (1M context), acting as a coding assistant for Rob Beezer*
