### PR TITLE
Lists: custom markers via inlined "@counter-style" rules

### DIFF
--- a/css/components/elements/_list-styles.scss
+++ b/css/components/elements/_list-styles.scss
@@ -34,11 +34,6 @@ ol.lower-alpha {
     list-style-type: lower-alpha;
 }
 
-// Match LaTeX style for second level (i.e. level="1") lists
-ol.lower-alpha-level-1 > li::marker {
-    content: "("counter(list-item,lower-alpha)") ";
-}
-
 ol.upper-alpha {
     list-style-type: upper-alpha;
 }

--- a/css/dist/epub.css
+++ b/css/dist/epub.css
@@ -29,9 +29,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/kindle.css
+++ b/css/dist/kindle.css
@@ -29,9 +29,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/pretext-reveal.css
+++ b/css/dist/pretext-reveal.css
@@ -10,9 +10,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/print-worksheet.css
+++ b/css/dist/print-worksheet.css
@@ -499,9 +499,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-boulder.css
+++ b/css/dist/theme-boulder.css
@@ -32,9 +32,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-default-modern.css
+++ b/css/dist/theme-default-modern.css
@@ -1756,9 +1756,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-denver.css
+++ b/css/dist/theme-denver.css
@@ -2091,9 +2091,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-greeley.css
+++ b/css/dist/theme-greeley.css
@@ -32,9 +32,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-salem.css
+++ b/css/dist/theme-salem.css
@@ -1891,9 +1891,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/css/dist/theme-tacoma.css
+++ b/css/dist/theme-tacoma.css
@@ -1598,9 +1598,6 @@ ol.decimal {
 ol.lower-alpha {
   list-style-type: lower-alpha;
 }
-ol.lower-alpha-level-1 > li::marker {
-  content: "(" counter(list-item, lower-alpha) ") ";
-}
 ol.upper-alpha {
   list-style-type: upper-alpha;
 }

--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -5587,7 +5587,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <li><p>Level 1, third.</p></li>
                 </ol></p>
 
-                <p>Now, nested lists with the defaults replaced by custom choices.  First, an ordered list, three deep, upper Roman numerals, then upper-case Latin, then more traditional Arabic numerals on the three elements of the third level.  Note the adornments of the labels will not currently be rendered by <url href="https://en.wikipedia.org/wiki/WebKit">WebKit</url>-based browsers (such as Safari) when viewing HTML output.<ol marker="*I*">
+                <p>Now, nested lists with the defaults replaced by custom choices.  First, an ordered list, three deep, upper Roman numerals, then upper-case Latin, then more traditional Arabic numerals on the three elements of the third level.  The adornments of the labels render in any browser supporting the <c>@counter-style</c> CSS rule (Safari from version 17, and much earlier for Firefox and Chrome); an older browser falls back to the plain numeration, without adornments.<ol marker="*I*">
                     <li><p>Level 1, first.</p></li>
                     <li><p>Level 1, second.<ol marker="++A">
                             <li><p>Level 2, first.</p></li>

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -819,6 +819,14 @@
             <link href="../{$css-dir}/epub.css" rel="stylesheet" type="text/css"/>
         </xsl:otherwise>
     </xsl:choose>
+    <!-- Custom list markers are "@counter-style" rules derived from -->
+    <!-- the source, so they ride along in every content file's head -->
+    <xsl:if test="$b-needs-custom-marker-css">
+        <style>
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:apply-templates select="exsl:node-set($ol-markers)//ol-marker" mode="ol-marker-style"/>
+        </style>
+    </xsl:if>
 </xsl:template>
 
 <!-- ############# -->

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -350,12 +350,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="not($b-subsetting) and not($b-portable-html)">
         <xsl:apply-templates select="." mode="make-xref-knowls"/>
     </xsl:if>
-    <!-- custom ol marker css production -->
-    <!-- A CDN cannot host these styles, since they are derived from the -->
-    <!-- source.  CDN builds get them inline instead, see "css-common".  -->
-    <xsl:if test="not($b-subsetting) and not($b-cdn-resources)">
-        <xsl:call-template name="ol-marker-styles"/>
-    </xsl:if>
 </xsl:template>
 
 <!-- However, some PTX document types do not have    -->
@@ -6225,6 +6219,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:value-of select="$cols-class-name"/>
             </xsl:if>
         </xsl:attribute>
+        <!-- a custom marker is a named "@counter-style" rule, inlined -->
+        <!-- with the page's CSS, referenced from right here           -->
+        <xsl:variable name="ol-marker-name">
+            <xsl:apply-templates select="." mode="ol-marker-name"/>
+        </xsl:variable>
+        <xsl:if test="not($ol-marker-name = '')">
+            <xsl:attribute name="style">
+                <xsl:text>list-style: </xsl:text>
+                <xsl:value-of select="$ol-marker-name"/>
+                <xsl:text>;</xsl:text>
+            </xsl:attribute>
+        </xsl:if>
         <xsl:attribute name="id">
             <xsl:apply-templates select="." mode="html-id" />
         </xsl:attribute>
@@ -6240,14 +6246,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:element>
 </xsl:template>
 
-<xsl:template match="ol[@marker]" mode="ol-marker-class">
+<xsl:template match="ol[@marker]" mode="ol-marker-name">
     <xsl:variable name="marker-value" select="./@marker" />
     <xsl:for-each select="exsl:node-set($ol-markers)">
         <!-- Should be only one match since ol marker -->
         <!-- index node set contains no duplicates    -->
-        <xsl:value-of select="key('marker-key', $marker-value)[1]/@classname"/>
+        <xsl:value-of select="key('marker-key', $marker-value)[1]/@name"/>
     </xsl:for-each >
 </xsl:template>
+
+<xsl:template match="ol|ul" mode="ol-marker-name"/>
 
 <xsl:template match="ol[not(@marker) and @pi:format-code = 'a' and @pi:ordered-list-level = '1']" mode="ol-marker-class">
     <xsl:text>lower-alpha-level-1</xsl:text>
@@ -6261,38 +6269,39 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:copy-of select="@marker"/>
         <xsl:copy-of select="@pi:marker-prefix"/>
         <xsl:copy-of select="@pi:marker-suffix"/>
-        <xsl:attribute name="classname">
-            <xsl:text>ol-marker-</xsl:text>
+        <xsl:attribute name="name">
+            <xsl:text>ptx-marker-</xsl:text>
             <xsl:value-of select="position()" />
         </xsl:attribute>
     </xsl:element>
 </xsl:template>
 
-<!-- Creates custom formatting for each unique ol/@marker -->
+<!-- One "@counter-style" rule per distinct marker.  The author's     -->
+<!-- prefix and suffix become CSS strings, escaped; the suffix gains  -->
+<!-- the trailing space that separates a marker from its item.  Each  -->
+<!-- list references its rule by name from a "style" attribute, so    -->
+<!-- these rules are the only shared CSS a custom marker needs.       -->
+<!-- They cannot be per-list: an at-rule only lives in a stylesheet.  -->
+<!-- Should WebKit ever support "content" on "::marker" (WebKit bug   -->
+<!-- 204163), one static theme rule reading custom properties could   -->
+<!-- replace all of this, and markers would be entirely per-list      -->
+<!-- inline, with no shared rules and no marker index at all.         -->
 <xsl:template match="ol-marker" mode="ol-marker-style">
-    <!-- format child li elements according to marker prefix/code/suffix -->
-    <xsl:text>ol.</xsl:text>
-    <xsl:value-of select="./@classname"/>
-    <xsl:text> &gt; li::marker { content: &quot;</xsl:text>
-    <xsl:value-of select="./@pi:marker-prefix" />
-    <xsl:text>&quot;counter(list-item,</xsl:text>
+    <xsl:text>@counter-style </xsl:text>
+    <xsl:value-of select="./@name"/>
+    <xsl:text> { system: extends </xsl:text>
     <xsl:apply-templates select="." mode="html-list-class" />
-    <xsl:text>)&quot;</xsl:text>
-    <xsl:value-of select="./@pi:marker-suffix" />
-    <xsl:text> &quot;; }&#xa;</xsl:text>
+    <xsl:text>; prefix: '</xsl:text>
+    <xsl:call-template name="css-string-escape">
+        <xsl:with-param name="text" select="./@pi:marker-prefix"/>
+    </xsl:call-template>
+    <xsl:text>'; suffix: '</xsl:text>
+    <xsl:call-template name="css-string-escape">
+        <xsl:with-param name="text" select="./@pi:marker-suffix"/>
+    </xsl:call-template>
+    <xsl:text> '; }&#xa;</xsl:text>
 </xsl:template>
 
-<!-- CSS file for custom ol markers -->
-<xsl:template name="ol-marker-styles">
-    <!-- We don't produce a file if it will be empty. This would  -->
-    <!-- "naturally" be the case, but we have a boolean anyway.   -->
-    <xsl:if test="$b-needs-custom-marker-css">
-        <xsl:variable name="ol-marker-nodes" select="exsl:node-set($ol-markers)" />
-        <exsl:document href="{$html.css.dir}/ol-markers.css" method="text">
-            <xsl:apply-templates select="$ol-marker-nodes//ol-marker" mode="ol-marker-style" />
-        </exsl:document>
-    </xsl:if>
-</xsl:template>
 
 <!-- We let CSS react to narrow titles for dl -->
 <!-- But no support for multiple columns      -->
@@ -14647,22 +14656,16 @@ TODO:
 
 <!-- CSS header -->
 <xsl:template name="css-common">
-    <!-- Temporary until css handling overhaul by ascholer complete -->
+    <!-- Custom list markers are "@counter-style" rules derived from the -->
+    <!-- source, one per distinct marker, referenced by name from each   -->
+    <!-- list's "style" attribute.  Inlined unconditionally: they are    -->
+    <!-- tiny, they cannot live on a CDN, and portable HTML has no place -->
+    <!-- to link out to anyway.                                          -->
     <xsl:if test="$b-needs-custom-marker-css">
-        <xsl:choose>
-            <!-- These styles are derived from the source, so they are not on  -->
-            <!-- the CDN and "$html.css.dir" does not point at them.  Inline   -->
-            <!-- them: there is one short rule per unique author-supplied      -->
-            <!-- marker, and portable HTML has no place to link out to anyway. -->
-            <xsl:when test="$b-cdn-resources">
-                <style>
-                    <xsl:apply-templates select="exsl:node-set($ol-markers)//ol-marker" mode="ol-marker-style"/>
-                </style>
-            </xsl:when>
-            <xsl:otherwise>
-                <link href="{$html.css.dir}/ol-markers.css" rel="stylesheet" type="text/css"/>
-            </xsl:otherwise>
-        </xsl:choose>
+        <style>
+            <xsl:text>&#xa;</xsl:text>
+            <xsl:apply-templates select="exsl:node-set($ol-markers)//ol-marker" mode="ol-marker-style"/>
+        </style>
     </xsl:if>
     <!-- If extra CSS is specified, then unpack multiple CSS files -->
     <xsl:if test="not($html.css.extra = '')">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -244,6 +244,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:variable name="ol-markers">
     <ol-markers>
         <xsl:apply-templates select="$document-root//ol[@marker and count(. | key('marker-key', @marker)[1]) = 1]" mode="ol-markers"/>
+        <!-- A legacy exercise-parts list letters as "(a)" with no     -->
+        <!-- authored @marker; it joins the index as a reserved entry, -->
+        <!-- so one mechanism serves it, unless an authored "(a)" is   -->
+        <!-- already present to share.  The parenthesized letters are  -->
+        <!-- LaTeX's custom for second-level lists, which PreTeXt      -->
+        <!-- matches in every output (assembly stamps the adornments). -->
+        <xsl:if test="$document-root//ol[not(@marker) and @pi:format-code = 'a' and @pi:ordered-list-level = '1'] and not($document-root//ol[@marker = '(a)'])">
+            <ol-marker pi:format-code="a" marker="(a)" pi:marker-prefix="(" pi:marker-suffix=")" name="ptx-marker-0"/>
+        </xsl:if>
     </ol-markers>
 </xsl:variable>
 <!-- Following should be more efficient than 'select="boolean($document-root//ol[@marker])"' -->
@@ -6203,13 +6212,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:element name="{local-name(.)}">
         <xsl:attribute name="class">
             <xsl:apply-templates select="." mode="html-list-class" />
-            <xsl:variable name="ol-marker-class">
-                <xsl:apply-templates select="." mode="ol-marker-class" />
-            </xsl:variable>
-            <xsl:if test="not($ol-marker-class = '')">
-                <xsl:text> </xsl:text>
-                <xsl:value-of select="$ol-marker-class"/>
-            </xsl:if>
             <xsl:variable name="cols-class-name">
                 <!-- HTML-specific, but in pretext-common.xsl -->
                 <xsl:apply-templates select="." mode="number-cols-CSS-class"/>
@@ -6255,13 +6257,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:for-each >
 </xsl:template>
 
-<xsl:template match="ol|ul" mode="ol-marker-name"/>
-
-<xsl:template match="ol[not(@marker) and @pi:format-code = 'a' and @pi:ordered-list-level = '1']" mode="ol-marker-class">
-    <xsl:text>lower-alpha-level-1</xsl:text>
+<!-- the reserved "(a)" entry, or an authored twin, by the same lookup -->
+<xsl:template match="ol[not(@marker) and @pi:format-code = 'a' and @pi:ordered-list-level = '1']" mode="ol-marker-name">
+    <xsl:for-each select="exsl:node-set($ol-markers)">
+        <xsl:value-of select="key('marker-key', '(a)')[1]/@name"/>
+    </xsl:for-each>
 </xsl:template>
 
-<xsl:template match="ol|ul" mode="ol-marker-class"/>
+<xsl:template match="ol|ul" mode="ol-marker-name"/>
 
 <xsl:template match="ol[@marker]" mode="ol-markers">
     <xsl:element name="ol-marker">

--- a/xsl/pretext-jupyter.xsl
+++ b/xsl/pretext-jupyter.xsl
@@ -354,6 +354,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>.mathbook-content table tr.header-vertical th {writing-mode: vertical-rl; padding-left: 2em;}&#xa;</xsl:text>
             <xsl:text>.mathbook-content .sbspanel img {max-width: 100%;}&#xa;</xsl:text>
             <xsl:text>.mathbook-content .tablenotes {list-style: none; padding-left: 0;}&#xa;</xsl:text>
+            <!-- custom list markers, one "@counter-style" rule per -->
+            <!-- distinct marker, referenced from each list's       -->
+            <!-- "style" attribute                                  -->
+            <xsl:apply-templates select="exsl:node-set($ol-markers)//ol-marker" mode="ol-marker-style"/>
             <xsl:text>&lt;/style&gt;</xsl:text>
             <xsl:call-template name="end-string" />
         </xsl:with-param>

--- a/xsl/pretext-text-utilities.xsl
+++ b/xsl/pretext-text-utilities.xsl
@@ -1299,4 +1299,34 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
+<!-- Escape arbitrary text for a single-quoted CSS string:          -->
+<!-- backslash and apostrophe by a backslash, and a less-than by    -->
+<!-- its code point (with delimiting space).  The last means the    -->
+<!-- text can never terminate an enclosing HTML "style" element     -->
+<!-- prematurely, since an HTML parser ends such an element at a    -->
+<!-- literal "</style" no matter the surrounding CSS syntax.        -->
+<xsl:template name="css-string-escape">
+    <xsl:param name="text"/>
+    <xsl:if test="not($text = '')">
+        <xsl:variable name="first" select="substring($text, 1, 1)"/>
+        <xsl:choose>
+            <xsl:when test="$first = '\'">
+                <xsl:text>\\</xsl:text>
+            </xsl:when>
+            <xsl:when test='$first = "&apos;"'>
+                <xsl:text>\&apos;</xsl:text>
+            </xsl:when>
+            <xsl:when test="$first = '&lt;'">
+                <xsl:text>\3c </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$first"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:call-template name="css-string-escape">
+            <xsl:with-param name="text" select="substring($text, 2)"/>
+        </xsl:call-template>
+    </xsl:if>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/xsl/tests/pretext-text-utilities-test.xsl
+++ b/xsl/tests/pretext-text-utilities-test.xsl
@@ -444,6 +444,88 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:variable>
 
 <!--========================================================================-->
+<!-- test css-string-escape -->
+<xsl:variable name="css-string-escape-plain">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text" select="'(a)'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="'(a)'"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-plain'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="css-string-escape-empty">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text" select="''"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected" select="''"/>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-empty'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="css-string-escape-apostrophe">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text">don't</xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected">don\'t</xsl:with-param>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-apostrophe'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="css-string-escape-backslash">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text">a\b</xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected">a\\b</xsl:with-param>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-backslash'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<!-- less-than becomes its code point with a delimiting space, so -->
+<!-- escaped text can never close an enclosing "style" element    -->
+<xsl:variable name="css-string-escape-less-than">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text">a&lt;b</xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected">a\3c b</xsl:with-param>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-less-than'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<xsl:variable name="css-string-escape-hostile">
+  <xsl:variable name="test-val">
+    <xsl:call-template name="css-string-escape">
+      <xsl:with-param name="text">'a\&lt;/style></xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:call-template name="assert-equal">
+    <xsl:with-param name="expected">\'a\\\3c /style></xsl:with-param>
+    <xsl:with-param name="actual" select="$test-val"/>
+    <xsl:with-param name="test-name" select="'css-string-escape-hostile'"/>
+  </xsl:call-template>
+</xsl:variable>
+
+<!--========================================================================-->
 
 <!-- "main" -->
 <xsl:template match="/">


### PR DESCRIPTION
Implements the second approach of #3157. A custom `ol/@marker` becomes a named CSS rule, `@counter-style ptx-marker-N { system: extends <numeration>; prefix: '...'; suffix: '... '; }` — one per distinct marker, inlined with every page — and each marked list carries `style="list-style: ptx-marker-N;"`. This is the delivery Safari supports (17+; `content` on `::marker` never rendered there), and it is unconditional: the generated `ol-markers.css` file, its `exsl:document` writer, and the CDN/local/portable special-casing all disappear. A browser without `@counter-style` falls back to the list's plain numeration class, as it always has.

The default `(a)` lettering of a second-level list — LaTeX's custom, which PreTeXt matches — joins the same mechanism as a reserved index entry (`ptx-marker-0`), shared with an authored `"(a)"` marker when one exists; the static `lower-alpha-level-1` rule leaves the themes (`css/dist` regenerated here).

Author marker text is now escaped for its CSS string context by a new `css-string-escape` text utility, with unit tests in the standalone testbed: backslash, apostrophe, and `<` (as `\3c `, so hostile text like a literal `</style>` can never terminate the enclosing element — verified by rendering exactly that marker).

EPUB and Jupyter, which build their own heads and so silently dropped custom markers, now carry the same rules: EPUB in every content file's head (epubcheck output identical to master's), Jupyter in its existing styling cell (notebook remains valid JSON).

Rendering verified in Firefox and Chrome against master: every custom form in the sample article's lists section — three-deep `*I*`/`++A`/`1)` nesting, zero-based `(0)`/`-0-`, lettered conditions, two-column marked lists — renders identically, to hairline marker kerning. A comment records the future: should WebKit ever support `content` on `::marker` (WebKit bug 204163), one static theme rule reading custom properties could replace the shared rules and the marker index entirely.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
