### PR TITLE
WeBWorK: use server's MathJax config

### DIFF
--- a/js/src/pretext-webwork.js
+++ b/js/src/pretext-webwork.js
@@ -342,61 +342,12 @@ async function handleWW(ww_id, action) {
         }
 
         let iframeContents = '<!DOCTYPE html><head>' +
-            '<script src="' + ww_domain + '/webwork2_files/node_modules/jquery/dist/jquery.min.js"></script>' +
-            `<script>
-                window.MathJax = {
-                    tex: { packages: { '[+]': ['noerrors'] } },
-                    loader: { load: ['input/asciimath', '[tex]/noerrors'] },
-                    startup: {
-                        ready() {
-                            const AM = MathJax.InputJax.AsciiMath.AM;
-
-                            // Modify existing AsciiMath triggers.
-                            AM.symbols[AM.names.indexOf('**')] = {
-                                input: '**',
-                                tag: 'msup',
-                                output: '^',
-                                tex: null,
-                                ttype: AM.TOKEN.INFIX
-                            };
-
-                            const i = AM.names.indexOf('infty');
-                            AM.names[i] = 'infinity';
-                            AM.symbols[i] = { input: 'infinity', tag: 'mo', output: '\u221E', tex: 'infty', ttype: AM.TOKEN.CONST };
-
-                            return MathJax.startup.defaultReady();
-                        }
-                    },
-                    options: {
-                        processHtmlClass: "process-math",
-                        renderActions: {
-                            findScript: [
-                                10,
-                                (doc) => {
-                                    for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-                                        const math = new doc.options.MathItem(
-                                            node.textContent,
-                                            doc.inputJax[0],
-                                            !!node.type.match(/; *mode=display/)
-                                        );
-                                        const text = document.createTextNode('');
-                                        node.parentNode.replaceChild(text, node);
-                                        math.start = { node: text, delim: '', n: 0 };
-                                        math.end = { node: text, delim: '', n: 0 };
-                                        doc.math.push(math);
-                                    }
-                                },
-                                ''
-                            ]
-                        },
-                        ignoreHtmlClass: 'tex2jax_ignore'
-                    }
-                };
-            </script>` +
-            '<script src="' + ww_domain + '/webwork2_files/node_modules/mathjax/es5/tex-chtml.js" id="MathJax-script" defer></script>' +
+            `<script src="${ww_domain}/webwork2_files/node_modules/jquery/dist/jquery.min.js"></script>` +
+            `<script src="${ww_domain}/webwork2_files/js/MathJaxConfig/mathjax-config.js"></script>` +
+            `<script src="${ww_domain}/webwork2_files/node_modules/mathjax/es5/tex-chtml.js" id="MathJax-script" defer></script>` +
             `<script src="${courseUrlBase}_static/pretext/js/dist/knowl.js" defer></script>` +
-            '<link rel="stylesheet" href="' + ww_domain + '/webwork2_files/node_modules/bootstrap/dist/css/bootstrap.min.css"/>' +
-            '<script src="' + ww_domain + '/webwork2_files/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js" defer></script>';
+            `<link rel="stylesheet" href="${ww_domain}/webwork2_files/node_modules/bootstrap/dist/css/bootstrap.min.css"/>` +
+            `<script src="${ww_domain}/webwork2_files/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js" defer></script>`;
 
         // Determine javascript and css dependencies
         const extra_css_files = [];


### PR DESCRIPTION
Head up: I don't think this clashes with #3147, but all the same, it would be better to process #3147 before this one.

In the past, when we supported old versions of WeBWorK, we needed to hard code the MathJax config here in `pretext-webwork.js`. Now that we only support 2.19 and 2.20, we do not need to do that, and we should use the webwork2 server's MathJax (v3) config. So that is the main change here. Most of the red in the diff here is replaced by one line of green at the new line 345.

Nearby, I changed some lines to interpolate a js variable, to make the code more readable.

Tested directly with 2.20. For 2.19, I located some live 2.19 servers and just checked that the path which is used here for a MathJax config file is valid on those servers. So it should work exactly the same.

[Sometime coming up soon, we will add support for 2.21 (with MJ v4). The change here will make that project cleaner. But I want to be clear that this PR alone is not bringing support for 2.21.]