### PR TITLE
Bug fix: don't delete latex-images for cdn hosted resources builds

### DIFF
--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4235,8 +4235,14 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
     # names for scratch directories
     tmp_dir = common.get_temporary_directory()
 
+    # Two variants of limiting the files produced for HTML: CDN resources are
+    # used for portable HTML as well as resources/@host="cdn", either of which
+    # set b-cdn-resources to "true" in the publisher file.  Some generated
+    # assets are inlined for the portable HTML (but not for CDN resources),
+    #  which is indicated by portable-html="true"
     pub_vars = common.get_publisher_variable_report(xml, pub_file, stringparams)
     include_static_files = common.get_publisher_variable(pub_vars, 'b-cdn-resources') != "true"
+    include_generated_svgs = common.get_publisher_variable(pub_vars, 'portable-html') != "yes"
     time_logger.log("pubvars loaded")
 
     if include_static_files:
@@ -4288,7 +4294,7 @@ def html(xml, pub_file, stringparams, xmlid_root, file_format, extra_xsl, out_fi
         common.xsltproc(runestone_page_template_xslt, xml, None, tmp_dir, stringparams)
         time_logger.log("runestone page template extraction complete")
 
-    if not(include_static_files):
+    if not(include_generated_svgs):
         # remove latex-image generated directories for portable builds
         shutil.rmtree(os.path.join(tmp_dir, "generated", "latex-image"), ignore_errors=True)
 
@@ -6207,7 +6213,7 @@ def _jing_server(schema_filename, assembled_source):
 ###################
 
 
-        
+
 
 def python_version():
     """Return 'major.minor' version number as string/info"""


### PR DESCRIPTION
First there was the "portable" builds that were meant to create a single HTML file whenever possible.  We inlined the svgs created by latex-images, so in the pretext script, deleted all the generated latex-images.

Then we added cdn hosted js/css as a separate publication option to reduce the bundle size of things like SCORM and not require PreTeXt Plus to copy the large number of js files all the time.  But this does not inline svgs, so we still need the latex-images generated folder.

In setting up the cdn hosted resources, I was sloppy and tied both cases to a single boolean.  

This PR fixes that mistake.  There are already publisher variables being reported, so it was a minimal fix.

I am aware that there is some cleanup that can be done (switching the pub var being reported to the boolean, adding additional generated svgs to the list of things that shouldn't be copied over in true portable builds), but I wanted to get this fixed as a first step.