### PR TITLE
HTML: let the DoenetML coordinator manage a page's activities

### DIFF
--- a/doc/guide/publisher/online-html.xml
+++ b/doc/guide/publisher/online-html.xml
@@ -109,6 +109,23 @@
             <p>A window that allows for entering, and executing, computer programs can be made available for every page.  The reader can click on a pencil icon to activate this window.  Some languages can run in a web browser as part of any <init>HTML</init> output, while some other languages require infrastructure on a Runestone server to execute, and so are only available when you specify that hosting option.  Note that the publisher will select a single language for use with the entire document. See <xref ref="online-activecode"/> for details on specifying this option.</p>
         </subsection>
 
+        <subsection xml:id="online-html-doenetml">
+            <title>DoenetML Activities</title>
+            <idx><h>DoenetML</h><h>coordinator</h></idx>
+
+            <p>A DoenetML activity is a substantial piece of software.  A page carrying a dozen of them once started every one the moment the page opened, and held every one in memory for as long as the reader stayed<mdash/>enough, on a modest machine, that the activities could be slow to appear, or fail to appear at all.  So a page carrying DoenetML activities loads a small <term>coordinator</term> script, served from the same place as the activities themselves, which takes charge of them: it starts them a couple at a time as the reader nears them, so an activity the reader never scrolls to is never started, and it puts away the ones the reader has left well behind.  A reader's work is saved before an activity is put away and restored if the reader returns to it, and the space the activity occupies on the page is held while it is away, so nothing shifts.  This is on by default and needs nothing from an author, though a publisher can turn it off (<xref ref="online-doenetml-options"/>).</p>
+
+            <p>The coordinator also lets the activities on a page share a pool of the background workers they compute in.  A worker is the largest part of what an activity costs in memory, so the pool is most of the coordinator's saving; it too can be turned off, giving each activity a worker of its own.  Turning the coordinator off turns the pool off with it, since the coordinator is what owns the pool.</p>
+
+            <p>Two limits tune how much the coordinator allows at once: the number of activities kept running, and the number allowed to be starting up at the same time.  A book whose activities are small might raise them; but raising them asks more of the reader's machine, which is what the coordinator exists to avoid, and the defaults suit a reader on modest hardware.</p>
+
+            <p>The version of DoenetML in use, including the version of the coordinator, comes from the <tag>doenetml</tag> element of <tag>docinfo</tag> rather than from the publication file, since it is a property of the source: see <xref ref="topic-docinfo"/>.  A book that names no version, or names a partial one such as <c>0.7</c>, gets the newest release, which is what this machinery is written for.  A book that pins an exact version should pin <c>0.7.25</c> or later.</p>
+
+            <p>Two earlier boundaries matter to a book that does pin one.  The coordinator first shipped with DoenetML <c>0.7.21</c>, so a book pinned before that will not find the script at all and behaves as if the coordinator were turned off.  From <c>0.7.21</c> through <c>0.7.24</c> the script is there, but it does not yet share a page well with a book that saves the reader's work itself, as a Runestone or <init>SCORM</init> deployment does.  Two parties then answer an activity's request for its saved work<mdash/>the coordinator, from what it took down when it put the activity away, and the book's own saving<mdash/>and before <c>0.7.25</c> each answer rebuilt the activity in turn, so every restore built the document twice over.  That is the very cost the coordinator is there to avoid.  And since the answer that arrived last was the one kept, a book whose saving answers out of storage it has to go and fetch could have the fresher copy the coordinator was holding overwritten by an older one, leaving the reader to find work they had just done replaced.  A book pinned into that range should turn the coordinator off; a build that can see the combination will say so.</p>
+
+            <p>See <xref ref="online-doenetml-options"/> for the publication file entries controlling all of the above.</p>
+        </subsection>
+
         <subsection xml:id="online-base-url">
             <title>Base URL</title>
             <idx>base URL</idx>

--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1099,6 +1099,51 @@
             </p>
         </subsection>
 
+        <subsection xml:id="online-doenetml-options">
+            <title>DoenetML Options</title>
+            <idx><h>publisher options</h><h>DoenetML</h></idx>
+            <idx><h>DoenetML</h><h>coordinator</h></idx>
+
+            <p>
+                A page carrying DoenetML activities loads a small <term>coordinator</term> script that manages them, so that a page carrying many activities need not run them all at once.  The
+                <cd>
+                    <cline>/publication/html/interactives/doenetml</cline>
+                </cd>
+                element can have an attribute <attr>coordinator</attr> with values:<ul>
+                    <li><c>yes</c>: the default, let the coordinator manage the DoenetML activities on a page.</li>
+                    <li><c>no</c>: start every activity on a page at once, and keep every one of them running.</li>
+                </ul>
+            </p>
+
+            <p>
+                The same element can have an attribute <attr>shared-core-workers</attr> with values:<ul>
+                    <li><c>yes</c>: the default, let the activities on a page share a pool of the background workers they compute in.</li>
+                    <li><c>no</c>: give each activity a worker of its own.</li>
+                </ul>
+            </p>
+
+            <p>
+                Two attributes tune how much the coordinator allows at once: <attr>max-live-viewers</attr>, the number of activities kept running (default <c>3</c>), and <attr>max-concurrent-boots</attr>, the number allowed to be starting up at the same time (default <c>2</c>).  Both take a positive integer; any other value is reported during the build and the default used.
+            </p>
+
+            <p>
+                An example, for a book whose activities are small enough that more of them can be alive at once:
+                <cd>
+                    <cline>&lt;publication&gt;</cline>
+                    <cline>    &lt;html&gt;</cline>
+                    <cline>        &lt;interactives&gt;</cline>
+                    <cline>            &lt;doenetml max-live-viewers="6" max-concurrent-boots="3"/&gt;</cline>
+                    <cline>        &lt;/interactives&gt;</cline>
+                    <cline>    &lt;/html&gt;</cline>
+                    <cline>&lt;/publication&gt;</cline>
+                </cd>
+            </p>
+
+            <p>
+                See <xref ref="online-html-doenetml"/> for more information, including a caution for a book that pins its DoenetML version.
+            </p>
+        </subsection>
+
         <subsection xml:id="online-read-aloud-options">
             <title>Read Aloud Options</title>
             <idx><h>read aloud</h><h>publisher options</h></idx>

--- a/js/ptx_scorm_events.js
+++ b/js/ptx_scorm_events.js
@@ -484,16 +484,34 @@
     // Subject must be "SPLICE.getState.response" with the message_id echoed back.
     // State must be a JS object (not a JSON string) because Doenet checks state.cid directly.
     function respondToGetState(sourceWindow, messageId) {
+        // A request that arrives before the restore data is ready is queued and
+        // answered later, by which time its frame may be gone.  The DoenetML
+        // coordinator parks an activity the reader has scrolled well past by
+        // pointing its iframe at about:blank, and that discards the browsing
+        // context the request came from: the MessageEvent.source captured when
+        // the request arrived reads back as null (verified in Chrome; the
+        // iframe's own contentWindow stays valid, it is the captured source
+        // that goes), so posting to it throws.  Unguarded, that throw escapes
+        // the loop draining the queue and every activity still behind it
+        // loses its saved state.
+        if (!sourceWindow) {
+            console.log('[PTX-SCORM] SPLICE.getState: requesting frame is gone; skipping response');
+            return;
+        }
         var divId = resolveIframeId(sourceWindow);
         var stateObj = divId ? loadDoenetState(divId) : null;  // JS object; Doenet checks state.cid
         console.log('[PTX-SCORM] SPLICE.getState from "' + (divId || '?') + '" — ' +
                     (stateObj ? 'sending saved state (cid: ' + (stateObj.cid || '?') + ')' : 'no saved state (first visit)'));
         if (divId) _doenetSentStateAt[divId] = Date.now();
-        sourceWindow.postMessage({
-            subject:    'SPLICE.getState.response',
-            message_id: messageId,
-            state:      stateObj || null
-        }, '*');
+        try {
+            sourceWindow.postMessage({
+                subject:    'SPLICE.getState.response',
+                message_id: messageId,
+                state:      stateObj || null
+            }, '*');
+        } catch (e) {
+            console.log('[PTX-SCORM] SPLICE.getState: could not reach the requesting frame: ' + e);
+        }
     }
 
     /**

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -337,13 +337,25 @@
                     calcplot3d |
                     circuitjs |
                     d3 |
-                    doenetml |
                     iframe |
                     javascript |
                     jsxgraph |
                     sage
                 ) {
                     attribute resize-behavior { "fixed-height" | "responsive" }?
+                }
+                | Doenetml
+
+            # DoenetML activities are additionally managed on the page by a
+            # "coordinator" script, which starts them a few at a time as the
+            # reader nears them and puts away the ones left well behind.
+            Doenetml =
+                element doenetml {
+                    attribute resize-behavior { "fixed-height" | "responsive" }?,
+                    attribute coordinator { "yes" | "no" }?,
+                    attribute shared-core-workers { "yes" | "no" }?,
+                    attribute max-live-viewers { xsd:positiveInteger }?,
+                    attribute max-concurrent-boots { xsd:positiveInteger }?
                 }
 
             Knowls =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -960,25 +960,70 @@
     </element>
   </define>
   <define name="InteractiveTypes">
-    <element>
-      <choice>
-        <name>geogebra</name>
-        <name>desmos</name>
-        <name>calcplot3d</name>
-        <name>circuitjs</name>
-        <name>d3</name>
-        <name>doenetml</name>
-        <name>iframe</name>
-        <name>javascript</name>
-        <name>jsxgraph</name>
-        <name>sage</name>
-      </choice>
+    <choice>
+      <element>
+        <choice>
+          <name>geogebra</name>
+          <name>desmos</name>
+          <name>calcplot3d</name>
+          <name>circuitjs</name>
+          <name>d3</name>
+          <name>iframe</name>
+          <name>javascript</name>
+          <name>jsxgraph</name>
+          <name>sage</name>
+        </choice>
+        <optional>
+          <attribute name="resize-behavior">
+            <choice>
+              <value>fixed-height</value>
+              <value>responsive</value>
+            </choice>
+          </attribute>
+        </optional>
+      </element>
+      <ref name="Doenetml"/>
+    </choice>
+  </define>
+  <!--
+    DoenetML activities are additionally managed on the page by a
+    "coordinator" script, which starts them a few at a time as the
+    reader nears them and puts away the ones left well behind.
+  -->
+  <define name="Doenetml">
+    <element name="doenetml">
       <optional>
         <attribute name="resize-behavior">
           <choice>
             <value>fixed-height</value>
             <value>responsive</value>
           </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="coordinator">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="shared-core-workers">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="max-live-viewers">
+          <data type="positiveInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="max-concurrent-boots">
+          <data type="positiveInteger"/>
         </attribute>
       </optional>
     </element>

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -539,13 +539,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     calcplot3d |
                     circuitjs |
                     d3 |
-                    doenetml |
                     iframe |
                     javascript |
                     jsxgraph |
                     sage
                 ) {
                     attribute resize-behavior { "fixed-height" | "responsive" }?
+                }
+                | Doenetml
+
+            # DoenetML activities are additionally managed on the page by a
+            # "coordinator" script, which starts them a few at a time as the
+            # reader nears them and puts away the ones left well behind.
+            Doenetml =
+                element doenetml {
+                    attribute resize-behavior { "fixed-height" | "responsive" }?,
+                    attribute coordinator { "yes" | "no" }?,
+                    attribute shared-core-workers { "yes" | "no" }?,
+                    attribute max-live-viewers { xsd:positiveInteger }?,
+                    attribute max-concurrent-boots { xsd:positiveInteger }?
                 }
 
             Knowls =

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -228,6 +228,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="b-has-sage"         select="boolean($document-root//sage)"/>
 <xsl:variable name="b-has-sfrac"        select="boolean($document-root//m[contains(text(),'sfrac')] or $document-root//mrow[contains(text(),'sfrac')])" />
 <xsl:variable name="b-has-geogebra"     select="boolean($document-root//interactive[@platform='geogebra'])"/>
+<xsl:variable name="b-has-doenetml"     select="boolean($document-root//interactive[@platform='doenetml'])"/>
 <xsl:variable name="b-has-mermaid"      select="boolean($document-root//image[mermaid]|/image[mermaid])"/>
 <!-- 2018-04-06:  jsxgraph deprecated -->
 <xsl:variable name="b-has-jsxgraph"     select="boolean($document-root//jsxgraph)"/>
@@ -10199,6 +10200,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:attribute name="src">
             <xsl:apply-templates select="." mode="iframe-filename" />
         </xsl:attribute>
+        <!-- how the coordinator script recognizes an activity it manages -->
+        <xsl:if test="(@platform = 'doenetml') and $b-doenetml-coordinator">
+            <xsl:attribute name="data-doenet-coordinate">true</xsl:attribute>
+        </xsl:if>
         <xsl:apply-templates select="." mode="iframe-accessibility-attributes"/>
     </iframe>
     <!-- possibly give a long description -->
@@ -10359,6 +10364,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{$d3-library-url}"></script>
 </xsl:template>
 
+<!-- The version of DoenetML a document asks for, absent any request from -->
+<!-- an individual "interactive".  Also the version of the coordinator    -->
+<!-- script a page carrying DoenetML activities loads.                    -->
+<xsl:variable name="doenetml-document-version">
+    <xsl:choose>
+        <xsl:when test="$docinfo/doenetml/@version">
+            <xsl:value-of select="$docinfo/doenetml/@version"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>latest</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!-- DoenetML header libraries -->
 <xsl:template match="interactive[@platform = 'doenetml']" mode="header-libraries">
     <xsl:variable name="doenet-version">
@@ -10366,11 +10385,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:when test="@version">
                 <xsl:value-of select="@version"/>
             </xsl:when>
-            <xsl:when test="$docinfo/doenetml/@version">
-                <xsl:value-of select="$docinfo/doenetml/@version"/>
-            </xsl:when>
             <xsl:otherwise>
-                <xsl:text>latest</xsl:text>
+                <xsl:value-of select="$doenetml-document-version"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
@@ -11526,6 +11542,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:call-template name="scorm-js"/>
     <xsl:call-template name="diagcess-header"/>
     <xsl:call-template name="lti-iframe-resizer"/>
+    <!-- NB: deliberately not in the iframe head cache above - the      -->
+    <!-- coordinator belongs on the page that *holds* the activities,   -->
+    <!-- and a standalone page holds the one it was extracted for.      -->
+    <xsl:call-template name="doenetml-coordinator" />
 </xsl:variable>
 
 <!-- Content used by simple-file-wrap -->
@@ -14600,6 +14620,51 @@ TODO:
 <xsl:template name="geogebra">
     <xsl:if test="$b-has-calculator and contains($html-calculator,'geogebra')">
         <script src="https://cdn.geogebra.org/apps/deployggb.js"></script>
+    </xsl:if>
+</xsl:template>
+
+<!-- DoenetML coordinator -->
+<!-- A "coordinator" script, served alongside the DoenetML bundle that   -->
+<!-- the activities already load, takes charge of a page's activity      -->
+<!-- "iframe"s so that a page carrying many of them need not run them    -->
+<!-- all at once.  See publisher-variables.xsl for what it does and for  -->
+<!-- the publisher's control over it.  The activity pages need no        -->
+<!-- cooperation - the coordinator marks each activity's URL and the     -->
+<!-- bundle recognizes the mark - so this one script tag is all of it.   -->
+<xsl:template name="doenetml-coordinator">
+    <xsl:if test="$b-has-doenetml and $b-doenetml-coordinator">
+        <xsl:variable name="doenet-coordinator-url">
+            <xsl:text>https://cdn.jsdelivr.net/npm/@doenet/standalone@</xsl:text>
+            <xsl:value-of select="$doenetml-document-version"/>
+            <xsl:text>/coordinator.js</xsl:text>
+        </xsl:variable>
+        <!-- A document pinned to a DoenetML version from 0.7.21 through    -->
+        <!-- 0.7.24 gets a coordinator that restores a parked activity's    -->
+        <!-- work itself, racing a host that restores saved work of its     -->
+        <!-- own - and the older copy can win, replacing work a reader      -->
+        <!-- just did.  The publisher may not have read the paragraph in    -->
+        <!-- the Guide that says so, and both facts are visible here, so    -->
+        <!-- warn.  A partial pin like "0.7" floats to the newest release   -->
+        <!-- and is safe; its patch part is empty, and fails the numeric    -->
+        <!-- comparisons below.                                             -->
+        <xsl:if test="$b-host-runestone or $b-host-scorm">
+            <xsl:variable name="doenetml-pin-patch" select="substring-after(substring-after($doenetml-document-version, '.'), '.')"/>
+            <xsl:if test="(substring-before($doenetml-document-version, '.') = '0') and (substring-before(substring-after($doenetml-document-version, '.'), '.') = '7') and (number($doenetml-pin-patch) &gt;= 21) and (number($doenetml-pin-patch) &lt;= 24)">
+                <xsl:message>PTX:WARNING: this document pins DoenetML version <xsl:value-of select="$doenetml-document-version"/>, whose activity coordinator can replace a reader's saved work with an older copy when the book is hosted on Runestone or as SCORM.  Pin version 0.7.25 or later, or set the "coordinator" attribute of the "doenetml" element of the publication file to "no"</xsl:message>
+            </xsl:if>
+        </xsl:if>
+        <!-- The selector confines the script to DoenetML activities (see   -->
+        <!-- the "data-doenet-coordinate" attribute placed on their         -->
+        <!-- "iframe"s); the script's own default would also sweep up every -->
+        <!-- "-if.html" iframe, which for PreTeXt means every other         -->
+        <!-- platform's interactive too.                                    -->
+        <!-- Two notes on the tag itself: it is a classic script, so        -->
+        <!-- "document.currentScript" still supplies its options under      -->
+        <!-- "defer", which keeps a CDN fetch from blocking every page of   -->
+        <!-- the book; and the script reads the shared-core-workers value   -->
+        <!-- as anything but the string "false", so the publisher's "no"    -->
+        <!-- must be stringified as "false" rather than passed through.     -->
+        <script defer="defer" src="{$doenet-coordinator-url}" data-iframe-selector="iframe[data-doenet-coordinate]" data-max-live-viewers="{$doenetml-max-live-viewers}" data-max-concurrent-boots="{$doenetml-max-concurrent-boots}" data-shared-core-workers="{$b-doenetml-shared-core-workers}"></script>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -2672,6 +2672,70 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 <xsl:variable name="b-video-privacy" select="$embedded-video-privacy = 'yes'"/>
 
+<!--                           -->
+<!-- HTML DoenetML Coordinator -->
+<!--                           -->
+
+<!-- A page carrying many DoenetML activities used to start every one of  -->
+<!-- them the moment the page loaded, and then hold every one of them in  -->
+<!-- memory for as long as the reader stayed.  The "coordinator" is a     -->
+<!-- small script, served from the same CDN as the activities themselves, -->
+<!-- which takes charge of the activity "iframe"s on a page: it starts    -->
+<!-- them a couple at a time as the reader nears them, and puts away the  -->
+<!-- ones the reader has left well behind (saving a reader's work, and    -->
+<!-- restoring it on the way back).  A publisher who prefers the older    -->
+<!-- behavior can say "no" here.                                          -->
+<xsl:variable name="doenetml-coordinator">
+    <xsl:apply-templates select="$publisher-attribute-options/html/interactives/doenetml/pi:pub-attribute[@name='coordinator']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-doenetml-coordinator" select="$doenetml-coordinator = 'yes'"/>
+
+<!-- Each DoenetML activity ordinarily gets a dedicated web worker to run -->
+<!-- in, which is the largest part of what an activity costs.  With the   -->
+<!-- coordinator in charge, the activities on a page can instead share a  -->
+<!-- pool of workers that the coordinator owns.  Only consulted when the  -->
+<!-- coordinator is in use.                                               -->
+<xsl:variable name="doenetml-shared-core-workers">
+    <xsl:apply-templates select="$publisher-attribute-options/html/interactives/doenetml/pi:pub-attribute[@name='shared-core-workers']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="b-doenetml-shared-core-workers" select="$doenetml-shared-core-workers = 'yes'"/>
+
+<!-- How many DoenetML activities the coordinator keeps running at once,  -->
+<!-- and how many it allows to be starting up at once.  The defaults suit -->
+<!-- a reader on modest hardware; a publisher whose activities are small, -->
+<!-- or whose readers are known to have capable machines, may raise them. -->
+<!-- Freeform entries, validated here to positive integers: the script    -->
+<!-- reads each one as a number, and an unusable number would leave it    -->
+<!-- forever waiting for room, never starting any activity at all.        -->
+<xsl:variable name="doenetml-max-live-viewers-entered">
+    <xsl:apply-templates select="$publisher-attribute-options/html/interactives/doenetml/pi:pub-attribute[@name='max-live-viewers']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="doenetml-max-live-viewers">
+    <xsl:choose>
+        <xsl:when test="(number($doenetml-max-live-viewers-entered) = round(number($doenetml-max-live-viewers-entered))) and (number($doenetml-max-live-viewers-entered) &gt; 0)">
+            <xsl:value-of select="round(number($doenetml-max-live-viewers-entered))"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:FALLBACK: the DoenetML "max-live-viewers" in the publication file ("<xsl:value-of select="$doenetml-max-live-viewers-entered"/>") must be a positive whole number of activities, using the default, 3</xsl:message>
+            <xsl:text>3</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+<xsl:variable name="doenetml-max-concurrent-boots-entered">
+    <xsl:apply-templates select="$publisher-attribute-options/html/interactives/doenetml/pi:pub-attribute[@name='max-concurrent-boots']" mode="set-pubfile-variable"/>
+</xsl:variable>
+<xsl:variable name="doenetml-max-concurrent-boots">
+    <xsl:choose>
+        <xsl:when test="(number($doenetml-max-concurrent-boots-entered) = round(number($doenetml-max-concurrent-boots-entered))) and (number($doenetml-max-concurrent-boots-entered) &gt; 0)">
+            <xsl:value-of select="round(number($doenetml-max-concurrent-boots-entered))"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:FALLBACK: the DoenetML "max-concurrent-boots" in the publication file ("<xsl:value-of select="$doenetml-max-concurrent-boots-entered"/>") must be a positive whole number of activities, using the default, 2</xsl:message>
+            <xsl:text>2</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
 <!--                       -->
 <!-- HTML Platform Options -->
 <!--                       -->
@@ -3608,6 +3672,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </desmos>
             <doenetml>
                 <pi:pub-attribute name="resize-behavior" default="fixed-height" options="responsive"/>
+                <pi:pub-attribute name="coordinator" default="yes" options="no"/>
+                <pi:pub-attribute name="shared-core-workers" default="yes" options="no"/>
+                <pi:pub-attribute name="max-live-viewers" default="3" freeform="yes"/>
+                <pi:pub-attribute name="max-concurrent-boots" default="2" freeform="yes"/>
             </doenetml>
             <geogebra>
                 <pi:pub-attribute name="resize-behavior" default="fixed-height" options="responsive"/>


### PR DESCRIPTION
Proposed on pretext-dev: https://groups.google.com/g/pretext-dev/c/kkF9ZJst3NI

## The problem

A page carrying many DoenetML activities starts all of them the moment it loads, and then holds all of them in memory for as long as the reader stays. On modest hardware the activities can take minutes to appear, or fail outright with "The document viewer could not be started."

## What this adds

DoenetML publishes a coordinator script alongside the bundle the activities already load. Given one script tag on the page that *holds* the activities, it takes charge of their iframes:

* it starts them a couple at a time as the reader nears them, so an activity the reader never scrolls to never starts at all;
* it parks the ones the reader has left well behind — flushing their state first and handing it back if the reader returns, so no work is lost. The iframe element stays in the layout while parked, so nothing shifts;
* with shared core workers, the activities draw on one pool of background workers instead of each taking a dedicated one, which is the bulk of what an activity costs.

The activity pages need no cooperation: the coordinator marks each activity's URL and the DoenetML bundle recognizes the mark. So the whole of it is the script tag, plus a `data-doenet-coordinate` attribute on the activity iframes so that only DoenetML activities are swept up — the script's own default selector would take every `*-if.html` iframe, which for PreTeXt means every other platform's interactives too.

The script goes in the head shared by content pages, and deliberately not in the one iframe pages get — it belongs on the page that holds the activities, not inside one. Standalone pages for a single interactive do not get it either, having nothing to coordinate.

## Measurements

The section of Active Calculus that prompted this (ten activities, https://mattboelkins.github.io/active-calculus-single-mbx/doenet/sec-1-3-derivative-pt.html), in headless Chrome, memory summed (PSS) across every browser process. Both arms pin DoenetML 0.7.25, so the coordinator is the only variable:

| scenario | without coordinator | with coordinator |
| --- | --- | --- |
| open the page and leave it | peak 2871 MB, settled 1446 MB | peak 986 MB, settled 552 MB |
| scroll through the whole page | peak 2881 MB, settled 1426 MB | peak 1481 MB, settled 775 MB |

In the second row every one of the ten activities is brought into view and read, so everything boots at least once; even then the peak is halved, and memory comes back down when the reader stops, which without the coordinator it never does. The first activity also appears sooner, since the page no longer starts all ten at once.

## Publisher entries

New entries on `html/interactives/doenetml`, documented in the publisher's guide:

* `@coordinator` — `"yes"` (default) or `"no"`;
* `@shared-core-workers` — `"yes"` (default) or `"no"`;
* `@max-live-viewers` and `@max-concurrent-boots` — positive integers for a publisher who wants to tune how much is allowed at once (defaults 3 and 2).

The schema source, the `.rnc`, and the `.rng` are all updated; the numeric entries are declared as positive integers, so the schema rejects what the guide forbids.

## Versions

The DoenetML version in use is a property of the source (`docinfo/doenetml/@version`), not of the publication file. A book that names no version or a partial one such as `0.7` gets the newest release, which is what these options are written for. The coordinator script first shipped in DoenetML `0.7.21`, so a book pinned earlier simply will not find it and behaves as before; a book pinned into `0.7.21`–`0.7.24` should set `@coordinator` to `no` — the build now warns when it can see that combination (a pin in that range together with a Runestone or SCORM host) — because in that range a restored activity is rebuilt once per party answering its request for saved state, and on some hosts the slower, staler answer could overwrite the reader's newer work. Both points are spelled out in the guide text this PR adds; `0.7.25`, current as of this PR, is safe.

## The SCORM commit

The second commit hardens `js/ptx_scorm_events.js` independently of any publisher choice. A `SPLICE.getState` request that arrives before the SCORM restore data is ready is queued and answered later, and the answer posts to the window that asked. With the coordinator managing the page, that window may be gone by then: parking an activity points its iframe at `about:blank`, which discards the browsing context the request came from. Measured in Chrome, the `MessageEvent.source` captured at arrival then reads back as `null` — while the iframe's own `contentWindow` stays valid — so posting to it throws, and since the throw happens inside the loop that drains the queue, every activity still queued behind it silently lost its saved state too. A missing window is now skipped and the post is guarded, so one departed frame costs only its own response.

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Fable 5, after earlier drafting by Claude Opus 5

