### PR TITLE
publisher control of Beamer slide shape and font size

### DIFF
--- a/doc/guide/publisher/publication-file.xml
+++ b/doc/guide/publisher/publication-file.xml
@@ -1249,6 +1249,26 @@
                 <li><attr>theme</attr>: the name of a Beamer theme, as it would appear in a <c>\usetheme</c> command, such as <c>Singapore</c> or <c>Madrid</c>.  The default is <c>Boadilla</c>.  Any theme your <latex/> installation provides may be named, including a locally-installed custom theme.  A name the <latex/> installation cannot find stops the build with an error repeating the name; capitalization is the first thing to check.  See <xref ref="publisher-beamer"/>.</li>
             </ul></p>
         </subsection>
+
+        <subsection xml:id="beamer-page-options" label="beamer-page-options">
+            <title>Beamer Slide Shape</title>
+            <idx><h>publisher options</h><h>Beamer slide shape</h></idx>
+            <idx><h>Beamer</h><h>aspect ratio</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/beamer/page/@aspect-ratio</cline>
+            </cd>attribute can have the value <c>16:9</c> (the default), <c>4:3</c>, <c>16:10</c>, <c>14:9</c>, <c>5:4</c>, or <c>3:2</c>.  Elect the shape of the display you will present on.  See <xref ref="publisher-beamer"/> for the effect this has on the room available for content.</p>
+        </subsection>
+
+        <subsection xml:id="beamer-font-size-options" label="beamer-font-size-options">
+            <title>Beamer Font Sizes</title>
+            <idx><h>font size options</h><h>Beamer</h></idx>
+            <idx><h>Beamer</h><h>font size option</h></idx>
+
+            <p>The<cd>
+                <cline>/publication/beamer/@font-size</cline>
+            </cd>attribute can have the value <c>8</c>, <c>9</c>, <c>10</c>, <c>11</c>, <c>12</c>, <c>14</c>, <c>17</c>, or <c>20</c>, which are interpreted in points (<q>pt</q>) as the unit of measure.  The default value is <c>11</c>, which is also Beamer's own default.  A value other than <c>10</c>, <c>11</c>, or <c>12</c> requires the <c>extsizes</c> package to be part of your <latex/> installation.  This is the control to reach for when slides are too crowded<mdash/>see <xref ref="publisher-beamer"/>.</p>
+        </subsection>
     </section>
 
     <section xml:id="publication-file-epub">

--- a/doc/guide/publisher/slides.xml
+++ b/doc/guide/publisher/slides.xml
@@ -150,6 +150,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             Theme names are case-sensitive<mdash/>it is <c>Singapore</c>, never <c>singapore</c><mdash/>so check capitalization before anything else.
         </p>
         <p>
+            Beamer builds each slide as a small page<mdash/>16 centimeters by 9 centimeters for the default shape<mdash/>which a <init>PDF</init> viewer then scales up to fill whatever screen you present on.
+            So a point size is never what a viewer sees.
+            What a viewer sees is the size of the type <em>relative to the slide</em>, and that is what the two options below control.
+        </p>
+        <p>
+            Elect the shape with the <attr>aspect-ratio</attr> attribute of the <tag>page</tag> element within the <tag>beamer</tag> element of the publication file (<xref ref="beamer-page-options"/>).
+            The default is <c>16:9</c>, which matches most projectors and displays made this century.
+            Choose <c>4:3</c> for an older projector, or one of the other shapes on offer to match a particular room.
+            A wider shape buys width for your content and gives back a little height, so slides that are already tall may need attention after a change<mdash/>in particular an image sized as a percentage of the width will grow taller as the slide grows wider.
+        </p>
+        <p>
+            Beamer's default type is large, which is right for a lecture hall and can be too large when you want room to write on a slide, or when you have a lot to show at once.
+            Reduce it with the <attr>font-size</attr> attribute of the <tag>beamer</tag> element (<xref ref="beamer-font-size-options"/>).
+            The default is <c>11</c>, and a smaller value scales everything together<mdash/>body text, slide titles, blocks, and mathematics<mdash/>so the whole slide simply holds more.
+            Going from <c>11</c> to <c>9</c>, for instance, leaves the type a fifth smaller on screen, whatever the screen.
+        </p>
+        <p>
             Beamer's own habit is to center a frame's content vertically.
             A <pretext/> slideshow instead places content at the top of every frame by default, in agreement with the Reveal.js conversion.
             For the classic centered look<mdash/>title page, section pages, and every slide<mdash/>set a document-wide default of <c>middle</c> with the <attr>valign</attr> attribute described in <xref ref="topic-slides"/>.

--- a/examples/sample-slideshow/publication.xml
+++ b/examples/sample-slideshow/publication.xml
@@ -49,9 +49,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <navigation mode="default"/>
     </revealjs>
 
-    <beamer>
+    <!-- font-size="11" is the default, and is Beamer's own default -->
+    <beamer font-size="11">
         <!-- theme="Boadilla" is the default -->
         <appearance theme="Singapore"/>
+        <!-- aspect-ratio="16:9" is the default; "4:3", "16:10",   -->
+        <!-- "14:9", "5:4" and "3:2" are the other shapes on offer -->
+        <page aspect-ratio="16:9"/>
     </beamer>
 
 </publication>

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -188,7 +188,7 @@
                     attribute print { "yes" | "no" }?,
                     attribute sides { "one" | "two" }?,
                     attribute open-odd { "add-blanks" | "skip-pages" | "no" }?,
-                    attribute font-size { "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
                     attribute snapshow { "yes" | "no" }?,

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -458,12 +458,18 @@
 
             Beamer =
                 element beamer {
-                    AppearanceBeamer?
+                    attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    ( AppearanceBeamer? & PageBeamer? )
                 }
 
             AppearanceBeamer =
                 element appearance {
                     attribute theme { text }
+                }
+
+            PageBeamer =
+                element page {
+                    attribute aspect-ratio { "4:3" | "16:9" | "16:10" | "14:9" | "5:4" | "3:2" }?
                 }
 
             Epub =

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -555,6 +555,7 @@
       <optional>
         <attribute name="font-size">
           <choice>
+            <value>8</value>
             <value>9</value>
             <value>10</value>
             <value>11</value>

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -1427,13 +1427,48 @@
   <define name="Beamer">
     <element name="beamer">
       <optional>
-        <ref name="AppearanceBeamer"/>
+        <attribute name="font-size">
+          <choice>
+            <value>8</value>
+            <value>9</value>
+            <value>10</value>
+            <value>11</value>
+            <value>12</value>
+            <value>14</value>
+            <value>17</value>
+            <value>20</value>
+          </choice>
+        </attribute>
       </optional>
+      <interleave>
+        <optional>
+          <ref name="AppearanceBeamer"/>
+        </optional>
+        <optional>
+          <ref name="PageBeamer"/>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="AppearanceBeamer">
     <element name="appearance">
       <attribute name="theme"/>
+    </element>
+  </define>
+  <define name="PageBeamer">
+    <element name="page">
+      <optional>
+        <attribute name="aspect-ratio">
+          <choice>
+            <value>4:3</value>
+            <value>16:9</value>
+            <value>16:10</value>
+            <value>14:9</value>
+            <value>5:4</value>
+            <value>3:2</value>
+          </choice>
+        </attribute>
+      </optional>
     </element>
   </define>
   <define name="Epub">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -360,7 +360,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     attribute print { "yes" | "no" }?,
                     attribute sides { "one" | "two" }?,
                     attribute open-odd { "add-blanks" | "skip-pages" | "no" }?,
-                    attribute font-size { "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
                     attribute snapshow { "yes" | "no" }?,

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -687,12 +687,18 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <code>
             Beamer =
                 element beamer {
-                    AppearanceBeamer?
+                    attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
+                    ( AppearanceBeamer? &amp; PageBeamer? )
                 }
 
             AppearanceBeamer =
                 element appearance {
                     attribute theme { text }
+                }
+
+            PageBeamer =
+                element page {
+                    attribute aspect-ratio { "4:3" | "16:9" | "16:10" | "14:9" | "5:4" | "3:2" }?
                 }
             </code>
         </fragment>

--- a/xsl/pretext-beamer.xsl
+++ b/xsl/pretext-beamer.xsl
@@ -477,8 +477,41 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Beamer-specific treatment of \alert and no styling hooks) and     -->
 <!-- the engine/font setup (fontenc/fontspec, where the regular        -->
 <!-- "font-support" prescribes document fonts a theme should control). -->
+
+<!-- The Beamer class names a slide's shape with the digits of the   -->
+<!-- aspect ratio run together, so "16:9" becomes "aspectratio=169". -->
+<!-- The publisher expresses the ratio in its readable form, and the -->
+<!-- options the publication file admits are exactly those the class -->
+<!-- recognizes, so no value can reach here without a translation.   -->
+<xsl:template name="beamer-aspect-ratio-option">
+    <xsl:choose>
+        <xsl:when test="$beamer-aspect-ratio = '4:3'">
+            <xsl:text>43</xsl:text>
+        </xsl:when>
+        <xsl:when test="$beamer-aspect-ratio = '16:9'">
+            <xsl:text>169</xsl:text>
+        </xsl:when>
+        <xsl:when test="$beamer-aspect-ratio = '16:10'">
+            <xsl:text>1610</xsl:text>
+        </xsl:when>
+        <xsl:when test="$beamer-aspect-ratio = '14:9'">
+            <xsl:text>149</xsl:text>
+        </xsl:when>
+        <xsl:when test="$beamer-aspect-ratio = '5:4'">
+            <xsl:text>54</xsl:text>
+        </xsl:when>
+        <xsl:when test="$beamer-aspect-ratio = '3:2'">
+            <xsl:text>32</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
+
 <xsl:template name="beamer-preamble">
-    <xsl:text>\documentclass[11pt, compress]{beamer}&#xa;</xsl:text>
+    <xsl:text>\documentclass[</xsl:text>
+    <xsl:value-of select="$beamer-font-size"/>
+    <xsl:text>, aspectratio=</xsl:text>
+    <xsl:call-template name="beamer-aspect-ratio-option"/>
+    <xsl:text>, compress]{beamer}&#xa;</xsl:text>
     <xsl:if test="$latex.preamble.early != ''">
         <xsl:text>%% Custom Preamble Entries, early (use latex.preamble.early)&#xa;</xsl:text>
         <xsl:value-of select="$latex.preamble.early" />

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3122,6 +3122,33 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:value-of select="substring-after($join-latex-pagebreaks, ' ')"/>
 </xsl:variable>
 
+<!-- The document classes of the LaTeX conversions, and the Beamer   -->
+<!-- class, accept the same eight point sizes as a class option, so  -->
+<!-- the check on a publisher's choice is shared.  A caller provides -->
+<!-- the value to test, the value to use when the test fails, and    -->
+<!-- the name of the publication file entry, for the message.        -->
+<xsl:template name="validate-font-size">
+    <xsl:param name="candidate"/>
+    <xsl:param name="fallback"/>
+    <xsl:param name="entry"/>
+    <xsl:choose>
+        <xsl:when test="($candidate =  '8') or
+                        ($candidate =  '9') or
+                        ($candidate = '10') or
+                        ($candidate = '11') or
+                        ($candidate = '12') or
+                        ($candidate = '14') or
+                        ($candidate = '17') or
+                        ($candidate = '20')">
+            <xsl:value-of select="$candidate"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:message>PTX:FALLBACK: <xsl:value-of select="$entry"/> in publication file should be 8, 9, 10, 11, 12, 14, 17 or 20 points, not "<xsl:value-of select="$candidate"/>".  Proceeding with default value: "<xsl:value-of select="$fallback"/>"</xsl:message>
+            <xsl:value-of select="$fallback"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
 <!-- For historical reasons, this variable has "pt" as part -->
 <!-- of its value.  A change would need to be coordinated   -->
 <!-- with every application in the -latex conversion.       -->
@@ -3129,25 +3156,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:choose>
         <!-- via publication file -->
         <xsl:when test="$publication/latex/@font-size">
-            <!-- provisional, convenience -->
-            <xsl:variable name="fs" select="$publication/latex/@font-size"/>
-            <xsl:choose>
-                <xsl:when test="($fs =  '8') or
-                                ($fs =  '9') or
-                                ($fs = '10') or
-                                ($fs = '11') or
-                                ($fs = '12') or
-                                ($fs = '14') or
-                                ($fs = '17') or
-                                ($fs = '20')">
-                    <xsl:value-of select="$fs"/>
-                    <xsl:text>pt</xsl:text>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:message>PTX:FALLBACK: LaTeX @font-size in publication file should be 8, 9, 10, 11, 12, 14, 17 or 20 points, not "<xsl:value-of select="$publication/latex/@font-size"/>".  Proceeding with default value: "10"</xsl:message>
-                    <xsl:text>10pt</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:call-template name="validate-font-size">
+                <xsl:with-param name="candidate" select="$publication/latex/@font-size"/>
+                <xsl:with-param name="fallback" select="'10'"/>
+                <xsl:with-param name="entry" select="'LaTeX @font-size'"/>
+            </xsl:call-template>
+            <xsl:text>pt</xsl:text>
         </xsl:when>
         <!-- via deprecated stringparam: assumes "pt" as the unit of measure   -->
         <!-- (this is recycled code, so no real attempt to do better)          -->

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3542,6 +3542,40 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="$publisher-attribute-options/beamer/appearance/pi:pub-attribute[@name='theme']" mode="set-pubfile-variable"/>
 </xsl:variable>
 
+<!-- Beamer Aspect Ratio -->
+
+<!-- Beamer builds a slide as a small page, which a viewer scales up -->
+<!-- to fill a screen, so the shape of that page is all a publisher  -->
+<!-- chooses.  The Beamer class realizes a shape as a class option,  -->
+<!-- spelled without the separator, and the conversion does that     -->
+<!-- translation; here we only record the publisher's choice.        -->
+<xsl:variable name="beamer-aspect-ratio">
+    <xsl:apply-templates select="$publisher-attribute-options/beamer/page/pi:pub-attribute[@name='aspect-ratio']" mode="set-pubfile-variable"/>
+</xsl:variable>
+
+<!-- Beamer Font Size -->
+
+<!-- The Beamer class accepts the same eight point sizes as the    -->
+<!-- LaTeX document classes, and 11 points is its own default.  A  -->
+<!-- size other than 10, 11, or 12 points needs the "extsizes"     -->
+<!-- package.  As with the LaTeX conversion, this variable carries -->
+<!-- "pt" as part of its value.                                    -->
+<xsl:variable name="beamer-font-size">
+    <xsl:choose>
+        <xsl:when test="$publication/beamer/@font-size">
+            <xsl:call-template name="validate-font-size">
+                <xsl:with-param name="candidate" select="$publication/beamer/@font-size"/>
+                <xsl:with-param name="fallback" select="'11'"/>
+                <xsl:with-param name="entry" select="'Beamer @font-size'"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text>11</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>pt</xsl:text>
+</xsl:variable>
+
 
 <!-- ########################################### -->
 <!-- Set Values/Defaults for Publisher Variables -->
@@ -3799,6 +3833,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <appearance>
             <pi:pub-attribute name="theme" default="Boadilla" freeform="yes"/>
         </appearance>
+        <page>
+            <pi:pub-attribute name="aspect-ratio" default="16:9" options="4:3 16:10 14:9 5:4 3:2"/>
+        </page>
     </beamer>
 </pi:publisher>
 


### PR DESCRIPTION
A pretext-support request for 16:9 slides with smaller type turned up that neither was possible. The Beamer conversion emitted a fixed `\documentclass[11pt, compress]{beamer}`, so every slideshow was Beamer's default 4:3 at 11pt, with no way to influence it: the aspect ratio is a class option, and the early preamble insertion lands after `\documentclass`.

Two publication file entries now cover both.

- `/publication/beamer/page/@aspect-ratio` — `16:9` (default), `4:3`, `16:10`, `14:9`, `5:4`, `3:2`.
- `/publication/beamer/@font-size` — `8`, `9`, `10`, `11` (default), `12`, `14`, `17`, `20`, the same eight sizes the LaTeX conversion accepts. Anything other than 10, 11, or 12 requires the `extsizes` package.

**The default aspect ratio is 16:9, not Beamer's 4:3.** Existing slideshows will reflow; `aspect-ratio="4:3"` keeps the old shape.

Because a viewer scales a Beamer page up to fill a screen, an absolute point size is never what an audience sees — only the size of the type relative to the slide. Font size is therefore the control for fitting more onto a slide, and the Guide now says so, both in the reference entries and in the Beamer section of the slideshow chapter.

Two smaller pieces ride along. The check on `@font-size` is now a single template shared by both conversions, message included. And `8` is restored to the LaTeX `@font-size` values in the publication schema, which the conversion and the Guide have always accepted.

Testing: `examples/sample-slideshow` builds at the new defaults to a 160mm by 90mm page, 50 pages, content unchanged; with `font-size="9"` and `aspect-ratio="4:3"` it returns the old page and fits more per slide. An illegal value for either entry falls back with a message and the build completes. The sample article's LaTeX output is unchanged across the shared-check refactor apart from build timestamps.

One known consequence, not addressed here: an image sized as a percentage of the width grows taller as the slide grows wider, so slides that were already tight get tighter — two image slides in the sample slideshow overflow further than before. Capping image height on a slide is separate work.

*Claude Opus 5 (1M context), acting as a coding assistant for Rob Beezer*
