### PR TITLE
Slideshow: valid HTML for paragraphs containing displays

### DIFF
--- a/examples/sample-slideshow/sample-slideshow.xml
+++ b/examples/sample-slideshow/sample-slideshow.xml
@@ -193,6 +193,20 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     </li>
                 </dl></p>
             </slide>
+
+            <slide>
+                <title>A Bare List</title>
+
+                <p>A list may stand bare on a slide, outside of any paragraph<mdash/>lighter markup for a genre that is mostly lists.</p>
+
+                <!-- this list is authored bare: no "p" wraps it -->
+                <ul>
+                    <li>This list has no <tag>p</tag> around it in the source</li>
+                    <li>Legal at the top level of a <tag>slide</tag> or <tag>subslide</tag>, and only there</li>
+                    <li>A nested list still lives inside a paragraph</li>
+                    <li>Rendered identically to the wrapped form</li>
+                </ul>
+            </slide>
         </section>
 
         <section>

--- a/xsl/pretext-assembly.xsl
+++ b/xsl/pretext-assembly.xsl
@@ -3611,6 +3611,25 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:if>
 </xsl:template>
 
+<!-- A list ("ol", "ul", "dl") may stand bare at the top level   -->
+<!-- of a "slide" or "subslide", an authoring convenience        -->
+<!-- particular to the slideshow genre.  Internally we keep the  -->
+<!-- main grammar's single shape - a list lives within a         -->
+<!-- paragraph - so every later consumer of the tree meets only  -->
+<!-- one form.  The manufactured paragraph does not survive to   -->
+<!-- output as an HTML "p": the Reveal.js conversion explodes    -->
+<!-- any paragraph containing displays, and for a paragraph that -->
+<!-- is exactly one list the explosion is precisely the bare     -->
+<!-- list again.  A @pause stays on the list itself, where the   -->
+<!-- list item templates consult it.                             -->
+<xsl:template match="slide/ol|slide/ul|slide/dl|subslide/ol|subslide/ul|subslide/dl" mode="repair">
+    <p>
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*" mode="repair"/>
+        </xsl:copy>
+    </p>
+</xsl:template>
+
 
 <!-- ############################## -->
 <!-- Killed, in Chronological Order -->

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -525,6 +525,107 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
   </p>
 </xsl:template>
 
+<!-- A paragraph containing displays - lists ("ol", "ul", "dl"),   -->
+<!-- display mathematics ("md"), or code display ("cd") - cannot   -->
+<!-- be realized as a single HTML "p".  Each display renders as    -->
+<!-- an element that HTML forbids inside a "p" (a list, a "pre",   -->
+<!-- a "div" of online mathematics), and a browser recovers by     -->
+<!-- closing the paragraph at the display, leaving the remainder   -->
+<!-- orphaned outside any paragraph.  So, just as in the HTML      -->
+<!-- conversion, such a paragraph is exploded: each maximal run    -->
+<!-- of inline content becomes a "p" (an empty run produces        -->
+<!-- nothing at all), with the displays standing in between.       -->
+<!-- (With embedded mathematics a display is a "span", legal       -->
+<!-- within a "p" and block-level only by styling, but it is       -->
+<!-- exploded identically: the presentation is the same and the    -->
+<!-- template stays uniform.)                                      -->
+<!--                                                               -->
+<!-- This realization is demanded by the output format alone; it   -->
+<!-- is not the undoing of upstream normalization.  An author may  -->
+<!-- place a display mid-paragraph, so the explosion is necessary  -->
+<!-- even when no paragraph is ever manufactured.  Conversely,     -->
+<!-- when the assembly wraps a bare list on a "slide" in a         -->
+<!-- paragraph, so the internal tree presents the main grammar's   -->
+<!-- one shape to every consumer, that paragraph's inline runs     -->
+<!-- are all empty and the exploded output is exactly the bare     -->
+<!-- list again.  The two maneuvers are complementary: normalize   -->
+<!-- toward the grammar internally, adapt to the medium at output. -->
+<!--                                                               -->
+<!-- A paused paragraph must advance as a single unit, so its      -->
+<!-- exploded parts ride together in one container carrying the    -->
+<!-- "fragment" class.                                             -->
+<xsl:template match="p[ol|ul|dl|md[mrow]|cd]">
+    <xsl:choose>
+        <xsl:when test="@pause = 'yes'">
+            <div class="fragment">
+                <xsl:apply-templates select="." mode="exploded-paragraph"/>
+            </div>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:apply-templates select="." mode="exploded-paragraph"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- The explosion itself, patterned on the HTML conversion's      -->
+<!-- template for a "p" with displays, simplified: no HTML id, no  -->
+<!-- permalink, no knowl machinery on the pieces of a slide.       -->
+<xsl:template match="p" mode="exploded-paragraph">
+    <xsl:variable name="displays" select="ol|ul|dl|md[mrow]|cd"/>
+    <!-- content prior to the first display; if empty -->
+    <!-- we do not manufacture an empty paragraph     -->
+    <xsl:variable name="initial" select="$displays[1]/preceding-sibling::*|$displays[1]/preceding-sibling::text()"/>
+    <xsl:variable name="initial-content">
+        <xsl:apply-templates select="$initial"/>
+    </xsl:variable>
+    <!-- XSLT 1.0: RTF is just a string if not converted to node set -->
+    <xsl:if test="not($initial-content = '')">
+        <p>
+            <xsl:copy-of select="$initial-content"/>
+        </p>
+    </xsl:if>
+    <!-- for each display: the display itself, then trailing content -->
+    <xsl:for-each select="$displays">
+        <xsl:apply-templates select="."/>
+        <xsl:variable name="rightward" select="following-sibling::*|following-sibling::text()"/>
+        <xsl:variable name="next-display" select="following-sibling::*[self::ul or self::ol or self::dl or self::md[mrow] or self::cd][1]"/>
+        <xsl:choose>
+            <xsl:when test="$next-display">
+                <xsl:variable name="leftward" select="$next-display/preceding-sibling::*|$next-display/preceding-sibling::text()"/>
+                <!-- device below forms set intersection -->
+                <xsl:variable name="common" select="$rightward[count(. | $leftward) = count($leftward)]"/>
+                <xsl:variable name="common-content">
+                    <xsl:apply-templates select="$common"/>
+                </xsl:variable>
+                <xsl:if test="not($common-content = '')">
+                    <p>
+                        <!-- interstitial content arising from an authored -->
+                        <!-- "intertext" is marked, as in the HTML         -->
+                        <!-- conversion, for styling purposes              -->
+                        <xsl:if test="$common[self::pi:intertext]">
+                            <xsl:attribute name="class">
+                                <xsl:text>intertext</xsl:text>
+                            </xsl:attribute>
+                        </xsl:if>
+                        <xsl:copy-of select="$common-content"/>
+                    </p>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- finish the trailing content, if nonempty -->
+                <xsl:variable name="common-content">
+                    <xsl:apply-templates select="$rightward"/>
+                </xsl:variable>
+                <xsl:if test="not($common-content = '')">
+                    <p>
+                        <xsl:copy-of select="$common-content"/>
+                    </p>
+                </xsl:if>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:for-each>
+</xsl:template>
+
 <!-- Images get wrapped in a div with @class="fragment" if they are  -->
 <!-- paused                                                          -->
 <xsl:template match="image[not(ancestor::sidebyside) and (@pause='yes')]">


### PR DESCRIPTION
Two related changes for the Reveal.js conversion.

**Explode a paragraph containing displays.** A paragraph containing a list, display mathematics, or a code display was emitted as a single HTML `<p>` wrapping block elements (`ol`/`ul`/`dl`, `pre`, or the `div` of online mathematics) — invalid HTML. A browser recovers by closing the paragraph at the display: the sample slideshow's deck carried 27 phantom empty `<p>` elements in the parsed DOM, and the remainder of such a paragraph was orphaned outside it — outside its fragment, for a paused paragraph, so the tail appeared before the pause. Now such a paragraph is exploded, as the HTML conversion does: runs of inline content become `<p>` fragments (empty runs suppressed), displays stand between them, `intertext` interstitials are marked `class="intertext"`, and a paused paragraph's pieces ride in a single fragment `div`. With embedded mathematics a display is a `span`, legal within a `<p>`; it explodes identically, so the template needs no distinction between the two modes.

**Wrap a bare list on a slide in a paragraph.** The schema lets a list stand bare at the top level of a `slide` or `subslide`, a convenience of the genre. The assembly repair now wraps such a list in a paragraph, so the internal tree presents the main grammar's one shape to every consumer. The wrapper does not survive to output: exploding a paragraph that is exactly one list yields precisely the bare list again, and a deck built from bare-list source is byte-identical to one built from wrapped source.

The sample slideshow gains a slide, "A Bare List," ending its Lists section: a list authored bare, with commentary in the slide text and a source comment, so authors see the idiom — and so the repair is exercised by committed source.

Testing: before/after builds of the sample slideshow differ exactly at the wrapped lists and mid-paragraph displays, ids unchanged; a bare-list variant builds byte-identically; probes exercised the paused-paragraph, code-display, and `intertext` paths; the assembled sample article is unchanged, so the repair is inert outside slideshows; a browser audit of the built deck shows zero empty-paragraph artifacts and unchanged slide geometry.

*Claude Fable 5, acting as a coding assistant for Rob Beezer*
