### PR TITLE
Permalinks for inline headings

### DIFF
--- a/css/components/chunks/_discussion-inline.scss
+++ b/css/components/chunks/_discussion-inline.scss
@@ -26,10 +26,6 @@
       content: "\2009";
     }
 
-    & + .para {
-      display: inline;
-    }
-
     .space,
     .codenumber,
     .period {

--- a/css/components/chunks/_exercises.scss
+++ b/css/components/chunks/_exercises.scss
@@ -18,6 +18,7 @@
 //********************************************************************
 
 @use '../helpers/cols';
+@use './helpers/inline-heading-mixin';
 
 // generate multi column rules for exercises
 @include cols.allow-cols('.exercise-like');
@@ -32,6 +33,7 @@
 }
 
 .exercisegroup {
+  @include inline-heading-mixin.heading;
 
   .exercise-like {
     margin-top: 1em;
@@ -41,15 +43,6 @@
     font-size: 1.10em;
     line-height: 1.05em;
     margin-top: 0.75em;
-    display: inline;
-
-    & + .introduction {
-      display: inline;
-
-      & > .para:first-child {
-        display: inline;
-      }
-    }
   }
 
   // push the actual exercises down from any possible heading/intro

--- a/css/components/chunks/helpers/_inline-heading-mixin.scss
+++ b/css/components/chunks/helpers/_inline-heading-mixin.scss
@@ -32,19 +32,21 @@
     // For now limit to logical paragraphs and introductions as they seem to cover
     // the plain text cases. Not clear we would want same treatment for other
     // kinds of content
-    & + :is(.para, .para.logical, .introduction) {
+    & + :is(.para, .para.logical, .introduction):nth-child(2) {
       display: inline;
-      // possible first child that is the actual text
-      & > .para:first-child {
-        display: inline;
-        }
-      // an introduction could have a para.logical with a para
+      // Disable the autopermalink for this first child that is now inline
+      & > .autopermalink {
+          display: none;
+      }
+      
+      // possible first child that is the actual text also needs to be inlined
+      // and have permalink suppressed.
+      & > .para:first-child,
       & > .para.logical:first-child > .para:first-child {
         display: inline;
-      }
-      // Disable the autopermalink for this first child that is now inline
-      & .autopermalink {
-        display: none;
+        & > .autopermalink {
+          display: none;
+        }
       }
     }
   }

--- a/css/components/chunks/helpers/_inline-heading-mixin.scss
+++ b/css/components/chunks/helpers/_inline-heading-mixin.scss
@@ -42,6 +42,10 @@
       & > .para.logical:first-child > .para:first-child {
         display: inline;
       }
+      // Disable the autopermalink for this first child that is now inline
+      & .autopermalink {
+        display: none;
+      }
     }
   }
 }

--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -86,14 +86,19 @@ li > .autopermalink {
   left: -2.9em;
 }
 
-
-.axiom-like, .example-like, .exercise-like, .solution-like, .assemblage-like, .definition-like, .remark-like, .project-like, .openproblem-like, .computation-like, .theorem-like, .proof, .case, li, dd {
+// Hide the autopermalink for the first para of a list item or definition term
+li, dd {
   > .para:first-of-type > .autopermalink {
     display:none;
   }
+}
 
+// An unheaded solution-like or assemblage-like block and its first paragraph
+// occupy the same starting position.  Show only the block permalink there.
+:is(.solution-like, .assemblage-like):not(:has(> .heading)) {
+  > .para:first-of-type > .autopermalink,
   > .introduction > .para:first-of-type > .autopermalink {
-    display:none;
+    display: none;
   }
 }
 

--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -18,7 +18,7 @@
 //********************************************************************
 
 // TODO - refactor
-$opacity: 0.0 !default;
+$opacity: 1 !default;
 
 /*
 So that we can position things (like .autopermalink) absolutely wrt these items.

--- a/css/targets/html/default-modern/_chunks-default.scss
+++ b/css/targets/html/default-modern/_chunks-default.scss
@@ -104,6 +104,6 @@ section.solutions:not(:is(:first-child)) {
 }
 
 .paragraphs,
-article {
+article:not(:is(.assemblage-like, .goal-like)) {
   @include inline-heading-mixin.heading;
 }

--- a/css/targets/html/denver/_chunks-denver.scss
+++ b/css/targets/html/denver/_chunks-denver.scss
@@ -115,8 +115,9 @@ $chunk-heading-font-size: 1.125em !default;
 }
 
 .solution-like {
+  @include inline-heading-mixin.heading;
+
   .heading {
-    display: inline;
     font-style: italic;
     font-size: unset;
   }

--- a/css/targets/html/greeley/_chunks-greeley.scss
+++ b/css/targets/html/greeley/_chunks-greeley.scss
@@ -88,8 +88,9 @@ $border-radius: 8px !default;
 }
 
 .solution-like {
+  @include inline-heading-mixin.heading;
+
   .heading {
-    display: inline;
     font-style: italic;
     font-size: unset;
   }

--- a/css/targets/html/tacoma/_chunks-minimal.scss
+++ b/css/targets/html/tacoma/_chunks-minimal.scss
@@ -78,8 +78,6 @@ $border-radius: 8px !default;
 }
 
 .solution-like {
-  @include inline-heading-mixin.heading;
-
   .heading {
     font-style: italic;
     font-size: unset;

--- a/css/targets/html/tacoma/_chunks-minimal.scss
+++ b/css/targets/html/tacoma/_chunks-minimal.scss
@@ -78,8 +78,9 @@ $border-radius: 8px !default;
 }
 
 .solution-like {
+  @include inline-heading-mixin.heading;
+
   .heading {
-    display: inline;
     font-style: italic;
     font-size: unset;
   }


### PR DESCRIPTION
Cleanup for inline heading logic in CSS based on:
https://github.com/PreTeXtBook/pretext/pull/3150

Ties link "hide permalink" for affected elements to the fact that a particular element has an inlined heading, not on its type (`.solution-like`, `.proof`, etc...).