### PR TITLE
XSL-FO: an end-mark takes its own line after a list or code display

### DIFF
--- a/examples/sample-article/sample-article.xml
+++ b/examples/sample-article/sample-article.xml
@@ -2761,6 +2761,59 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                 </investigation>
             </subsection>
 
+            <subsection xml:id="block-samples-closing-with-blocks" label="block-samples-closing-with-blocks">
+                <title>Blocks Closing with a List or a Display</title>
+                <p>Some blocks end with a mark, such as the filled square that closes a proof.  In print the mark rides the last line of the block's final paragraph, pushed to the right margin.  A paragraph may also hold a list, a code display, or displayed mathematics, and then the mark cannot ride the paragraph's last line without disturbing the layout of the paragraph and of the list, so it takes a line of its own.  Each block here ends with such a paragraph.</p>
+                <example>
+                    <title>Closing with a Bulleted List</title>
+                    <p>This <tag>example</tag> ends with a paragraph whose final child is an unordered list, and the first item has two words so that a justified last line would be visible.<ul>
+                        <li><p>first item</p></li>
+                        <li><p>second</p></li>
+                        <li><p>third</p></li>
+                    </ul></p>
+                </example>
+                <example>
+                    <title>A List, Then More Text</title>
+                    <p>Here the paragraph continues after the list, so its last line is running text, but the list is still inside the paragraph.<ol>
+                        <li><p>one item</p></li>
+                        <li><p>another item</p></li>
+                    </ol>The paragraph resumes here and ends with words, not a list.</p>
+                </example>
+                <example>
+                    <title>Closing with a Code Display</title>
+                    <p>A paragraph can also end with a <tag>cd</tag>, a short display of code, as in<cd>
+                        <cline>print("the last thing")</cline>
+                    </cd></p>
+                </example>
+                <example>
+                    <title>Closing with Displayed Mathematics</title>
+                    <p>And a paragraph can end with displayed mathematics, the case that has always placed the mark on its own line, given here for comparison:<md>
+                        <mrow>a^2 + b^2 \amp = c^2</mrow>
+                    </md></p>
+                </example>
+                <definition>
+                    <title>A Statement Closing with a Description List</title>
+                    <statement>
+                        <p>A <term>closing list</term> is a list that is the final child of a block's final paragraph, of any of three kinds; here the paragraph closes a <tag>statement</tag>.<dl>
+                            <li><title>ordered</title><p>numbered or lettered</p></li>
+                            <li><title>unordered</title><p>bulleted</p></li>
+                            <li><title>description</title><p>this one, with a term for each item</p></li>
+                        </dl></p>
+                    </statement>
+                </definition>
+                <theorem>
+                    <title>A Proof Closing with a List</title>
+                    <statement>
+                        <p>Every proof that ends with a list is followed by its mark on a line of its own.</p>
+                    </statement>
+                    <proof>
+                        <p>The proof has two cases.<ol>
+                            <li><p>The proof ends with running text, and the mark rides its last line.</p></li>
+                            <li><p>The proof ends with a list, as this one does, and the mark takes the next line.</p></li>
+                        </ol></p>
+                    </proof>
+                </theorem>
+            </subsection>
             <subsection>
                 <title>Miscellaneous Blocks</title>
                 <assemblage>

--- a/xsl/pretext-fo.xsl
+++ b/xsl/pretext-fo.xsl
@@ -1273,13 +1273,16 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="idx | notation"/>
     <xsl:variable name="content" select="*[not(self::title) and not(self::idx) and not(self::notation)]"/>
     <xsl:variable name="last" select="$content[last()]"/>
-    <!-- The mark rides a closing paragraph only when that paragraph   -->
-    <!-- holds running text alone.  A paragraph that carries a display  -->
-    <!-- ("...written as <md/>") would otherwise have its line          -->
-    <!-- justified (to push the mark to the margin), spreading the text -->
-    <!-- around the display; such a block takes the mark on its own     -->
-    <!-- line instead.                                                  -->
-    <xsl:variable name="b-mark-rides" select="boolean(($last[self::p] and not($last/md)) or ($last[self::statement] and $last/*[last()][self::p] and not($last/*[last()]/md)))"/>
+    <!-- The mark rides the paragraph that closes the block (directly,   -->
+    <!-- or by closing a "statement") only when that paragraph holds     -->
+    <!-- running text alone.  A paragraph carrying a block-level child   -->
+    <!-- (a display "md", a code display "cd", or a list "ol", "ul",     -->
+    <!-- "dl") would otherwise have "text-align-last" justified to push  -->
+    <!-- the mark to the margin, which spreads the text line before the  -->
+    <!-- block and, since the property inherits, the last line of every  -->
+    <!-- list item; such a block takes the mark on its own line instead. -->
+    <xsl:variable name="closing-paragraph" select="$last[self::p] | $last[self::statement]/*[last()][self::p]"/>
+    <xsl:variable name="b-mark-rides" select="$closing-paragraph and not($closing-paragraph/*[self::md or self::cd or self::ol or self::ul or self::dl])"/>
     <!-- the heading runs in to a leading paragraph, plain or in a "statement" -->
     <xsl:choose>
         <xsl:when test="$content[1][self::p] or ($content[1][self::statement] and $content[1]/*[1][self::p])">


### PR DESCRIPTION
A block that closes with a mark (the square after a proof, the triangle
after an example, the diamond after a definition) lets the mark ride the
last line of its final paragraph, which is justified so an elastic leader
pushes the mark to the margin.  That paragraph may hold a list or a code
display, and then the justification spreads the text line before the list
and, since the property inherits, the last line of every list item.  A
paragraph holding displayed mathematics was already excluded for the same
reason.

* The mark now rides the closing paragraph only when it holds running text
  alone: no `md`, `cd`, `ol`, `ul`, or `dl`.  Otherwise it takes a line of
  its own after the paragraph, as the LaTeX route also does after a list.
* The sample article gains a subsection of blocks closing each way, so the
  placement is exercised by an example, a definition, and a proof.

Verified on the sample article and the humanities example: with the
stylesheet change alone, the position of every word is unchanged except on
the pages holding an affected block, and there the text no longer spreads.
The sample article validates as before and builds in every route.

*Claude Fable 5.1, acting as a coding assistant for Rob Beezer*
