### PR TITLE
Offline math: music notation reaches XSL-FO, EPUB, braille, and slideshows

### DIFF
--- a/xsl/pretext-braille-preprint.xsl
+++ b/xsl/pretext-braille-preprint.xsl
@@ -156,7 +156,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- *are* present in "math-original" but that introduces a new  -->
 <!-- element in-between "md" and "mrow", so matches on           -->
 <!-- "md[mrow]" can be problematic here (and perhaps elsewhere). -->
-<xsl:template match="m|md" mode="meld-math">
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord") is  -->
+<!-- set as inline math, so it has a representation as an "m" does. -->
+<xsl:template match="m|md|n|scaledeg|timesignature|chord" mode="meld-math">
     <!-- preserve author's element -->
     <xsl:copy>
         <!-- preserve attributes -->
@@ -1777,6 +1779,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             </math>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord") is   -->
+<!-- LaTeX built by the -common templates and set as inline math,    -->
+<!-- melded with a Nemeth representation just as an "m" is.  It      -->
+<!-- always has structure (an accidental, an octave, a chord's       -->
+<!-- figures), so it is never one of the simple cases above, and it  -->
+<!-- absorbs no clause-ending punctuation, so none is restored here. -->
+<xsl:template match="n|scaledeg|timesignature|chord">
+    <xsl:variable name="raw-braille">
+        <xsl:call-template name="brf-symbols-filter">
+            <xsl:with-param name="text" select="math-nemeth"/>
+        </xsl:call-template>
+    </xsl:variable>
+    <math>
+        <xsl:value-of select="$raw-braille"/>
+    </math>
 </xsl:template>
 
 <xsl:template match="m[contains(math-nemeth, '&#xa;')]|md">

--- a/xsl/pretext-epub.xsl
+++ b/xsl/pretext-epub.xsl
@@ -1574,8 +1574,10 @@
 <!-- Math -->
 <!-- #### -->
 
-<!-- Pluck SVGs from the file full of them, with matching IDs -->
-<xsl:template match="m|md[mrow]">
+<!-- Pluck SVGs from the file full of them, with matching IDs.  -->
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord") -->
+<!-- is set as inline math, so it has a representation as well. -->
+<xsl:template match="m|md[mrow]|n|scaledeg|timesignature|chord">
     <!-- NB: math-representation file writes with "unique-id" -->
     <xsl:variable name="id">
         <xsl:apply-templates select="." mode="unique-id"/>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -3997,10 +3997,14 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- FO "alignment-adjust": FOP raises the object by the length,  -->
 <!-- so the (negative) drop lowers it below the baseline, exactly -->
 <!-- as in CSS (verified empirically, 2026-06-11).                -->
-<xsl:template match="m|me|men|md|mdn">
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord") is   -->
+<!-- LaTeX built by the -common templates and set as inline math,   -->
+<!-- so it has a representation, and a placeholder, just as "m".    -->
+<xsl:template match="m|me|men|md|mdn|n|scaledeg|timesignature|chord">
     <xsl:variable name="id">
         <xsl:apply-templates select="." mode="unique-id"/>
     </xsl:variable>
+    <xsl:variable name="b-inline" select="self::m or self::n or self::scaledeg or self::timesignature or self::chord"/>
     <xsl:variable name="svg" select="$math-repr/pi:math[@id = $id]/div[@class = 'svg']/svg:svg"/>
     <xsl:variable name="speech" select="normalize-space($speech-repr/pi:math[@id = $id]/div[@class = 'speech'])"/>
     <!-- A display fills the full text measure only when no     -->
@@ -4069,7 +4073,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
     </xsl:variable>
     <xsl:choose>
-        <xsl:when test="$svg and self::m">
+        <xsl:when test="$svg and $b-inline">
             <!-- for math sitting on the baseline (e.g. a lone digit),  -->
             <!-- MathJax writes "vertical-align: 0;", unitless, and the -->
             <!-- parse of the "ex" quantity comes up empty, not zero    -->
@@ -4192,6 +4196,15 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:value-of select="."/>
     </fo:inline>
 </xsl:template>
+<!-- The LaTeX of a music element is built by the "inner-music"  -->
+<!-- templates of the -common stylesheet, the same LaTeX MathJax -->
+<!-- receives; this mode only boxes it, as for "m" above.        -->
+<xsl:template match="n|scaledeg|timesignature|chord" mode="math-placeholder">
+    <fo:inline font-family="{$font-family-monospace}" border="solid 0.5pt #888888" padding-left="2pt" padding-right="2pt">
+        <xsl:apply-templates select="." mode="inner-music"/>
+    </fo:inline>
+</xsl:template>
+
 
 <!-- Assembly rewrites every display to "md", so that is the only    -->
 <!-- form seen here.  Each "mrow" is one line of the display: emit    -->

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -4205,6 +4205,30 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     </fo:inline>
 </xsl:template>
 
+<!-- Accidentals in prose ("sharp", "flat", and so on, outside any  -->
+<!-- note or chord); the -common templates for the elements call    -->
+<!-- these by name.  The body fonts lack the glyphs, and FOP falls  -->
+<!-- back to another face only for a whole word, so each is set     -->
+<!-- outright in the symbol font, as the end-marks are.  FOP cannot -->
+<!-- address a character beyond the Basic Multilingual Plane (it    -->
+<!-- mangles the surrogate pair), so the double sharp and double    -->
+<!-- flat, U+1D12A and U+1D12B, are the single characters doubled,  -->
+<!-- as the MathJax representations also render them.               -->
+<xsl:template name="doublesharp">
+    <fo:inline font-family="{$font-family-symbol}">&#x266F;&#x266F;</fo:inline>
+</xsl:template>
+<xsl:template name="sharp">
+    <fo:inline font-family="{$font-family-symbol}">&#x266F;</fo:inline>
+</xsl:template>
+<xsl:template name="natural">
+    <fo:inline font-family="{$font-family-symbol}">&#x266E;</fo:inline>
+</xsl:template>
+<xsl:template name="flat">
+    <fo:inline font-family="{$font-family-symbol}">&#x266D;</fo:inline>
+</xsl:template>
+<xsl:template name="doubleflat">
+    <fo:inline font-family="{$font-family-symbol}">&#x266D;&#x266D;</fo:inline>
+</xsl:template>
 
 <!-- Assembly rewrites every display to "md", so that is the only    -->
 <!-- form seen here.  Each "mrow" is one line of the display: emit    -->
@@ -4656,6 +4680,7 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         self::nbsp or self::ndash or self::mdash or self::lsq or self::rsq or self::lq or self::rq or self::ldblbracket or self::rdblbracket or self::langle or self::rangle or self::ellipsis or self::midpoint or self::swungdash or self::permille or self::pilcrow or self::section-mark or self::minus or self::times or self::solidus or self::obelus or self::plusminus or self::copyright or self::phonomark or self::copyleft or self::registered or self::trademark or self::servicemark or self::degree or self::prime or self::dblprime or
         self::q or self::sq or self::dblbrackets or self::angles or
         self::c or self::cline or self::tag or self::tage or self::attr or self::today or self::timeofday or self::pi:localize or
+        self::sharp or self::flat or self::natural or self::doublesharp or self::doubleflat or
         self::xref or self::index-list or self::notation-list or self::list-of)]">
     <xsl:message>PTX:FO-TODO: <xsl:value-of select="local-name()"/> (child of "<xsl:value-of select="local-name(parent::*)"/>")</xsl:message>
     <xsl:apply-templates select="*"/>

--- a/xsl/pretext-revealjs.xsl
+++ b/xsl/pretext-revealjs.xsl
@@ -757,7 +757,9 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- match covers all mathematics.  Slides never link to an         -->
 <!-- equation (a cross-reference renders as its text), so no HTML   -->
 <!-- id is placed, unlike EPUB.                                     -->
-<xsl:template match="m|md[mrow]">
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord")     -->
+<!-- is set as inline math, so it has a representation as well.     -->
+<xsl:template match="m|md[mrow]|n|scaledeg|timesignature|chord">
     <xsl:choose>
         <xsl:when test="$b-reveal-embedded-math">
             <!-- NB: math-representation file writes with "unique-id" -->

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -167,10 +167,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- Flag the context as "inline" v. "displaymath"     -->
 <!-- so that we can do things like place a CSS class   -->
 <!-- for MathJax to see when processing the math bits. -->
-<xsl:template match="m|md" mode="extraction">
+<!-- Music notation ("n", "scaledeg", "timesignature", "chord") is  -->
+<!-- LaTeX built by the -common templates and set as inline math, so -->
+<!-- it needs a representation exactly as an "m" does.               -->
+<xsl:template match="m|md|n|scaledeg|timesignature|chord" mode="extraction">
     <xsl:variable name="context">
         <xsl:choose>
-            <xsl:when test="self::m">
+            <xsl:when test="self::m or self::n or self::scaledeg or self::timesignature or self::chord">
                 <xsl:text>inline</xsl:text>
             </xsl:when>
             <xsl:when test="self::md">

--- a/xsl/support/extract-math.xsl
+++ b/xsl/support/extract-math.xsl
@@ -105,6 +105,23 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- and package math for subsequent processing, so no such            -->
 <!-- contortions are necessary and a simpler wrapping is possible.     -->
 
+<!-- Accidentals inside music notation are the Unicode characters    -->
+<!-- the HTML conversion writes, which MathJax renders from its own  -->
+<!-- fonts, except the double sharp and double flat, for which it    -->
+<!-- has no glyph: it emits them as fallback text in a generic serif -->
+<!-- face, which a PDF or EPUB font may lack (FOP prints a "#"), and -->
+<!-- the Speech Rule Engine can neither speak nor braille them.  So  -->
+<!-- the extracted LaTeX doubles the single characters instead,      -->
+<!-- braced so that a superscript takes both.  Written as characters -->
+<!-- rather than \sharp and \flat, they are legal inside the \text{} -->
+<!-- that holds a chord's alterations.                               -->
+<xsl:template name="doublesharp">
+    <xsl:text>{&#x266F;&#x266F;}</xsl:text>
+</xsl:template>
+<xsl:template name="doubleflat">
+    <xsl:text>{&#x266D;&#x266D;}</xsl:text>
+</xsl:template>
+
 <!-- Inline math does not need a "span", just delimiters -->
 <xsl:template name="inline-math-wrapper">
      <xsl:param name="math"/>


### PR DESCRIPTION
Musical notation (`n`, `scaledeg`, `timesignature`, `chord`) is LaTeX built
by the common templates and set as inline math, but the offline MathJax
extraction collected only `m` and `md`, so no representation ever existed
for it.  The conversions that depend on those representations then lost
it: the XSL-FO and braille conversions dropped the elements outright, and
EPUB and embedded reveal.js emitted the raw LaTeX.

* The extraction now collects the four music elements as inline math, and
  the XSL-FO, EPUB, reveal.js, and braille conversions look them up exactly
  as they do an `m`.
* MathJax has no glyph for the double sharp and double flat, and the
  Speech Rule Engine cannot voice or braille them, so the extracted LaTeX
  writes them as the single characters doubled.
* Accidentals in prose, outside any note or chord, were also dropped by
  the XSL-FO conversion; they are now set in the symbol font.

Verified on the humanities example: the note, scale-degree, time-signature
and chord lists render in the PDF, the EPUB, and the braille file, and a
slide with a note and a chord renders with embedded mathematics.  The PDF
validates as before, and the LaTeX and HTML output are unchanged.

*Claude Fable 5.1, acting as a coding assistant for Rob Beezer*
