### PR TITLE
Schema: "rename" requires a non-empty new name

### DIFF
--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -2164,7 +2164,7 @@
                 element rename {
                     attribute element {text},
                     attribute xml:lang {text}?,
-                    text
+                    xsd:token { minLength = "1" }
                 }
 
             Configuration |=

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -5607,7 +5607,9 @@
       <optional>
         <attribute name="xml:lang"/>
       </optional>
-      <text/>
+      <data type="token">
+        <param name="minLength">1</param>
+      </data>
     </element>
   </define>
   <define name="Configuration" combine="choice">

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3985,7 +3985,7 @@
                 element rename {
                     attribute element {text},
                     attribute xml:lang {text}?,
-                    text
+                    xsd:token { minLength = "1" }
                 }
             </code>
         </fragment>


### PR DESCRIPTION
Closes #645.

A `docinfo/rename` accepted any text, including nothing at all. An empty one renamed a block to the empty string, which is how the issue described the symptom in 2017 — "lots of stray spaces littered about", the surrounding punctuation and spacing still emitted around a name that isn't there.

The content model becomes `xsd:token { minLength = "1" }`, in the literate source with its derived `.rnc` and `.rng` in the same commit.

`token` rather than `string` is the substantive choice, and it does more than reject the empty case. XSD collapses whitespace in a `token` before the length is measured, so a `rename` holding only spaces normalizes to the empty string and fails too — jing reports "actual length was 0" for an element that literally contains three spaces. With `xsd:string` those three spaces would have counted as length 3 and passed, leaving exactly the stray-space output the issue is about.

Tested against both schemas: a real rename validates, an empty one and a whitespace-only one are both rejected, and the dev schema inherits the rule through its `include`. The sample article, the showcase, the custom-theming example and the Guide all use `rename` and are unaffected — validation is unchanged from master.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
