### PR TITLE
Script: ensure entities resolve even with newest lxml

### DIFF
--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -280,7 +280,14 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
     control = None
     if output_dir:
         control = ET.XSLTAccessControl(write_file=True)
-    xsl_tree = ET.parse(xsl)
+    # Our stylesheets use an internal DTD subset to pull in "../entities.ent"
+    # (see the "entity tricks" comment atop each stylesheet) via an external
+    # parameter entity. lxml 6.1.3 stopped resolving external parameter
+    # entities by default (LP#2165901), so this must be requested explicitly.
+    # The stylesheet is always our own bundled/trusted XSL, never
+    # user-supplied XML content, so re-enabling resolution here is safe.
+    xsl_parser = ET.XMLParser(resolve_entities=True)
+    xsl_tree = ET.parse(xsl, parser=xsl_parser)
     xslt = ET.XSLT(xsl_tree, access_control=control)
 
     # do the transformation, with parameterization


### PR DESCRIPTION
The issue reported on [-support](https://groups.google.com/g/pretext-support/c/QaM3kiiHns4) appears to be cause by `uvx` downloading the latest security patch of lxml, which breaks PreTeXt's entities tricks.  This PR should fix that.  Without this, the next time the CLI or anyone using the pretext script upgrades their lxml, their pretext will also break.