### PR TITLE
Verbatim license text: "@xml:lang" on "shortlicense", examples, Guide; Italian quotation style

### DIFF
--- a/doc/guide/appendices/gfdl-pretext.xml
+++ b/doc/guide/appendices/gfdl-pretext.xml
@@ -21,7 +21,11 @@ along with The PBR.  If not, see <http://www.gnu.org/licenses/>.
 <!-- addition of the <pretext /> elements employed to   -->
 <!-- render the license within a <pretext /> document   -->
 
-<appendix xml:id="appendix-gfdl">
+<!-- A license is presented verbatim, so its text is always English,   -->
+<!-- whatever the language of the document.  The @xml:lang keeps       -->
+<!-- language features, such as quotation marks, from changing with it -->
+
+<appendix xml:id="appendix-gfdl" xml:lang="en-US">
     <title>GNU Free Documentation License</title>
 
     <p>Version 1.3, 3 November 2008</p>

--- a/doc/guide/frontmatter.xml
+++ b/doc/guide/frontmatter.xml
@@ -47,7 +47,10 @@
         <copyright>
             <year>2013<ndash />2019</year>
             <holder>Robert A. Beezer, David Farmer, Alex Jordan, Mitchel T. Keller</holder>
-            <shortlicense>Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the section entitled <q>GNU Free Documentation License</q>.</shortlicense>
+            <!-- A license is presented verbatim, so its text is always English,   -->
+            <!-- whatever the language of the document.  The @xml:lang keeps       -->
+            <!-- language features, such as quotation marks, from changing with it -->
+            <shortlicense xml:lang="en-US">Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the section entitled <q>GNU Free Documentation License</q>.</shortlicense>
         </copyright>
     </bibinfo>
 

--- a/doc/guide/publisher/open-licenses.xml
+++ b/doc/guide/publisher/open-licenses.xml
@@ -144,6 +144,8 @@
             <cline>  &lt;/colophon&gt;</cline>
             <cline>&lt;/frontmatter&gt;</cline>
         </cd>The <init>GFDL</init> is also explicit about including the complete license with your document.  You can find various places a version formatted for inclusion in a <pretext /> project, including as part of the source for this document.</p>
+
+        <p>A license should appear verbatim.  Some features of text, such as quotation marks, follow the language in effect (see <xref ref="topic-localization"/>), so a license written in a language other than that of your document needs its own language, not the document's: place an <attr>xml:lang</attr> attribute, with the code for the language the license is written in, on the <tag>shortlicense</tag> element of your <tag>copyright</tag> and on the appendix holding the complete license.  For example, the <init>GFDL</init> in English gets <c>xml:lang="en-US"</c>.  This is harmless when your document is already in the language of the license, and the source of this document does exactly this.</p>
     </section>
 
     <section>

--- a/examples/custom-theming/source/frontmatter.ptx
+++ b/examples/custom-theming/source/frontmatter.ptx
@@ -22,7 +22,10 @@
         <copyright>
             <year>2020<ndash />2024</year>
             <holder>You</holder>
-            <shortlicense> This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit <url href="https://creativecommons.org/licenses/by-sa/4.0/" visual="creativecommons.org/licenses/by-sa/4.0"> CreativeCommons.org</url>
+            <!-- A license is presented verbatim, so its text is always English,   -->
+            <!-- whatever the language of the document.  The @xml:lang keeps       -->
+            <!-- language features, such as quotation marks, from changing with it -->
+            <shortlicense xml:lang="en-US"> This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit <url href="https://creativecommons.org/licenses/by-sa/4.0/" visual="creativecommons.org/licenses/by-sa/4.0"> CreativeCommons.org</url>
             </shortlicense>
         </copyright>
         

--- a/examples/sample-book/frontmatter.xml
+++ b/examples/sample-book/frontmatter.xml
@@ -83,7 +83,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
             <year>1997<ndash />2015</year>
             <holder>Thomas W. Judson, Robert A. Beezer</holder>
             <minilicense>GFDL License</minilicense>
-            <shortlicense>Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the appendix entitled <q>GNU Free Documentation License.</q>  All trademarks<trademark /> are the registered<registered /> marks of their respective owners. An <url href="https://example.com" visual="example.com">external link</url> is included<fn>A second footnote, as well.</fn> to test its footnote.</shortlicense>
+            <!-- A license is presented verbatim, so its text is always English,   -->
+            <!-- whatever the language of the document.  The @xml:lang keeps       -->
+            <!-- language features, such as quotation marks, from changing with it -->
+            <shortlicense xml:lang="en-US">Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the appendix entitled <q>GNU Free Documentation License.</q>  All trademarks<trademark /> are the registered<registered /> marks of their respective owners. An <url href="https://example.com" visual="example.com">external link</url> is included<fn>A second footnote, as well.</fn> to test its footnote.</shortlicense>
         </copyright>
 
         <keywords>

--- a/examples/sample-book/gfdl-mathbook.xml
+++ b/examples/sample-book/gfdl-mathbook.xml
@@ -24,7 +24,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- addition of the MathBook XML elements employed to   -->
 <!-- render the license within a MathBook XML document   -->
 
-<appendix xml:id="appendix-gfdl">
+<!-- A license is presented verbatim, so its text is always English,   -->
+<!-- whatever the language of the document.  The @xml:lang keeps       -->
+<!-- language features, such as quotation marks, from changing with it -->
+
+<appendix xml:id="appendix-gfdl" xml:lang="en-US">
     <title>GNU Free Documentation License</title>
 
     <p>Version 1.3, 3 November 2008</p>

--- a/examples/sample-book/sample-book-solutions-manual.xml
+++ b/examples/sample-book/sample-book-solutions-manual.xml
@@ -72,7 +72,10 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
                     <year>1997<ndash />2015</year>
                     <holder>Thomas W. Judson, Robert A. Beezer</holder>
                     <minilicense>GFDL License</minilicense>
-                    <shortlicense>Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the appendix entitled <q>GNU Free Documentation License.</q>  All trademarks<trademark /> are the registered<registered /> marks of their respective owners.</shortlicense>
+                    <!-- A license is presented verbatim, so its text is always English,   -->
+                    <!-- whatever the language of the document.  The @xml:lang keeps       -->
+                    <!-- language features, such as quotation marks, from changing with it -->
+                    <shortlicense xml:lang="en-US">Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the appendix entitled <q>GNU Free Documentation License.</q>  All trademarks<trademark /> are the registered<registered /> marks of their respective owners.</shortlicense>
                 </copyright>
             </colophon>
 

--- a/schema/pretext-dev.rnc
+++ b/schema/pretext-dev.rnc
@@ -176,8 +176,8 @@
 
             ShortLicense_X =
                 element shortlicense {
-                    TextLong &
-                    Footnote*
+                    XMLLang?,
+                    (TextLong & Footnote*)
                 }
             ShortLicense |= ShortLicense_X
             Website_X = element website {

--- a/schema/pretext-dev.rng
+++ b/schema/pretext-dev.rng
@@ -427,6 +427,9 @@
   </define>
   <define name="ShortLicense_X">
     <element name="shortlicense">
+      <optional>
+        <ref name="XMLLang"/>
+      </optional>
       <interleave>
         <ref name="TextLong"/>
         <zeroOrMore>

--- a/schema/pretext.rnc
+++ b/schema/pretext.rnc
@@ -322,7 +322,11 @@
                     element role {TextShort},
                     element entity {TextLong}
                 }
-            ShortLicense = element shortlicense {TextLong}
+            ShortLicense =
+                element shortlicense {
+                    XMLLang?,
+                    TextLong
+                }
             Website = element website {Url}
             Copyright =
                 element copyright {

--- a/schema/pretext.rng
+++ b/schema/pretext.rng
@@ -1018,6 +1018,9 @@
   </define>
   <define name="ShortLicense">
     <element name="shortlicense">
+      <optional>
+        <ref name="XMLLang"/>
+      </optional>
       <ref name="TextLong"/>
     </element>
   </define>

--- a/schema/pretext.xml
+++ b/schema/pretext.xml
@@ -3621,7 +3621,7 @@
     <section>
         <title>Front Matter</title>
 
-        <p>Articles and books have material at the start, which gets organized in interesting ways. <c>minilicense</c> is very restrictive, <c>shortlicense</c> allows references (<eg/> <init>URL</init>s).  <c>bibinfo</c> is like a very small database whose content migrates to a titlepage and colophon if <c>titlepage/titlepage-items</c> or <c>colophon/colophon-items</c> are present. For HTML, titlepage means the page for the <c>frontmatter</c> , and for <latex/> these items migrate to the half-title and title pages.  Since it generally makes no sense as the target of a cross-reference, <c>titlepage</c> does not allow an <c>@xml:id</c> attribute.</p>
+        <p>Articles and books have material at the start, which gets organized in interesting ways. <c>minilicense</c> is very restrictive, <c>shortlicense</c> allows references (<eg/> <init>URL</init>s) and an <attr>xml:lang</attr> attribute, since a license is usually reproduced verbatim in its original language, whatever the language of the surrounding document.  <c>bibinfo</c> is like a very small database whose content migrates to a titlepage and colophon if <c>titlepage/titlepage-items</c> or <c>colophon/colophon-items</c> are present. For HTML, titlepage means the page for the <c>frontmatter</c> , and for <latex/> these items migrate to the half-title and title pages.  Since it generally makes no sense as the target of a cross-reference, <c>titlepage</c> does not allow an <c>@xml:id</c> attribute.</p>
 
         <p>Some notes about new additions to <c>bibinfo</c>.
         <ul>
@@ -3764,7 +3764,11 @@
                     element role {TextShort},
                     element entity {TextLong}
                 }
-            ShortLicense = element shortlicense {TextLong}
+            ShortLicense =
+                element shortlicense {
+                    XMLLang?,
+                    TextLong
+                }
             Website = element website {Url}
             Copyright =
                 element copyright {
@@ -3825,8 +3829,8 @@
             <code>
             ShortLicense_X =
                 element shortlicense {
-                    TextLong &amp;
-                    Footnote*
+                    XMLLang?,
+                    (TextLong &amp; Footnote*)
                 }
             ShortLicense |= ShortLicense_X
             Website_X = element website {

--- a/xsl/localizations/it-IT.xml
+++ b/xsl/localizations/it-IT.xml
@@ -24,10 +24,11 @@ along with PreTeXt.  If not, see <http://www.gnu.org/licenses/>.
 <!-- it-IT, Italian (Italy) -->
 <!-- Valerio Monti, gedeonedepaperoni@gmail.com, 2020-07-27   -->
 
+<!-- Quotation marks: the English style is a deliberate choice for   -->
+<!-- Italian, not a default (Valerio Monti, pretext-dev, 2026-09-02) -->
 <locale language="it-IT" direction="ltr"
         quote-primary="english-double" quote-secondary="english-single">
     <!-- THEOREM-LIKE blocks -->
-    <!-- The english quotation style above is just a default, it needs adjustment -->
     <localization string-id='theorem'>Teorema</localization>
     <localization string-id='corollary'>Corollario</localization>
     <localization string-id='lemma'>Lemma</localization>


### PR DESCRIPTION
From the pretext-dev thread [Quotation mark styles for different languages](https://groups.google.com/d/msgid/pretext-dev/00a1e43b-7b60-4da3-93eb-4137100a38e6n%40googlegroups.com) (Valerio Monti, 2026-08-31 and 2026-09-02).

Quotation marks (`q`, `sq`) now follow the nearest `@xml:lang`.  A license is reproduced verbatim, usually in English, so in a document written in another language its quotation marks were taking the document's style: the GFDL appendix and the `shortlicense` of a French book came out with guillemets.  The appendix could already carry `@xml:lang`; the `shortlicense` could not.

* **Localizations:** Italian keeps the English quotation style.  `it-IT.xml` already carried it as an untouched default; the file now records it as the maintainer's decision (Valerio, in the thread) and the "needs adjustment" comment is gone.  No output changes.
* **Schema:** `shortlicense` accepts `@xml:lang`, in the base schema and in the development overlay (which adds footnotes to `shortlicense`).  Literate source and the four derived files, one commit; regeneration is idempotent.
* **Sample book, Guide, custom theming:** `xml:lang="en-US"` on every `shortlicense` (four) and on both GFDL appendices, each with the same comment: a license is presented verbatim, so its text is always English, and the attribute keeps language features such as quotation marks from changing with the document.
* **Guide:** the Copyright and Licensing chapter now advises giving license text the language it is written in, on the `shortlicense` and on the appendix holding the complete license, with a cross-reference to the localization topic.

**Testing.**  Sample book (LaTeX and HTML), solutions manual (LaTeX), Guide (LaTeX) and custom theming (HTML and LaTeX) built before and after: the only differences are timestamps.  The sample book with its root element temporarily switched to `fr-FR`: 48 quotation pairs go from guillemets to English marks (one in the `shortlicense`, 47 in the GFDL appendix), and the LaTeX preamble gains `\setotherlanguage[variant=usmax]{english}`; nothing else changes.  Validation (`-V`) of all four documents reports the same messages before and after; the attribute on `shortlicense` draws no complaint.

**Left as is, on purpose.**  `@xml:lang` on a division also localizes the division's name and, in HTML, the page chrome: the GFDL appendix of a French book is headed "Appendix G" and its page has English navigation strings.  That is existing behavior of the attribute on a division and is out of scope here.  The LaTeX conversion has no `en-US` case in `country-to-language`, so no `\begin{english}` surrounds the appendix and hyphenation does not switch; a possible follow-on.

*Claude Fable 5.1, acting as a coding assistant for Rob Beezer*
