### PR TITLE
assorted small fixes, one per commit

### DIFF
--- a/doc/guide/appendices/schema-install.xml
+++ b/doc/guide/appendices/schema-install.xml
@@ -52,7 +52,9 @@
         <subsection xml:id="validation-terse">
             <title>Validation for Programs</title>
 
-            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The <c>terse</c> method serves exactly this purpose: the report is one line per message, five tab-separated fields<mdash/>file, path, line, check, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.  Unlike that report, every element of a path carries its count, so a program may consume paths uniformly.  Sorting on the <c>check</c> field clusters occurrences of the same problem.)  Elect it with <c>-V -M terse</c> at the command line, or call the library directly, as in the following complete driver, which prints the report on standard output and is simple enough to serve as a model.<listing>
+            <p>A program iteratively <em>producing</em> <pretext/> source<mdash/>a conversion of legacy material, say, or an <init>AI</init> agent translating another format<mdash/>wants the validation results, without the surrounding help meant for a human.  The <c>terse</c> method serves exactly this purpose: the report is one line per message, five tab-separated fields<mdash/>file, path, line, check, message<mdash/>and nothing else.  (As in the human-readable report, the line number references the assembled version of the source, deposited alongside the report.  Unlike that report, every element of a path carries its count, so a program may consume paths uniformly.  Sorting on the <c>check</c> field clusters occurrences of the same problem.)  Elect it with <c>-V -M terse</c> at the command line, or call the library directly, as in the following complete driver, which prints the report on standard output and is simple enough to serve as a model.</p>
+
+            <listing>
                 <title>A driver for machine-readable validation</title>
                 <program language="python">
                     <code>
@@ -86,7 +88,7 @@ with open(report) as f:
     sys.stdout.write(f.read())
                     </code>
                 </program>
-            </listing></p>
+            </listing>
         </subsection>
 
         <subsection xml:id="jing-ubuntu">

--- a/doc/guide/author/topics.xml
+++ b/doc/guide/author/topics.xml
@@ -6283,8 +6283,6 @@
       </paragraphs>
     </subsection>
     <conclusion>
-        <title>Conclusion</title>
-
         <p>Watching a blind reader navigate a web page can be a very enlightening experience.  Or you might even undertake learning one yourself.  Here are some suggestions for getting started (current on 2018-05-31).<ul>
             <li><init>NVDA</init>, <url href="https://www.nvaccess.org/" visual="www.nvaccess.org"/>, Windows, open source via GPL</li>
             <li>Orca, <url href="https://help.gnome.org/users/orca/stable/" visual="help.gnome.org/users"/>, Linux, open source via LGPL</li>

--- a/examples/minimal/source/main.ptx
+++ b/examples/minimal/source/main.ptx
@@ -55,7 +55,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </titlepage>
 
             <abstract>
-                <p>This is a very short article, but it still exercises some advanced features of MathBook XML.</p>
+                <p>This is a very short article, but it still exercises some advanced features of <pretext/>.</p>
             </abstract>
 
         </frontmatter>

--- a/examples/sample-book/backmatter.xml
+++ b/examples/sample-book/backmatter.xml
@@ -104,7 +104,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </index>
 
     <colophon xml:id="back-colophon">
-        <p>This book was authored in MathBook XML.</p>
+        <p>This book was authored in <pretext/>.</p>
     </colophon>
 
 </backmatter>

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -4859,6 +4859,11 @@ def pdf(xml, pub_file, stringparams, extra_xsl, out_file, dest_dir, method, outp
         latex_cmd = latex_exec_cmd + ["-halt-on-error", sourcename]
         logname = basename + ".log"
         result = _latex_compile(latex_cmd, logname, sourcename)
+        # A failed compilation leaves no PDF behind, so say so here.  Copying
+        # the absent file would raise instead, and the author would read a
+        # Python traceback rather than a sentence naming the log to consult.
+        if result.returncode != 0:
+            raise OSError("the LaTeX compilation of {} failed, so no PDF was produced.  Consult {} for the errors reported by the LaTeX engine".format(sourcename, logname))
 
         # If we want all outputs, we copy the entire build directory now that the PDF is built
         # so we can get the *.log, *.aux, etc build files.

--- a/pretext/lib/pretext.py
+++ b/pretext/lib/pretext.py
@@ -2096,7 +2096,7 @@ def preview_images(xml_source, pub_file, stringparams, xmlid_root, dest_dir, met
     Generate preview images for interactive elements using playwright.
     'method' is expected to be "fast" or "slow", corresponding to a 5000 or 10000 ms timeout.
     """
-    import asyncio  # get_event_loop()
+    import asyncio  # run()
 
     # external module, often forgotten
     # imported here, used only in interior

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -434,7 +434,8 @@
 
             Appearance =
                 element appearance {
-                    attribute theme { text }
+                    attribute theme { text }?,
+                    attribute custom-css { text }?
                 }
 
             Controls =

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -439,7 +439,7 @@
 
             Controls =
                 element controls {
-                    attribute backarrow { "faded" | "hidden" | "visible" }?,
+                    attribute backarrows { "faded" | "hidden" | "visible" }?,
                     attribute display { "yes" | "no" }?,
                     attribute layout { "edges" | "bottom-right" }?,
                     attribute tutorial { "yes" | "no" }?

--- a/schema/publication-schema.rnc
+++ b/schema/publication-schema.rnc
@@ -191,7 +191,7 @@
                     attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
-                    attribute snapshow { "yes" | "no" }?,
+                    attribute snapshot { "yes" | "no" }?,
                     attribute link-highlight { "none" | "underline" }?,
                     ( Page? & Worksheet? & Cover? & Asymptote?)
                 }

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -583,7 +583,7 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="snapshow">
+        <attribute name="snapshot">
           <choice>
             <value>yes</value>
             <value>no</value>

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -1361,7 +1361,7 @@
   <define name="Controls">
     <element name="controls">
       <optional>
-        <attribute name="backarrow">
+        <attribute name="backarrows">
           <choice>
             <value>faded</value>
             <value>hidden</value>

--- a/schema/publication-schema.rng
+++ b/schema/publication-schema.rng
@@ -1355,7 +1355,12 @@
   </define>
   <define name="Appearance">
     <element name="appearance">
-      <attribute name="theme"/>
+      <optional>
+        <attribute name="theme"/>
+      </optional>
+      <optional>
+        <attribute name="custom-css"/>
+      </optional>
     </element>
   </define>
   <define name="Controls">

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -650,7 +650,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             Appearance =
                 element appearance {
-                    attribute theme { text }
+                    attribute theme { text }?,
+                    attribute custom-css { text }?
                 }
 
             Controls =

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -363,7 +363,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     attribute font-size { "8" | "9" | "10" | "11" | "12" | "14" | "17" | "20" }?,
                     attribute page-ref { "yes" | "no" }?,
                     attribute draft { "yes" | "no" }?,
-                    attribute snapshow { "yes" | "no" }?,
+                    attribute snapshot { "yes" | "no" }?,
                     attribute link-highlight { "none" | "underline" }?,
                     ( Page? &amp; Worksheet? &amp; Cover? &amp; Asymptote?)
                 }

--- a/schema/publication-schema.xml
+++ b/schema/publication-schema.xml
@@ -655,7 +655,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 
             Controls =
                 element controls {
-                    attribute backarrow { "faded" | "hidden" | "visible" }?,
+                    attribute backarrows { "faded" | "hidden" | "visible" }?,
                     attribute display { "yes" | "no" }?,
                     attribute layout { "edges" | "bottom-right" }?,
                     attribute tutorial { "yes" | "no" }?

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -11975,6 +11975,7 @@ http://andrewmccarthy.ie/2014/11/06/swung-dash-in-latex/
         <xsl:with-param name="message" select="'an &quot;sbsgroup&quot; now requires at least two &quot;sidebyside&quot;.  A group of one behaves exactly like the &quot;sidebyside&quot; alone, so use the &quot;sidebyside&quot; by itself, with the layout attributes moved onto it'"/>
     </xsl:call-template>
     <!--  -->
+    <!-- End of the chronological sequence: a new entry goes just above. -->
 </xsl:template>
 
 <!-- Miscellaneous -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -5819,10 +5819,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:if test="@marker or ($format-code = '0') or ancestor::exercises or ancestor::worksheet or ancestor::handout or ancestor::reading-questions or ancestor::references">
         <xsl:text>[label={</xsl:text>
         <xsl:apply-templates select="." mode="latex-list-label" />
+        <xsl:text>}</xsl:text>
+        <!-- The braces delimit the replacement text of the "label" key. -->
+        <!-- "start" is a key in its own right, so it follows them.      -->
         <xsl:if test="$format-code = '0'">
             <xsl:text>, start=0</xsl:text>
         </xsl:if>
-        <xsl:text>}]</xsl:text>
+        <xsl:text>]</xsl:text>
     </xsl:if>
     <xsl:text>&#xa;</xsl:text>
      <xsl:apply-templates select="li"/>

--- a/xsl/publisher-variables.xsl
+++ b/xsl/publisher-variables.xsl
@@ -3974,7 +3974,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- is to allow deprecation warnings to flag (and often react        -->
 <!-- favorably) to attempted uses. Dated, and in chronological        -->
 <!-- order.  Grep, or the git pickaxe (log -S) using the date strings -->
- <!-- is often effective in locating all the pieces of a deprecation. -->
+<!-- is often effective in locating all the pieces of a deprecation.  -->
+<!-- A NEW ENTRY GOES AT THE END OF THE BANK, just above the marker   -->
+<!-- that closes it, never beside a similar parameter higher up.      -->
 
 <!-- Conversion specific parameters that die will   -->
 <!-- live on in warnings, which are isolated in the -->
@@ -4199,6 +4201,8 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- html/annotation/@platform  in publisher file -->
 <xsl:param name="html.annotation" select="''" />
 
+<!-- End of the bank: a new retired parameter goes just above. -->
+
 <!-- ###################################### -->
 <!-- Parameter Deprecation Warning Messages -->
 <!-- ###################################### -->
@@ -4240,6 +4244,12 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:variable name="document-root" select="./*[not(self::docinfo)]"/>
 
 
+    <!-- The messages below are in the order the parameters were deprecated, -->
+    <!-- and they print in that order, so A NEW ENTRY GOES AT THE END OF THE -->
+    <!-- SEQUENCE, just above the marker that closes it.  Placing one beside -->
+    <!-- a similar message instead lands it among far older dates, where the -->
+    <!-- next reader will not think to look for it.                          -->
+    <!--  -->
     <!-- 2017-07-05  sidebyside cannot be cross-referenced anymore, so not knowlizable -->
     <xsl:call-template name="parameter-deprecation-message">
         <xsl:with-param name="date-string" select="'2017-07-05'" />
@@ -4871,6 +4881,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="incorrect-use" select="($directory.images != '')" />
     </xsl:call-template>
     <!--  -->
+    <!-- End of the chronological sequence: a new entry goes just above. -->
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
A batch of unrelated small problems, collected while working on other things. Each is its own commit and none depends on any other, so they can be read in any order and reverted independently.

**Publication schema, where the conversion is plainly authoritative.** Three attribute names had drifted from what `publisher-variables.xsl` actually reads. `latex/@snapshot` was spelled `snapshow`, so the working spelling failed validation and the typo validated and did nothing — the sample article's own publication files author `snapshot="yes"`. `revealjs/controls/@backarrows` was spelled `backarrow`. And `revealjs/appearance/@custom-css` was missing altogether, though the code declares it and the sample slideshow uses it; `@theme` becomes optional in the same commit, since it has a default and otherwise the new attribute could not be used on its own. With these, `examples/sample-slideshow/publication.xml` validates clean.

**A visible LaTeX defect.** An `ol` whose marker starts at zero emitted `start=0` inside the `enumitem` label braces, so the key became part of the label. Such a list rendered `1., start=0` / `2., start=0` and numbered from one. It now renders `0.` `1.` `2.` The sample article carries two such lists.

**A build failure that read as a crash.** A failed LaTeX compilation was never detected, so the next step tried to copy a PDF that did not exist and the author saw `FileNotFoundError` with a traceback. The engine's return code is now checked, and the failure is reported with the source and the log file to consult.

**Two documentation errors**, which together take the Guide from two schema errors to none. The `listing` authored inside a `p` is my doing: I added it in `fab528eff`, documenting validation via the `pretext` script, and did not validate the addition — a schema error in the very section about validating. The `title` on a `conclusion` is older, from 2023, and has been deprecated and ignored since July.

**Three pieces of tidying.** The `asyncio` import comment named `get_event_loop()`, a call replaced by `asyncio.run` in July, and now names `run()`, following this module's habit of listing the methods an import supplies. Two examples told a reader they were authored in MathBook XML. And the three date-ordered deprecation sequences gain a header and an end marker, so a new entry lands at the end rather than beside a similar message among far older dates; existing entries are not reordered, since message order is output order.

Testing: schema regeneration is idempotent and every publication file under `examples/` and `doc/` was re-validated; the Guide's schema errors go from two to zero and its build no longer emits a deprecation warning; the zero-based list and the failed-compile message were each verified by building and compiling both before and after; the two comment-only changes were confirmed to leave the sample article's LaTeX byte-identical apart from build timestamps.

*Claude Opus 5 (1M context), acting as a coding assistant for Rob Beezer*
