### PR TITLE
JS: provide opt out hook for image expansion dialog

### DIFF
--- a/js/src/image-dialog.js
+++ b/js/src/image-dialog.js
@@ -20,7 +20,9 @@ function initializeImageDialogs() {
     ].join(', ');
 
     document.querySelectorAll(magnifiableImageSelector).forEach((image) => {
-        if (initializedImageDialogs.has(image)) {
+        // Do not initialize the same image twice, and do not initialize
+        // anything that explicitly opts out.
+        if (initializedImageDialogs.has(image) || image.closest('[data-ptx-image-dialog="false"]')) {
             return;
         }
 


### PR DESCRIPTION
Currently not used directly in PTX, but needed so we can disable image expansion for images inside RS context when it makes sense to do so. Could also be useful internally for PTX.