### PR TITLE
Sample article: a publication file for the Alegreya XSL-FO PDF

### DIFF
--- a/examples/sample-article/publication-alegreya.xml
+++ b/examples/sample-article/publication-alegreya.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--********************************************************************
+Copyright (C) 2015-2026  Robert A. Beezer
+
+This file is part of PreTeXt.
+
+PreTeXt is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+PreTeXt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- Variant of  publication.xml  strictly for the XSL-FO PDF    -->
+<!-- ("pdf-fo") set in the Alegreya font.  The website builds    -->
+<!-- the sample article twice by this route, once with each of   -->
+<!-- the two available text fonts, so a reader can compare them. -->
+<!--   *  "common", "source", "stack", "numbering", and "latex"  -->
+<!--      sections should match  publication.xml  exactly.       -->
+<!--   *  the "pdf" section is the entire point of this file.    -->
+<!--   *  "html" section has been removed, the XSL-FO conversion -->
+<!--      reads nothing from it.                                 -->
+<!-- Doing a diff might help sync-up edits.                      -->
+
+<publication>
+
+    <!-- Common Options -->
+    <common>
+        <!-- How deep to go for separate files, in HTML the -->
+        <!-- default for an article with sections is 1      -->
+        <chunking level="1"/>
+        <!-- How deep to nest a Table of Contents, for an article   -->
+        <!-- with subsections in HTML, the default is 2, but in the -->
+        <!-- LateX conversion the default is no ToC at all.  So we  -->
+        <!-- let these conversion-specific defaults play out, and   -->
+        <!-- just leave this example as a comment.                  -->
+        <!-- <tableofcontents level="2"/> -->
+        <!-- These "exercise component visibility" settings are the -->
+        <!-- defaults, but can be switched to "no" in order to hide -->
+        <!-- parts of an exercise, where born.                      -->
+        <exercise-inline hint="yes"/>
+        <exercise-project answer="yes"/>
+        <!-- fillin styles are "underline" (the default for text),  -->
+        <!-- "box", and "shade" (the default for math)              -->
+        <fillin textstyle="underline" mathstyle="shade"/>
+        <qrcode image="misc/ptx-logo-square.png"/>
+        <!-- This is the minimum information to locate a     -->
+        <!-- Citation Stylesheet Language (CSL) style file   -->
+        <!-- in the CSL repository.  It is not expected to   -->
+        <!-- have the ".csl" suffix.  Default is "harvard1". -->
+        <!-- Note: "harvard1" might be best first use.       -->
+        <!-- 2025-08-13: this is experimental and opt-in.    -->
+        <!--  -->
+        <!-- "harvard1" style available in CiteProcPy code?  -->
+        <!-- <citation-stylesheet-language style="harvard1"/> -->
+        <!--  -->
+        <!-- numeric style, ". " for suffix -->
+        <!-- <citation-stylesheet-language style="vancouver-brackets"/> -->
+        <!--  -->
+        <!-- "elsevier-with-titles" is a "numeric" style, [6] -->
+        <!-- <citation-stylesheet-language style="elsevier-with-titles"/> -->
+        <!--  -->
+        <!-- <citation-stylesheet-language style="taylor-and-francis-chicago-author-date"/> -->
+        <!--  -->
+        <!-- 2025-06-03: "chicago-fullnote" uses footnotes/endnotes, and       -->
+        <!-- therefore should throw an error as an unsupported style, and halt -->
+        <!-- <citation-stylesheet-language style="chicago-fullnote-bibliography-with-ibid"/> -->
+        <!-- If desired, defaults for mermaid theme and layout engine -->
+        <!-- can be specifed. These values can be overriden in a      -->
+        <!-- diagram using config: frontmatter                        -->
+        <!-- <mermaid theme="forest" layout-engine="elk"/> -->
+    </common>
+
+    <!-- we use customizations-two for the oscarlevin style example -->
+    <source customizations="customizations-one.xml">
+        <directories generated="gen"/>
+        <!-- this is an example of placing @generated *outside* of revision control -->
+        <!-- <directories external="media" generated="../../../altgen"/> -->
+    </source>
+
+    <!-- Server to process STACK problems embedded in HTML -->
+    <stack server="https://stack-api.maths.ed.ac.uk"/>
+
+    <!-- For an "article" with "section" we can only go 3 levels    -->
+    <!-- deep (section > subsection > subsubsection) and this is    -->
+    <!-- the default for divisions' levels.  For numbers on smaller -->
+    <!-- pieces of content, the default is XX.NN, i.e. level 1.     -->
+    <!-- Read the PreTeXt Guide for more on numbering and levels.   -->
+    <numbering>
+        <divisions level="3"/>
+        <blocks    level="1"/>
+        <projects  level="1" distinct="yes"/>
+        <equations level="1"/>
+        <footnotes level="1"/>
+    </numbering>
+
+    <!-- PDF-Specific Options (the XSL-FO route) -->
+    <!-- Alegreya is a book face for text-heavy documents.  The -->
+    <!-- default, "latin-modern", matches the LaTeX conversion  -->
+    <!-- and is what  publication.xml  gets.                    -->
+    <pdf font="alegreya"/>
+
+    <!-- 10pt font is the default   -->
+    <!-- draft mode default is "no" -->
+    <!-- snapshot default is "no", but we elect to stress the supported package -->
+    <latex print="no" sides="one" font-size="10" draft="no" snapshot="yes">
+        <!-- these are the default alignments, given just as an example -->
+        <!-- Even if you set  @crop-marks  to something like "letter" or "a4"    -->
+        <!-- you may not see a change.  You need to use the  geometery  package  -->
+        <!-- to set a smaller (logical) page size.                               -->
+        <page right-alignment="flush" bottom-alignment="ragged" crop-marks="none"/>
+        <!-- Uncomment this to experiment with a LaTeX OTF font              -->
+        <!-- commonly included in TeX distributions.  Be sure                -->
+        <!-- to use the  xelatex  engine (the default).                      -->
+        <!-- TeX Gyre Pagella: has slashed zeros that go the *opposite* way  -->
+        <!-- from the slashed zeros in our Inconsolata monospace font.       -->
+        <!-- TeX Gyre Pagella Math: with a "french" style, Greek letters     -->
+        <!-- *and* upper-case Latin letters will be upright in mathematics.  -->
+        <!--
+        <fonts>
+            <main regular="TeX Gyre Pagella" options="Numbers={SlashedZero}"/>
+            <math regular="TeX Gyre Pagella Math" options="math-style=french"/>
+        </fonts>
+        -->
+        <!-- worksheets are formatted separately by default.   -->
+        <!-- change to "no" to format as regular sections.     -->
+        <worksheet formatted="yes"/>
+        <asymptote links="yes"/>
+        <insertions pagebreaks="quotations exercises-section-multiple pre-roll-countdown-8"/>
+        <insertions pagebreaks="sidebyside-bully-pulpit sbsgroup-pagebreak-test"/>
+    </latex>
+
+</publication>

--- a/examples/sample-article/publication.xml
+++ b/examples/sample-article/publication.xml
@@ -91,6 +91,13 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
         <footnotes level="1"/>
     </numbering>
 
+    <!-- PDF-Specific Options (the XSL-FO route) -->
+    <!-- "latin-modern" is the default, and matches the fonts of  -->
+    <!-- the LaTeX conversion.  Stated here to advertise the      -->
+    <!-- option;  publication-alegreya.xml  is the same file with -->
+    <!-- the other choice, "alegreya".                            -->
+    <pdf font="latin-modern"/>
+
     <!-- HTML-Specific Options -->
     <!-- favicon "simple" scheme expects -->
     <!--     favicon/favicon-32x32.png   -->


### PR DESCRIPTION
The `pdf-fo` route offers two text fonts, and the font is a publication
file setting, so building the sample article in each of them takes two
publication files.

* `publication-alegreya.xml` is a copy of `publication.xml` carrying
  `<pdf font="alegreya"/>`.  The `common`, `source`, `stack`,
  `numbering`, and `latex` sections are verbatim, so the two PDFs
  differ in nothing but the text font.  The `html` section is dropped,
  as `pretext-fo.xsl` reads nothing from it; a header comment says to
  diff against `publication.xml` to sync later edits, the way
  `publication-print.xml` does.
* `publication.xml` now states `<pdf font="latin-modern"/>` rather than
  taking it by default.  The output is unchanged; written out, it
  advertises the option and names the companion file.

Verified by building both with FOP 2.8.  Each is PDF/UA-1 compliant
under veraPDF, with no failed rules.  `pdffonts` reports
`Alegreya-Regular`, `-Italic`, `-Bold`, and `-BoldItalic` in the one and
the `LMRoman10` faces in the other, `Inconsolata` and the symbol
companion in both, everything embedded.  Alegreya comes to 316 pages,
Latin Modern to 321.  The Alegreya build draws on the `STIX Two Text`
fallback nowhere at all, as Alegreya covers the characters Latin Modern
needs it for.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
