### PR TITLE
CSS: hide image-expansion button on printouts

### DIFF
--- a/css/targets/print-worksheet/print-worksheet.scss
+++ b/css/targets/print-worksheet/print-worksheet.scss
@@ -150,6 +150,7 @@ $runestone-light-colors: (
 //   buttons in general (to remove Runestone "Check Me" button)
 // We remove these here.
 .image-description,
+.ptx-image-expand-button,
 .ptx-content .webwork-button,
 .ptx-runestone-container button.btn {
   display: none;


### PR DESCRIPTION
The recently merged work on image expansions left a dangling image expansion button on all images in printouts (always, not just on hover).  

This PR hides that, like we do for the image description icon.

Will require a rebuild of the distributed CSS.