### PR TITLE
Bug fix: ensure correct parbreaks around image and tabular in sidebyside

### DIFF
--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -7345,14 +7345,42 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
 </xsl:template>
 
-<!-- Second: images already constrained by side-by-side panels -->
-<xsl:template match="image[ancestor::sidebyside]">
-    <!-- get a newline if inside a "stack" -->
-    <xsl:if test="parent::stack and preceding-sibling::*">
+<!-- An "image" or a "tabular" in a side-by-side panel is set as a  -->
+<!-- bare box, so if a paragraph is already in progress the box is  -->
+<!-- appended to it, hanging off that paragraph final line, and the -->
+<!-- leading "\noindent" is a no-op.  So break the paragraph, and   -->
+<!-- start a fresh one for whatever follows.  Two panels need no    -->
+<!-- break: one that *is* the object, and a "figure" or "table",    -->
+<!-- whose "caption" is a sibling but is deferred to the bottom of  -->
+<!-- its box.  The panels that do are the containers holding        -->
+<!-- several things: a "stack", a list item, and the "statement"    -->
+<!-- of an "exercise" (or of its "task") in a worksheet or handout. -->
+<xsl:template match="image|tabular" mode="panel-paragraph-break">
+    <xsl:param name="side"/>
+
+    <!-- neighbors that would otherwise share the paragraph, skipping -->
+    <!-- a "caption" or "title" that is not set here.  Another image  -->
+    <!-- or tabular breaks on its own account, so a trailing break    -->
+    <!-- before one would just be a second, redundant "\par".         -->
+    <xsl:variable name="lead" select="preceding-sibling::*[not(&METADATA-FILTER;)]"/>
+    <xsl:variable name="trail" select="following-sibling::*[not(&METADATA-FILTER;)][1]"/>
+    <xsl:if test="not(parent::sidebyside) and
+                  ((($side = 'before') and $lead) or
+                   (($side = 'after') and $trail[not(self::image or self::tabular)]))">
         <xsl:text>\par&#xa;</xsl:text>
     </xsl:if>
+</xsl:template>
+
+<!-- Second: images already constrained by side-by-side panels -->
+<xsl:template match="image[ancestor::sidebyside]">
+    <xsl:apply-templates select="." mode="panel-paragraph-break">
+        <xsl:with-param name="side" select="'before'"/>
+    </xsl:apply-templates>
     <xsl:text>\noindent</xsl:text>
     <xsl:apply-templates select="." mode="image-inclusion" />
+    <xsl:apply-templates select="." mode="panel-paragraph-break">
+        <xsl:with-param name="side" select="'after'"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <!-- Various versions of images have their width set to the         -->
@@ -7595,12 +7623,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 </xsl:template>
 
 <xsl:template match="tabular[ancestor::sidebyside]">
+    <xsl:apply-templates select="." mode="panel-paragraph-break">
+        <xsl:with-param name="side" select="'before'"/>
+    </xsl:apply-templates>
     <!-- with layout control (inside sidebyside), scale down, but not up  -->
     <!-- https://tex.stackexchange.com/questions/327887/                  -->
     <!-- resizing-or-scaling-table-only-if-it-is-larger-than-column-width -->
     <xsl:text>\noindent\resizebox{\ifdim\width > \linewidth\linewidth\else\width\fi}{!}{%&#xa;</xsl:text>
     <xsl:apply-templates select="." mode="tabular-inclusion"/>
     <xsl:text>}%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="panel-paragraph-break">
+        <xsl:with-param name="side" select="'after'"/>
+    </xsl:apply-templates>
 </xsl:template>
 
 <xsl:template match="tabular" mode="tabular-inclusion">
@@ -7661,10 +7695,6 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <!-- get a newline if inside a "stack" -->
-    <xsl:if test="parent::stack and preceding-sibling::*">
-        <xsl:text>\par&#xa;</xsl:text>
-    </xsl:if>
     <!-- center within a sidebyside if by itself       -->
     <!-- \centering needs a closing \par within a      -->
     <!-- defensive group if it is to be effective      -->


### PR DESCRIPTION
This fixes two related bugs with the latex conversion.

1. If a worksheet contains a sidebyside to lay out exercises, those exercises can contain a mix of paragraphs and images.  As in a stack, a paragraph followed by an image in a sidebyside needs special care to ensure there is a paragraph break between the paragraph and the image.  The test for this only checked whether the image was in a stack.
2. The same sort of check needs to be applied to tabulars after paragraphs.  Claude uncovered that this is not happening because the tabular-inclusion code lived inside a `\resizebox{...}{`.  See the pdf of the sample article corresponding to this [Paragraph](https://pretextbook.org/examples/sample-article/html/section-side-by-side.html#stacking-side-by-side-8-1-3) 
https://pretextbook.org/examples/sample-article/html/section-side-by-side.html#stacking-side-by-side-8-1-3

Claude claimed that the same thing was happening with the text after an image, specifically the text after the QR codes for interactives.  This may be, but those QR codes are wide enough that the next word went to the following line anyway.  But in theory it does make sense to guard against the "after" case too.