### PR TITLE
Script: correct the stylesheet entity note, state "no_network"

### DIFF
--- a/pretext/lib/common.py
+++ b/pretext/lib/common.py
@@ -280,13 +280,16 @@ def xsltproc(xsl, xml, result, output_dir=None, stringparams={}):
     control = None
     if output_dir:
         control = ET.XSLTAccessControl(write_file=True)
-    # Our stylesheets use an internal DTD subset to pull in "../entities.ent"
+    # Our stylesheets use an internal DTD subset to pull in "entities.ent"
     # (see the "entity tricks" comment atop each stylesheet) via an external
-    # parameter entity. lxml 6.1.3 stopped resolving external parameter
-    # entities by default (LP#2165901), so this must be requested explicitly.
-    # The stylesheet is always our own bundled/trusted XSL, never
-    # user-supplied XML content, so re-enabling resolution here is safe.
-    xsl_parser = ET.XMLParser(resolve_entities=True)
+    # parameter entity.  lxml resolves internal entities only unless it
+    # is asked otherwise, so external parameter entities are requested here.
+    #     https://bugs.launchpad.net/lxml/+bug/2165901
+    # This is safe because the stylesheet always comes from whoever runs
+    # the build, either bundled with PreTeXt or supplied by the publisher,
+    # and never from the document being processed.  Resolution stays on
+    # local files: "no_network" is the default, but we are explicit here.
+    xsl_parser = ET.XMLParser(resolve_entities=True, no_network=True)
     xsl_tree = ET.parse(xsl, parser=xsl_parser)
     xslt = ET.XSLT(xsl_tree, access_control=control)
 


### PR DESCRIPTION
A follow-up to #3204, which added the parser argument that keeps entity resolution working on lxml 6.1.3. This adjusts the note that explains it, and states the second parser argument that the safety argument depends on.

No behaviour change: `no_network=True` is already lxml's default, and everything else is comment text.

## What changes

- **The safety claim is made accurate.** The note said the stylesheet is "never user-supplied XML content". The `-X` option takes a stylesheet path from whoever runs the build and hands it to this same function, and the Guide's transition appendix shows authors the entity trick for use in exactly such a stylesheet. The property that actually holds, and that makes external entity resolution safe here, is a different one: the stylesheet always comes from the person running the build — bundled with PreTeXt or supplied by the publisher — and never from the document being processed.

- **`no_network=True` is stated.** It is the default, but it is half the reason the setting is safe, so it is worth reading at the call site. This matches what the same function already does nine lines above for access control, and what `pretext.py` does where it parses SVG.

- **The description of lxml's behaviour is turned right way round.** The note had lxml "stopped resolving external parameter entities by default". Per the linked report, `resolve_entities='internal'` was always meant to exclude external entities and a gap let external parameter entities through anyway; that gap is now closed. Requesting resolution explicitly is therefore the intended way to opt in, not a workaround. The note now describes the standing rule rather than the release that changed it, so it will not need revisiting.

- **The bug reference is spelled out** as a URL instead of an abbreviation.

- **The entity filename loses its path prefix.** The note named `"../entities.ent"`; across the stylesheets that spelling appears 9 times, against 25 for `"entities.ent"`, 3 for `"./entities.ent"` and one `"../xsl/entities.ent"`. The bare filename covers all of them.

## Verification

The sample article was built to HTML under both lxml versions that matter:

- **lxml 6.1.3** — completes, 175 files. This is the version that fails without #3204, so it confirms the parser call still does its job with the second argument in place.
- **lxml 6.1.1** — output is identical to a build from `master`, apart from the two lines carrying the build timestamp.

*Claude Opus 5, acting as a coding assistant for Rob Beezer*
