### PR TITLE
CSS: make permalink indent adjustments style aware

### DIFF
--- a/css/components/chunks/helpers/_C-box-mixin.scss
+++ b/css/components/chunks/helpers/_C-box-mixin.scss
@@ -61,6 +61,17 @@ $heading-color: var(--block-head-color) !default;
       border-bottom-left-radius: $border-radius;
     }
 
+    // Note - once inherit() is widely supported, refactor permalinks
+    & > .autopermalink {
+      // own permalink is offset by border width
+      left: calc(-1 * ($border-width + 2em));
+    }
+
+    & > * > .autopermalink {
+      // child element permalink is offset by border width and padding on side with border
+      left: calc(-1 * ($padding-left + $border-width + 2em));
+    }
+
     & > .heading:first-child {
       background-color: $heading-background;
       display: inline-block;

--- a/css/components/chunks/helpers/_L-mixin.scss
+++ b/css/components/chunks/helpers/_L-mixin.scss
@@ -40,6 +40,19 @@ $pad: 10px !default;
       color: $head-color;
     }
 
+    // Note - once inherit() is widely supported, refactor permalinks
+    @if $L-side == left {
+      & > .autopermalink {
+        // own permalink is offset by border width
+        left: calc(-1 * ($border-width + 2em));
+      }
+
+      & > * > .autopermalink {
+        // child element permalink is offset by border width and padding on side with border
+        left: calc(-1 * ($padding + $border-width + 2em));
+      }
+    }
+
     &::after {
       content: '';
       border-bottom: $border-width $style $border-color;

--- a/css/components/chunks/helpers/_heading-box-mixin.scss
+++ b/css/components/chunks/helpers/_heading-box-mixin.scss
@@ -70,6 +70,17 @@ $side-borders: true !default;
       border-radius: $border-radius;
     }
 
+    // Note - once inherit() is widely supported, refactor permalinks
+    & > .autopermalink {
+      // own permalink is offset by border width
+      left: calc(-1 * ($border-width + 2em));
+    }
+
+    & > * > .autopermalink {
+      // child element permalink is offset by border width and padding on side with border
+      left: calc(-1 * ($pad + $border-width + 2em));
+    }
+
     & > .heading:first-child {
       background-color: $heading-background;
       display: block;

--- a/css/components/chunks/helpers/_sidebar-mixin.scss
+++ b/css/components/chunks/helpers/_sidebar-mixin.scss
@@ -46,6 +46,17 @@ $border-width: 2px !default;
       border-radius: $border-radius;
     }
 
+    // Note - once inherit() is widely supported, refactor permalinks
+    & > .autopermalink {
+      // own permalink is offset by border width
+      left: calc(-1 * ($border-width + 2em));
+    }
+
+    & > * > .autopermalink {
+      // child element permalink is offset by border width and padding on side with border
+      left: calc(-1 * ($padside + $border-width + 2em));
+    }
+
     > .heading:first-child {
       margin-top: 0;
     }

--- a/css/components/elements/_permalinks.scss
+++ b/css/components/elements/_permalinks.scss
@@ -72,19 +72,6 @@ li > .autopermalink {
   top: 1.5ex;
 }
 
-// In some styles, the autopermalink for paras land right on the border line.
-// This is an attempt to fix that.  TODO: find a more robust solution, maybe
-// using a variable for the left offset of paras inside blocks.
-.assemblage-like > .para > .autopermalink,
-.example-like > .para > .autopermalink,
-.example-like > .exercise-like > .autopermalink,
-.project-like > .para > .autopermalink,
-.project-like > .exercise-like > .autopermalink,
-.project-like > .exercise-like > .introduction > .para > .autopermalink,
-.project-like > .exercise-like > .conclusion > .para > .autopermalink,
-.remark-like > .para > .autopermalink {
-  left: -2.9em;
-}
 
 
 .axiom-like, .example-like, .exercise-like, .solution-like, .assemblage-like, .definition-like, .remark-like, .project-like, .openproblem-like, .computation-like, .theorem-like, .proof, .case, li, dd {


### PR DESCRIPTION
Inspired by all the fun we are having over on https://github.com/PreTeXtBook/pretext/pull/3168

Current permalink positioning has a similar problem. We have ad hoc rules to change the offset of the permalinks based on what containers do in terms of padding and left border in some styles. But the current rules apply to elements regardless of what style is applied.

This reengineers the positioning to be based on things like "permalink is immediate child of a heading box" instead of "permalink is an immediate child of an example-like"

Results are slightly cleaner at a pixel level (handles different offset amounts for different kinds of boxes) and basically the same at a macro level.

Heads up for @oscarlevin 