### PR TITLE
Offline mathematics is serialized as XML

### DIFF
--- a/script/mjsre/mj-sre-page.js
+++ b/script/mjsre/mj-sre-page.js
@@ -386,15 +386,14 @@ if (!(argv.svg || argv.svgenhanced)) {
   //
   await html.renderPromise();
   //
-  //  Output the resulting document.  This is deliberately the HTML
-  //  serialization: the XML serialization would add the XHTML
-  //  namespace to the bare "html" root of the mock page, and every
-  //  namespace-less element match in the packaging stylesheet
-  //  (xsl/support/package-math.xsl) would then miss.  The attribute
-  //  escaping it would add is not needed: no output attribute can
-  //  hold a raw "<" now that the "data-latex" attributes are
-  //  filtered away.
+  //  Output the resulting document as XML.  Speech enrichment writes
+  //  the author's LaTeX into "data-semantic-attributes", which nothing
+  //  filters, so a macro such as \newcommand{\lt}{<} would put a raw
+  //  "<" into an attribute value; the XML serialization escapes it,
+  //  where the HTML serialization does not.  The XHTML namespace this
+  //  puts on the mock page's "html" root is expected by the packaging
+  //  stylesheet (xsl/support/package-math.xsl), which matches on it.
   //
-  console.log(adaptor.outerHTML(adaptor.root(html.document)));
+  console.log(adaptor.serializeXML(adaptor.root(html.document)));
 })()
   .catch((err) => console.error(err));

--- a/xsl/support/package-math.xsl
+++ b/xsl/support/package-math.xsl
@@ -48,7 +48,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     xmlns:pi="http://pretextbook.org/2020/pretext/internal"
     xmlns:svg="http://www.w3.org/2000/svg"
     xmlns:math="http://www.w3.org/1998/Math/MathML"
-    exclude-result-prefixes="svg"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    exclude-result-prefixes="svg xhtml"
 >
 
 <xsl:output method="xml" encoding="UTF-8"/>
@@ -70,10 +71,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
 <!-- We explicitly kill the LaTeX macro div, lest  -->
 <!-- it get picked up as similar to the other math -->
-<xsl:template match="div[@id = 'latex-macros']"/>
+<xsl:template match="xhtml:div[@id = 'latex-macros']"/>
 
 <!-- Body has what we want/need -->
-<xsl:template match="body">
+<xsl:template match="xhtml:body">
     <pi:math-representations>
         <xsl:apply-templates select="node()|@*"/>
         <xsl:text>&#xa;&#xa;</xsl:text>
@@ -83,14 +84,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Replace PreTeXt "div" w/ location info plus MJ "mjx-data" -->
 <!-- container by a consolidated PreteXt "pi:math" container   -->
 <!-- with location info                                        -->
-<xsl:template match="div/mjx-data">
+<xsl:template match="xhtml:div/xhtml:mjx-data">
     <xsl:text>&#xa;&#xa;</xsl:text>
     <pi:math>
         <!-- duplicate location, context info -->
         <xsl:copy-of select="../@*"/>
         <!-- pickup whatever gets produced by MJ/SRE script with    -->
         <!-- its own containerization: MathML, SVG, braille, speech -->
-        <xsl:apply-templates select="math:math|svg:svg|mjx-braille|mjx-speech"/>
+        <xsl:apply-templates select="math:math|svg:svg|xhtml:mjx-braille|xhtml:mjx-speech"/>
     </pi:math>
 </xsl:template>
 
@@ -109,13 +110,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </xsl:template>
 
-<xsl:template match="mjx-braille">
+<xsl:template match="xhtml:mjx-braille">
     <div class="braille">
         <xsl:copy-of select="node()"/>
     </div>
 </xsl:template>
 
-<xsl:template match="mjx-speech">
+<xsl:template match="xhtml:mjx-speech">
     <div class="speech">
         <xsl:copy-of select="node()"/>
     </div>
@@ -129,7 +130,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- NB: need to have this prefixed with "body" to   -->
 <!-- identify it as top-level, global situation,     -->
 <!-- rather than local to each individual SVG        -->
-<xsl:template match="body/svg:svg[svg:defs]">
+<xsl:template match="xhtml:body/svg:svg[svg:defs]">
     <xsl:copy>
         <xsl:attribute name="id">
             <xsl:text>font-data</xsl:text>


### PR DESCRIPTION
**Nothing in PreTeXt's output changes.** All four modes we run — SVG, MathML, braille, speech — come out byte-identical. This is about a latent defect in a script we share with PreFigure, and about the two copies of that script staying the same text.

`script/mjsre/mj-sre-page.js` also offers `--svgenhanced`, which adds Speech Rule Engine enrichment to the SVG. PreTeXt never invokes it; PreFigure does, for the labels in its diagrams. Enrichment writes the author's LaTeX into `data-semantic-attributes`, and nothing filters that attribute — so a macro as ordinary as `\newcommand{\lt}{<}` puts a raw `<` inside an attribute value, and the HTML serialization the script used produces something no XML parser will read.

Davide Cervone diagnosed this on davidaustinm/prefigure#87 and pointed at the remedy: `adaptor.serializeXML()` in place of `adaptor.outerHTML()`, which escapes the character and keeps the attributes.

The reason we could not simply take that one line is that `serializeXML` declares the XHTML namespace on the mock page's `html` root, and `xsl/support/package-math.xsl` matched `body`, `div/mjx-data`, `mjx-braille` and `mjx-speech` with no prefix. Every one of those would then miss — measured, five of fourteen offline-MathJax runs went from real content to zero bytes, every braille and every speech one, while SVG and MathML survived on their own namespaces.

So the serializer and its reader move together here, in one commit: the output line, and the stylesheet gaining `xmlns:xhtml` plus prefixes on eight name tests across six templates. `math:math` and `svg:svg` are untouched. Literal result elements stay namespace-less, so the packaged representations keep their existing shape.

### Verification

- **Fourteen offline-MathJax runs byte-identical** against master: sample article, EPUB sampler, braille test, fonts, slideshow and humanities, across SVG, MathML, braille and speech as each document supports.
- **Seven consumer builds** — EPUB in all four flavours, braille emboss and electronic, and the reveal.js slideshow — every one exits cleanly, and every differing file differs only in a build timestamp. That includes `package.opf`, whose two differing characters sit inside `dcterms:modified`.
- **The defect is fixed**: `--svgenhanced` on a page defining and using `\newcommand{\lt}{<}` now parses as XML, with the attribute written `latex:\newcommand{\lt}{&lt;}`.

### On the shared script

PreFigure carries its own copy, identical to ours apart from the output block. Their reader needs the matching change — an `xhtml` prefix on three XPath lookups in `label_tools.py` — and that is theirs to make when it suits them. The two copies differ by one line until then, and match again afterwards. Neither project has to wait on the other, and nothing breaks in either while they are out of step; the hazard would be copying the file wholesale between the repositories before the receiving reader is ready.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
