### PR TITLE
HTML: render empty table headings as td

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -6673,6 +6673,29 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </tabular>
             </table>
 
+            <p>Generating empty header cells as <tag>th</tag> elements is an accessibility issue. They should render as <tag>td</tag> elements instead.  This next table tests that behavior.</p>
+
+            <table>
+                <title>Empty Header Stress Test</title>
+                <tabular row-headers="yes">
+                    <row header="yes">
+                        <cell><fillin characters="5"/></cell>
+                        <cell><nbsp/></cell>
+                        <cell></cell>
+                    </row>
+                    <row>
+                        <cell></cell>
+                        <cell>??</cell>
+                        <cell>??</cell>
+                    </row>
+                    <row>
+                        <cell>??</cell>
+                        <cell>??</cell>
+                        <cell>??</cell>
+                    </row>
+                </tabular>
+            </table>
+
             <table>
                 <title>Column Span Example</title>
                 <tabular top="minor" left="minor" halign="center">

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -8325,17 +8325,19 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="effective-top"/>
     </xsl:variable>
 
-    <!-- a cell of a header row needs to be "th" -->
-    <!-- else the HTML mark up is "td"           -->
+    <!-- A nonempty cell of a header row needs to be "th".  Empty cells -->
+    <!-- are data cells, even when their row supplies headers.           -->
+    <!-- All other HTML table cells are "td".                            -->
     <xsl:variable name="header-row-elt">
+        <xsl:variable name="b-has-contents" select="*[not(self::nbsp)] or normalize-space(.) != ''"/>
         <xsl:choose>
-            <xsl:when test="parent::row/@header = 'yes'">
+            <xsl:when test="$b-has-contents and parent::row/@header = 'yes'">
                 <xsl:text>th</xsl:text>
             </xsl:when>
-            <xsl:when test="parent::row/@header = 'vertical'">
+            <xsl:when test="$b-has-contents and parent::row/@header = 'vertical'">
                 <xsl:text>th</xsl:text>
             </xsl:when>
-            <xsl:when test="$b-row-header">
+            <xsl:when test="$b-has-contents and $b-row-header">
                 <xsl:text>th</xsl:text>
             </xsl:when>
             <!-- "no" is other choice, or no attribute at all -->


### PR DESCRIPTION
Fix for immediate issue reported here:
https://groups.google.com/g/pretext-a11y/c/LlGCpMDTmCk/m/ROhzFu3hAgAJ

Pre screenshot with WAVE:
<img width="915" height="307" alt="image" src="https://github.com/user-attachments/assets/a5d470e5-9257-4cd8-89d4-2a961686d308" />

Post:
<img width="1223" height="297" alt="image" src="https://github.com/user-attachments/assets/f02ad93e-b0bb-41a1-8fd7-847bf840679b" />

Heads up to @oscarlevin who reported issue