### PR TITLE
XSL-FO: a document "subtitle" joins the title on the title page

### DIFF
--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -585,6 +585,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
               role="H1">
         <xsl:apply-templates select="." mode="link-id-attribute"/>
         <xsl:apply-templates select="." mode="title-full"/>
+        <!-- A subtitle belongs to the heading, as it does in HTML, so it  -->
+        <!-- sits inside this block rather than following it.  Lighter and -->
+        <!-- smaller than the title, and on a line of its own.             -->
+        <xsl:if test="subtitle">
+            <fo:block font-size="60%"
+                      font-weight="normal"
+                      space-before="0.5em">
+                <xsl:apply-templates select="." mode="subtitle"/>
+            </fo:block>
+        </xsl:if>
     </fo:block>
 </xsl:template>
 


### PR DESCRIPTION
A document `subtitle` was silently absent from `pdf-fo` output, [reported on pretext-dev](https://groups.google.com/d/msgid/pretext-dev/c220bd5b-21c5-4c8d-8eed-9c9efb3acb8fn%40googlegroups.com) by Mitch Keller.

Nothing subtle was dropping it: the conversion never emitted it. `document-title-block` rendered the title and stopped. The report came from an article, but that template matches `article|book`, so a book's subtitle was equally absent.

The fix adds a `subtitle` block inside the block carrying the title. It reuses `mode="subtitle"` from `pretext-common.xsl`, so a subtitle structured as `line` elements needs no extra code, and it sits *inside* the `role="H1"` block rather than following it, mirroring HTML where the subtitle is a `span` within the heading.

Tested on the sample article and the sample book. The tokenized `.fo` diff is exactly one change, and the PDF's first page now reads title, subtitle, byline. Since the subtitle now sits inside the heading's structure element, PDF/UA-1 was worth confirming: veraPDF gives `isCompliant="true"`, 106 rules passed, none failed — unchanged from before.

The XMP `dc:title` still carries the title alone, as HTML's `meta` title does.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
